### PR TITLE
Visualization - Physicalised Marker Scale, Line Rendering (Using a geometry shader)

### DIFF
--- a/src/Draw/TKOpenGlTest/OpenGlTest/OpenGlTest_Commands.cxx
+++ b/src/Draw/TKOpenGlTest/OpenGlTest/OpenGlTest_Commands.cxx
@@ -182,6 +182,7 @@ void VUserDrawObj::Render(const occ::handle<OpenGl_Workspace>& theWorkspace) con
                                          Graphic3d_TypeOfShadingModel_Unlit,
                                          Graphic3d_AlphaMode_Opaque,
                                          false,
+                                         false,
                                          occ::handle<OpenGl_ShaderProgram>());
   aCtx->SetColor4fv(aColor);
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsSprite.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsSprite.cxx
@@ -90,6 +90,7 @@ void OpenGl_AspectsSprite::UpdateRediness(const occ::handle<Graphic3d_Aspects>& 
   spriteKeys(theAspect->MarkerImage(),
              theAspect->MarkerType(),
              theAspect->MarkerScale(),
+             theAspect->MarkerPhysical(),
              theAspect->ColorRGBA(),
              aSpriteKeyNew,
              aSpriteAKeyNew);
@@ -100,8 +101,9 @@ void OpenGl_AspectsSprite::UpdateRediness(const occ::handle<Graphic3d_Aspects>& 
   if (aSpriteKeyNew.IsEmpty() || aSpriteKeyOld != aSpriteKeyNew || aSpriteAKeyNew.IsEmpty()
       || aSpriteAKeyOld != aSpriteAKeyNew)
   {
-    myIsSpriteReady = false;
-    myMarkerSize    = theAspect->MarkerScale();
+    myIsSpriteReady  = false;
+    myMarkerSize     = theAspect->MarkerScale();
+    myMarkerPhysical = theAspect->MarkerPhysical();
   }
 }
 
@@ -118,6 +120,7 @@ const occ::handle<OpenGl_PointSprite>& OpenGl_AspectsSprite::Sprite(
           theAspects->MarkerImage(),
           theAspects->MarkerType(),
           theAspects->MarkerScale(),
+          theAspects->MarkerPhysical(),
           theAspects->ColorRGBA(),
           myMarkerSize);
     myIsSpriteReady = true;
@@ -131,12 +134,13 @@ void OpenGl_AspectsSprite::build(const occ::handle<OpenGl_Context>&        theCt
                                  const occ::handle<Graphic3d_MarkerImage>& theMarkerImage,
                                  Aspect_TypeOfMarker                       theType,
                                  float                                     theScale,
+                                 bool                                      thePhysicalScale,
                                  const NCollection_Vec4<float>&            theColor,
                                  float&                                    theMarkerSize)
 {
   // generate key for shared resource
   TCollection_AsciiString aNewKey, aNewKeyA;
-  spriteKeys(theMarkerImage, theType, theScale, theColor, aNewKey, aNewKeyA);
+  spriteKeys(theMarkerImage, theType, theScale, thePhysicalScale, theColor, aNewKey, aNewKeyA);
 
   const TCollection_AsciiString& aSpriteKeyOld =
     !mySprite.IsNull() ? mySprite->ResourceId() : TCollection_AsciiString::EmptyString();
@@ -342,6 +346,7 @@ void OpenGl_AspectsSprite::build(const occ::handle<OpenGl_Context>&        theCt
 void OpenGl_AspectsSprite::spriteKeys(const occ::handle<Graphic3d_MarkerImage>& theMarkerImage,
                                       Aspect_TypeOfMarker                       theType,
                                       float                                     theScale,
+                                      bool                          thePhysicalScale,
                                       const NCollection_Vec4<float>&            theColor,
                                       TCollection_AsciiString&                  theKey,
                                       TCollection_AsciiString&                  theKeyA)
@@ -355,7 +360,7 @@ void OpenGl_AspectsSprite::spriteKeys(const occ::handle<Graphic3d_MarkerImage>& 
       theKeyA = theMarkerImage->GetImageAlphaId();
     }
   }
-  else if (theType != Aspect_TOM_POINT && theType != Aspect_TOM_EMPTY)
+  else if (theType != Aspect_TOM_POINT && theType != Aspect_TOM_EMPTY && !thePhysicalScale)
   {
     // predefined markers are defined with 0.5 step
     const int aScale = int(theScale * 10.0f + 0.5f);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsSprite.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_AspectsSprite.hxx
@@ -35,6 +35,8 @@ public:
 
   float MarkerSize() const { return myMarkerSize; }
 
+  bool MarkerPhysical() const { return myMarkerPhysical; }
+
   //! Return TRUE if resource is up-to-date.
   bool IsReady() const { return myIsSpriteReady; }
 
@@ -67,6 +69,7 @@ private:
                              const occ::handle<Graphic3d_MarkerImage>& theMarkerImage,
                              Aspect_TypeOfMarker                       theType,
                              float                                     theScale,
+                             bool                                      thePhysicalScale,
                              const NCollection_Vec4<float>&            theColor,
                              float&                                    theMarkerSize);
 
@@ -74,6 +77,7 @@ private:
   static void spriteKeys(const occ::handle<Graphic3d_MarkerImage>& theMarkerImage,
                          Aspect_TypeOfMarker                       theType,
                          float                                     theScale,
+                         bool                                      thePhysicalScale,
                          const NCollection_Vec4<float>&            theColor,
                          TCollection_AsciiString&                  theKey,
                          TCollection_AsciiString&                  theKeyA);
@@ -82,6 +86,7 @@ private:
   occ::handle<OpenGl_PointSprite> mySprite;
   occ::handle<OpenGl_PointSprite> mySpriteA;
   float                           myMarkerSize;
+  bool                            myMarkerPhysical;
   bool                            myIsSpriteReady;
 };
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Caps.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Caps.cxx
@@ -27,6 +27,7 @@ OpenGl_Caps::OpenGl_Caps()
       keepArrayData(false),
       ffpEnable(false),
       usePolygonMode(false),
+      lineGeomDisable(false),
       useSystemBuffer(false),
       swapInterval(1),
       useZeroToOneDepth(false),
@@ -65,6 +66,7 @@ OpenGl_Caps& OpenGl_Caps::operator=(const OpenGl_Caps& theCopy)
   pntSpritesDisable         = theCopy.pntSpritesDisable;
   keepArrayData             = theCopy.keepArrayData;
   ffpEnable                 = theCopy.ffpEnable;
+  lineGeomDisable           = theCopy.lineGeomDisable;
   useSystemBuffer           = theCopy.useSystemBuffer;
   swapInterval              = theCopy.swapInterval;
   useZeroToOneDepth         = theCopy.useZeroToOneDepth;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Caps.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Caps.hxx
@@ -36,6 +36,7 @@ public
   bool keepArrayData;     //!< Disables freeing CPU memory after building VBOs (OFF by default)
   bool ffpEnable;         //!< Enables FFP (fixed-function pipeline), do not use built-in GLSL programs (OFF by default)
   bool usePolygonMode;    //!< Enables Polygon Mode instead of built-in GLSL programs (OFF by default; unsupported on OpenGL ES)
+  bool lineGeomDisable;   //!< Disables GLSL shader for line rendering (OFF by default)
   bool useSystemBuffer;   //!< Enables usage of system backbuffer for blitting (OFF by default on desktop OpenGL and ON on OpenGL ES for testing)
   int swapInterval;      //!< controls swap interval - 0 for VSync off and 1 for VSync on, 1 by default
   bool useZeroToOneDepth; //!< use [0, 1] depth range instead of [-1, 1] range, when possible (OFF by default)

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
@@ -551,6 +551,7 @@ void OpenGl_PrimitiveArray::drawEdges(const occ::handle<OpenGl_Workspace>& theWo
                                                  Graphic3d_TypeOfShadingModel_Unlit,
                                                  Graphic3d_AlphaMode_Opaque,
                                                  false,
+                                                 false,
                                                  anAspect->ShaderProgramRes(aGlContext));
   }
   aGlContext->SetSampleAlphaToCoverage(
@@ -883,6 +884,16 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
 
   bool toDrawArray = true, toSetLinePolygMode = false;
   int  toDrawInteriorEdges = 0; // 0 - no edges, 1 - glsl edges, 2 - polygonMode
+  int  toDrawLineGeometry = 1; // 1 - render using FFP, 2 - render using glsl
+
+  if (myDrawMode == GL_LINES || myDrawMode == GL_LINE_STRIP)
+  {
+    if (aCtx->hasGeometryStage != OpenGl_FeatureNotAvailable && !aCtx->caps->lineGeomDisable)
+    {
+      toDrawLineGeometry = 2;
+    }
+  }
+
   if (myIsFillType)
   {
     toDrawArray = anAspectFace->Aspect()->InteriorStyle() != Aspect_IS_EMPTY;
@@ -981,7 +992,14 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
                                                aShadingModel,
                                                Graphic3d_AlphaMode_Opaque,
                                                hasVertColor,
+                                               toDrawLineGeometry == 2,
                                                anAspectFace->ShaderProgramRes(aCtx));
+
+        if (toDrawLineGeometry == 2)
+        {
+          aCtx->ShaderManager()->PushInteriorState (aCtx->ActiveProgram(), anAspectFace->Aspect());
+        }
+
         break;
       }
       default: {

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
@@ -979,6 +979,7 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
         aCtx->ShaderManager()->BindMarkerProgram(aTextureSet,
                                                  aShadingModel,
                                                  Graphic3d_AlphaMode_Opaque,
+                                                 anAspectFace->Aspect()->MarkerPhysical(),
                                                  hasVertColor,
                                                  anAspectFace->ShaderProgramRes(aCtx));
         break;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.cxx
@@ -1494,6 +1494,7 @@ bool OpenGl_ShaderManager::BindMarkerProgram(
   const occ::handle<OpenGl_TextureSet>&    theTextures,
   Graphic3d_TypeOfShadingModel             theShadingModel,
   Graphic3d_AlphaMode                      theAlphaMode,
+  bool                                     theRenderPhysicalCircle,
   bool                                     theHasVertColor,
   const occ::handle<OpenGl_ShaderProgram>& theCustomProgram)
 {
@@ -1513,6 +1514,11 @@ bool OpenGl_ShaderManager::BindMarkerProgram(
   {
     aBits |= Graphic3d_ShaderFlags_PointSimple;
   }
+
+  if (theRenderPhysicalCircle) {
+    aBits |= Graphic3d_ShaderFlags_PointCircle;
+  }
+
   occ::handle<OpenGl_ShaderProgram>& aProgram = getStdProgram(theShadingModel, aBits);
   return bindProgramWithState(aProgram, theShadingModel);
 }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
@@ -148,6 +148,7 @@ public:
                        const Graphic3d_TypeOfShadingModel       theShadingModel,
                        const Graphic3d_AlphaMode                theAlphaMode,
                        const bool                               theHasVertColor,
+                       const bool                               theEnableLineGeometry,
                        const occ::handle<OpenGl_ShaderProgram>& theCustomProgram)
   {
     if (!theCustomProgram.IsNull() || myContext->caps->ffpEnable)
@@ -157,6 +158,12 @@ public:
 
     int aBits =
       getProgramBits(theTextures, theAlphaMode, Aspect_IS_SOLID, theHasVertColor, false, false);
+
+    if (theEnableLineGeometry)
+    {
+      aBits |= Graphic3d_ShaderFlags_LineWidth;
+    }
+
     if (theLineType != Aspect_TOL_SOLID)
     {
       aBits |= Graphic3d_ShaderFlags_StippleLine;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
@@ -177,6 +177,7 @@ public:
   Standard_EXPORT bool BindMarkerProgram(const occ::handle<OpenGl_TextureSet>&    theTextures,
                                          Graphic3d_TypeOfShadingModel             theShadingModel,
                                          Graphic3d_AlphaMode                      theAlphaMode,
+                                         bool                                     theRenderPhysicalCircle,
                                          bool                                     theHasVertColor,
                                          const occ::handle<OpenGl_ShaderProgram>& theCustomProgram);
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Structure.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Structure.cxx
@@ -91,6 +91,7 @@ void OpenGl_Structure::renderBoundingBox(const occ::handle<OpenGl_Workspace>& th
                                            Graphic3d_TypeOfShadingModel_Unlit,
                                            Graphic3d_AlphaMode_Opaque,
                                            false,
+                                           false,
                                            occ::handle<OpenGl_ShaderProgram>());
     aCtx->SetColor4fv(theWorkspace->InteriorColor());
     aCtx->core11fwd->glDisable(GL_LIGHTING);

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.cxx
@@ -33,6 +33,7 @@ Graphic3d_Aspects::Graphic3d_Aspects()
       myLinePattern(0xFFFF),
       myMarkerType(Aspect_TOM_POINT),
       myMarkerScale(1.0f),
+      myMarkerPhysical(false),
       myTextStyle(Aspect_TOST_NORMAL),
       myTextDisplayType(Aspect_TODT_NORMAL),
       myTextFontAspect(Font_FontAspect_Regular),

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.hxx
@@ -353,6 +353,14 @@ public:
     myMarkerScale = theScale;
   }
 
+  //! Whether the marker is rendered as a physical sphere in view space
+  bool MarkerPhysical() const { return myMarkerPhysical; }
+
+  void SetMarkerPhysical (const bool theMarkerPhysical)
+  {
+    myMarkerPhysical = theMarkerPhysical;
+  }
+
   //! Returns marker's image texture.
   //! Could be null handle if marker aspect has been initialized as default type of marker.
   const occ::handle<Graphic3d_MarkerImage>& MarkerImage() const { return myMarkerImage; }
@@ -532,6 +540,7 @@ public:
            && myLineWidth == theOther.myLineWidth && myLineFactor == theOther.myLineFactor
            && myLinePattern == theOther.myLinePattern && myMarkerType == theOther.myMarkerType
            && myMarkerScale == theOther.myMarkerScale && myHatchStyle == theOther.myHatchStyle
+           && myMarkerPhysical == theOther.myMarkerPhysical
            && myTextFont == theOther.myTextFont && myPolygonOffset == theOther.myPolygonOffset
            && myTextStyle == theOther.myTextStyle && myTextDisplayType == theOther.myTextDisplayType
            && myTextFontAspect == theOther.myTextFontAspect && myTextAngle == theOther.myTextAngle
@@ -602,6 +611,7 @@ protected:
 
   Aspect_TypeOfMarker myMarkerType;
   float               myMarkerScale;
+  bool                myMarkerPhysical;
 
   Aspect_TypeOfStyleText   myTextStyle;
   Aspect_TypeOfDisplayText myTextDisplayType;

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderFlags.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderFlags.hxx
@@ -43,14 +43,17 @@ enum Graphic3d_ShaderFlags
   Graphic3d_ShaderFlags_WriteOit =
     0x0800, //!< write coverage buffer for Blended Order-Independent Transparency
   Graphic3d_ShaderFlags_OitDepthPeeling = 0x1000, //!< handle Depth Peeling OIT
+  Graphic3d_ShaderFlags_PointCircle     = 0x2000, //!< output points as circle billboards with diameter (gl_PointSize) instead
+  Graphic3d_ShaderFlags_LineWidth       = 0x4000, //!< expand line primitives in screen space using triangles
   //
-  Graphic3d_ShaderFlags_NB      = 0x2000, //!< overall number of combinations
+  Graphic3d_ShaderFlags_NB      = 0x8000, //!< overall number of combinations
   Graphic3d_ShaderFlags_IsPoint = Graphic3d_ShaderFlags_PointSimple
                                   | Graphic3d_ShaderFlags_PointSprite
-                                  | Graphic3d_ShaderFlags_PointSpriteA,
+                                  | Graphic3d_ShaderFlags_PointSpriteA
+                                  | Graphic3d_ShaderFlags_PointCircle,
   Graphic3d_ShaderFlags_HasTextures =
     Graphic3d_ShaderFlags_TextureRGB | Graphic3d_ShaderFlags_TextureEnv,
-  Graphic3d_ShaderFlags_NeedsGeomShader = Graphic3d_ShaderFlags_MeshEdges,
+  Graphic3d_ShaderFlags_NeedsGeomShader = Graphic3d_ShaderFlags_MeshEdges|Graphic3d_ShaderFlags_PointCircle|Graphic3d_ShaderFlags_LineWidth,
 };
 
 #endif // _Graphic3d_ShaderFlags_HeaderFile

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -16,6 +16,7 @@
 #include <Graphic3d_LightSet.hxx>
 #include <Graphic3d_ShaderProgram.hxx>
 #include <Graphic3d_TextureSetBits.hxx>
+#include <Graphic3d_TypeOfPrimitiveArray.hxx>
 #include <Message.hxx>
 
 #include "../Shaders/Shaders_LightShadow_glsl.pxx"
@@ -762,12 +763,46 @@ TCollection_AsciiString Graphic3d_ShaderManager::pointSpriteShadingSrc(
   return aSrcFragGetColor;
 }
 
-//! Prepare GLSL source for geometry shader according to parameters.
-static TCollection_AsciiString prepareGeomMainSrc(
-  Graphic3d_ShaderObject::ShaderVariableList& theUnifoms,
+static TCollection_AsciiString genGeomPassthroughCode(
   Graphic3d_ShaderObject::ShaderVariableList& theStageInOuts,
-  int                                         theBits)
+  int                                         theInVertIdx)
 {
+  TCollection_AsciiString passthrough = TCollection_AsciiString();
+  const TCollection_AsciiString aVertIndex (theInVertIdx);
+
+  // pass variables from Vertex shader to Fragment shader through Geometry shader
+  for (Graphic3d_ShaderObject::ShaderVariableList::Iterator aVarListIter (theStageInOuts); aVarListIter.More(); aVarListIter.Next())
+  {
+    if (aVarListIter.Value().Stages == (Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT))
+    {
+      const TCollection_AsciiString aVarName = aVarListIter.Value().Name.Token (" ", 2);
+      if (aVarName.Value (aVarName.Length()) == ']')
+      {
+        // copy the whole array
+        const TCollection_AsciiString aVarName2 = aVarName.Token ("[", 1);
+        passthrough += TCollection_AsciiString()
+          + EOL"  geomOut." + aVarName2 + " = geomIn[" + aVertIndex + "]." + aVarName2 + ";";
+      }
+      else
+      {
+        passthrough += TCollection_AsciiString()
+          + EOL"  geomOut." + aVarName + " = geomIn[" + aVertIndex + "]." + aVarName + ";";
+        }
+    }
+  }
+
+  return passthrough;
+}
+
+//! Prepare GLSL source for geometry shader according to parameters.
+static TCollection_AsciiString prepareGeomMainSrc(Graphic3d_ShaderObject::ShaderVariableList &theUnifoms,
+                                                  Graphic3d_ShaderObject::ShaderVariableList &theStageInOuts,
+                                                  int theBits, int &theNbInputPoints, int &theNbOutputPoints,
+                                                  Graphic3d_TypeOfPrimitiveArray &theInputArrayType)
+{
+  theNbInputPoints = 0;
+  theNbOutputPoints = 0;
+
   if ((theBits & Graphic3d_ShaderFlags_NeedsGeomShader) == 0)
   {
     return TCollection_AsciiString();
@@ -810,40 +845,17 @@ static TCollection_AsciiString prepareGeomMainSrc(
             "  float aQuadArea = abs (aSideB.x * aSideC.y - aSideB.y * aSideC.x);" EOL
             "  vec3 aLenABC    = vec3 (length (aSideA), length (aSideB), length (aSideC));" EOL
             "  vec3 aHeightABC = vec3 (aQuadArea) / aLenABC;"
-      // clang-format off
-      EOL"  aHeightABC = max (aHeightABC, vec3 (10.0 * occLineWidth));" // avoid shrunk presentation disappearing at distance
-      // clang-format on
-      EOL "  float aQuadModeHeightC = occIsQuadMode ? occLineWidth + 1.0 : 0.0;";
-  }
+        // clang-format off
+        EOL"  aHeightABC = max (aHeightABC, vec3 (10.0 * occLineWidth));" // avoid shrunk presentation disappearing at distance
+        // clang-format on
+        EOL "  float aQuadModeHeightC = occIsQuadMode ? occLineWidth + 1.0 : 0.0;";
 
-  for (int aVertIter = 0; aVertIter < 3; ++aVertIter)
-  {
-    const TCollection_AsciiString aVertIndex(aVertIter);
-    // pass variables from Vertex shader to Fragment shader through Geometry shader
-    for (Graphic3d_ShaderObject::ShaderVariableList::Iterator aVarListIter(theStageInOuts);
-         aVarListIter.More();
-         aVarListIter.Next())
+    for (int aVertIter = 0; aVertIter < 3; ++aVertIter)
     {
-      if (aVarListIter.Value().Stages == (Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT))
-      {
-        const TCollection_AsciiString aVarName = aVarListIter.Value().Name.Token(" ", 2);
-        if (aVarName.Value(aVarName.Length()) == ']')
-        {
-          // copy the whole array
-          const TCollection_AsciiString aVarName2 = aVarName.Token("[", 1);
-          aSrcMainGeom += TCollection_AsciiString() + EOL "  geomOut." + aVarName2 + " = geomIn["
-                          + aVertIndex + "]." + aVarName2 + ";";
-        }
-        else
-        {
-          aSrcMainGeom += TCollection_AsciiString() + EOL "  geomOut." + aVarName + " = geomIn["
-                          + aVertIndex + "]." + aVarName + ";";
-        }
-      }
-    }
+      const TCollection_AsciiString aVertIndex (aVertIter);
 
-    if ((theBits & Graphic3d_ShaderFlags_MeshEdges) != 0)
-    {
+      aSrcMainGeom += genGeomPassthroughCode(theStageInOuts, aVertIter);
+
       switch (aVertIter)
       {
         case 0:
@@ -856,11 +868,19 @@ static TCollection_AsciiString prepareGeomMainSrc(
           aSrcMainGeom += EOL "  EdgeDistance = vec3 (0.0, 0.0, aHeightABC[2]);";
           break;
       }
+
+      aSrcMainGeom += TCollection_AsciiString() + EOL "  gl_Position = gl_in[" + aVertIndex
+                      + "].gl_Position;" EOL "  EmitVertex();";
     }
-    aSrcMainGeom += TCollection_AsciiString() + EOL "  gl_Position = gl_in[" + aVertIndex
-                    + "].gl_Position;" EOL "  EmitVertex();";
+
+    aSrcMainGeom += EOL "  EndPrimitive();";
+
+    theInputArrayType = Graphic3d_TOPA_TRIANGLES;
+    theNbOutputPoints = 3;
+    theNbInputPoints = 3;
   }
-  aSrcMainGeom += EOL "  EndPrimitive();" EOL "}";
+
+  aSrcMainGeom += EOL"}";
 
   return aSrcMainGeom;
 }
@@ -1075,7 +1095,12 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
   aSrcVert = aSrcVertExtraFunc + EOL "void main()" EOL "{" + aSrcVertExtraMain
              + THE_VERT_gl_Position + aSrcVertEndMain + EOL "}";
 
-  TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits);
+  int aNbGeomInputVerts = 0;
+  int aNbGeomOutputVerts = 0;
+
+  Graphic3d_TypeOfPrimitiveArray aGeomInputType;
+
+  TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits, aNbGeomInputVerts, aNbGeomOutputVerts, aGeomInputType);
   aSrcFragGetColor += (theBits & Graphic3d_ShaderFlags_MeshEdges) != 0 ? THE_FRAG_WIREFRAME_COLOR
                                                                        : EOL
                         "#define getFinalColor getColor";
@@ -1090,28 +1115,33 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
   aProgramSrc->SetNbShadowMaps(0);
   aProgramSrc->SetNbClipPlanesMax(aNbClipPlanes);
   aProgramSrc->SetAlphaTest((theBits & Graphic3d_ShaderFlags_AlphaTest) != 0);
-  const int aNbGeomInputVerts = !aSrcGeom.IsEmpty() ? 3 : 0;
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcVert,
                                                                      Graphic3d_TOS_VERTEX,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "",
                                                                      "",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcGeom,
                                                                      Graphic3d_TOS_GEOMETRY,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "geomIn",
                                                                      "geomOut",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcFrag,
                                                                      Graphic3d_TOS_FRAGMENT,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "",
                                                                      "",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   return aProgramSrc;
 }
 
