### PR TITLE
Configuration - Option to extend debug symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,11 @@ set_property(CACHE USE_MMGR_TYPE PROPERTY STRINGS "NATIVE" "FLEXIBLE" "TBB" "JEM
 set (BUILD_OPT_PROFILE "Default" CACHE STRING "Select profile for compiler and linker.")
 set_property(CACHE BUILD_OPT_PROFILE PROPERTY STRINGS "Default" "Production")
 
+# set setting flag to enable or disable the extended debug information for the compiler
+if (NOT MSVC)
+  set (BUILD_DEBUG_SYMBOLS OFF CACHE BOOL "${BUILD_DEBUG_SYMBOLS_DESCR}")
+endif()
+
 # include variable description
 OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/vardescr")
 

--- a/adm/cmake/occt_defs_flags.cmake
+++ b/adm/cmake/occt_defs_flags.cmake
@@ -141,6 +141,11 @@ if (MSVC)
 elseif (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPILER_ID MATCHES "[Cc][Ll][Aa][Nn][Gg]"))
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 
+  if (BUILD_DEBUG_SYMBOLS)
+    set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -fno-limit-debug-info -glldb")
+    set (CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -fno-limit-debug-info -glldb")
+  endif()
+
   if ("${BUILD_OPT_PROFILE}" STREQUAL "Production")
     # /Ot (favor speed over size) is similar to -O2 or -O3 in GCC/Clang.
     # /Oy (omit frame pointers) is similar to -fomit-frame-pointer in GCC/Clang.

--- a/adm/cmake/occt_macros.cmake
+++ b/adm/cmake/occt_macros.cmake
@@ -421,11 +421,16 @@ function (COLLECT_AND_INSTALL_OCCT_HEADER_FILES THE_ROOT_TARGET_OCCT_DIR THE_OCC
 
   foreach (OCCT_HEADER_FILE ${OCCT_HEADER_FILES_COMPLETE})
     get_filename_component (HEADER_FILE_NAME ${OCCT_HEADER_FILE} NAME)
-    if (BUILD_INCLUDE_SYMLINK)
-      file (CREATE_LINK "${OCCT_HEADER_FILE}" "${THE_ROOT_TARGET_OCCT_DIR}/${THE_OCCT_INSTALL_DIR_PREFIX}/${HEADER_FILE_NAME}" SYMBOLIC)
-    else()
-      set (OCCT_HEADER_FILE_CONTENT "#include \"${OCCT_HEADER_FILE}\"")
-      configure_file ("${TEMPLATE_HEADER_PATH}" "${THE_ROOT_TARGET_OCCT_DIR}/${THE_OCCT_INSTALL_DIR_PREFIX}/${HEADER_FILE_NAME}" @ONLY)
+    set(TARGET_FILE "${THE_ROOT_TARGET_OCCT_DIR}/${THE_OCCT_INSTALL_DIR_PREFIX}/${HEADER_FILE_NAME}")
+
+    # Check if the file already exists in the target directory
+    if (NOT EXISTS "${TARGET_FILE}")
+      if (BUILD_INCLUDE_SYMLINK)
+        file (CREATE_LINK "${OCCT_HEADER_FILE}" "${TARGET_FILE}" COPY_ON_ERROR SYMBOLIC)
+      else()
+        set (OCCT_HEADER_FILE_CONTENT "#include \"${OCCT_HEADER_FILE}\"")
+        configure_file ("${TEMPLATE_HEADER_PATH}" "${TARGET_FILE}" @ONLY)
+      endif()
     endif()
   endforeach()
 

--- a/adm/cmake/vardescr.cmake
+++ b/adm/cmake/vardescr.cmake
@@ -25,6 +25,11 @@ set (BUILD_WITH_DEBUG_DESCR
 These include messages on internal errors and special cases encountered, timing etc.
 Applies only for Debug configuration.")
 
+set (BUILD_DEBUG_SYMBOLS_DESCR
+"Enables extended debug information in the OCCT libraries. This option change the
+compiler flags to produce more debug symbols. It is recommended to enable this option
+in case of deep debugging of OCCT algorithms or applications.")
+
 set (BUILD_SHARED_LIBRARY_NAME_POSTFIX_DESCR
 "Append the postfix to names of output libraries")
 


### PR DESCRIPTION
New CMake variable created for updates compiler flags in debug mode.
Used only on GCC and Clang compilers.
As a result, the final product will higher size.
The changes is not final and can be reverted later, used for developers feedback.