### PR TITLE
0033487: Data Exchange, Step Import - Unresolved reference crashes

### DIFF
--- a/src/STEPConstruct/STEPConstruct_Styles.cxx
+++ b/src/STEPConstruct/STEPConstruct_Styles.cxx
@@ -213,8 +213,8 @@ namespace
       // SurfaceStyleFillArea, SurfaceStyleBoundary, SurfaceStyleRendering.
       // So we're using && operator to stop as soon as this type is processed.
       ProcessAsSurfaceStyleFillArea(aSSES, aSSU->Side(), theSurfaceColour)
-        && ProcessAsSurfaceStyleBoundary(aSSES, theBoundaryColour)
-        && ProcessAsSurfaceStyleRendering(aSSES, theRenderColour, theRenderTransparency);
+        || ProcessAsSurfaceStyleBoundary(aSSES, theBoundaryColour)
+        || ProcessAsSurfaceStyleRendering(aSSES, theRenderColour, theRenderTransparency);
     }
     return Standard_True;
   }
@@ -799,7 +799,7 @@ Standard_Boolean STEPConstruct_Styles::GetColors(const Handle(StepVisual_StyledI
                                  theBoundaryColour,
                                  theRenderColour,
                                  theRenderTransparency)
-        && ProcessAsCurveStyle(aPSS, theCurveColour);
+        || ProcessAsCurveStyle(aPSS, theCurveColour);
     }
   }
   return !theSurfaceColour.IsNull() || !theBoundaryColour.IsNull() || !theCurveColour.IsNull()

--- a/src/STEPConstruct/STEPConstruct_Styles.cxx
+++ b/src/STEPConstruct/STEPConstruct_Styles.cxx
@@ -71,6 +71,176 @@
 #include <StepVisual_ContextDependentOverRidingStyledItem.hxx>
 #include <StepShape_ShapeRepresentation.hxx>
 
+namespace
+{
+  //=======================================================================
+  //function : ProcessAsSurfaceStyleRendering
+  //purpose  : Process StepVisual_SurfaceStyleElementSelect to extract a
+  //           render color and render trnasparency from it. Returns true,
+  //           if theSSES was of type StepVisual_SurfaceStyleRendering
+  //           (even if color and transparency data couldn't be extracted
+  //           for some reason), otherwise returns false.
+  //=======================================================================
+  Standard_Boolean ProcessAsSurfaceStyleRendering (
+    const StepVisual_SurfaceStyleElementSelect& theSSES,
+    Handle (StepVisual_Colour)&                 theRenderColour,
+    Standard_Real&                              theRenderTransparency)
+  {
+    const Handle (StepVisual_SurfaceStyleRendering) aSSR = theSSES.SurfaceStyleRendering();
+    if (aSSR.IsNull())
+    {
+      return Standard_False;
+    }
+    theRenderColour       = aSSR->SurfaceColour();
+    theRenderTransparency = 0.0;
+    const Handle (StepVisual_SurfaceStyleRenderingWithProperties) aSSRWP =
+      Handle (StepVisual_SurfaceStyleRenderingWithProperties)::DownCast (aSSR);
+    if (aSSRWP.IsNull())
+    {
+      return Standard_True;
+    }
+    const Handle (StepVisual_HArray1OfRenderingPropertiesSelect) aHARP = aSSRWP->Properties();
+    if (aHARP.IsNull())
+    {
+      return Standard_True;
+    }
+
+    for (Standard_Integer aPropIndex = 1; aPropIndex <= aHARP->Length(); ++aPropIndex)
+    {
+      const Handle (StepVisual_SurfaceStyleTransparent) aSST =
+        aHARP->Value (aPropIndex).SurfaceStyleTransparent();
+      if (!aSST.IsNull())
+      {
+        theRenderTransparency = aSST->Transparency();
+      }
+    }
+    return Standard_True;
+  }
+
+  //=======================================================================
+  //function : ProcessAsSurfaceStyleBoundary
+  //purpose  : Process StepVisual_SurfaceStyleElementSelect to extract a
+  //           boundary color from it. Returns true,
+  //           if theSSES was of type StepVisual_SurfaceStyleBoundary
+  //           (even if boundary color data couldn't be extracted
+  //           for some reason), otherwise returns false.
+  //=======================================================================
+  Standard_Boolean ProcessAsSurfaceStyleBoundary (
+    const StepVisual_SurfaceStyleElementSelect& theSSES,
+    Handle (StepVisual_Colour)&                 theBoundaryColour)
+  {
+    const Handle (StepVisual_SurfaceStyleBoundary) aSSB = theSSES.SurfaceStyleBoundary();
+    if (aSSB.IsNull())
+    {
+      return Standard_False;
+    }
+    const Handle (StepVisual_CurveStyle) aCS = aSSB->StyleOfBoundary();
+    if (aCS.IsNull())
+    {
+      return Standard_True;
+    }
+    theBoundaryColour = aCS->CurveColour();
+    return Standard_True;
+  }
+
+  //=======================================================================
+  //function : ProcessAsSurfaceStyleFillArea
+  //purpose  : Process StepVisual_SurfaceStyleElementSelect to extract a
+  //           surface color from it. Doesn't return color for negative
+  //           side. Returns true, if theSSES was of type
+  //           StepVisual_SurfaceStyleFillArea (even if surface color data
+  //           couldn't be extracted or some reason), otherwise returns
+  //           false.
+  //=======================================================================
+  Standard_Boolean ProcessAsSurfaceStyleFillArea (
+    const StepVisual_SurfaceStyleElementSelect& theSSES,
+    const StepVisual_SurfaceSide                theSide,
+    Handle (StepVisual_Colour)&                 theSurfaceColour)
+  {
+    const Handle (StepVisual_SurfaceStyleFillArea) aSSFA = theSSES.SurfaceStyleFillArea();
+    if (aSSFA.IsNull())
+    {
+      return Standard_False;
+    }
+    if (theSide == StepVisual_ssNegative)
+    {
+      return Standard_True;
+    }
+    const Handle (StepVisual_FillAreaStyle) aFAS = aSSFA->FillArea();
+    if (aFAS.IsNull())
+    {
+      return Standard_True;
+    }
+
+    for (Standard_Integer aFSSIndex = 1; aFSSIndex <= aFAS->NbFillStyles(); aFSSIndex++)
+    {
+      const StepVisual_FillStyleSelect              aFSS  = aFAS->FillStylesValue (aFSSIndex);
+      const Handle (StepVisual_FillAreaStyleColour) aFASC = aFSS.FillAreaStyleColour();
+      if (!aFASC.IsNull() && theSurfaceColour.IsNull()) //abv 30 Mar 00: trj3_s1-pe.stp
+      {
+        theSurfaceColour = aFASC->FillColour();
+      }
+    }
+    return Standard_True;
+  }
+
+  //=======================================================================
+  //function : ProcessAsSurfaceStyleUsage
+  //purpose  : Process StepVisual_PresentationStyleSelect to extract
+  //           following data from it: surface color, boundary color,
+  //           render color, render transparency. Returns true,
+  //           if thePSS was of type StepVisual_SurfaceStyleUsage
+  //           (even if no data at all could be extracted for some reason),
+  //           otherwise returns false.
+  //=======================================================================
+  Standard_Boolean ProcessAsSurfaceStyleUsage (const StepVisual_PresentationStyleSelect& thePSS,
+                                               Handle (StepVisual_Colour)& theSurfaceColour,
+                                               Handle (StepVisual_Colour)& theBoundaryColour,
+                                               Handle (StepVisual_Colour)& theRenderColour,
+                                               Standard_Real&              theRenderTransparency)
+  {
+    const Handle (StepVisual_SurfaceStyleUsage) aSSU = thePSS.SurfaceStyleUsage();
+    if (aSSU.IsNull())
+    {
+      return Standard_False;
+    }
+
+    const Handle (StepVisual_SurfaceSideStyle) aSSS = aSSU->Style();
+    for (Standard_Integer aSSESIndex = 1; aSSESIndex <= aSSS->NbStyles(); ++aSSESIndex)
+    {
+      const StepVisual_SurfaceStyleElementSelect aSSES = aSSS->StylesValue (aSSESIndex);
+      // SurfaceStyleElementSelect can be of only one of the following types:
+      // SurfaceStyleFillArea, SurfaceStyleBoundary, SurfaceStyleRendering.
+      // So we're using && operator to stop as soon as this type is processed.
+      ProcessAsSurfaceStyleFillArea (aSSES, aSSU->Side(), theSurfaceColour)
+        && ProcessAsSurfaceStyleBoundary (aSSES, theBoundaryColour)
+        && ProcessAsSurfaceStyleRendering (aSSES, theRenderColour, theRenderTransparency);
+    }
+    return Standard_True;
+  }
+
+  //=======================================================================
+  //function : ProcessAsCurveStyle
+  //purpose  : Process StepVisual_PresentationStyleSelect to extract a
+  //           curve color from it. Returns true,
+  //           if thePSS was of type StepVisual_SurfaceStyleRendering
+  //           (even if curve color data couldn't be extracted
+  //           for some reason), otherwise returns false.
+  //=======================================================================
+  Standard_Boolean ProcessAsCurveStyle (const StepVisual_PresentationStyleSelect& thePSS,
+                                        Handle (StepVisual_Colour)&               theCurveColour)
+  {
+    const Handle (StepVisual_CurveStyle) aCS = thePSS.CurveStyle();
+    if (aCS.IsNull())
+    {
+      return Standard_False;
+    }
+
+    theCurveColour = aCS->CurveColour();
+    return Standard_True;
+  }
+}
+
 //=======================================================================
 //function : STEPConstruct_Styles
 //purpose  : 
