### PR TITLE
Testing, GitHub - Marking warnings as errors

### DIFF
--- a/.github/workflows/build-linux-gcc-x64-dynamic.yml
+++ b/.github/workflows/build-linux-gcc-x64-dynamic.yml
@@ -32,7 +32,9 @@ jobs:
               -D CMAKE_C_COMPILER=gcc \
               -D CMAKE_CXX_COMPILER=g++ \
               -D USE_FREETYPE=OFF \
-              -D CMAKE_BUILD_TYPE=Release ..
+              -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_C_FLAGS="-Werror" \
+              -D CMAKE_CXX_FLAGS="-Werror" ..
 
     - name: Build OCCT
       run: |

--- a/.github/workflows/build-windows-msvc-x64-dynamic.yml
+++ b/.github/workflows/build-windows-msvc-x64-dynamic.yml
@@ -34,11 +34,11 @@ jobs:
 
     - name: Configure OCCT
       run: |
-        mkdir build
-        cd build
-        cmake -T host=x64 -D USE_FREETYPE=OFF -D BUILD_MODULE_Draw=OFF -D CMAKE_BUILD_TYPE=Release ..
-
+          mkdir build
+          cd build
+          cmake -T host=x64 -D USE_FREETYPE=OFF -D BUILD_MODULE_Draw=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_FLAGS="/WX" -D CMAKE_CXX_FLAGS="/WX" ..
+  
     - name: Build OCCT
       run: |
-        cd build
-        cmake --build . --config Release -- /m
+          cd build
+          cmake --build . --config Release -- /m


### PR DESCRIPTION
Windows, Linux builds now starts checking the warning.
  In warning case the job will be failed.
MacOS having too much warnings related with sprintf.
  Needs to fix them first.
  It will be later.