@@ -1458,7 +1488,11 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
           "  BackColor   = computeLighting (aNormal, aView, aPositionWorld, false);"
     + aSrcVertExtraMain + THE_VERT_gl_Position + EOL "}";
 
-  TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits);
+  int aNbGeomInputVerts = 0;
+  int aNbGeomOutputVerts = 0;
+  Graphic3d_TypeOfPrimitiveArray aGeomInputType;
+
+  TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits, aNbGeomInputVerts, aNbGeomOutputVerts, aGeomInputType);
   aSrcFragGetColor += (theBits & Graphic3d_ShaderFlags_MeshEdges) != 0 ? THE_FRAG_WIREFRAME_COLOR
                                                                        : EOL
                         "#define getFinalColor getColor";
@@ -1475,28 +1509,33 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
   aProgramSrc->SetNbShadowMaps(0);
   aProgramSrc->SetNbClipPlanesMax(aNbClipPlanes);
   aProgramSrc->SetAlphaTest((theBits & Graphic3d_ShaderFlags_AlphaTest) != 0);
-  const int aNbGeomInputVerts = !aSrcGeom.IsEmpty() ? 3 : 0;
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcVert,
                                                                      Graphic3d_TOS_VERTEX,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "",
                                                                      "",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcGeom,
                                                                      Graphic3d_TOS_GEOMETRY,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "geomIn",
                                                                      "geomOut",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcFrag,
                                                                      Graphic3d_TOS_FRAGMENT,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "",
                                                                      "",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   return aProgramSrc;
 }
 