@@ -590,95 +760,51 @@ Handle(StepVisual_PresentationStyleAssignment) STEPConstruct_Styles::GetColorPSA
   }
   return PSA;
 }
-  
 
 //=======================================================================
 //function : GetColors
-//purpose  : 
+//purpose  :
 //=======================================================================
-
-Standard_Boolean STEPConstruct_Styles::GetColors (const Handle(StepVisual_StyledItem) &style,
-						  Handle(StepVisual_Colour) &SurfCol,
-						  Handle(StepVisual_Colour) &BoundCol,
-						  Handle(StepVisual_Colour) &CurveCol,
-                                                  Handle(StepVisual_Colour) &RenderCol,
-                                                  Standard_Real& RenderTransp,
-                                                  Standard_Boolean& IsComponent) const
+Standard_Boolean STEPConstruct_Styles::GetColors (const Handle (StepVisual_StyledItem)& theStyle,
+                                                  Handle (StepVisual_Colour)& theSurfaceColour,
+                                                  Handle (StepVisual_Colour)& theBoundaryColour,
+                                                  Handle (StepVisual_Colour)& theCurveColour,
+                                                  Handle (StepVisual_Colour)& theRenderColour,
+                                                  Standard_Real&              theRenderTransparency,
+                                                  Standard_Boolean&           theIsComponent) const
 {
-  SurfCol.Nullify();
-  BoundCol.Nullify();
-  CurveCol.Nullify();
-  RenderCol.Nullify();
-    
+  theSurfaceColour.Nullify();
+  theBoundaryColour.Nullify();
+  theCurveColour.Nullify();
+  theRenderColour.Nullify();
+
   // parse on styles
-  for(Standard_Integer j=1; j<=style->NbStyles(); j++ ) {
-    Handle(StepVisual_PresentationStyleAssignment) PSA = style->StylesValue ( j );
-    if(PSA.IsNull() || PSA->Styles().IsNull()) continue;
-    IsComponent = Standard_True;
-    
-    for(Standard_Integer k=1; k<=PSA->NbStyles(); k++ ) {
-      StepVisual_PresentationStyleSelect PSS = PSA->StylesValue(k);
+  for (Standard_Integer aPSAIndex = 1; aPSAIndex <= theStyle->NbStyles(); ++aPSAIndex)
+  {
+    const Handle (StepVisual_PresentationStyleAssignment) aPSA = theStyle->StylesValue (aPSAIndex);
+    if (aPSA.IsNull() || aPSA->Styles().IsNull())
+    {
+      continue;
+    }
+    theIsComponent = Standard_True;
 
-      // try surface_style_usage
-      Handle(StepVisual_SurfaceStyleUsage) SSU = PSS.SurfaceStyleUsage();
-      if( !SSU.IsNull() ) {
-	Handle(StepVisual_SurfaceSideStyle) SSS = SSU->Style();
-	for(Standard_Integer l=1; l<=SSS->NbStyles(); l++ ) {
-	  StepVisual_SurfaceStyleElementSelect SSES = SSS->StylesValue(l);
-	  // try fill color
-	  Handle(StepVisual_SurfaceStyleFillArea) SSFA = SSES.SurfaceStyleFillArea();
-	  if ( !SSFA.IsNull() ) {
-	    Handle(StepVisual_FillAreaStyle) FAS = SSFA->FillArea();
-      if (FAS.IsNull())
-        continue;
-	    for ( Standard_Integer m=1; m <= FAS->NbFillStyles(); m++ ) {
-	      StepVisual_FillStyleSelect FSS = FAS->FillStylesValue ( m );
-	      Handle(StepVisual_FillAreaStyleColour) FASC = FSS.FillAreaStyleColour();
-	      if ( SurfCol.IsNull() || SSU->Side() != StepVisual_ssNegative ) //abv 30 Mar 00: trj3_s1-pe.stp
-		SurfCol = FASC->FillColour();
-	    }
-	    continue;
-	  }
-	  // try boundary color
-	  Handle(StepVisual_SurfaceStyleBoundary) SSB = SSES.SurfaceStyleBoundary();
-	  if(!SSB.IsNull()) {
-	    Handle(StepVisual_CurveStyle) CS = SSB->StyleOfBoundary();
-	    if ( ! CS.IsNull() ) BoundCol = CS->CurveColour();
-	    continue;
-	  }
-      // try rendering color and transparency
-      Handle(StepVisual_SurfaceStyleRendering) SSR = SSES.SurfaceStyleRendering();
-      if (!SSR.IsNull()) {
-          RenderCol = SSR->SurfaceColour();
-          RenderTransp = 0.0;
-          Handle(StepVisual_SurfaceStyleRenderingWithProperties) SSRWP =
-              Handle(StepVisual_SurfaceStyleRenderingWithProperties)::DownCast(SSR);
-          if (!SSRWP.IsNull()) {
-              Handle(StepVisual_HArray1OfRenderingPropertiesSelect) HARP = SSRWP->Properties();
-              if (!HARP.IsNull())
-              {
-                  for (Standard_Integer aPropIndex = 1; aPropIndex <= HARP->Length(); ++aPropIndex) {
-                      Handle(StepVisual_SurfaceStyleTransparent) SST = HARP->Value(aPropIndex).SurfaceStyleTransparent();
-                      if (!SST.IsNull()) {
-                          RenderTransp = SST->Transparency();
-                      }
-                  }
-               }
-          }
-      }
-
-	}
-	continue;
-      }
-      
-      // try curve_style
-      Handle(StepVisual_CurveStyle) CS = PSS.CurveStyle();
-      if ( ! CS.IsNull() ) CurveCol = CS->CurveColour();
+    for (Standard_Integer aPSSIndex = 1; aPSSIndex <= aPSA->NbStyles(); ++aPSSIndex)
+    {
+      const StepVisual_PresentationStyleSelect aPSS = aPSA->StylesValue (aPSSIndex);
+    // PresentationStyleSelect can be of only one of the following types:
+    // SurfaceStyleUsage, CurveStyle.
+    // So we're using && operator to stop as soon as this type is processed.
+      ProcessAsSurfaceStyleUsage (aPSS,
+                                  theSurfaceColour,
+                                  theBoundaryColour,
+                                  theRenderColour,
+                                  theRenderTransparency)
+        && ProcessAsCurveStyle (aPSS, theCurveColour);
     }
   }
-  return ! SurfCol.IsNull() || ! BoundCol.IsNull() || ! CurveCol.IsNull() || ! RenderCol.IsNull();
+  return !theSurfaceColour.IsNull() || !theBoundaryColour.IsNull() || !theCurveColour.IsNull()
+      || !theRenderColour.IsNull();
 }
-
 
 //=======================================================================
 //function : EncodeColor

--- a/src/STEPConstruct/STEPConstruct_Styles.cxx
+++ b/src/STEPConstruct/STEPConstruct_Styles.cxx
@@ -81,25 +81,25 @@ namespace
   //           (even if color and transparency data couldn't be extracted
   //           for some reason), otherwise returns false.
   //=======================================================================
-  Standard_Boolean ProcessAsSurfaceStyleRendering (
+  Standard_Boolean ProcessAsSurfaceStyleRendering(
     const StepVisual_SurfaceStyleElementSelect& theSSES,
-    Handle (StepVisual_Colour)&                 theRenderColour,
+    Handle(StepVisual_Colour)&                  theRenderColour,
     Standard_Real&                              theRenderTransparency)
   {
-    const Handle (StepVisual_SurfaceStyleRendering) aSSR = theSSES.SurfaceStyleRendering();
+    const Handle(StepVisual_SurfaceStyleRendering) aSSR = theSSES.SurfaceStyleRendering();
     if (aSSR.IsNull())
     {
       return Standard_False;
     }
     theRenderColour       = aSSR->SurfaceColour();
     theRenderTransparency = 0.0;
-    const Handle (StepVisual_SurfaceStyleRenderingWithProperties) aSSRWP =
-      Handle (StepVisual_SurfaceStyleRenderingWithProperties)::DownCast (aSSR);
+    const Handle(StepVisual_SurfaceStyleRenderingWithProperties) aSSRWP =
+      Handle(StepVisual_SurfaceStyleRenderingWithProperties)::DownCast(aSSR);
     if (aSSRWP.IsNull())
     {
       return Standard_True;
     }
-    const Handle (StepVisual_HArray1OfRenderingPropertiesSelect) aHARP = aSSRWP->Properties();
+    const Handle(StepVisual_HArray1OfRenderingPropertiesSelect) aHARP = aSSRWP->Properties();
     if (aHARP.IsNull())
     {
       return Standard_True;
@@ -107,8 +107,8 @@ namespace
 
     for (Standard_Integer aPropIndex = 1; aPropIndex <= aHARP->Length(); ++aPropIndex)
     {
-      const Handle (StepVisual_SurfaceStyleTransparent) aSST =
-        aHARP->Value (aPropIndex).SurfaceStyleTransparent();
+      const Handle(StepVisual_SurfaceStyleTransparent) aSST =
+        aHARP->Value(aPropIndex).SurfaceStyleTransparent();
       if (!aSST.IsNull())
       {
         theRenderTransparency = aSST->Transparency();
@@ -125,16 +125,16 @@ namespace
   //           (even if boundary color data couldn't be extracted
   //           for some reason), otherwise returns false.
   //=======================================================================
-  Standard_Boolean ProcessAsSurfaceStyleBoundary (
+  Standard_Boolean ProcessAsSurfaceStyleBoundary(
     const StepVisual_SurfaceStyleElementSelect& theSSES,
-    Handle (StepVisual_Colour)&                 theBoundaryColour)
+    Handle(StepVisual_Colour)&                  theBoundaryColour)
   {
-    const Handle (StepVisual_SurfaceStyleBoundary) aSSB = theSSES.SurfaceStyleBoundary();
+    const Handle(StepVisual_SurfaceStyleBoundary) aSSB = theSSES.SurfaceStyleBoundary();
     if (aSSB.IsNull())
     {
       return Standard_False;
     }
-    const Handle (StepVisual_CurveStyle) aCS = aSSB->StyleOfBoundary();
+    const Handle(StepVisual_CurveStyle) aCS = aSSB->StyleOfBoundary();
     if (aCS.IsNull())
     {
       return Standard_True;
@@ -152,12 +152,12 @@ namespace
   //           couldn't be extracted or some reason), otherwise returns
   //           false.
   //=======================================================================
-  Standard_Boolean ProcessAsSurfaceStyleFillArea (
+  Standard_Boolean ProcessAsSurfaceStyleFillArea(
     const StepVisual_SurfaceStyleElementSelect& theSSES,
     const StepVisual_SurfaceSide                theSide,
-    Handle (StepVisual_Colour)&                 theSurfaceColour)
+    Handle(StepVisual_Colour)&                  theSurfaceColour)
   {
-    const Handle (StepVisual_SurfaceStyleFillArea) aSSFA = theSSES.SurfaceStyleFillArea();
+    const Handle(StepVisual_SurfaceStyleFillArea) aSSFA = theSSES.SurfaceStyleFillArea();
     if (aSSFA.IsNull())
     {
       return Standard_False;
@@ -166,7 +166,7 @@ namespace
     {
       return Standard_True;
     }
-    const Handle (StepVisual_FillAreaStyle) aFAS = aSSFA->FillArea();
+    const Handle(StepVisual_FillAreaStyle) aFAS = aSSFA->FillArea();
     if (aFAS.IsNull())
     {
       return Standard_True;
@@ -174,8 +174,8 @@ namespace
 
     for (Standard_Integer aFSSIndex = 1; aFSSIndex <= aFAS->NbFillStyles(); aFSSIndex++)
     {
-      const StepVisual_FillStyleSelect              aFSS  = aFAS->FillStylesValue (aFSSIndex);
-      const Handle (StepVisual_FillAreaStyleColour) aFASC = aFSS.FillAreaStyleColour();
+      const StepVisual_FillStyleSelect             aFSS  = aFAS->FillStylesValue(aFSSIndex);
+      const Handle(StepVisual_FillAreaStyleColour) aFASC = aFSS.FillAreaStyleColour();
       if (!aFASC.IsNull() && theSurfaceColour.IsNull()) //abv 30 Mar 00: trj3_s1-pe.stp
       {
         theSurfaceColour = aFASC->FillColour();
@@ -193,28 +193,28 @@ namespace
   //           (even if no data at all could be extracted for some reason),
   //           otherwise returns false.
   //=======================================================================
-  Standard_Boolean ProcessAsSurfaceStyleUsage (const StepVisual_PresentationStyleSelect& thePSS,
-                                               Handle (StepVisual_Colour)& theSurfaceColour,
-                                               Handle (StepVisual_Colour)& theBoundaryColour,
-                                               Handle (StepVisual_Colour)& theRenderColour,
-                                               Standard_Real&              theRenderTransparency)
+  Standard_Boolean ProcessAsSurfaceStyleUsage(const StepVisual_PresentationStyleSelect& thePSS,
+                                              Handle(StepVisual_Colour)& theSurfaceColour,
+                                              Handle(StepVisual_Colour)& theBoundaryColour,
+                                              Handle(StepVisual_Colour)& theRenderColour,
+                                              Standard_Real&             theRenderTransparency)
   {
-    const Handle (StepVisual_SurfaceStyleUsage) aSSU = thePSS.SurfaceStyleUsage();
+    const Handle(StepVisual_SurfaceStyleUsage) aSSU = thePSS.SurfaceStyleUsage();
     if (aSSU.IsNull())
     {
       return Standard_False;
     }
 
-    const Handle (StepVisual_SurfaceSideStyle) aSSS = aSSU->Style();
+    const Handle(StepVisual_SurfaceSideStyle) aSSS = aSSU->Style();
     for (Standard_Integer aSSESIndex = 1; aSSESIndex <= aSSS->NbStyles(); ++aSSESIndex)
     {
-      const StepVisual_SurfaceStyleElementSelect aSSES = aSSS->StylesValue (aSSESIndex);
+      const StepVisual_SurfaceStyleElementSelect aSSES = aSSS->StylesValue(aSSESIndex);
       // SurfaceStyleElementSelect can be of only one of the following types:
       // SurfaceStyleFillArea, SurfaceStyleBoundary, SurfaceStyleRendering.
       // So we're using && operator to stop as soon as this type is processed.
-      ProcessAsSurfaceStyleFillArea (aSSES, aSSU->Side(), theSurfaceColour)
-        && ProcessAsSurfaceStyleBoundary (aSSES, theBoundaryColour)
-        && ProcessAsSurfaceStyleRendering (aSSES, theRenderColour, theRenderTransparency);
+      ProcessAsSurfaceStyleFillArea(aSSES, aSSU->Side(), theSurfaceColour)
+        && ProcessAsSurfaceStyleBoundary(aSSES, theBoundaryColour)
+        && ProcessAsSurfaceStyleRendering(aSSES, theRenderColour, theRenderTransparency);
     }
     return Standard_True;
   }
@@ -227,10 +227,10 @@ namespace
   //           (even if curve color data couldn't be extracted
   //           for some reason), otherwise returns false.
   //=======================================================================
-  Standard_Boolean ProcessAsCurveStyle (const StepVisual_PresentationStyleSelect& thePSS,
-                                        Handle (StepVisual_Colour)&               theCurveColour)
+  Standard_Boolean ProcessAsCurveStyle(const StepVisual_PresentationStyleSelect& thePSS,
+                                       Handle(StepVisual_Colour)&                theCurveColour)
   {
-    const Handle (StepVisual_CurveStyle) aCS = thePSS.CurveStyle();
+    const Handle(StepVisual_CurveStyle) aCS = thePSS.CurveStyle();
     if (aCS.IsNull())
     {
       return Standard_False;
@@ -765,13 +765,13 @@ Handle(StepVisual_PresentationStyleAssignment) STEPConstruct_Styles::GetColorPSA
 //function : GetColors
 //purpose  :
 //=======================================================================
-Standard_Boolean STEPConstruct_Styles::GetColors (const Handle (StepVisual_StyledItem)& theStyle,
-                                                  Handle (StepVisual_Colour)& theSurfaceColour,
-                                                  Handle (StepVisual_Colour)& theBoundaryColour,
-                                                  Handle (StepVisual_Colour)& theCurveColour,
-                                                  Handle (StepVisual_Colour)& theRenderColour,
-                                                  Standard_Real&              theRenderTransparency,
-                                                  Standard_Boolean&           theIsComponent) const
+Standard_Boolean STEPConstruct_Styles::GetColors(const Handle(StepVisual_StyledItem)& theStyle,
+                                                 Handle(StepVisual_Colour)& theSurfaceColour,
+                                                 Handle(StepVisual_Colour)& theBoundaryColour,
+                                                 Handle(StepVisual_Colour)& theCurveColour,
+                                                 Handle(StepVisual_Colour)& theRenderColour,
+                                                 Standard_Real&             theRenderTransparency,
+                                                 Standard_Boolean&          theIsComponent) const
 {
   theSurfaceColour.Nullify();
   theBoundaryColour.Nullify();
@@ -781,7 +781,7 @@ Standard_Boolean STEPConstruct_Styles::GetColors (const Handle (StepVisual_Style
   // parse on styles
   for (Standard_Integer aPSAIndex = 1; aPSAIndex <= theStyle->NbStyles(); ++aPSAIndex)
   {
-    const Handle (StepVisual_PresentationStyleAssignment) aPSA = theStyle->StylesValue (aPSAIndex);
+    const Handle(StepVisual_PresentationStyleAssignment) aPSA = theStyle->StylesValue(aPSAIndex);
     if (aPSA.IsNull() || aPSA->Styles().IsNull())
     {
       continue;
@@ -790,16 +790,16 @@ Standard_Boolean STEPConstruct_Styles::GetColors (const Handle (StepVisual_Style
 
     for (Standard_Integer aPSSIndex = 1; aPSSIndex <= aPSA->NbStyles(); ++aPSSIndex)
     {
-      const StepVisual_PresentationStyleSelect aPSS = aPSA->StylesValue (aPSSIndex);
-    // PresentationStyleSelect can be of only one of the following types:
-    // SurfaceStyleUsage, CurveStyle.
-    // So we're using && operator to stop as soon as this type is processed.
-      ProcessAsSurfaceStyleUsage (aPSS,
-                                  theSurfaceColour,
-                                  theBoundaryColour,
-                                  theRenderColour,
-                                  theRenderTransparency)
-        && ProcessAsCurveStyle (aPSS, theCurveColour);
+      const StepVisual_PresentationStyleSelect aPSS = aPSA->StylesValue(aPSSIndex);
+      // PresentationStyleSelect can be of only one of the following types:
+      // SurfaceStyleUsage, CurveStyle.
+      // So we're using && operator to stop as soon as this type is processed.
+      ProcessAsSurfaceStyleUsage(aPSS,
+                                 theSurfaceColour,
+                                 theBoundaryColour,
+                                 theRenderColour,
+                                 theRenderTransparency)
+        && ProcessAsCurveStyle(aPSS, theCurveColour);
     }
   }
   return !theSurfaceColour.IsNull() || !theBoundaryColour.IsNull() || !theCurveColour.IsNull()

--- a/src/STEPConstruct/STEPConstruct_Styles.cxx
+++ b/src/STEPConstruct/STEPConstruct_Styles.cxx
@@ -162,10 +162,6 @@ namespace
     {
       return Standard_False;
     }
-    if (theSide == StepVisual_ssNegative)
-    {
-      return Standard_True;
-    }
     const Handle(StepVisual_FillAreaStyle) aFAS = aSSFA->FillArea();
     if (aFAS.IsNull())
     {
@@ -176,7 +172,11 @@ namespace
     {
       const StepVisual_FillStyleSelect             aFSS  = aFAS->FillStylesValue(aFSSIndex);
       const Handle(StepVisual_FillAreaStyleColour) aFASC = aFSS.FillAreaStyleColour();
-      if (!aFASC.IsNull() && theSurfaceColour.IsNull()) //abv 30 Mar 00: trj3_s1-pe.stp
+      if (!aFASC.IsNull()
+          // If current surface color is null, we will use negative side color.
+          // Otherwise negative side color is ignored.
+          && (theSurfaceColour.IsNull()
+              || theSide != StepVisual_ssNegative)) //abv 30 Mar 00: trj3_s1-pe.stp
       {
         theSurfaceColour = aFASC->FillColour();
       }

--- a/src/STEPConstruct/STEPConstruct_Styles.hxx
+++ b/src/STEPConstruct/STEPConstruct_Styles.hxx
@@ -27,6 +27,7 @@
 #include <TColStd_HSequenceOfTransient.hxx>
 #include <STEPConstruct_DataMapOfAsciiStringTransient.hxx>
 #include <STEPConstruct_DataMapOfPointTransient.hxx>
+
 class XSControl_WorkSession;
 class StepVisual_StyledItem;
 class StepRepr_RepresentationItem;
@@ -39,7 +40,6 @@ class StepRepr_ProductDefinitionShape;
 class StepVisual_Colour;
 class Quantity_Color;
 
-
 //! Provides a mechanism for reading and writing shape styles
 //! (such as color) to and from the STEP file
 //! This tool maintains a list of styles, either taking them
@@ -48,135 +48,144 @@ class Quantity_Color;
 //! Some methods deal with general structures of styles and
 //! presentations in STEP, but there are methods which deal
 //! with particular implementation of colors (as described in RP)
-class STEPConstruct_Styles  : public STEPConstruct_Tool
+class STEPConstruct_Styles : public STEPConstruct_Tool
 {
 public:
-
   DEFINE_STANDARD_ALLOC
 
-  
   //! Creates an empty tool
   Standard_EXPORT STEPConstruct_Styles();
-  
+
   //! Creates a tool and initializes it
-  Standard_EXPORT STEPConstruct_Styles(const Handle(XSControl_WorkSession)& WS);
-  
+  Standard_EXPORT STEPConstruct_Styles (const Handle (XSControl_WorkSession)& WS);
+
   //! Initializes tool; returns True if succeeded
-  Standard_EXPORT Standard_Boolean Init (const Handle(XSControl_WorkSession)& WS);
-  
+  Standard_EXPORT Standard_Boolean Init (const Handle (XSControl_WorkSession)& WS);
+
   //! Returns number of defined styles
   Standard_EXPORT Standard_Integer NbStyles() const;
-  
+
   //! Returns style with given index
-  Standard_EXPORT Handle(StepVisual_StyledItem) Style (const Standard_Integer i) const;
+  Standard_EXPORT Handle (StepVisual_StyledItem) Style (const Standard_Integer i) const;
 
   //! Returns number of override styles
   Standard_EXPORT Standard_Integer NbRootStyles() const;
-  
+
   //! Returns override style with given index
-  Standard_EXPORT Handle(StepVisual_StyledItem) RootStyle (const Standard_Integer i) const;
-  
+  Standard_EXPORT Handle (StepVisual_StyledItem) RootStyle (const Standard_Integer i) const;
+
   //! Clears all defined styles and PSA sequence
   Standard_EXPORT void ClearStyles();
-  
+
   //! Adds a style to a sequence
-  Standard_EXPORT void AddStyle (const Handle(StepVisual_StyledItem)& style);
-  
+  Standard_EXPORT void AddStyle (const Handle (StepVisual_StyledItem)& style);
+
   //! Create a style linking giving PSA to the item, and add it to the
   //! sequence of stored styles. If Override is not Null, then
   //! the resulting style will be of the subtype OverridingStyledItem.
-  Standard_EXPORT Handle(StepVisual_StyledItem) AddStyle (const Handle(StepRepr_RepresentationItem)& item, const Handle(StepVisual_PresentationStyleAssignment)& PSA, const Handle(StepVisual_StyledItem)& Override);
-  
+  Standard_EXPORT Handle (StepVisual_StyledItem) AddStyle (
+    const Handle (StepRepr_RepresentationItem)&            item,
+    const Handle (StepVisual_PresentationStyleAssignment)& PSA,
+    const Handle (StepVisual_StyledItem)&                  Override);
+
   //! Create a style linking giving PSA to the Shape, and add it to the
   //! sequence of stored styles. If Override is not Null, then
   //! the resulting style will be of the subtype OverridingStyledItem.
   //! The Sape is used to find corresponding STEP entity by call to
   //! STEPConstruct::FindEntity(), then previous method is called.
-  Standard_EXPORT Handle(StepVisual_StyledItem) AddStyle (const TopoDS_Shape& Shape, const Handle(StepVisual_PresentationStyleAssignment)& PSA, const Handle(StepVisual_StyledItem)& Override);
-  
+  Standard_EXPORT Handle (StepVisual_StyledItem) AddStyle (
+    const TopoDS_Shape&                                    Shape,
+    const Handle (StepVisual_PresentationStyleAssignment)& PSA,
+    const Handle (StepVisual_StyledItem)&                  Override);
+
   //! Create MDGPR, fill it with all the styles previously defined,
   //! and add it to the model
-  Standard_EXPORT Standard_Boolean CreateMDGPR (const Handle(StepRepr_RepresentationContext)& Context,
-                                                Handle(StepVisual_MechanicalDesignGeometricPresentationRepresentation)& MDGPR,
-                                                Handle(StepData_StepModel)& theStepModel);
-  
+  Standard_EXPORT Standard_Boolean
+    CreateMDGPR (const Handle (StepRepr_RepresentationContext)&                           Context,
+                 Handle (StepVisual_MechanicalDesignGeometricPresentationRepresentation)& MDGPR,
+                 Handle (StepData_StepModel)& theStepModel);
+
   //! Create MDGPR, fill it with all the styles previously defined,
   //! and add it to the model
   //! IMPORTANT: <initPDS> must be null when use for NAUO colors
   //! <initPDS> initialised only for SHUO case.
-  Standard_EXPORT Standard_Boolean CreateNAUOSRD (const Handle(StepRepr_RepresentationContext)& Context, const Handle(StepShape_ContextDependentShapeRepresentation)& CDSR, const Handle(StepRepr_ProductDefinitionShape)& initPDS);
-  
+  Standard_EXPORT Standard_Boolean
+    CreateNAUOSRD (const Handle (StepRepr_RepresentationContext)&                Context,
+                   const Handle (StepShape_ContextDependentShapeRepresentation)& CDSR,
+                   const Handle (StepRepr_ProductDefinitionShape)&               initPDS);
+
   //! Searches the STEP model for the RepresentationContext in which
   //! given shape is defined. This context (if found) can be used
   //! then in call to CreateMDGPR()
-  Standard_EXPORT Handle(StepRepr_RepresentationContext) FindContext (const TopoDS_Shape& Shape) const;
-  
+  Standard_EXPORT Handle (StepRepr_RepresentationContext) FindContext (
+    const TopoDS_Shape& Shape) const;
+
   //! Searches the STEP model for the MDGPR or DM entities
   //! (which bring styles) and fills sequence of styles
   Standard_EXPORT Standard_Boolean LoadStyles();
-  
+
   //! Searches the STEP model for the INISIBILITY entities
   //! (which bring styles) and fills out sequence of styles
-  Standard_EXPORT Standard_Boolean LoadInvisStyles (Handle(TColStd_HSequenceOfTransient)& InvSyles) const;
-  
+  Standard_EXPORT Standard_Boolean
+    LoadInvisStyles (Handle (TColStd_HSequenceOfTransient)& InvSyles) const;
+
   //! Create a PresentationStyleAssignment entity which defines
   //! two colors (for filling surfaces and curves)
   //! if isForNAUO true then returns PresentationStyleByContext
-  Standard_EXPORT Handle(StepVisual_PresentationStyleAssignment) MakeColorPSA (const Handle(StepRepr_RepresentationItem)& item, const Handle(StepVisual_Colour)& SurfCol, const Handle(StepVisual_Colour)& CurveCol, const Handle(StepVisual_Colour) &RenderCol, const Standard_Real RenderTransp, const Standard_Boolean isForNAUO = Standard_False) const;
-  
+  Standard_EXPORT Handle (StepVisual_PresentationStyleAssignment) MakeColorPSA (
+    const Handle (StepRepr_RepresentationItem)& item,
+    const Handle (StepVisual_Colour)&           SurfCol,
+    const Handle (StepVisual_Colour)&           CurveCol,
+    const Handle (StepVisual_Colour)&           RenderCol,
+    const Standard_Real                         RenderTransp,
+    const Standard_Boolean                      isForNAUO = Standard_False) const;
+
   //! Returns a PresentationStyleAssignment entity which defines
   //! surface and curve colors as Col. This PSA is either created
   //! or taken from internal map where all PSAs created by this
   //! method are remembered.
-  Standard_EXPORT Handle(StepVisual_PresentationStyleAssignment) GetColorPSA (const Handle(StepRepr_RepresentationItem)& item, const Handle(StepVisual_Colour)& Col);
-  
+  Standard_EXPORT Handle (StepVisual_PresentationStyleAssignment) GetColorPSA (
+    const Handle (StepRepr_RepresentationItem)& item,
+    const Handle (StepVisual_Colour)&           Col);
+
   //! Extract color definitions from the style entity
   //! For each type of color supported, result can be either
   //! NULL if it is not defined by that style, or last
   //! definition (if they are 1 or more)
-  Standard_EXPORT Standard_Boolean GetColors (const Handle(StepVisual_StyledItem)& style, Handle(StepVisual_Colour)& SurfCol, Handle(StepVisual_Colour)& BoundCol, Handle(StepVisual_Colour)& CurveCol, Handle(StepVisual_Colour)& RenderCol, Standard_Real& RenderTransp, Standard_Boolean& IsComponent) const;
-  
+  Standard_EXPORT Standard_Boolean GetColors (const Handle (StepVisual_StyledItem)& theStyle,
+                                              Handle (StepVisual_Colour)& theSurfaceColour,
+                                              Handle (StepVisual_Colour)& theBoundaryColour,
+                                              Handle (StepVisual_Colour)& theCurveColour,
+                                              Handle (StepVisual_Colour)& theRenderColour,
+                                              Standard_Real&              theRenderTransparency,
+                                              Standard_Boolean&           theIsComponent) const;
+
   //! Create STEP color entity by given Quantity_Color
   //! The analysis is performed for whether the color corresponds to
   //! one of standard colors predefined in STEP. In that case,
   //! PredefinedColour entity is created instead of RGBColour
-  Standard_EXPORT static Handle(StepVisual_Colour) EncodeColor (const Quantity_Color& Col);
-  
+  Standard_EXPORT static Handle (StepVisual_Colour) EncodeColor (const Quantity_Color& Col);
+
   //! Create STEP color entity by given Quantity_Color
   //! The analysis is performed for whether the color corresponds to
   //! one of standard colors predefined in STEP. In that case,
   //! PredefinedColour entity is created instead of RGBColour
-  Standard_EXPORT static Handle(StepVisual_Colour) EncodeColor (const Quantity_Color& Col, STEPConstruct_DataMapOfAsciiStringTransient& DPDCs, STEPConstruct_DataMapOfPointTransient& ColRGBs);
-  
+  Standard_EXPORT static Handle (StepVisual_Colour) EncodeColor (
+    const Quantity_Color&                        Col,
+    STEPConstruct_DataMapOfAsciiStringTransient& DPDCs,
+    STEPConstruct_DataMapOfPointTransient&       ColRGBs);
+
   //! Decodes STEP color and fills the Quantity_Color.
   //! Returns True if OK or False if color is not recognized
-  Standard_EXPORT static Standard_Boolean DecodeColor (const Handle(StepVisual_Colour)& Colour, Quantity_Color& Col);
-
-
-
+  Standard_EXPORT static Standard_Boolean DecodeColor (const Handle (StepVisual_Colour)& Colour,
+                                                       Quantity_Color&                   Col);
 
 protected:
-
-
-
-
-
 private:
-
-
-
   TColStd_IndexedDataMapOfTransientTransient myMapOfStyles;
-  TColStd_IndexedMapOfTransient myStyles;
-  TColStd_IndexedMapOfTransient myRootStyles;
-  TColStd_SequenceOfTransient myPSA;
-
-
+  TColStd_IndexedMapOfTransient              myStyles;
+  TColStd_IndexedMapOfTransient              myRootStyles;
+  TColStd_SequenceOfTransient                myPSA;
 };
-
-
-
-
-
-
 
 #endif // _STEPConstruct_Styles_HeaderFile

--- a/src/STEPConstruct/STEPConstruct_Styles.hxx
+++ b/src/STEPConstruct/STEPConstruct_Styles.hxx
@@ -57,67 +57,67 @@ public:
   Standard_EXPORT STEPConstruct_Styles();
 
   //! Creates a tool and initializes it
-  Standard_EXPORT STEPConstruct_Styles (const Handle (XSControl_WorkSession)& WS);
+  Standard_EXPORT STEPConstruct_Styles(const Handle(XSControl_WorkSession)& WS);
 
   //! Initializes tool; returns True if succeeded
-  Standard_EXPORT Standard_Boolean Init (const Handle (XSControl_WorkSession)& WS);
+  Standard_EXPORT Standard_Boolean Init(const Handle(XSControl_WorkSession)& WS);
 
   //! Returns number of defined styles
   Standard_EXPORT Standard_Integer NbStyles() const;
 
   //! Returns style with given index
-  Standard_EXPORT Handle (StepVisual_StyledItem) Style (const Standard_Integer i) const;
+  Standard_EXPORT Handle(StepVisual_StyledItem) Style(const Standard_Integer i) const;
 
   //! Returns number of override styles
   Standard_EXPORT Standard_Integer NbRootStyles() const;
 
   //! Returns override style with given index
-  Standard_EXPORT Handle (StepVisual_StyledItem) RootStyle (const Standard_Integer i) const;
+  Standard_EXPORT Handle(StepVisual_StyledItem) RootStyle(const Standard_Integer i) const;
 
   //! Clears all defined styles and PSA sequence
   Standard_EXPORT void ClearStyles();
 
   //! Adds a style to a sequence
-  Standard_EXPORT void AddStyle (const Handle (StepVisual_StyledItem)& style);
+  Standard_EXPORT void AddStyle(const Handle(StepVisual_StyledItem)& style);
 
   //! Create a style linking giving PSA to the item, and add it to the
   //! sequence of stored styles. If Override is not Null, then
   //! the resulting style will be of the subtype OverridingStyledItem.
-  Standard_EXPORT Handle (StepVisual_StyledItem) AddStyle (
-    const Handle (StepRepr_RepresentationItem)&            item,
-    const Handle (StepVisual_PresentationStyleAssignment)& PSA,
-    const Handle (StepVisual_StyledItem)&                  Override);
+  Standard_EXPORT Handle(StepVisual_StyledItem) AddStyle(
+    const Handle(StepRepr_RepresentationItem)&            item,
+    const Handle(StepVisual_PresentationStyleAssignment)& PSA,
+    const Handle(StepVisual_StyledItem)&                  Override);
 
   //! Create a style linking giving PSA to the Shape, and add it to the
   //! sequence of stored styles. If Override is not Null, then
   //! the resulting style will be of the subtype OverridingStyledItem.
   //! The Sape is used to find corresponding STEP entity by call to
   //! STEPConstruct::FindEntity(), then previous method is called.
-  Standard_EXPORT Handle (StepVisual_StyledItem) AddStyle (
-    const TopoDS_Shape&                                    Shape,
-    const Handle (StepVisual_PresentationStyleAssignment)& PSA,
-    const Handle (StepVisual_StyledItem)&                  Override);
+  Standard_EXPORT Handle(StepVisual_StyledItem) AddStyle(
+    const TopoDS_Shape&                                   Shape,
+    const Handle(StepVisual_PresentationStyleAssignment)& PSA,
+    const Handle(StepVisual_StyledItem)&                  Override);
 
   //! Create MDGPR, fill it with all the styles previously defined,
   //! and add it to the model
   Standard_EXPORT Standard_Boolean
-    CreateMDGPR (const Handle (StepRepr_RepresentationContext)&                           Context,
-                 Handle (StepVisual_MechanicalDesignGeometricPresentationRepresentation)& MDGPR,
-                 Handle (StepData_StepModel)& theStepModel);
+    CreateMDGPR(const Handle(StepRepr_RepresentationContext)&                           Context,
+                Handle(StepVisual_MechanicalDesignGeometricPresentationRepresentation)& MDGPR,
+                Handle(StepData_StepModel)& theStepModel);
 
   //! Create MDGPR, fill it with all the styles previously defined,
   //! and add it to the model
   //! IMPORTANT: <initPDS> must be null when use for NAUO colors
   //! <initPDS> initialised only for SHUO case.
   Standard_EXPORT Standard_Boolean
-    CreateNAUOSRD (const Handle (StepRepr_RepresentationContext)&                Context,
-                   const Handle (StepShape_ContextDependentShapeRepresentation)& CDSR,
-                   const Handle (StepRepr_ProductDefinitionShape)&               initPDS);
+    CreateNAUOSRD(const Handle(StepRepr_RepresentationContext)&                Context,
+                  const Handle(StepShape_ContextDependentShapeRepresentation)& CDSR,
+                  const Handle(StepRepr_ProductDefinitionShape)&               initPDS);
 
   //! Searches the STEP model for the RepresentationContext in which
   //! given shape is defined. This context (if found) can be used
   //! then in call to CreateMDGPR()
-  Standard_EXPORT Handle (StepRepr_RepresentationContext) FindContext (
+  Standard_EXPORT Handle(StepRepr_RepresentationContext) FindContext(
     const TopoDS_Shape& Shape) const;
 
   //! Searches the STEP model for the MDGPR or DM entities
@@ -127,60 +127,59 @@ public:
   //! Searches the STEP model for the INISIBILITY entities
   //! (which bring styles) and fills out sequence of styles
   Standard_EXPORT Standard_Boolean
-    LoadInvisStyles (Handle (TColStd_HSequenceOfTransient)& InvSyles) const;
+    LoadInvisStyles(Handle(TColStd_HSequenceOfTransient)& InvSyles) const;
 
   //! Create a PresentationStyleAssignment entity which defines
   //! two colors (for filling surfaces and curves)
   //! if isForNAUO true then returns PresentationStyleByContext
-  Standard_EXPORT Handle (StepVisual_PresentationStyleAssignment) MakeColorPSA (
-    const Handle (StepRepr_RepresentationItem)& item,
-    const Handle (StepVisual_Colour)&           SurfCol,
-    const Handle (StepVisual_Colour)&           CurveCol,
-    const Handle (StepVisual_Colour)&           RenderCol,
-    const Standard_Real                         RenderTransp,
-    const Standard_Boolean                      isForNAUO = Standard_False) const;
+  Standard_EXPORT Handle(StepVisual_PresentationStyleAssignment) MakeColorPSA(
+    const Handle(StepRepr_RepresentationItem)& item,
+    const Handle(StepVisual_Colour)&           SurfCol,
+    const Handle(StepVisual_Colour)&           CurveCol,
+    const Handle(StepVisual_Colour)&           RenderCol,
+    const Standard_Real                        RenderTransp,
+    const Standard_Boolean                     isForNAUO = Standard_False) const;
 
   //! Returns a PresentationStyleAssignment entity which defines
   //! surface and curve colors as Col. This PSA is either created
   //! or taken from internal map where all PSAs created by this
   //! method are remembered.
-  Standard_EXPORT Handle (StepVisual_PresentationStyleAssignment) GetColorPSA (
-    const Handle (StepRepr_RepresentationItem)& item,
-    const Handle (StepVisual_Colour)&           Col);
+  Standard_EXPORT Handle(StepVisual_PresentationStyleAssignment) GetColorPSA(
+    const Handle(StepRepr_RepresentationItem)& item,
+    const Handle(StepVisual_Colour)&           Col);
 
   //! Extract color definitions from the style entity
   //! For each type of color supported, result can be either
   //! NULL if it is not defined by that style, or last
   //! definition (if they are 1 or more)
-  Standard_EXPORT Standard_Boolean GetColors (const Handle (StepVisual_StyledItem)& theStyle,
-                                              Handle (StepVisual_Colour)& theSurfaceColour,
-                                              Handle (StepVisual_Colour)& theBoundaryColour,
-                                              Handle (StepVisual_Colour)& theCurveColour,
-                                              Handle (StepVisual_Colour)& theRenderColour,
-                                              Standard_Real&              theRenderTransparency,
-                                              Standard_Boolean&           theIsComponent) const;
+  Standard_EXPORT Standard_Boolean GetColors(const Handle(StepVisual_StyledItem)& theStyle,
+                                             Handle(StepVisual_Colour)&           theSurfaceColour,
+                                             Handle(StepVisual_Colour)&           theBoundaryColour,
+                                             Handle(StepVisual_Colour)&           theCurveColour,
+                                             Handle(StepVisual_Colour)&           theRenderColour,
+                                             Standard_Real&    theRenderTransparency,
+                                             Standard_Boolean& theIsComponent) const;
 
   //! Create STEP color entity by given Quantity_Color
   //! The analysis is performed for whether the color corresponds to
   //! one of standard colors predefined in STEP. In that case,
   //! PredefinedColour entity is created instead of RGBColour
-  Standard_EXPORT static Handle (StepVisual_Colour) EncodeColor (const Quantity_Color& Col);
+  Standard_EXPORT static Handle(StepVisual_Colour) EncodeColor(const Quantity_Color& Col);
 
   //! Create STEP color entity by given Quantity_Color
   //! The analysis is performed for whether the color corresponds to
   //! one of standard colors predefined in STEP. In that case,
   //! PredefinedColour entity is created instead of RGBColour
-  Standard_EXPORT static Handle (StepVisual_Colour) EncodeColor (
+  Standard_EXPORT static Handle(StepVisual_Colour) EncodeColor(
     const Quantity_Color&                        Col,
     STEPConstruct_DataMapOfAsciiStringTransient& DPDCs,
     STEPConstruct_DataMapOfPointTransient&       ColRGBs);
 
   //! Decodes STEP color and fills the Quantity_Color.
   //! Returns True if OK or False if color is not recognized
-  Standard_EXPORT static Standard_Boolean DecodeColor (const Handle (StepVisual_Colour)& Colour,
-                                                       Quantity_Color&                   Col);
+  Standard_EXPORT static Standard_Boolean DecodeColor(const Handle(StepVisual_Colour)& Colour,
+                                                      Quantity_Color&                  Col);
 
-protected:
 private:
   TColStd_IndexedDataMapOfTransientTransient myMapOfStyles;
   TColStd_IndexedMapOfTransient              myStyles;

--- a/tests/bugs/step/bug33487
+++ b/tests/bugs/step/bug33487
@@ -1,0 +1,37 @@
+puts "# ====================================================================="
+puts "# 0033487: Data Exchange, Step Import - Unresolved reference crashes"
+puts "# ====================================================================="
+
+# This test checks if crash happens when reading step file with missing
+# FILL_AREA_STYLE_COLOUR entities.
+
+# Read original file as plain text.
+set aSourceFilePath [locate_data_file trj6_as1-hc-214.stp]
+set aSourceFileChannel [open $aSourceFilePath r]
+set aSourceTextData [read $aSourceFileChannel]
+close $aSourceFileChannel
+
+# Create a 'broken' text data for step file by removing all FILL_AREA_STYLE_COLOUR entities.
+set aBrokenStepTextData ""
+set aToRemove "FILL_AREA_STYLE_COLOUR"
+set aSourceFileLines [split $aSourceTextData ";"]
+foreach aCurrentLine $aSourceFileLines {
+  if {[string first $aToRemove $aCurrentLine] == -1} {
+    # Add all strings from source file, except for strings that contain FILL_AREA_STYLE_COLOUR,
+    # to the new file.
+    append aBrokenStepTextData $aCurrentLine ";"
+  }
+}
+
+# Write 'broken' plain text data into temporary step file.
+set aTmpFilePath "$imagedir/${casename}.stp"
+set aTmpFileChannel [open $aTmpFilePath w]
+puts $aTmpFileChannel $aBrokenStepTextData
+close $aTmpFileChannel
+
+# Read temporary file and delete it.
+# If something is wrong with step reader, crash will occur while executing ReadFile command.
+# If step reader works correctly, we expect just 'Unresolved Reference' message.
+puts {REQUIRED All: ERR StepReaderData : Unresolved Reference : Fails Count : 39}
+ReadFile aDoc $aTmpFilePath
+file delete $aTmpFilePath


### PR DESCRIPTION
Fixed crash in STEPConstruct_Styles::GetColors() due to nullptr dereferencing when source step file has missing
FILL_AREA_STYLE_COLOUR entities.

STEPConstruct_Styles::GetColors () is refactored.

Test bug33487 ia added to check that crash doesn't occur.