### PR TITLE
Testing - Removing direct DCAF loading

### DIFF
--- a/tests/bugs/caf/begin
+++ b/tests/bugs/caf/begin
@@ -1,4 +1,4 @@
-pload DCAF
+pload OCAF
 
 set subgroup caf
 

--- a/tests/bugs/caf/bug24164_1
+++ b/tests/bugs/caf/bug24164_1
@@ -1,4 +1,4 @@
-pload DCAF
+pload OCAF
 
 if { [info exists imagedir] == 0 } {
     set imagedir .

--- a/tests/bugs/caf/bug24164_2
+++ b/tests/bugs/caf/bug24164_2
@@ -1,4 +1,4 @@
-pload DCAF
+pload OCAF
 
 set BugNumber OCC24164
 if { [info exists imagedir] == 0 } {

--- a/tests/bugs/caf/bug26229_1
+++ b/tests/bugs/caf/bug26229_1
@@ -6,7 +6,7 @@ puts ""
 # Add the possibility in OCAF to open/save a document from/to a stream object (BinOcaf format)
 ###################################################################################################
 
-pload DCAF
+pload OCAF
 
 NewDocument D BinOcaf
 

--- a/tests/bugs/caf/bug26229_2
+++ b/tests/bugs/caf/bug26229_2
@@ -6,7 +6,7 @@ puts ""
 # Add the possibility in OCAF to open/save a document from/to a stream object (XmlOcaf format)
 ###################################################################################################
 
-pload DCAF
+pload OCAF
 
 NewDocument D XmlOcaf
 

--- a/tests/bugs/fclasses/bug23852
+++ b/tests/bugs/fclasses/bug23852
@@ -6,7 +6,7 @@ puts ""
 # OSD_Path interprets unc paths incorrectly
 #######################################################################
 
-pload DCAF
+pload OCAF
 
 set BugNumber OCC23852
 

--- a/tests/bugs/fclasses/bug984_1
+++ b/tests/bugs/fclasses/bug984_1
@@ -6,7 +6,7 @@ puts ""
 ## LDOM hangs-up attempting to read a file which contains a reference to "*dtd"file
 ####################################################
 
-pload DCAF
+pload OCAF
 set BugNumber OCC984
 cpulimit 60
 

--- a/tests/bugs/iges/bug33327
+++ b/tests/bugs/iges/bug33327
@@ -2,7 +2,7 @@ puts "============"
 puts "0033327: Data Exchange, IGES Import - SubfigureDef can't read string"
 puts "============"
 
-pload DCAF
+pload OCAF
 
 Close D -silent
 

--- a/tests/bugs/modalg_4/bug8228
+++ b/tests/bugs/modalg_4/bug8228
@@ -9,7 +9,7 @@ puts ""
 set BugNumber OCC8228
 
 catch {pload XDE}
-catch {pload DCAF}
+catch {pload OCAF}
 
 # Create a new document and set UndoLimit
 

--- a/tests/bugs/modalg_5/bug24849_1
+++ b/tests/bugs/modalg_5/bug24849_1
@@ -6,7 +6,7 @@ puts ""
 ## Crash on Pipe creation
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug24849_Study1_GEOM.cbf] D
 

--- a/tests/bugs/modalg_5/bug24849_1_std
+++ b/tests/bugs/modalg_5/bug24849_1_std
@@ -6,7 +6,7 @@ puts ""
 ## Crash on Pipe creation
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug24849_Study1_GEOM.sgd] D
 

--- a/tests/bugs/modalg_5/bug24849_2
+++ b/tests/bugs/modalg_5/bug24849_2
@@ -6,7 +6,7 @@ puts ""
 ## Crash on Pipe creation
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug24849_Study1_GEOM.cbf] D
 

--- a/tests/bugs/modalg_5/bug24849_2_std
+++ b/tests/bugs/modalg_5/bug24849_2_std
@@ -6,7 +6,7 @@ puts ""
 ## Crash on Pipe creation
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug24849_Study1_GEOM.sgd] D
 

--- a/tests/bugs/modalg_6/bug26576_2
+++ b/tests/bugs/modalg_6/bug26576_2
@@ -6,7 +6,7 @@ puts ""
 ## Wrong result obtained by intersection algorithm.
 ###############################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug26576_study1_new_geom.cbf] D
 