@@ -1710,7 +1749,11 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramPhong
              "    View = normalize (anEye - PositionWorld.xyz);" EOL "  }"
              + aSrcVertExtraMain + THE_VERT_gl_Position + EOL "}";
 
-  TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits);
+  int aNbGeomInputVerts = 0;
+  int aNbGeomOutputVerts = 0;
+  Graphic3d_TypeOfPrimitiveArray aGeomInputType;
+
+  TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits, aNbGeomInputVerts, aNbGeomOutputVerts, aGeomInputType);
   aSrcFragGetColor += (theBits & Graphic3d_ShaderFlags_MeshEdges) != 0 ? THE_FRAG_WIREFRAME_COLOR
                                                                        : EOL
                         "#define getFinalColor getColor";
@@ -1737,28 +1780,33 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramPhong
   aProgramSrc->SetNbClipPlanesMax(aNbClipPlanes);
   aProgramSrc->SetAlphaTest((theBits & Graphic3d_ShaderFlags_AlphaTest) != 0);
 
-  const int aNbGeomInputVerts = !aSrcGeom.IsEmpty() ? 3 : 0;
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcVert,
                                                                      Graphic3d_TOS_VERTEX,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "",
                                                                      "",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcGeom,
                                                                      Graphic3d_TOS_GEOMETRY,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "geomIn",
                                                                      "geomOut",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcFrag,
                                                                      Graphic3d_TOS_FRAGMENT,
                                                                      aUniforms,
                                                                      aStageInOuts,
                                                                      "",
                                                                      "",
