### PR TITLE
0033541: Modeling Algorithms - Simple sphere cut from cylinder fails

### DIFF
--- a/src/IntPatch/IntPatch_WLineTool.cxx
+++ b/src/IntPatch/IntPatch_WLineTool.cxx
@@ -1728,7 +1728,6 @@ static Standard_Boolean IsNeedSkipWL(const Handle(IntPatch_WLine)& theWL,
 {
   Standard_Real aFirstp, aLastp;
   Standard_Integer aNbVtx = theWL->NbVertex();
-  Standard_Boolean isNeedSkip = Standard_True;
 
   for (Standard_Integer i = 1; i < aNbVtx; i++) {
     aFirstp = theWL->Vertex (i).ParameterOnLine();
@@ -1739,14 +1738,13 @@ static Standard_Boolean IsNeedSkipWL(const Handle(IntPatch_WLine)& theWL,
     const IntSurf_PntOn2S& aPmid = theWL->Point (pmid);
     aPmid.Parameters (aU1, aV1, aU2, aV2);
 
-    if (!IsOutOfDomain (theBoxS1, theBoxS2, aPmid, theArrPeriods))
+    if (IsOutOfDomain (theBoxS1, theBoxS2, aPmid, theArrPeriods))
     {
-      isNeedSkip = Standard_False;
-      break;
+      return Standard_True;
     }
   }
 
-  return isNeedSkip;
+  return Standard_False;
 }
 
 //=======================================================================

--- a/tests/bugs/modalg_8/bug33541
+++ b/tests/bugs/modalg_8/bug33541
@@ -1,0 +1,12 @@
+puts "================================"
+puts "0033541: Modeling Algorithms - Simple sphere cut from cylinder fails"
+puts "================================"
+puts ""
+
+pcylinder c 1 1 
+psphere s 1 
+ttranslate s 1 1 1
+bcut result c s 
+
+checknbshapes result -vertex 3 -edge 5 -wire 4 -face 4
+checkview -display result -2d -path ${imagedir}/${test_image}.png


### PR DESCRIPTION
Changed condition for combination of WLines into one. WLine would be excluded from consideration for merging, if one of its middle points between vertices is out of domain (does not lie on both surfaces).