### PR TITLE
33487: Fix uninitialized structure StepVisual_FillAreaStyleColour for file with Unresoved Reference

### DIFF
--- a/src/StepVisual/StepVisual_FillAreaStyleColour.cxx
+++ b/src/StepVisual/StepVisual_FillAreaStyleColour.cxx
@@ -37,7 +37,7 @@ void StepVisual_FillAreaStyleColour::SetName(const Handle(TCollection_HAsciiStri
 
 Handle(TCollection_HAsciiString) StepVisual_FillAreaStyleColour::Name() const
 {
-	return name;
+	return this == nullptr ? nullptr : name;
 }
 
 void StepVisual_FillAreaStyleColour::SetFillColour(const Handle(StepVisual_Colour)& aFillColour)
@@ -47,5 +47,5 @@ void StepVisual_FillAreaStyleColour::SetFillColour(const Handle(StepVisual_Colou
 
 Handle(StepVisual_Colour) StepVisual_FillAreaStyleColour::FillColour() const
 {
-	return fillColour;
+	return this == nullptr ? nullptr : fillColour;
 }


### PR DESCRIPTION
Fix of reported bug: [33487](https://tracker.dev.opencascade.org/view.php?id=33487)