-                                                                     aNbGeomInputVerts));
+                                                                     aNbGeomInputVerts,
+                                                                     aNbGeomOutputVerts,
+                                                                     aGeomInputType));
   return aProgramSrc;
 }
 

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -54,6 +54,9 @@ static int roundUpMaxLightSources(int theNbLights)
   return aMaxLimit;
 }
 
+  //! Number of points used for rendering points rendered as physical circles
+  const int THE_NB_POINT_CIRCLE_SEGMENTS = 7;
+
   //! Number of points used for rendering circular end caps of lines
   const int THE_LINE_END_CAP_SEGMENTS = 4;
 
@@ -179,6 +182,10 @@ const char THE_FRAG_WIREFRAME_COLOR[] =
 //! Compute gl_Position vertex shader output.
 const char THE_VERT_gl_Position[] =
   EOL "  gl_Position = occProjectionMatrix * occWorldViewMatrix * occModelWorldMatrix * occVertex;";
+
+//! Compute gl_Position as world position for later processing in a geometry shader
+const char THE_VERT_gl_ViewPosition[] =
+EOL"  gl_Position = occWorldViewMatrix * occModelWorldMatrix * occVertex;";
 
 //! Displace gl_Position alongside vertex normal for outline rendering.
 //! This code adds silhouette only for smooth surfaces of closed primitive, and produces visual