--- a/tests/bugs/modalg_6/bug26588
+++ b/tests/bugs/modalg_6/bug26588
@@ -6,7 +6,7 @@ puts ""
 ## SIGSEGV in BRepFeat_MakeDPrism::Perform()
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug26588_Study1_new_GEOM.cbf] D
 

--- a/tests/bugs/moddata_1/bug22694
+++ b/tests/bugs/moddata_1/bug22694
@@ -7,7 +7,7 @@ puts "==========="
 
 set BugNumber OCC22694
 
-catch {pload DCAF}
+catch {pload OCAF}
 catch {pload XDE}
 
 # Create a new document and set UndoLimit

--- a/tests/bugs/moddata_3/bug23733
+++ b/tests/bugs/moddata_3/bug23733
@@ -6,7 +6,7 @@ puts ""
 ## PCurve for edge on face creation failure
 ###############################################
 
-pload DCAF TOPTEST
+pload OCAF TOPTEST
 
 Open [locate_data_file bug_glue_edges_GEOM.cbf] D
 

--- a/tests/bugs/moddata_3/bug23733_std
+++ b/tests/bugs/moddata_3/bug23733_std
@@ -6,7 +6,7 @@ puts ""
 ## PCurve for edge on face creation failure
 ###############################################
 
-pload DCAF TOPTEST
+pload OCAF TOPTEST
 
 Open [locate_data_file bug_glue_edges_GEOM.sgd] D
 

--- a/tests/bugs/step/bug26342
+++ b/tests/bugs/step/bug26342
@@ -7,7 +7,7 @@ puts ""
 # No materials are read from STEP
 #######################################################################
 
-pload DCAF
+pload OCAF
 
 ReadStep D [locate_data_file OCC23251-dm1-oc-214.stp]
 

--- a/tests/bugs/step/bug26657
+++ b/tests/bugs/step/bug26657
@@ -3,7 +3,7 @@ puts "OCC26657: STEP OCAF writers should keep hierarchy and colors when saving n
 puts "========"
 puts ""
 
-pload DCAF TOPTEST XDE XDEDRAW
+pload OCAF TOPTEST XDE XDEDRAW
 ReadStep D1 [locate_data_file bug26657.stp]
 
 set aTmpFile ${imagedir}/${casename}_temp.stp

--- a/tests/bugs/step/bug26925
+++ b/tests/bugs/step/bug26925
@@ -3,7 +3,7 @@ puts "# 0026925: Data Exchange - Exceptions can be raised if assembly is empty"
 puts "# ====================================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 XNewDoc D
 XNewShape D
 box a 0 0 0 10 10 10

--- a/tests/bugs/step/bug27313
+++ b/tests/bugs/step/bug27313
@@ -6,7 +6,7 @@ puts ""
 # Exception during WriteStep with PMI
 ##########################################################################
 
-pload DCAF
+pload OCAF
 
 box b 10 10 10
 explode b

--- a/tests/bugs/step/bug28345
+++ b/tests/bugs/step/bug28345
@@ -3,7 +3,7 @@ puts "# 0028345: Data Exchange - Reading STEP model using STEPCAF crashes"
 puts "# ====================================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 ReadStep D_1 [locate_data_file bug28345_30338.stp]
 
 # Check imported names

--- a/tests/bugs/step/bug29240
+++ b/tests/bugs/step/bug29240
@@ -3,7 +3,7 @@ puts "	0029240: Data Exchange - Crash during reading STEP file"
 puts "=========="
 puts ""
 
-pload DCAF
+pload OCAF
 
 ReadStep D_First [locate_data_file nist_ctc_05_asme1_ap242-1.stp]
 XGetOneShape result D_First 

--- a/tests/bugs/step/bug29403
+++ b/tests/bugs/step/bug29403
@@ -6,7 +6,7 @@ puts ""
 param read.stepcaf.subshapes.name 1
 param write.stepcaf.subshapes.name 1
 
-pload DCAF
+pload OCAF
 
 ReadStep doc [locate_data_file bug29403_ECOR030312.stp]
 set info1 [XStat doc]

--- a/tests/bugs/step/bug30053
+++ b/tests/bugs/step/bug30053
@@ -3,7 +3,7 @@ puts " 0030533: STEP read fails due to comment string "
 puts "==================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 ReadStep D [locate_data_file bug30053.stp] 
 

--- a/tests/bugs/step/bug30362
+++ b/tests/bugs/step/bug30362
@@ -6,7 +6,7 @@ puts ""
 # Writing dimensions with inches produced invalid file
 #########################################################
 
