### PR TITLE
0033765: Data Exchange, IGES Export - Missing Model Curves in transfer cache

### DIFF
--- a/src/BRepToIGESBRep/BRepToIGESBRep_Entity.cxx
+++ b/src/BRepToIGESBRep/BRepToIGESBRep_Entity.cxx
@@ -234,7 +234,7 @@ Standard_Integer BRepToIGESBRep_Entity::AddEdge(const TopoDS_Edge& myedge,
   Standard_Integer index = myEdges.FindIndex(E);
   if (index == 0) {
     index = myEdges.Add(E);
-    myCurves.Add(C);
+    myCurves.Append(C);
   }
   
   return index;

--- a/src/BRepToIGESBRep/BRepToIGESBRep_Entity.hxx
+++ b/src/BRepToIGESBRep/BRepToIGESBRep_Entity.hxx
@@ -23,6 +23,7 @@
 
 #include <TopTools_IndexedMapOfShape.hxx>
 #include <TColStd_IndexedMapOfTransient.hxx>
+#include <TColStd_SequenceOfTransient.hxx>
 #include <BRepToIGES_BREntity.hxx>
 #include <Standard_Integer.hxx>
 #include <Message_ProgressRange.hxx>
@@ -136,7 +137,7 @@ private:
 
   TopTools_IndexedMapOfShape myVertices;
   TopTools_IndexedMapOfShape myEdges;
-  TColStd_IndexedMapOfTransient myCurves;
+  TColStd_SequenceOfTransient myCurves;
   Handle(IGESSolid_EdgeList) myEdgeList;
   Handle(IGESSolid_VertexList) myVertexList;
 


### PR DESCRIPTION
Curve list should be not unique, list is recommended.
One curve can be used by multiple edges.