@@ -871,7 +878,7 @@ static TCollection_AsciiString prepareGeomMainSrc(Graphic3d_ShaderObject::Shader
           aSrcMainGeom += EOL "  EdgeDistance = vec3 (0.0, 0.0, aHeightABC[2]);";
           break;
       }
-
+    
       aSrcMainGeom += TCollection_AsciiString() + EOL "  gl_Position = gl_in[" + aVertIndex
                       + "].gl_Position;" EOL "  EmitVertex();";
     }
@@ -880,7 +887,49 @@ static TCollection_AsciiString prepareGeomMainSrc(Graphic3d_ShaderObject::Shader
 
     theInputArrayType = Graphic3d_TOPA_TRIANGLES;
     theNbOutputPoints = 3;
-    theNbInputPoints = 3;
+    theNbInputPoints = 3;      
+  }
+
+  if ((theBits & Graphic3d_ShaderFlags_PointCircle) != 0)
+  {
+    aSrcMainGeom += TCollection_AsciiString()
+    + EOL"  vec4 center = gl_in[0].gl_Position;"
+    + EOL"  vec4 centerNdc = occProjectionMatrix * center;"
+    + EOL"  vec3 normNdc = centerNdc.xyz / centerNdc.w;"
+    + EOL""
+    + EOL"  if (!((normNdc.x >= -1.0 && normNdc.x <= 1.0) &&"
+    + EOL"        (normNdc.y >= -1.0 && normNdc.y <= 1.0) &&"
+    + EOL"        (normNdc.z >= -1.0 && normNdc.z <= 1.0))) {"
+    + EOL"    EndPrimitive();"
+    + EOL"    return;"
+    + EOL"  }"
+    + EOL""
+    + EOL"  float pRadius = occPointSize / 2.0;"
+    + genGeomPassthroughCode(theStageInOuts, 0)
+    + EOL""
+    + EOL"  const int nbSegments = " + THE_NB_POINT_CIRCLE_SEGMENTS + ";"
+    + EOL""
+    + EOL"  gl_Position = occProjectionMatrix * (center + vec4(pRadius, 0.0, 0.0, 0.0));"
+    + EOL"  EmitVertex();"
+    + EOL"  for (int i = (nbSegments - 2); i >= 1; --i) {"
+    + EOL"    float phi = -PI_DIV_2 + (i / float(nbSegments - 1)) * PI;"
+    + EOL""
+    + EOL"    float x = pRadius * sin(phi);"
+    + EOL"    float y = pRadius * cos(phi);"
+    + EOL""
+    + EOL"    gl_Position = occProjectionMatrix * (center + vec4(x, y, 0.0, 0.0));"
+    + EOL"    EmitVertex();"
+    + EOL"    gl_Position = occProjectionMatrix * (center + vec4(x, -y, 0.0, 0.0));"
+    + EOL"    EmitVertex();"
+    + EOL"  }"
+    + EOL"  gl_Position = occProjectionMatrix * (center + vec4(-pRadius, 0.0, 0.0, 0.0));"
+    + EOL"  EmitVertex();"
+    + EOL""
+    + EOL"  EndPrimitive();";
+
+    theNbOutputPoints = THE_NB_POINT_CIRCLE_SEGMENTS * 2 - 2;
+    theInputArrayType = Graphic3d_TOPA_POINTS;
+    theNbInputPoints = 1;
   }
 
   if ((theBits & Graphic3d_ShaderFlags_LineWidth) != 0)
