### PR TITLE
Coding - Resolving C26439 & type formatting warnings

### DIFF
--- a/src/BOPTest/BOPTest_BOPCommands.cxx
+++ b/src/BOPTest/BOPTest_BOPCommands.cxx
@@ -229,7 +229,6 @@ Standard_Integer bopsmt(Draw_Interpretor& di,
     return 0;
   }
   //
-  char buf[64];
   Standard_Boolean bRunParallel;
   Standard_Integer aNb;
   BOPAlgo_BOP aBOP;
@@ -237,8 +236,7 @@ Standard_Integer bopsmt(Draw_Interpretor& di,
   const TopTools_ListOfShape& aLC=pPF->Arguments();
   aNb=aLC.Extent();
   if (aNb!=2) {
-    Sprintf (buf, " wrong number of arguments %s\n", aNb);
-    di << buf;
+    di << " wrong number of arguments " << aNb << '\n';
     return 0;
   }
   // 
@@ -298,7 +296,6 @@ Standard_Integer bopsection(Draw_Interpretor& di,
     return 0;
   }
   //
-  char buf[64];
   Standard_Boolean bRunParallel;
   Standard_Integer aNb;
   BOPAlgo_Section aBOP;
@@ -306,8 +303,7 @@ Standard_Integer bopsection(Draw_Interpretor& di,
   const TopTools_ListOfShape& aLC=pPF->Arguments();
   aNb=aLC.Extent();
   if (aNb!=2) {
-    Sprintf (buf, " wrong number of arguments %s\n", aNb);
-    di << buf;
+    di << " wrong number of arguments " << aNb << '\n';
     return 0;
   }
   //

--- a/src/NCollection/NCollection_DynamicArray.hxx
+++ b/src/NCollection/NCollection_DynamicArray.hxx
@@ -240,7 +240,7 @@ public: //! @name public methods
   }
 
   //! Assignment operator
-  NCollection_DynamicArray& operator= (NCollection_DynamicArray&& theOther)
+  NCollection_DynamicArray& operator= (NCollection_DynamicArray&& theOther) noexcept
   {
     return Assign(std::forward<NCollection_DynamicArray>(theOther));
   }

--- a/src/NCollection/NCollection_UtfString.hxx
+++ b/src/NCollection/NCollection_UtfString.hxx
@@ -81,7 +81,7 @@ public:
   NCollection_UtfString (const NCollection_UtfString& theCopy);
 
   //! Move constructor
-  NCollection_UtfString (NCollection_UtfString&& theOther);
+  NCollection_UtfString (NCollection_UtfString&& theOther) noexcept;
 
   //! Copy constructor from UTF-8 string.
   //! @param theCopyUtf8 UTF-8 string to copy

--- a/src/NCollection/NCollection_UtfString.lxx
+++ b/src/NCollection/NCollection_UtfString.lxx
@@ -95,7 +95,7 @@ NCollection_UtfString<Type>::NCollection_UtfString (const NCollection_UtfString&
 // purpose  :
 // =======================================================================
 template<typename Type> inline
-NCollection_UtfString<Type>::NCollection_UtfString (NCollection_UtfString&& theOther)
+NCollection_UtfString<Type>::NCollection_UtfString (NCollection_UtfString&& theOther) noexcept
 : myString(theOther.myString),
   mySize  (theOther.mySize),
   myLength(theOther.myLength)


### PR DESCRIPTION
Sprintf  with %s always convert values into char*, not safety from int.
Move operators and constructors can be marked as noexcept