-pload DCAF
+pload OCAF
 
 ReadStep D [locate_data_file bug26689_nist_ctc_01_asme1_ap242.stp]
 param write.step.unit 1

--- a/tests/bugs/step/bug30533
+++ b/tests/bugs/step/bug30533
@@ -3,7 +3,7 @@ puts " 0030533: Data Exchange - Crash during STEP import."
 puts "==================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 param read.stepcaf.subshapes.name On
 

--- a/tests/bugs/step/bug30789
+++ b/tests/bugs/step/bug30789
@@ -5,7 +5,7 @@ puts ""
 
 # Load file
 
-pload DCAF
+pload OCAF
 ReadStep D [locate_data_file bug30789.stp]
 
 # Check several names came from problematic entities

--- a/tests/bugs/step/bug30856
+++ b/tests/bugs/step/bug30856
@@ -2,7 +2,7 @@ puts "========================"
 puts "0030856: Wrong colors after STEP file import"
 puts "========================"
 
-pload DCAF
+pload OCAF
 
 ReadStep D1 [locate_data_file bug30856_SOT223-4P230_700X190L65X72.step]
 WriteStep D1 $imagedir/${casename}.stp

--- a/tests/bugs/step/bug31489
+++ b/tests/bugs/step/bug31489
@@ -3,7 +3,7 @@ puts "0031489: Data Exchange - STEP Reader can't read a big file"
 puts "===================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 # Read file
 ReadStep D [locate_data_file bug31489.stp]

--- a/tests/bugs/step/bug31568
+++ b/tests/bugs/step/bug31568
@@ -2,7 +2,7 @@ puts "================================================================="
 puts "0031568: Data Exchange - invalid model produced after STEP import"
 puts "================================================================="
 
-pload DCAF
+pload OCAF
 
 ReadStep D [locate_data_file bug31568_Konecranes_Sample_3D.stp]
 set ref [XGetReferredShape D 0:1:1:41:11]

--- a/tests/bugs/step/bug31675
+++ b/tests/bugs/step/bug31675
@@ -3,7 +3,7 @@ puts "0031675: Er-ror opening the STEP-file"
 puts "===================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 # Read file
 ReadStep D [locate_data_file bug31675.stp]

--- a/tests/bugs/step/bug31685_1
+++ b/tests/bugs/step/bug31685_1
@@ -3,7 +3,7 @@ puts " 0031685: Data Exchange, STEPCAFControl_Reader - NULL dereference on trans
 puts "==================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 # Read file
 ReadStep D [locate_data_file bug31685_1.stp]

--- a/tests/bugs/step/bug31685_2
+++ b/tests/bugs/step/bug31685_2
@@ -3,7 +3,7 @@ puts " 0031685: Data Exchange, STEPCAFControl_Reader - NULL dereference on trans
 puts "==================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 # Read file
 ReadStep D [locate_data_file bug31685_2.stp] 

--- a/tests/bugs/step/bug31685_3
+++ b/tests/bugs/step/bug31685_3
@@ -3,7 +3,7 @@ puts " 0031685: Data Exchange, STEPCAFControl_Reader - NULL dereference on trans
 puts "==================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 # Read file
 ReadStep D [locate_data_file bug31685_3.stp] 

--- a/tests/bugs/step/bug32310
+++ b/tests/bugs/step/bug32310
@@ -3,7 +3,7 @@ puts "0032310: Data Exchange - Invalid STEP export/import of backslashes in name
 puts "===================================="
 puts ""
 
-pload DCAF
+pload OCAF
 Close D -silent
 
 XNewDoc D

--- a/tests/bugs/step/bug32681
+++ b/tests/bugs/step/bug32681
@@ -3,7 +3,7 @@ puts "0032681: Data Exchange - Missed dimension after STEP export"
 puts "Check adding of dimension"
 puts "=================================="
 
-pload DCAF
+pload OCAF
 
 ReadStep D [locate_data_file bug32681.stp]
 XGetOneShape s D

--- a/tests/bugs/step/bug33331
+++ b/tests/bugs/step/bug33331
@@ -3,7 +3,7 @@ puts "0033331: Data Exchange, Step Import - Unsupported Representation Items"
 puts "===================================="
 puts ""
 
-pload DCAF
+pload OCAF
 catch {Close D}
 
 param "read.stepcaf.subshapes.name" 1