@@ -1169,8 +1218,13 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
     }
   }
 
+
+  aSrcVertExtraMain += ((theBits & Graphic3d_ShaderFlags_PointCircle) != 0)
+                         ? THE_VERT_gl_ViewPosition
+                         : THE_VERT_gl_Position;
+
   aSrcVert = aSrcVertExtraFunc + EOL "void main()" EOL "{" + aSrcVertExtraMain
-             + THE_VERT_gl_Position + aSrcVertEndMain + EOL "}";
+             + aSrcVertEndMain + EOL "}";
 
   int aNbGeomInputVerts = 0;
   int aNbGeomOutputVerts = 0;
@@ -1192,6 +1246,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
   aProgramSrc->SetNbShadowMaps(0);
   aProgramSrc->SetNbClipPlanesMax(aNbClipPlanes);
   aProgramSrc->SetAlphaTest((theBits & Graphic3d_ShaderFlags_AlphaTest) != 0);
+  
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcVert,
                                                                      Graphic3d_TOS_VERTEX,
                                                                      aUniforms,
@@ -1552,6 +1607,11 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
   int                           aNbLights = 0;
   const TCollection_AsciiString aLights =
     stdComputeLighting(aNbLights, theLights, !aSrcVertColor.IsEmpty(), false, toUseTexColor, 0);
+
+  aSrcVertExtraMain += ((theBits & Graphic3d_ShaderFlags_PointCircle) != 0)
+    ? THE_VERT_gl_ViewPosition
+    : THE_VERT_gl_Position;
+
   aSrcVert =
     TCollection_AsciiString() + THE_FUNC_transformNormal_world + EOL + aSrcVertColor + aLights
     + EOL "void main()" EOL "{" EOL "  vec4 aPositionWorld = occModelWorldMatrix * occVertex;" EOL
@@ -1563,7 +1623,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
           "    aView = normalize (anEye - aPositionWorld.xyz);" EOL "  }" EOL
           "  FrontColor  = computeLighting (aNormal, aView, aPositionWorld, true);" EOL
           "  BackColor   = computeLighting (aNormal, aView, aPositionWorld, false);"
-    + aSrcVertExtraMain + THE_VERT_gl_Position + EOL "}";
+    + aSrcVertExtraMain + EOL "}";
 
   int aNbGeomInputVerts = 0;
   int aNbGeomOutputVerts = 0;
@@ -1586,6 +1646,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
   aProgramSrc->SetNbShadowMaps(0);
   aProgramSrc->SetNbClipPlanesMax(aNbClipPlanes);
   aProgramSrc->SetAlphaTest((theBits & Graphic3d_ShaderFlags_AlphaTest) != 0);
