### PR TITLE
Testing - Disable not-required workflow on PR

### DIFF
--- a/.github/workflows/build-and-test-multiplatform.yml
+++ b/.github/workflows/build-and-test-multiplatform.yml
@@ -82,6 +82,7 @@ jobs:
 
   prepare-and-build-windows-clang-x64:
     name: Prepare and Build on Windows with Clang (x64)
+    if: github.event_name != 'pull_request'
     runs-on: windows-2022
 
     steps:
@@ -146,6 +147,7 @@ jobs:
 
   prepare-and-build-macos-x64:
     name: Prepare and Build on macOS with Clang (x64)
+    if: github.event_name != 'pull_request'
     runs-on: macos-15
 
     steps:
@@ -317,6 +319,7 @@ jobs:
 
   prepare-and-build-linux-gcc-x64:
     name: Prepare and Build on Ubuntu with GCC (x64)
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
 
     steps:
@@ -430,6 +433,7 @@ jobs:
   test-windows-clang-x64:
     name: Test on Windows with Clang (x64)
     runs-on: windows-2022
+    if: github.event_name != 'pull_request'
     needs: prepare-and-build-windows-clang-x64
 
     steps:
@@ -484,6 +488,7 @@ jobs:
   test-macos-x64:
     name: Test on macOS (x64)
     runs-on: macos-15
+    if: github.event_name != 'pull_request'
     needs: prepare-and-build-macos-x64
 
     steps:
@@ -656,6 +661,7 @@ jobs:
   test-linux-gcc-x64:
     name: Test on Linux with GCC (x64)
     runs-on: ubuntu-24.04
+    if: github.event_name != 'pull_request'
     needs: prepare-and-build-linux-gcc-x64
 
     steps:
@@ -719,6 +725,7 @@ jobs:
   summarize:
       name: Summarize and Send PR Message
       runs-on: ubuntu-24.04
+      if: github.event_name == 'pull_request'
       needs: [test-windows-x64, test-windows-clang-x64, test-macos-x64, test-macos-gcc-x64, test-linux-clang-x64, test-linux-gcc-x64]
   
       steps:
@@ -743,7 +750,7 @@ jobs:
       - name: Download and extract install directory
         uses: actions/download-artifact@v4.1.7
         with:
-          name: install-linux-gcc-x64
+          name: install-linux-clang-x64
           path: install
 
       - name: Set execute permissions on DRAWEXE
@@ -771,6 +778,7 @@ jobs:
 
       - name: Download all test results (Windows Clang x64) from master
         uses: actions/download-artifact@v4.1.7
+        if: github.event_name != 'pull_request'
         with:
           name: results-windows-clang-x64
           path: install/bin/results/master/windows-clang-x64
@@ -779,6 +787,7 @@ jobs:
 
       - name: Download all test results (macOS x64) from master
         uses: actions/download-artifact@v4.1.7
+        if: github.event_name != 'pull_request'
         with:
           name: results-macos-x64
           path: install/bin/results/master/macos-x64
@@ -803,6 +812,7 @@ jobs:
 
       - name: Download all test results (Linux GCC x64) from master
         uses: actions/download-artifact@v4.1.7
+        if: github.event_name != 'pull_request'
         with:
           name: results-linux-gcc-x64
           path: install/bin/results/master/linux-gcc-x64
@@ -817,12 +827,14 @@ jobs:
 
       - name: Download all test results (Windows Clang x64)
         uses: actions/download-artifact@v4.1.7
+        if: github.event_name != 'pull_request'
         with:
           name: results-windows-clang-x64
           path: install/bin/results/current/windows-clang-x64
 
       - name: Download all test results (macOS x64)
         uses: actions/download-artifact@v4.1.7
+        if: github.event_name != 'pull_request'
         with:
           name: results-macos-x64
           path: install/bin/results/current/macos-x64
@@ -841,6 +853,7 @@ jobs:
 
       - name: Download all test results (Linux GCC x64)
         uses: actions/download-artifact@v4.1.7
+        if: github.event_name != 'pull_request'
         with:
           name: results-linux-gcc-x64
           path: install/bin/results/current/linux-gcc-x64
@@ -884,6 +897,7 @@ jobs:
 
       - name: Upload updated test results (Windows Clang x64)
         uses: actions/upload-artifact@v4.4.3
+        if: github.event_name != 'pull_request'
         with:
           name: results-windows-clang-x64
           overwrite: true
@@ -891,6 +905,7 @@ jobs:
 
       - name: Upload updated test results (macOS x64)
         uses: actions/upload-artifact@v4.4.3
+        if: github.event_name != 'pull_request'
         with:
           name: results-macos-x64
           overwrite: true
@@ -912,6 +927,7 @@ jobs:
 
       - name: Upload updated test results (Linux GCC x64)
         uses: actions/upload-artifact@v4.4.3
+        if: github.event_name != 'pull_request'
         with:
           name: results-linux-gcc-x64
           overwrite: true


### PR DESCRIPTION
Now on PR test only one per OS.
On master test and build on all available compilers