--- a/tests/bugs/xde/bug1669
+++ b/tests/bugs/xde/bug1669
@@ -8,7 +8,7 @@ puts ""
 
 set BugNumber OCC1669
 
-catch {pload DCAF}
+catch {pload OCAF}
 
 XNewDoc SA
 

--- a/tests/bugs/xde/bug16740
+++ b/tests/bugs/xde/bug16740
@@ -8,7 +8,7 @@ puts ""
 # XCAFDoc_ShapeMapTool is not restored
 ########################################
 
-pload DCAF
+pload OCAF
 
 # Check the output file and delete it if necessary
 set anOutputFile ${imagedir}/${casename}.xbf

--- a/tests/bugs/xde/bug1747
+++ b/tests/bugs/xde/bug1747
@@ -10,7 +10,7 @@ puts ""
 
 set BugNumber OCC1747
 
-catch {pload DCAF}
+catch {pload OCAF}
 
 XNewDoc SA
 

--- a/tests/bugs/xde/bug21046
+++ b/tests/bugs/xde/bug21046
@@ -6,7 +6,7 @@ puts ""
 # XShow raises an exception
 #######################################################################
 
-pload DCAF
+pload OCAF
 
 set BugNumber OCC21046
 

--- a/tests/bugs/xde/bug22776
+++ b/tests/bugs/xde/bug22776
@@ -6,7 +6,7 @@ puts ""
 # XCAFPrs_AISObject does not support transparency
 ######################################################################################
 
-catch {pload DCAF}
+catch {pload OCAF}
 pload QAcommands
 
 NewDocument D BinXCAF

--- a/tests/bugs/xde/bug22962
+++ b/tests/bugs/xde/bug22962
@@ -8,7 +8,7 @@ puts ""
 
 set BugNumber OCC22962
 set check_value 97
-pload DCAF
+pload OCAF
 
 ReadStep D1 [locate_data_file OCC22962-dm1-oc-214.stp]
 set dump_info [ XDumpDF D1 ]

--- a/tests/bugs/xde/bug22982
+++ b/tests/bugs/xde/bug22982
@@ -9,7 +9,7 @@ puts ""
 ##################################################################
 
 set BugNumber OCC22982
-pload DCAF
+pload OCAF
 
 NewDocument D11 BinXCAF
 UndoLimit D11 100

--- a/tests/bugs/xde/bug23384
+++ b/tests/bugs/xde/bug23384
@@ -1,6 +1,6 @@
 # Original bug : 23384
 # Date : 16 Aug 2012
-pload DCAF
+pload OCAF
 XOpen [locate_data_file bug23384-doc_subshapes_plain.xbf] doc
 set info1 [XStat doc]
 regexp {level N 0 +: +([-0-9.+eE]+)} $info1 full l0

--- a/tests/bugs/xde/bug23736
+++ b/tests/bugs/xde/bug23736
@@ -6,7 +6,7 @@ puts ""
 # Exception during reading STEP file in Test Harness
 ######################################################
 
-pload DCAF
+pload OCAF
 
 NewDocument D BinXCAF
 UndoLimit D 100

--- a/tests/bugs/xde/bug23773
+++ b/tests/bugs/xde/bug23773
@@ -5,7 +5,7 @@ puts ""
 ######################################################################################
 # Can not read names in STEP file
 ######################################################################################
-pload DCAF
+pload OCAF
 
 ReadStep d1 [locate_data_file bug23773_2012-or-136-004-014-izzi-asm_PCAM.stp]
 set info1 [GetName d1 0:1:1:1:9]

--- a/tests/bugs/xde/bug23921
+++ b/tests/bugs/xde/bug23921
@@ -6,7 +6,7 @@ puts ""
 # IGES reader cannot map subshapes colors inside nested assemblies
 #################################################################
 
-pload DCAF
+pload OCAF
 
 NewDocument D XmlXCAF
 

--- a/tests/bugs/xde/bug24430
+++ b/tests/bugs/xde/bug24430
@@ -6,7 +6,7 @@ puts ""
 # vviewlist draw command does not added name of viewer created by XShow draw command
 #######################################################################################
 
-pload DCAF
+pload OCAF
 NewDocument D XmlXCAF
 ReadIges D [locate_data_file bug23921_case2.igs]
 