+
   aProgramSrc->AttachShader(Graphic3d_ShaderObject::CreateFromSource(aSrcVert,
                                                                      Graphic3d_TOS_VERTEX,
                                                                      aUniforms,
@@ -1816,6 +1877,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramPhong
       "  }";
   }
 
+  aSrcVertExtraMain += ((theBits & Graphic3d_ShaderFlags_PointCircle) != 0)
+    ? THE_VERT_gl_ViewPosition
+    : THE_VERT_gl_Position;
+
   aSrcVert = TCollection_AsciiString() + aSrcVertExtraFunc
              + EOL
              "void main()" EOL "{" EOL "  PositionWorld = occModelWorldMatrix * occVertex;" EOL
@@ -1824,7 +1889,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramPhong
              "  else" EOL "  {" EOL
              "    vec3 anEye = (occWorldViewMatrixInverse * vec4(0.0, 0.0, 0.0, 1.0)).xyz;" EOL
              "    View = normalize (anEye - PositionWorld.xyz);" EOL "  }"
-             + aSrcVertExtraMain + THE_VERT_gl_Position + EOL "}";
+             + aSrcVertExtraMain + EOL "}";
 
   int aNbGeomInputVerts = 0;
   int aNbGeomOutputVerts = 0;

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -54,6 +54,9 @@ static int roundUpMaxLightSources(int theNbLights)
   return aMaxLimit;
 }
 
+  //! Number of points used for rendering circular end caps of lines
+  const int THE_LINE_END_CAP_SEGMENTS = 4;
+
 #define EOL "\n"
 
 //! Compute TexCoord value in Vertex Shader
