### PR TITLE
Coding - Compiling issue on aarch64

### DIFF
--- a/src/DE/DE_ShapeFixParameters.hxx
+++ b/src/DE/DE_ShapeFixParameters.hxx
@@ -18,7 +18,7 @@
 struct DE_ShapeFixParameters
 {
   //! Enum, classifying a type of value for parameters
-  enum class FixMode : char
+  enum class FixMode : signed char
   {
     FixOrNot = -1, //!< Procedure will be executed or not (depending on the situation)
     NotFix = 0,    //!< Procedure will be executed


### PR DESCRIPTION
Enumerator value evaluates to -1, which cannot be narrowed to type 'char' [-Wc++11-narrowing]