### PR TITLE
0033750: Configuration - make file configuration failed in mfc example

### DIFF
--- a/samples/mfc/standard/03_ImportExport/CMakeLists.txt
+++ b/samples/mfc/standard/03_ImportExport/CMakeLists.txt
@@ -11,7 +11,7 @@ project (ImportExport)
 add_definitions (-DWINVER=0x0501 -DUNICODE -D_UNICODE)
 set (CMAKE_MFC_FLAG 2)
 
-set (ImportExport_SRC_DIR      ${MFC_STANDARD_SAMPLES_DIR}/05_ImportExport/src)
+set (ImportExport_SRC_DIR      ${MFC_STANDARD_SAMPLES_DIR}/03_ImportExport/src)
 set (ImportExport_HEADER_FILES ${ImportExport_SRC_DIR}/ColoredShapes.h
                                ${ImportExport_SRC_DIR}/ImportExportApp.h
                                ${ImportExport_SRC_DIR}/ImportExportDoc.h
@@ -21,7 +21,7 @@ set (ImportExport_SOURCE_FILES ${ImportExport_SRC_DIR}/ColoredShapes.cpp
                                ${ImportExport_SRC_DIR}/ImportExportDoc.cpp
                                ${ImportExport_SRC_DIR}/StdAfx.cpp)
 
-set (ImportExport_RESOURCE_DIR    ${MFC_STANDARD_SAMPLES_DIR}/05_ImportExport/res)
+set (ImportExport_RESOURCE_DIR    ${MFC_STANDARD_SAMPLES_DIR}/03_ImportExport/res)
 set (ImportExport_RESOURCE_HEADER ${ImportExport_RESOURCE_DIR}/resource.h)
 set (ImportExport_RESOURCE_FILES  ${ImportExport_RESOURCE_DIR}/Toolbar.bmp
                                   ${ImportExport_RESOURCE_DIR}/ImportExport.rc)
@@ -55,7 +55,7 @@ else()
 endif()
 
 include_directories (${CMAKE_BINARY_DIR}/inc
-                     ${MFC_STANDARD_SAMPLES_DIR}/05_ImportExport
+                     ${MFC_STANDARD_SAMPLES_DIR}/03_ImportExport
                      ${ImportExport_SRC_DIR}
                      ${MFC_STANDARD_SAMPLES_DIR}/Common)
 

--- a/samples/mfc/standard/04_HLR/CMakeLists.txt
+++ b/samples/mfc/standard/04_HLR/CMakeLists.txt
@@ -11,7 +11,7 @@ project (HLR)
 add_definitions(-DWINVER=0x0501 -DUNICODE -D_UNICODE)
 set (CMAKE_MFC_FLAG 2)
 
-set (HLR_SRC_DIR      ${MFC_STANDARD_SAMPLES_DIR}/08_HLR/src)
+set (HLR_SRC_DIR      ${MFC_STANDARD_SAMPLES_DIR}/04_HLR/src)
 set (HLR_HEADER_FILES ${HLR_SRC_DIR}/HLRApp.h
                       ${HLR_SRC_DIR}/HLRDoc.h
                       ${HLR_SRC_DIR}/HLRView2D.h
@@ -23,7 +23,7 @@ set (HLR_SOURCE_FILES ${HLR_SRC_DIR}/HLRApp.cpp
                       ${HLR_SRC_DIR}/SelectionDialog.cpp
                       ${HLR_SRC_DIR}/StdAfx.cpp )
 
-set (HLR_RESOURCE_DIR    ${MFC_STANDARD_SAMPLES_DIR}/08_HLR/res)
+set (HLR_RESOURCE_DIR    ${MFC_STANDARD_SAMPLES_DIR}/04_HLR/res)
 set (HLR_RESOURCE_HEADER ${HLR_RESOURCE_DIR}/resource.h)
 set (HLR_RESOURCE_FILES  ${HLR_RESOURCE_DIR}/axoviewd.bmp
                          ${HLR_RESOURCE_DIR}/axoviewf.bmp

--- a/samples/mfc/standard/mfcsample/CMakeLists.txt
+++ b/samples/mfc/standard/mfcsample/CMakeLists.txt
@@ -82,7 +82,6 @@ set (COMMON_HEADER_FILES ${MFC_STANDARD_COMMON_SAMPLES_DIR}/AISDialogs.h
                          ${MFC_STANDARD_COMMON_SAMPLES_DIR}/OCC_StereoConfigDlg.h
                          ${MFC_STANDARD_COMMON_SAMPLES_DIR}/ParamsFacesPage.h
                          ${MFC_STANDARD_COMMON_SAMPLES_DIR}/ResultDialog.h
-                         ${MFC_STANDARD_COMMON_SAMPLES_DIR}/User_Cylinder.hxx
                          ${MFC_STANDARD_COMMON_SAMPLES_DIR}/ColoredMeshDlg.h
                          ${MFC_STANDARD_COMMON_SAMPLES_DIR}/DimensionDlg.h
                          ${MFC_STANDARD_COMMON_SAMPLES_DIR}/LengthParamsEdgePage.h


### PR DESCRIPTION
Updated MFC sample to build together with OCCT