### PR TITLE
0033570: Modeling Algorithms - Incorrect result of cutting spheres

### DIFF
--- a/src/ProjLib/ProjLib_ComputeApprox.cxx
+++ b/src/ProjLib/ProjLib_ComputeApprox.cxx
@@ -655,7 +655,7 @@ static void Function_SetUVBounds(Standard_Real& myU1,
         // si P1.Z() vaut +/- R on est sur le sommet : pas significatif.
         gp_Pnt pp = P1.Transformed(Trsf);
 
-        if ( Abs( Abs(pp.Z()) - R) < Tol) {
+        if ( Abs(pp.X() * pp.X() + pp.Y() * pp.Y() + pp.Z() * pp.Z() - R * R) < Tol) {
           gp_Pnt Center = Circle.Location();
           Standard_Real U,V;
           ElSLib::SphereParameters(gp_Ax3(gp::XOY()),1,Center, U, V);

--- a/tests/bugs/modalg_8/bug33570
+++ b/tests/bugs/modalg_8/bug33570
@@ -1,0 +1,14 @@
+puts "================================"
+puts "0033570: Modeling Algorithms - Incorrect result of cutting spheres"
+puts "================================"
+puts ""
+
+psphere s1 4 
+psphere s2 1 
+ttranslate s1 0 5.5 18 
+ttranslate s2 0 4.5 14 
+
+bcut result s1 s2 
+
+checknbshapes result -vertex 4 -edge 7 -wire 2 -face 2
+checkview -display result -2d -path ${imagedir}/${test_image}.png


### PR DESCRIPTION
The reason of current problem lies inside projection algorithm Function_SetUVBounds() for projection of circle onto sphere produces shifted bounds. Incorrect checking of placement on summit of the sphere was fixed.