--- a/tests/bugs/xde/bug25910
+++ b/tests/bugs/xde/bug25910
@@ -3,7 +3,7 @@ puts "OCC25910: The material with 0-density causes e r r o r s during writing ST
 puts "========"
 puts ""
 
-pload DCAF
+pload OCAF
 
 NewDocument D
 box b 10 10 10

--- a/tests/bugs/xde/bug27169
+++ b/tests/bugs/xde/bug27169
@@ -6,7 +6,7 @@ puts ""
 # Suspitious behavior of importing names during STEP import
 ########################################################################
 
-pload DCAF
+pload OCAF
 
 ReadStep D [locate_data_file bug27169_robot01.step]
 

--- a/tests/bugs/xde/bug27701
+++ b/tests/bugs/xde/bug27701
@@ -3,7 +3,7 @@ puts "OCC27701: C r a s h when export empty solid to STEP"
 puts "========"
 puts ""
 
-pload DCAF
+pload OCAF
 
 restore [locate_data_file bug27701.brep] s
 

--- a/tests/bugs/xde/bug28104
+++ b/tests/bugs/xde/bug28104
@@ -3,7 +3,7 @@ puts "0028104: Data Exchange - Extract sub-assembly (XDE)"
 puts "============================================================================"
 puts ""
 
-pload DCAF
+pload OCAF
 
 Close D0 -silent
 Close D1 -silent

--- a/tests/bugs/xde/bug28104_1
+++ b/tests/bugs/xde/bug28104_1
@@ -3,7 +3,7 @@ puts "0028104: Data Exchange - Extract sub-assembly (XDE)"
 puts "============================================================================"
 puts ""
 
-pload DCAF
+pload OCAF
 
 Close D0 -silent
 Close D1 -silent

--- a/tests/bugs/xde/bug28748
+++ b/tests/bugs/xde/bug28748
@@ -6,7 +6,7 @@ puts ""
 # XCAFDoc_GraphNode does not restore child on Undo
 ###########################################################
 
-pload DCAF
+pload OCAF
 
 ReadStep d [locate_data_file bug21802_as1-oc-214.stp]
 UndoLimit d 1

--- a/tests/bugs/xde/bug29282
+++ b/tests/bugs/xde/bug29282
@@ -6,7 +6,7 @@ puts ""
 # UpdateAssemblies is not worked for located root assemblies
 ###########################################################
 
-pload DCAF
+pload OCAF
 
 # create test Document
 box b 1 1 1

--- a/tests/bugs/xde/bug29854
+++ b/tests/bugs/xde/bug29854
@@ -3,7 +3,7 @@ puts "0029854: XCAF GD&T: Clear contents of reserved labels only"
 puts "============"
 puts ""
 
-pload DCAF
+pload OCAF
 
 box b 10 10 10
 

--- a/tests/bugs/xde/bug30727
+++ b/tests/bugs/xde/bug30727
@@ -3,7 +3,7 @@ puts "0030727: Data Exchange - Problems in Shape Tool"
 puts "==============================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 box b 1 1 1
 copy b bb

--- a/tests/bugs/xde/bug30779
+++ b/tests/bugs/xde/bug30779
@@ -3,7 +3,7 @@ puts "0030779: Data Exchange - Problems with located subshapes in expand compoun
 puts "============================================================================"
 puts ""
 
-pload DCAF
+pload OCAF
 
 XOpen [locate_data_file bug30779.xbf] D
 XExpand D 1

--- a/tests/bugs/xde/bug31382
+++ b/tests/bugs/xde/bug31382
@@ -2,7 +2,7 @@ puts "# ========================================================================
 puts "# 0031382: Data Exchange - BinXCAF should preserve length unit information"
 puts "# =============================================================================="
 
-pload DCAF
+pload OCAF
 
 box b 10 20 30
 

--- a/tests/bugs/xde/bug31466
+++ b/tests/bugs/xde/bug31466
@@ -3,7 +3,7 @@ puts "	0031466: Data Exchange - Cannot import layers from STeP file (7.4.0 regre
 puts "================================================================================="
 puts ""
 
-pload DCAF
+pload OCAF
 
 XNewDoc D
 box b 1 1 1

--- a/tests/bugs/xde/bug31517
+++ b/tests/bugs/xde/bug31517
@@ -3,7 +3,7 @@ puts "0031517: Data Exchange - wrong result of ShapeTool::UpdateAssemblies()"
 puts "======================================================================"
 puts ""
 