@@ -878,6 +881,80 @@ static TCollection_AsciiString prepareGeomMainSrc(Graphic3d_ShaderObject::Shader
     theInputArrayType = Graphic3d_TOPA_TRIANGLES;
     theNbOutputPoints = 3;
     theNbInputPoints = 3;
+  }
+
+  if ((theBits & Graphic3d_ShaderFlags_LineWidth) != 0)
+  {
+    theUnifoms.Append (Graphic3d_ShaderObject::ShaderVariable ("vec4 occViewport",       Graphic3d_TOS_GEOMETRY));
+    theUnifoms.Append (Graphic3d_ShaderObject::ShaderVariable ("float occLineWidth",     Graphic3d_TOS_GEOMETRY));
+
+    aSrcMainGeom = TCollection_AsciiString()
+    + EOL"vec3 ToViewPortTransform (vec4 theVec)"
+      EOL"{"
+      EOL"  vec3 aWinCoord = theVec.xyz / theVec.w;"
+      EOL"  aWinCoord    = aWinCoord * 0.5 + 0.5;"
+      EOL"  aWinCoord.xy = aWinCoord.xy * occViewport.zw + occViewport.xy;"
+      EOL"  return aWinCoord;"
+      EOL"}"
+    + EOL"vec4 FromViewPortTransform (vec3 theVec)"
+      EOL"{"
+      EOL"  vec3 aNdcCoord = vec3(theVec.xy / (occViewport.zw + occViewport.xy), theVec.z);"
+      EOL"  aNdcCoord      = aNdcCoord * 2.0 - 1.0;"
+      EOL"  return vec4(aNdcCoord, 1.0);"
+      EOL"}"
+    + aSrcMainGeom
+    + EOL"  vec3 aLineA = ToViewPortTransform(gl_in[0].gl_Position);"
+    + EOL"  vec3 aLineB = ToViewPortTransform(gl_in[1].gl_Position);"
+    + EOL""
+    + EOL"  vec3 aLineDir = normalize(aLineB - aLineA);"
+    + EOL"  vec3 aLinePerpPosDir = vec3(-aLineDir.y, aLineDir.x, 0.0);"
+    + EOL""
+    + EOL"  const int nbSegments = " + THE_LINE_END_CAP_SEGMENTS + ";"
+    + genGeomPassthroughCode(theStageInOuts, 0)
+    + EOL"  float aLineSideWidth = occLineWidth / 2.0;"
+    + EOL"  gl_Position = FromViewPortTransform(aLineA - aLineDir * aLineSideWidth);"
+    + EOL"  EmitVertex();"
+    + EOL"  for (int i = 1; i < nbSegments - 1; ++i) {"
+    + EOL"    float phi = (i / float(nbSegments - 1)) * PI_DIV_2;"
+    + EOL""
+    + EOL"    float x = aLineSideWidth * sin(phi);"
+    + EOL"    float y = aLineSideWidth * cos(phi);"
+    + EOL""
+    + EOL"    gl_Position = FromViewPortTransform(aLineA + y * -aLineDir + x * aLinePerpPosDir);"
+    + EOL"    EmitVertex();"
+    + EOL"    gl_Position = FromViewPortTransform(aLineA + y * -aLineDir + -x * aLinePerpPosDir);"
+    + EOL"    EmitVertex();"
+    + EOL"  }"
+    + EOL""
+    + EOL"  gl_Position = FromViewPortTransform(aLineA + aLineSideWidth * aLinePerpPosDir);"
+    + EOL"  EmitVertex();"
+    + EOL"  gl_Position = FromViewPortTransform(aLineA + aLineSideWidth * -aLinePerpPosDir);"
+    + EOL"  EmitVertex();"
+    + genGeomPassthroughCode(theStageInOuts, 1)
+    + EOL"  gl_Position = FromViewPortTransform(aLineB + aLineSideWidth * aLinePerpPosDir);"
+    + EOL"  EmitVertex();"
+    + EOL"  gl_Position = FromViewPortTransform(aLineB + aLineSideWidth * -aLinePerpPosDir);"
+    + EOL"  EmitVertex();"
+    + EOL""
+    + EOL"  for (int i = 1; i < nbSegments - 1; ++i) {"
+    + EOL"    float phi = PI_DIV_2 + (i / float(nbSegments - 1)) * PI_DIV_2;"
+    + EOL""
+    + EOL"    float x = aLineSideWidth * sin(phi);"
+    + EOL"    float y = aLineSideWidth * cos(phi);"
+    + EOL""
+    + EOL"    gl_Position = FromViewPortTransform(aLineB + y * -aLineDir + x * aLinePerpPosDir);"
+    + EOL"    EmitVertex();"
+    + EOL"    gl_Position = FromViewPortTransform(aLineB + y * -aLineDir + -x * aLinePerpPosDir);"
+    + EOL"    EmitVertex();"
+    + EOL"  }"
+    + EOL"  gl_Position = FromViewPortTransform(aLineB + aLineDir * aLineSideWidth);"
+    + EOL"  EmitVertex();"
+    + EOL""
+    + EOL"  EndPrimitive();";
+
+    theNbOutputPoints = 4 + ((std::max(THE_LINE_END_CAP_SEGMENTS, 2) - 2) * 2 + 1) * 2;
+    theInputArrayType = Graphic3d_TOPA_POLYLINES;
+    theNbInputPoints = 2;
   }
 
   aSrcMainGeom += EOL"}";

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.cxx
@@ -100,7 +100,9 @@ occ::handle<Graphic3d_ShaderObject> Graphic3d_ShaderObject::CreateFromSource(
   const ShaderVariableList&      theStageInOuts,
   const TCollection_AsciiString& theInName,
   const TCollection_AsciiString& theOutName,
-  int                            theNbGeomInputVerts)
+  int                            theNbGeomInputVerts,
+  int                            theNbGeomOutputVerts,
+  Graphic3d_TypeOfPrimitiveArray theGeometryInputType)
 {
   if (theSource.IsEmpty())
   {
@@ -136,7 +138,7 @@ occ::handle<Graphic3d_ShaderObject> Graphic3d_ShaderObject::CreateFromSource(
       continue;
     }
 
-    const bool hasGeomStage = theNbGeomInputVerts > 0 && aStageLower < Graphic3d_TOS_GEOMETRY
+    const bool hasGeomStage = theNbGeomOutputVerts > 0 && aStageLower < Graphic3d_TOS_GEOMETRY
                               && aStageUpper >= Graphic3d_TOS_GEOMETRY;
     const bool isAllStagesVar =
       aStageLower == Graphic3d_TOS_VERTEX && aStageUpper == Graphic3d_TOS_FRAGMENT;
@@ -186,10 +188,30 @@ occ::handle<Graphic3d_ShaderObject> Graphic3d_ShaderObject::CreateFromSource(
 
   if (theType == Graphic3d_TOS_GEOMETRY)
   {
+    TCollection_AsciiString aGeomShaderInput;
+
+    switch (theGeometryInputType) {
+      case Graphic3d_TOPA_POLYLINES:
+      case Graphic3d_TOPA_SEGMENTS:
+        aGeomShaderInput = "lines";
+        break;
+      case Graphic3d_TOPA_LINE_STRIP_ADJACENCY:
+      case Graphic3d_TOPA_LINES_ADJACENCY:
+        aGeomShaderInput = "lines_adjacency";
+        break;
+      case Graphic3d_TOPA_POINTS:
+        aGeomShaderInput = "points";
+        break;
+      case Graphic3d_TOPA_TRIANGLES:
+      default:
+        aGeomShaderInput = "triangles";
+        break;
+    }
+
     aSrcUniforms.Prepend(TCollection_AsciiString()
-                         + "\nlayout (triangles) in;"
+                         + "\nlayout (" + aGeomShaderInput + ") in;"
                            "\nlayout (triangle_strip, max_vertices = "
-                         + theNbGeomInputVerts + ") out;");
+                         + theNbGeomOutputVerts + ") out;");
   }
   if (!aSrcInStructs.IsEmpty() && theType == Graphic3d_TOS_GEOMETRY)
   {

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderObject.hxx
@@ -17,6 +17,7 @@
 #define _Graphic3d_ShaderObject_HeaderFile
 
 #include <Graphic3d_TypeOfShaderObject.hxx>
+#include <Graphic3d_TypeOfPrimitiveArray.hxx>
 #include <NCollection_Sequence.hxx>
 #include <OSD_Path.hxx>
 #include <TCollection_AsciiString.hxx>
@@ -83,7 +84,9 @@ public:
     const ShaderVariableList&      theStageInOuts,
     const TCollection_AsciiString& theInName           = TCollection_AsciiString::EmptyString(),
     const TCollection_AsciiString& theOutName          = TCollection_AsciiString::EmptyString(),
-    int                            theNbGeomInputVerts = 0);
+    int                            theNbGeomInputVerts = 0,
+    int                            theNbGeomOutputVerts = 0,
+    Graphic3d_TypeOfPrimitiveArray theGeometryInputType = Graphic3d_TOPA_TRIANGLES);
 
 private:
   //! Creates new shader object of specified type.


### PR DESCRIPTION
This patch introduces two (2) visualisation changes in the form of geometry shaders.

When point clouds are displayed in the OCCT viewer, sometime screen-space pixel values don't allow points to be easily identified. For our purposes, it was nice to have these occur as actual physical circular shapes with a configurable radius (marker size).

Line rendering in OpenCASCADE in the Core OpenGL profile suffers on some cards (MacOS for example) as the OpenGL implementation will not obey the line width and instead set a line width of 1 pixel. This patch also introduces a geometry shader which will be enabled for line rendering when geometry shading is supported by the OpenGL driver.

Physical scales for marker elements  are implemented in OpenGL using a geometry shader. This is currently exposed via the `SetMarkerPhysical` drawer attribute. I doubt this is the best way to express this - might be better to add this as an `Aspect3d_TypeOfMarker` or similar.

Some implementation notes;
- A geometry shader was chosen as it appears to fit in with pre-existing logic regarding mesh line presentation in (`Graphic3d_ShaderManager.cxx`). In the future, a mesh or instanced compute shader may be a better fit.
- Some new parameters needed to be provided to `Graphic3d_ShaderObject::CreateFromSource` such that differing numbers of geometry shader inputs and outputs can be specified
- The way this interacts with sprite markers (with textures) is untested, but will not work at the moment as the geometry shader does not export correct texture coordinates. This might either need to be made mutually exclusive or provided. In this case, a plane would be a more appropriate choice for generation too.
- The segments used for drawing the point polygon is hard-coded at the top of the file as `THE_NB_POINT_CIRCLE_SEGMENTS`
- The segments using for drawing line segment ends is hard-coded at the top of the file as `THE_LINE_END_CAP_SEGMENTS`