### PR TITLE
Update ViewerTest_CmdParser.cxx

### DIFF
--- a/src/ViewerTest/ViewerTest_CmdParser.cxx
+++ b/src/ViewerTest/ViewerTest_CmdParser.cxx
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <iostream>
 
 namespace
 {


### PR DESCRIPTION
Solves build error on debian linux : 

Consolidate compiler generated dependencies of target TKViewerTest [ 96%] Building CXX object src/TKViewerTest/CMakeFiles/TKViewerTest.dir/__/ViewerTest/ViewerTest_CmdParser.cxx.o /home/user/XCreator/vendor/OCCT/src/ViewerTest/ViewerTest_CmdParser.cxx:53:80: error: ‘numeric_limits’ is not a member of ‘std’
   53 | const std::size_t ViewerTest_CmdParser::THE_UNNAMED_COMMAND_OPTION_KEY = (std::numeric_limits<std::size_t>::max)();
      |                                                                                ^~~~~~~~~~~~~~
/home/user/XCreator/vendor/OCCT/src/ViewerTest/ViewerTest_CmdParser.cxx:53:106: error: expected primary-expression before ‘>’ token
   53 | const std::size_t ViewerTest_CmdParser::THE_UNNAMED_COMMAND_OPTION_KEY = (std::numeric_limits<std::size_t>::max)();
      |                                                                                                          ^
/home/user/XCreator/vendor/OCCT/src/ViewerTest/ViewerTest_CmdParser.cxx:53:109: error: ‘::max’ has not been declared; did you mean ‘std::max’?
   53 | const std::size_t ViewerTest_CmdParser::THE_UNNAMED_COMMAND_OPTION_KEY = (std::numeric_limits<std::size_t>::max)();
      |