-pload DCAF
+pload OCAF
 
 # make structure with two assemblies linked to one original assembly (2 * 3 boxes)
 box b1 1 1 1

--- a/tests/bugs/xde/bug33100
+++ b/tests/bugs/xde/bug33100
@@ -1,6 +1,6 @@
 puts "0033100: Modeling Algorithms - XCAFDoc_Editor::RescaleGeometry does not rescale triangulations"
 
-pload DCAF
+pload OCAF
 Close d -silent
 ReadStep d [locate_data_file "bug33100_window.step"]
 

--- a/tests/bugs/xde/bug3926
+++ b/tests/bugs/xde/bug3926
@@ -6,7 +6,7 @@ puts ""
 # Exception during reading file using XDEDRAWEXE
 ######################################################
 
-pload DCAF
+pload OCAF
 
 NewDocument D BinXCAF
 UndoLimit D 100

--- a/tests/bugs/xde/bug6307
+++ b/tests/bugs/xde/bug6307
@@ -7,7 +7,7 @@ puts "==========="
 
 set BugNumber OCC6307
 
-catch {pload DCAF}
+catch {pload OCAF}
 
 # Create a new document and set UndoLimit
 NewDocument D

--- a/tests/caf/begin
+++ b/tests/caf/begin
@@ -1,7 +1,7 @@
 # File : begin
 
 if { [array get Draw_Groups "DF basic commands"] == "" } {
-	pload DCAF
+	pload OCAF
 }
 
 chrono qat start

--- a/tests/caf/presentation/A2
+++ b/tests/caf/presentation/A2
@@ -41,4 +41,3 @@ Undo D
 AISRepaint D
 
 puts "There is the empty 3D viewer"
-

--- a/tests/de/begin
+++ b/tests/de/begin
@@ -1,4 +1,4 @@
-pload DCAF
+pload OCAF
 pload TOPTEST
 pload XDE
 

--- a/tests/lowalgos/classifier/bug25969
+++ b/tests/lowalgos/classifier/bug25969
@@ -6,7 +6,7 @@ puts ""
 ## Wrong result obtained by 2d classifier algorithm.
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug25969_pal22851.cbf] D
 

--- a/tests/lowalgos/classifier/bug25969_std
+++ b/tests/lowalgos/classifier/bug25969_std
@@ -6,7 +6,7 @@ puts ""
 ## Wrong result obtained by 2d classifier algorithm.
 ###############################################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug25969_pal22851.sgd] D
 

--- a/tests/lowalgos/intss/bug26576_1
+++ b/tests/lowalgos/intss/bug26576_1
@@ -6,7 +6,7 @@ puts ""
 ## Wrong result obtained by intersection algorithm.
 ###############################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug26576_study1_new_geom.cbf] D
 

--- a/tests/lowalgos/intss/bug26576_3
+++ b/tests/lowalgos/intss/bug26576_3
@@ -6,7 +6,7 @@ puts ""
 ## Wrong result obtained by intersection algorithm.
 ###############################
 
-pload DCAF
+pload OCAF
 
 Open [locate_data_file bug26576_study1_new_geom.cbf] D
 

--- a/tests/metadata/begin
+++ b/tests/metadata/begin
@@ -1,4 +1,4 @@
-pload DCAF
+pload OCAF
 pload XDE
 
 cpulimit 1000

--- a/tests/perf/caf/begin
+++ b/tests/perf/caf/begin
@@ -1,3 +1,3 @@
-pload DCAF
+pload OCAF
 
 set subgroup caf

--- a/tests/xcaf/begin
+++ b/tests/xcaf/begin
@@ -2,7 +2,7 @@
 # and expression "set AddToDocument COLORS_LAYERS" means initializing colors and layers
 #
 if { [array get Draw_Groups "TOPOLOGY Feature commands"] == "" } {
-    pload DCAF
+    pload OCAF
     pload TOPTEST
     pload XDE
 }


### PR DESCRIPTION
DCAF require VISUALIZATION for correct work.
In some scenario DRAWEXE can generate a dublicates of the internal static singletons.
This means each dynamic library will have their own instance of the static singleton.
Update all direct library loading to use the DCAF plugin mechanism.
This will ensure that the DCAF plugin is loaded only once and that the correct instance is used.
Originally issue is reproduced only Linux with dlopen with "RTLD_LAZY".
Can be resolved additionally adding "RTLD_LAZY | RTLD_GLOBAL" for dlopen
