### PR TITLE
Documentation - Update parameter annotations for consistency

### DIFF
--- a/src/AIS/AIS_Animation.hxx
+++ b/src/AIS/AIS_Animation.hxx
@@ -172,7 +172,7 @@ public:
   bool IsStopped() { return myState != AnimationState_Started; }
 
   //! Update single frame of animation, update timer state
-  //! @param thePts [in] the time moment within [0; Duration()]
+  //! @param[in] thePts  the time moment within [0; Duration()]
   //! @return True if timeline is in progress
   Standard_EXPORT virtual Standard_Boolean Update (const Standard_Real thePts);
 

--- a/src/AIS/AIS_ColorScale.hxx
+++ b/src/AIS/AIS_ColorScale.hxx
@@ -373,11 +373,11 @@ public:
 public:
 
   //! Returns the width of text.
-  //! @param theText [in] the text of which to calculate width.
+  //! @param[in] theText  the text of which to calculate width.
   Standard_EXPORT Standard_Integer TextWidth (const TCollection_ExtendedString& theText) const;
 
   //! Returns the height of text.
-  //! @param theText [in] the text of which to calculate height.
+  //! @param[in] theText  the text of which to calculate height.
   Standard_EXPORT Standard_Integer TextHeight (const TCollection_ExtendedString& theText) const;
 
   Standard_EXPORT void TextSize (const TCollection_ExtendedString& theText,
@@ -403,17 +403,17 @@ public:
 private:
 
   //! Returns the size of color scale.
-  //! @param theWidth [out] the width of color scale.
-  //! @param theHeight [out] the height of color scale.
+  //! @param[out] theWidth  the width of color scale.
+  //! @param[out] theHeight  the height of color scale.
   void SizeHint (Standard_Integer& theWidth, Standard_Integer& theHeight) const;
 
   //! Returns the upper value of given interval, or minimum for theIndex = 0.
   Standard_Real GetIntervalValue (const Standard_Integer theIndex) const;
 
   //! Returns the color for the given value in the given interval.
-  //! @param theValue [in] the current value of interval
-  //! @param theMin   [in] the min value of interval
-  //! @param theMax   [in] the max value of interval
+  //! @param[in] theValue  the current value of interval
+  //! @param[in] theMin    the min value of interval
+  //! @param[in] theMax    the max value of interval
   Quantity_Color colorFromValue (const Standard_Real theValue,
                                  const Standard_Real theMin,
                                  const Standard_Real theMax) const;
@@ -422,11 +422,11 @@ private:
   void updateTextAspect();
 
   //! Simple alias for Prs3d_Text::Draw().
-  //! @param theGroup [in] presentation group
-  //! @param theText  [in] text to draw
-  //! @param theX     [in] X coordinate of text position
-  //! @param theY     [in] Y coordinate of text position
-  //! @param theVertAlignment [in] text vertical alignment
+  //! @param[in] theGroup  presentation group
+  //! @param[in] theText   text to draw
+  //! @param[in] theX      X coordinate of text position
+  //! @param[in] theY      Y coordinate of text position
+  //! @param[in] theVertAlignment  text vertical alignment
   void drawText (const Handle(Graphic3d_Group)& theGroup,
                  const TCollection_ExtendedString& theText,
                  const Standard_Integer theX, const Standard_Integer theY,
@@ -451,11 +451,11 @@ private:
                      const Standard_Integer theColorBreadth);
 
   //! Draw a frame.
-  //! @param theX [in] the X coordinate of frame position.
-  //! @param theY [in] the Y coordinate of frame position.
-  //! @param theWidth [in] the width of frame.
-  //! @param theHeight [in] the height of frame.
-  //! @param theColor [in] the color of frame.
+  //! @param[in] theX  the X coordinate of frame position.
+  //! @param[in] theY  the Y coordinate of frame position.
+  //! @param[in] theWidth  the width of frame.
+  //! @param[in] theHeight  the height of frame.
+  //! @param[in] theColor  the color of frame.
   void drawFrame (const Handle(Prs3d_Presentation)& thePrs,
                   const Standard_Integer theX, const Standard_Integer theY,
                   const Standard_Integer theWidth, const Standard_Integer theHeight,

--- a/src/AIS/AIS_InteractiveContext.hxx
+++ b/src/AIS/AIS_InteractiveContext.hxx
@@ -247,21 +247,21 @@ public: //! @name highlighting management
   void SetSelectionStyle (const Handle(Prs3d_Drawer)& theStyle) { myStyles[Prs3d_TypeOfHighlight_Selected] = theStyle; }
 
   //! Returns highlight style of the object if it is marked as highlighted via global status
-  //! @param theObj [in] the object to check
+  //! @param[in] theObj  the object to check
   Standard_EXPORT Standard_Boolean HighlightStyle (const Handle(AIS_InteractiveObject)& theObj,
                                                    Handle(Prs3d_Drawer)& theStyle) const;
 
   //! Returns highlight style of the owner if it is selected
-  //! @param theOwner [in] the owner to check
+  //! @param[in] theOwner  the owner to check
   Standard_EXPORT Standard_Boolean HighlightStyle (const Handle(SelectMgr_EntityOwner)& theOwner,
                                                    Handle(Prs3d_Drawer)& theStyle) const;
 
   //! Returns true if the object is marked as highlighted via its global status
-  //! @param theObj [in] the object to check
+  //! @param[in] theObj  the object to check
   Standard_EXPORT Standard_Boolean IsHilighted (const Handle(AIS_InteractiveObject)& theObj) const;
 
   //! Returns true if the owner is marked as selected
-  //! @param theOwner [in] the owner to check
+  //! @param[in] theOwner  the owner to check
   Standard_EXPORT Standard_Boolean IsHilighted (const Handle(SelectMgr_EntityOwner)& theOwner) const;
 
   //! Changes the color of all the lines of the object in view.
@@ -461,10 +461,10 @@ public: //! @name Selection management
 
   //! Selects objects within the bounding rectangle.
   //! Viewer should be explicitly redrawn after selection.
-  //! @param thePntMin [in] rectangle lower point (in pixels)
-  //! @param thePntMax [in] rectangle upper point (in pixels)
-  //! @param theView   [in] active view where rectangle is defined
-  //! @param theSelScheme [in] selection scheme
+  //! @param[in] thePntMin  rectangle lower point (in pixels)
+  //! @param[in] thePntMax  rectangle upper point (in pixels)
+  //! @param[in] theView    active view where rectangle is defined
+  //! @param[in] theSelScheme  selection scheme
   //! @return picking status
   //! @sa StdSelect_ViewerSelector3d::AllowOverlapDetection()
   Standard_EXPORT AIS_StatusOfPick SelectRectangle (const Graphic3d_Vec2i&    thePntMin,
@@ -474,9 +474,9 @@ public: //! @name Selection management
 
   //! Select everything found in the polygon defined by bounding polyline.
   //! Viewer should be explicitly redrawn after selection.
-  //! @param thePolyline  [in] polyline defining polygon bounds (in pixels)
-  //! @param theView      [in] active view where polyline is defined
-  //! @param theSelScheme [in] selection scheme
+  //! @param[in] thePolyline   polyline defining polygon bounds (in pixels)
+  //! @param[in] theView       active view where polyline is defined
+  //! @param[in] theSelScheme  selection scheme
   //! @return picking status
   Standard_EXPORT AIS_StatusOfPick SelectPolygon (const TColgp_Array1OfPnt2d& thePolyline,
                                                   const Handle(V3d_View)&     theView,
@@ -484,9 +484,9 @@ public: //! @name Selection management
 
   //! Selects the topmost object picked by the point in the view,
   //! Viewer should be explicitly redrawn after selection.
-  //! @param thePnt  [in] point pixel coordinates within the view
-  //! @param theView [in] active view where point is defined
-  //! @param theSelScheme [in] selection scheme
+  //! @param[in] thePnt   point pixel coordinates within the view
+  //! @param[in] theView  active view where point is defined
+  //! @param[in] theSelScheme  selection scheme
   //! @return picking status
   Standard_EXPORT AIS_StatusOfPick SelectPoint (const Graphic3d_Vec2i&    thePnt,
                                                 const Handle(V3d_View)&   theView,
@@ -495,7 +495,7 @@ public: //! @name Selection management
   //! Select and hilights the previous detected via AIS_InteractiveContext::MoveTo() method;
   //! unhilights the previous picked.
   //! Viewer should be explicitly redrawn after selection.
-  //! @param theSelScheme [in] selection scheme
+  //! @param[in] theSelScheme  selection scheme
   //! @return picking status
   //!
   //! @sa HighlightStyle() defining default highlight styles of selected owners (Prs3d_TypeOfHighlight_Selected and Prs3d_TypeOfHighlight_LocalSelected)
@@ -1318,8 +1318,8 @@ protected: //! @name internal methods
   Standard_EXPORT void highlightSelected (const Handle(SelectMgr_EntityOwner)& theOwner);
 
   //! Helper function that highlights the owners with check for AutoHighlight, e.g. is used for selection.
-  //! @param theOwners [in] list of owners to highlight
-  //! @param theStyle  [in] highlight style to apply or NULL to apply selection style
+  //! @param[in] theOwners  list of owners to highlight
+  //! @param[in] theStyle   highlight style to apply or NULL to apply selection style
   Standard_EXPORT void highlightOwners (const AIS_NListOfEntityOwner& theOwners,
                                         const Handle(Prs3d_Drawer)& theStyle);
 
@@ -1347,32 +1347,32 @@ protected: //! @name internal methods
 
   //! Helper function that turns on sub-intensity in global status and highlights
   //! given objects with sub-intensity color
-  //! @param theObject [in] the object. If NULL is given, than sub-intensity will be turned on for
+  //! @param[in] theObject  the object. If NULL is given, than sub-intensity will be turned on for
   //! all inveractive objects of the context
-  //! @param theDispMode [in] display mode. If -1 is given, sub-intensity will be turned on for
+  //! @param[in] theDispMode  display mode. If -1 is given, sub-intensity will be turned on for
   //! all display modes in global status's list of modes
-  //! @param theIsDisplayedOnly [in] is true if sub-intensity should be applied only to objects with
+  //! @param[in] theIsDisplayedOnly  is true if sub-intensity should be applied only to objects with
   //! status AIS_DS_Displayed
   Standard_EXPORT void turnOnSubintensity (const Handle(AIS_InteractiveObject)& theObject = NULL,
                                            const Standard_Integer theDispMode = -1,
                                            const Standard_Boolean theIsDisplayedOnly = Standard_True) const;
 
   //! Helper function that highlights the object with sub-intensity color without any checks
-  //! @param theObject [in] the object that will be highlighted
-  //! @param theMode [in] display mode
+  //! @param[in] theObject  the object that will be highlighted
+  //! @param[in] theMode  display mode
   Standard_EXPORT void highlightWithSubintensity (const Handle(AIS_InteractiveObject)& theObject,
                                                   const Standard_Integer theMode) const;
 
   //! Helper function that highlights the owner with sub-intensity color without any checks
-  //! @param theOwner [in] the owner that will be highlighted
-  //! @param theMode [in] display mode
+  //! @param[in] theOwner  the owner that will be highlighted
+  //! @param[in] theMode  display mode
   Standard_EXPORT void highlightWithSubintensity (const Handle(SelectMgr_EntityOwner)& theOwner,
                                                   const Standard_Integer theMode) const;
 
   //! Helper function that returns correct dynamic highlight style for the object:
   //! if custom style is defined via object's highlight drawer, it will be used. Otherwise,
   //! dynamic highlight style of interactive context will be returned.
-  //! @param theObj [in] the object to check
+  //! @param[in] theObj  the object to check
   const Handle(Prs3d_Drawer)& getHiStyle (const Handle(AIS_InteractiveObject)& theObj,
                                           const Handle(SelectMgr_EntityOwner)& theOwner) const
   {
@@ -1392,7 +1392,7 @@ protected: //! @name internal methods
   //! Helper function that returns correct selection style for the object:
   //! if custom style is defined via object's highlight drawer, it will be used. Otherwise,
   //! selection style of interactive context will be returned.
-  //! @param theObj [in] the object to check
+  //! @param[in] theObj  the object to check
   const Handle(Prs3d_Drawer)& getSelStyle (const Handle(AIS_InteractiveObject)& theObj,
                                            const Handle(SelectMgr_EntityOwner)& theOwner) const
   {

--- a/src/AIS/AIS_InteractiveObject.hxx
+++ b/src/AIS/AIS_InteractiveObject.hxx
@@ -104,12 +104,12 @@ public:
   void ClearOwner() { myOwner.Nullify(); }
 
   //! Drag object in the viewer.
-  //! @param theCtx      [in] interactive context
-  //! @param theView     [in] active View
-  //! @param theOwner    [in] the owner of detected entity
-  //! @param theDragFrom [in] drag start point
-  //! @param theDragTo   [in] drag end point
-  //! @param theAction   [in] drag action
+  //! @param[in] theCtx       interactive context
+  //! @param[in] theView      active View
+  //! @param[in] theOwner     the owner of detected entity
+  //! @param[in] theDragFrom  drag start point
+  //! @param[in] theDragTo    drag end point
+  //! @param[in] theAction    drag action
   //! @return FALSE if object rejects dragging action (e.g. AIS_DragAction_Start)
   Standard_EXPORT virtual Standard_Boolean ProcessDragging (const Handle(AIS_InteractiveContext)& theCtx,
                                                             const Handle(V3d_View)& theView,

--- a/src/AIS/AIS_LightSource.hxx
+++ b/src/AIS/AIS_LightSource.hxx
@@ -148,11 +148,11 @@ public: //! @name Light properties
   }
 
   //! Returns light source icon.
-  //! @param theIsEnabled [in] marker index for enabled/disabled light source states
+  //! @param[in] theIsEnabled  marker index for enabled/disabled light source states
   const Handle(Graphic3d_MarkerImage)& MarkerImage (bool theIsEnabled) const { return myMarkerImages[theIsEnabled ? 1 : 0]; }
 
   //! Returns light source icon.
-  //! @param theIsEnabled [in] marker index for enabled/disabled light source states
+  //! @param[in] theIsEnabled  marker index for enabled/disabled light source states
   Aspect_TypeOfMarker MarkerType (bool theIsEnabled) const { return myMarkerTypes[theIsEnabled ? 1 : 0]; }
 
   //! Sets custom icon to light source.

--- a/src/AIS/AIS_Manipulator.hxx
+++ b/src/AIS/AIS_Manipulator.hxx
@@ -157,12 +157,12 @@ public:
 
 public:
   //! Drag object in the viewer.
-  //! @param theCtx      [in] interactive context
-  //! @param theView     [in] active View
-  //! @param theOwner    [in] the owner of detected entity
-  //! @param theDragFrom [in] drag start point
-  //! @param theDragTo   [in] drag end point
-  //! @param theAction   [in] drag action
+  //! @param[in] theCtx       interactive context
+  //! @param[in] theView      active View
+  //! @param[in] theOwner     the owner of detected entity
+  //! @param[in] theDragFrom  drag start point
+  //! @param[in] theDragTo    drag end point
+  //! @param[in] theAction    drag action
   //! @return FALSE if object rejects dragging action (e.g. AIS_DragAction_Start)
   Standard_EXPORT virtual Standard_Boolean ProcessDragging (const Handle(AIS_InteractiveContext)& theCtx,
                                                             const Handle(V3d_View)& theView,
@@ -187,7 +187,7 @@ public:
   Standard_EXPORT void Transform (const gp_Trsf& aTrsf);
 
   //! Reset start (reference) transformation.
-  //! @param theToApply [in] option to apply or to cancel the started transformation.
+  //! @param[in] theToApply  option to apply or to cancel the started transformation.
   //! @warning It is used in chain with StartTransform-Transform(gp_Trsf)-StopTransform
   //! and is used only for custom transform set.
   Standard_EXPORT void StopTransform (const Standard_Boolean theToApply = Standard_True);
@@ -319,7 +319,7 @@ public: //! @name Presentation computation
                                         const Standard_Integer theMode = 0) Standard_OVERRIDE;
 
   //! Computes selection sensitive zones (triangulation) for manipulator.
-  //! @param theNode [in] Selection mode that is treated as transformation mode.
+  //! @param[in] theNode  Selection mode that is treated as transformation mode.
   Standard_EXPORT virtual void ComputeSelection (const Handle(SelectMgr_Selection)& theSelection,
                                                  const Standard_Integer theMode) Standard_OVERRIDE;
 

--- a/src/AIS/AIS_PointCloud.hxx
+++ b/src/AIS/AIS_PointCloud.hxx
@@ -65,16 +65,16 @@ public:
 
   //! Sets the points from array of points.
   //! Method will not copy the input data - array will be stored as handle.
-  //! @param thePoints [in] the array of points
+  //! @param[in] thePoints  the array of points
   Standard_EXPORT virtual void SetPoints (const Handle(Graphic3d_ArrayOfPoints)& thePoints);
 
   //! Sets the points with optional colors.
   //! The input data will be copied into internal buffer.
   //! The input arrays should have equal length, otherwise
   //! the presentation will not be computed and displayed.
-  //! @param theCoords  [in] the array of coordinates
-  //! @param theColors  [in] optional array of colors
-  //! @param theNormals [in] optional array of normals
+  //! @param[in] theCoords   the array of coordinates
+  //! @param[in] theColors   optional array of colors
+  //! @param[in] theNormals  optional array of normals
   Standard_EXPORT virtual void SetPoints (const Handle(TColgp_HArray1OfPnt)&     theCoords,
                                           const Handle(Quantity_HArray1OfColor)& theColors  = NULL,
                                           const Handle(TColgp_HArray1OfDir)&     theNormals = NULL);

--- a/src/AIS/AIS_RubberBand.hxx
+++ b/src/AIS/AIS_RubberBand.hxx
@@ -41,9 +41,9 @@ public:
   Standard_EXPORT AIS_RubberBand();
 
   //! Constructs the rubber band with empty filling and defined line style.
-  //! @param theLineColor [in] color of rubber band lines
-  //! @param theType [in] type of rubber band lines
-  //! @param theLineWidth [in] width of rubber band line. By default it is 1.
+  //! @param[in] theLineColor  color of rubber band lines
+  //! @param[in] theType  type of rubber band lines
+  //! @param[in] theLineWidth  width of rubber band line. By default it is 1.
   //! @warning It binds this object with Graphic3d_ZLayerId_TopOSD layer.
   Standard_EXPORT AIS_RubberBand (const Quantity_Color& theLineColor,
                                   const Aspect_TypeOfLine theType,
@@ -51,11 +51,11 @@ public:
                                   const Standard_Boolean theIsPolygonClosed = Standard_True);
 
   //! Constructs the rubber band with defined filling and line parameters.
-  //! @param theLineColor [in] color of rubber band lines
-  //! @param theType [in] type of rubber band lines
-  //! @param theFillColor [in] color of rubber band filling
-  //! @param theTransparency [in] transparency of the filling. 0 is for opaque filling. By default it is transparent.
-  //! @param theLineWidth [in] width of rubber band line. By default it is 1.
+  //! @param[in] theLineColor  color of rubber band lines
+  //! @param[in] theType  type of rubber band lines
+  //! @param[in] theFillColor  color of rubber band filling
+  //! @param[in] theTransparency  transparency of the filling. 0 is for opaque filling. By default it is transparent.
+  //! @param[in] theLineWidth  width of rubber band line. By default it is 1.
   //! @warning It binds this object with Graphic3d_ZLayerId_TopOSD layer.
   Standard_EXPORT AIS_RubberBand (const Quantity_Color& theLineColor,
                                   const Aspect_TypeOfLine theType,
@@ -109,7 +109,7 @@ public:
   Standard_EXPORT Aspect_TypeOfLine LineType() const;
 
   //! Sets fill transparency.
-  //! @param theValue [in] the transparency value. 1.0 is for transparent background
+  //! @param[in] theValue  the transparency value. 1.0 is for transparent background
   Standard_EXPORT void SetFillTransparency (const Standard_Real theValue) const;
 
   //! @return fill transparency.
@@ -119,8 +119,8 @@ public:
   Standard_EXPORT void SetFilling (const Standard_Boolean theIsFilling);
 
   //! Enable filling of rubber band with defined parameters.
-  //! @param theColor [in] color of filling
-  //! @param theTransparency [in] transparency of the filling. 0 is for opaque filling.
+  //! @param[in] theColor  color of filling
+  //! @param[in] theTransparency  transparency of the filling. 0 is for opaque filling.
   Standard_EXPORT void SetFilling (const Quantity_Color theColor, const Standard_Real theTransparency);
 
   //! @return true if filling of rubber band is enabled.

--- a/src/AIS/AIS_Selection.hxx
+++ b/src/AIS/AIS_Selection.hxx
@@ -105,8 +105,8 @@ public:
 protected:
 
   //! Append the owner into the current selection if filter is Ok.
-  //! @param theOwner [in] element to change selection state
-  //! @param theFilter [in] context filter to skip not acceptable owners
+  //! @param[in] theOwner  element to change selection state
+  //! @param[in] theFilter  context filter to skip not acceptable owners
   //! @return result of selection
   Standard_EXPORT virtual AIS_SelectStatus appendOwner (const Handle(SelectMgr_EntityOwner)& theOwner,
                                                         const Handle(SelectMgr_Filter)& theFilter);

--- a/src/AIS/AIS_ViewController.hxx
+++ b/src/AIS/AIS_ViewController.hxx
@@ -500,11 +500,11 @@ public:
 
   //! Pick closest point under mouse cursor.
   //! This method is expected to be called from rendering thread.
-  //! @param thePnt   [out] result point
-  //! @param theCtx    [in] interactive context
-  //! @param theView   [in] active view
-  //! @param theCursor [in] mouse cursor
-  //! @param theToStickToPickRay [in] when TRUE, the result point will lie on picking ray
+  //! @param[out] thePnt    result point
+  //! @param[in] theCtx     interactive context
+  //! @param[in] theView    active view
+  //! @param[in] theCursor  mouse cursor
+  //! @param[in] theToStickToPickRay  when TRUE, the result point will lie on picking ray
   //! @return TRUE if result has been found
   Standard_EXPORT virtual bool PickPoint (gp_Pnt& thePnt,
                                           const Handle(AIS_InteractiveContext)& theCtx,
@@ -514,10 +514,10 @@ public:
 
   //! Pick closest point by axis.
   //! This method is expected to be called from rendering thread.
-  //! @param theTopPnt [out] result point
-  //! @param theCtx    [in] interactive context
-  //! @param theView   [in] active view
-  //! @param theAxis   [in] selection axis
+  //! @param[out] theTopPnt  result point
+  //! @param[in] theCtx     interactive context
+  //! @param[in] theView    active view
+  //! @param[in] theAxis    selection axis
   //! @return TRUE if result has been found
   Standard_EXPORT virtual bool PickAxis (gp_Pnt& theTopPnt,
                                          const Handle(AIS_InteractiveContext)& theCtx,
@@ -668,8 +668,8 @@ protected:
 
   //! Return current and previously fetched event times.
   //! This callback is intended to compute delta between sequentially processed events.
-  //! @param thePrevTime [out] events time fetched previous time by this method
-  //! @param theCurrTime [out] actual events time
+  //! @param[out] thePrevTime  events time fetched previous time by this method
+  //! @param[out] theCurrTime  actual events time
   void updateEventsTime (double& thePrevTime,
                          double& theCurrTime)
   {

--- a/src/AIS/AIS_ViewCube.hxx
+++ b/src/AIS/AIS_ViewCube.hxx
@@ -290,7 +290,7 @@ public: //! @name Style management API
   const Quantity_Color& BoxColor() const { return myDrawer->ShadingAspect()->Color(); }
 
   //! Set new value of front color for the 3D part of object.
-  //! @param theColor [in] input color value.
+  //! @param[in] theColor  input color value.
   void SetBoxColor (const Quantity_Color& theColor)
   {
     if (!myDrawer->ShadingAspect()->Color().IsEqual (theColor)
@@ -308,7 +308,7 @@ public: //! @name Style management API
   Standard_Real BoxTransparency() const { return myDrawer->ShadingAspect()->Transparency(); }
 
   //! Set new value of transparency for 3D part of object.
-  //! @param theValue [in] input transparency value
+  //! @param[in] theValue  input transparency value
   void SetBoxTransparency (Standard_Real theValue)
   {
     if (Abs (myDrawer->ShadingAspect()->Transparency() - theValue) > Precision::Confusion()
@@ -412,7 +412,7 @@ public: //! @name Style management API
 public:
 
   //! Set new value of color for the whole object.
-  //! @param theColor [in] input color value.
+  //! @param[in] theColor  input color value.
   virtual void SetColor (const Quantity_Color& theColor) Standard_OVERRIDE
   {
     SetBoxColor (theColor);
@@ -428,7 +428,7 @@ public:
   }
 
   //! Set new value of transparency for the whole object.
-  //! @param theValue [in] input transparency value.
+  //! @param[in] theValue  input transparency value.
   virtual void SetTransparency (const Standard_Real theValue) Standard_OVERRIDE
   {
     SetBoxTransparency (theValue);
@@ -469,7 +469,7 @@ public: //! @name animation methods
   Standard_EXPORT Standard_Real Duration() const;
 
   //! Set duration of animation.
-  //! @param theValue [in] input value of duration in seconds
+  //! @param[in] theValue  input value of duration in seconds
   Standard_EXPORT void SetDuration (Standard_Real theValue);
 
   //! Return TRUE if new camera Up direction should be always set to default value for a new camera Direction; FALSE by default.
@@ -490,11 +490,11 @@ public: //! @name animation methods
   Standard_EXPORT Standard_Boolean HasAnimation() const;
 
   //! Start camera transformation corresponding to the input detected owner.
-  //! @param theOwner [in] detected owner.
+  //! @param[in] theOwner  detected owner.
   Standard_EXPORT virtual void StartAnimation (const Handle(AIS_ViewCubeOwner)& theOwner);
 
   //! Perform one step of current camera transformation.
-  //! theToUpdate [in] enable/disable update of view.
+  //! theToUpdate[in]  enable/disable update of view.
   //! @return TRUE if animation is not stopped.
   Standard_EXPORT virtual Standard_Boolean UpdateAnimation (const Standard_Boolean theToUpdate);
 
@@ -508,7 +508,7 @@ protected:
   Standard_EXPORT Standard_Boolean updateAnimation();
 
   //! Fit selected/all into view.
-  //! @param theView [in] view definition to retrieve scene bounding box
+  //! @param[in] theView  view definition to retrieve scene bounding box
   //! @param theCamera [in,out] camera definition
   Standard_EXPORT virtual void viewFitAll (const Handle(V3d_View)& theView,
                                            const Handle(Graphic3d_Camera)& theCamera);
@@ -530,17 +530,17 @@ public: //! @name Presentation computation
   virtual Handle(SelectMgr_EntityOwner) GlobalSelOwner() const Standard_OVERRIDE { return Handle(SelectMgr_EntityOwner)(); }
 
   //! Compute 3D part of View Cube.
-  //! @param thePrsMgr [in] presentation manager.
-  //! @param thePrs [in] input presentation that is to be filled with flat presentation primitives.
-  //! @param theMode [in] display mode.
+  //! @param[in] thePrsMgr  presentation manager.
+  //! @param[in] thePrs  input presentation that is to be filled with flat presentation primitives.
+  //! @param[in] theMode  display mode.
   //! @warning this object accept only 0 display mode.
   Standard_EXPORT virtual void Compute (const Handle(PrsMgr_PresentationManager)& thePrsMgr,
                                         const Handle(Prs3d_Presentation)& thePrs,
                                         const Standard_Integer theMode = 0) Standard_OVERRIDE;
 
   //! Redefine computing of sensitive entities for View Cube.
-  //! @param theSelection [in] input selection object that is to be filled with sensitive entities.
-  //! @param theMode [in] selection mode.
+  //! @param[in] theSelection  input selection object that is to be filled with sensitive entities.
+  //! @param[in] theMode  selection mode.
   //! @warning object accepts only 0 selection mode.
   Standard_EXPORT virtual void ComputeSelection (const Handle(SelectMgr_Selection)& theSelection,
                                                  const Standard_Integer theMode) Standard_OVERRIDE;
@@ -553,9 +553,9 @@ public: //! @name Presentation computation
   virtual void ClearSelected() Standard_OVERRIDE {}
 
   //! Method which highlights input owner belonging to this selectable object.
-  //! @param thePM [in] presentation manager
-  //! @param theStyle [in] style for dynamic highlighting.
-  //! @param theOwner [in] input entity owner.
+  //! @param[in] thePM  presentation manager
+  //! @param[in] theStyle  style for dynamic highlighting.
+  //! @param[in] theOwner  input entity owner.
   Standard_EXPORT virtual void HilightOwnerWithColor (const Handle(PrsMgr_PresentationManager)& thePM,
                                                       const Handle(Prs3d_Drawer)& theStyle,
                                                       const Handle(SelectMgr_EntityOwner)& theOwner) Standard_OVERRIDE;
@@ -586,7 +586,7 @@ protected: //! @name Auxiliary classes to fill presentation with proper primitiv
   //! @param theTris    [in,out] triangulation to fill, or NULL to return size
   //! @param theNbNodes [in,out] should be incremented by a number of nodes defining this triangulation
   //! @param theNbTris  [in,out] should be incremented by a number of triangles defining this triangulation
-  //! @param theDir     [in] part to define
+  //! @param[in] theDir      part to define
   Standard_EXPORT virtual void createBoxPartTriangles (const Handle(Graphic3d_ArrayOfTriangles)& theTris,
                                                        Standard_Integer& theNbNodes,
                                                        Standard_Integer& theNbTris,
@@ -596,7 +596,7 @@ protected: //! @name Auxiliary classes to fill presentation with proper primitiv
   //! @param theTris    [in,out] triangulation to fill, or NULL to return size
   //! @param theNbNodes [in,out] should be incremented by a number of nodes defining this triangulation
   //! @param theNbTris  [in,out] should be incremented by a number of triangles defining this triangulation
-  //! @param theDir     [in] part to define
+  //! @param[in] theDir      part to define
   Standard_EXPORT virtual void createBoxSideTriangles (const Handle(Graphic3d_ArrayOfTriangles)& theTris,
                                                        Standard_Integer& theNbNodes,
                                                        Standard_Integer& theNbTris,
@@ -606,7 +606,7 @@ protected: //! @name Auxiliary classes to fill presentation with proper primitiv
   //! @param theTris    [in,out] triangulation to fill, or NULL to return size
   //! @param theNbNodes [in,out] should be incremented by a number of nodes defining this triangulation
   //! @param theNbTris  [in,out] should be incremented by a number of triangles defining this triangulation
-  //! @param theDir     [in] part to define
+  //! @param[in] theDir      part to define
   Standard_EXPORT virtual void createBoxEdgeTriangles (const Handle(Graphic3d_ArrayOfTriangles)& theTris,
                                                        Standard_Integer& theNbNodes,
                                                        Standard_Integer& theNbTris,
@@ -616,7 +616,7 @@ protected: //! @name Auxiliary classes to fill presentation with proper primitiv
   //! @param theTris    [in,out] triangulation to fill, or NULL to return size
   //! @param theNbNodes [in,out] should be incremented by a number of nodes defining this triangulation
   //! @param theNbTris  [in,out] should be incremented by a number of triangles defining this triangulation
-  //! @param theDir     [in] part to define
+  //! @param[in] theDir      part to define
   Standard_EXPORT virtual void createBoxCornerTriangles (const Handle(Graphic3d_ArrayOfTriangles)& theTris,
                                                          Standard_Integer& theNbNodes,
                                                          Standard_Integer& theNbTris,
@@ -628,9 +628,9 @@ protected:
   //! @param theTris    [in,out] triangulation to fill, or NULL to return size
   //! @param theNbNodes [in,out] should be incremented by a number of nodes defining this triangulation
   //! @param theNbTris  [in,out] should be incremented by a number of triangles defining this triangulation
-  //! @param theSize    [in] rectangle dimensions
-  //! @param theRadius  [in] radius at corners
-  //! @param theTrsf    [in] transformation
+  //! @param[in] theSize     rectangle dimensions
+  //! @param[in] theRadius   radius at corners
+  //! @param[in] theTrsf     transformation
   Standard_EXPORT static void createRoundRectangleTriangles (const Handle(Graphic3d_ArrayOfTriangles)& theTris,
                                                              Standard_Integer& theNbNodes,
                                                              Standard_Integer& theNbTris,

--- a/src/Adaptor3d/Adaptor3d_TopolTool.hxx
+++ b/src/Adaptor3d/Adaptor3d_TopolTool.hxx
@@ -127,18 +127,18 @@ public:
   //! Compute the sample-points for the intersections algorithms by adaptive algorithm for BSpline surfaces.
   //! For other surfaces algorithm is the same as in method ComputeSamplePoints(),
   //! but only fill arrays of U and V sample parameters;
-  //! @param theDefl  [in] a required deflection
-  //! @param theNUmin [in] minimal nb points for U
-  //! @param theNVmin [in] minimal nb points for V
+  //! @param[in] theDefl   a required deflection
+  //! @param[in] theNUmin  minimal nb points for U
+  //! @param[in] theNVmin  minimal nb points for V
   Standard_EXPORT virtual void SamplePnts (const Standard_Real theDefl,
                                            const Standard_Integer theNUmin,
                                            const Standard_Integer theNVmin);
 
   //! Compute the sample-points for the intersections algorithms
   //! by adaptive algorithm for BSpline surfaces - is used in SamplePnts
-  //! @param theDefl  [in] required deflection
-  //! @param theNUmin [in] minimal nb points for U
-  //! @param theNVmin [in] minimal nb points for V
+  //! @param[in] theDefl   required deflection
+  //! @param[in] theNUmin  minimal nb points for U
+  //! @param[in] theNVmin  minimal nb points for V
   Standard_EXPORT virtual void BSplSamplePnts (const Standard_Real theDefl,
                                                const Standard_Integer theNUmin,
                                                const Standard_Integer theNVmin);

--- a/src/Aspect/Aspect_GenId.hxx
+++ b/src/Aspect/Aspect_GenId.hxx
@@ -64,7 +64,7 @@ public:
   Standard_EXPORT Standard_Integer Next();
 
   //! Generates the next available identifier.
-  //! @param theId [out] generated identifier
+  //! @param[out] theId  generated identifier
   //! @return FALSE if all identifiers are busy.
   Standard_EXPORT Standard_Boolean Next (Standard_Integer& theId);
   

--- a/src/Aspect/Aspect_OpenVRSession.hxx
+++ b/src/Aspect/Aspect_OpenVRSession.hxx
@@ -65,12 +65,12 @@ public:
   Standard_EXPORT virtual void ProcessEvents() Standard_OVERRIDE;
 
   //! Submit texture eye to XR Composer.
-  //! @param theTexture     [in] texture handle
-  //! @param theGraphicsLib [in] graphics library in which texture handle is defined
-  //! @param theColorSpace  [in] texture color space;
+  //! @param[in] theTexture      texture handle
+  //! @param[in] theGraphicsLib  graphics library in which texture handle is defined
+  //! @param[in] theColorSpace   texture color space;
   //!                            sRGB means no color conversion by composer;
   //!                            Linear means to sRGB color conversion by composer
-  //! @param theEye [in] eye to display
+  //! @param[in] theEye  eye to display
   //! @return FALSE on error
   Standard_EXPORT virtual bool SubmitEye (void* theTexture,
                                           Aspect_GraphicsLibrary theGraphicsLib,

--- a/src/Aspect/Aspect_XRSession.hxx
+++ b/src/Aspect/Aspect_XRSession.hxx
@@ -84,12 +84,12 @@ public:
   virtual void ProcessEvents() = 0;
 
   //! Submit texture eye to XR Composer.
-  //! @param theTexture     [in] texture handle
-  //! @param theGraphicsLib [in] graphics library in which texture handle is defined
-  //! @param theColorSpace  [in] texture color space;
+  //! @param[in] theTexture      texture handle
+  //! @param[in] theGraphicsLib  graphics library in which texture handle is defined
+  //! @param[in] theColorSpace   texture color space;
   //!                            sRGB means no color conversion by composer;
   //!                            Linear means to sRGB color conversion by composer
-  //! @param theEye [in] eye to display
+  //! @param[in] theEye  eye to display
   //! @return FALSE on error
   virtual bool SubmitEye (void* theTexture,
                           Aspect_GraphicsLibrary theGraphicsLib,
@@ -153,8 +153,8 @@ public:
   virtual Standard_Integer NamedTrackedDevice (Aspect_XRTrackedDeviceRole theDevice) const = 0;
 
   //! Load model for displaying device.
-  //! @param theDevice  [in] device index
-  //! @param theTexture [out] texture source
+  //! @param[in] theDevice   device index
+  //! @param[out] theTexture  texture source
   //! @return model triangulation or NULL if not found
   Handle(Graphic3d_ArrayOfTriangles) LoadRenderModel (Standard_Integer theDevice,
                                                       Handle(Image_Texture)& theTexture)
@@ -163,9 +163,9 @@ public:
   }
 
   //! Load model for displaying device.
-  //! @param theDevice  [in] device index
-  //! @param theToApplyUnitFactor [in] flag to apply unit scale factor
-  //! @param theTexture [out] texture source
+  //! @param[in] theDevice   device index
+  //! @param[in] theToApplyUnitFactor  flag to apply unit scale factor
+  //! @param[out] theTexture  texture source
   //! @return model triangulation or NULL if not found
   Handle(Graphic3d_ArrayOfTriangles) LoadRenderModel (Standard_Integer theDevice,
                                                       Standard_Boolean theToApplyUnitFactor,
@@ -175,16 +175,16 @@ public:
   }
 
   //! Fetch data for digital input action (like button).
-  //! @param theAction [in] action of Aspect_XRActionType_InputDigital type
+  //! @param[in] theAction  action of Aspect_XRActionType_InputDigital type
   virtual Aspect_XRDigitalActionData GetDigitalActionData (const Handle(Aspect_XRAction)& theAction) const = 0;
 
   //! Fetch data for digital input action (like axis).
-  //! @param theAction [in] action of Aspect_XRActionType_InputAnalog type
+  //! @param[in] theAction  action of Aspect_XRActionType_InputAnalog type
   virtual Aspect_XRAnalogActionData GetAnalogActionData (const Handle(Aspect_XRAction)& theAction) const = 0;
 
   //! Fetch data for pose input action (like fingertip position).
   //! The returned values will match the values returned by the last call to WaitPoses().
-  //! @param theAction [in] action of Aspect_XRActionType_InputPose type
+  //! @param[in] theAction  action of Aspect_XRActionType_InputPose type
   virtual Aspect_XRPoseActionData GetPoseActionDataForNextFrame (const Handle(Aspect_XRAction)& theAction) const = 0;
 
   //! Trigger vibration.
@@ -228,9 +228,9 @@ protected:
   Standard_EXPORT Aspect_XRSession();
 
   //! Load model for displaying device.
-  //! @param theDevice  [in] device index
-  //! @param theToApplyUnitFactor [in] flag to apply unit scale factor
-  //! @param theTexture [out] texture source
+  //! @param[in] theDevice   device index
+  //! @param[in] theToApplyUnitFactor  flag to apply unit scale factor
+  //! @param[out] theTexture  texture source
   //! @return model triangulation or NULL if not found
   virtual Handle(Graphic3d_ArrayOfTriangles) loadRenderModel (Standard_Integer theDevice,
                                                               Standard_Boolean theToApplyUnitFactor,

--- a/src/BOPAlgo/BOPAlgo_MakeConnected.hxx
+++ b/src/BOPAlgo/BOPAlgo_MakeConnected.hxx
@@ -146,14 +146,14 @@ public: //! @name Constructor
 public: //! @name Setters for the shapes to make connected
 
   //! Sets the shape for making them connected.
-  //! @param theArgs [in] The arguments for the operation.
+  //! @param[in] theArgs  The arguments for the operation.
   void SetArguments(const TopTools_ListOfShape& theArgs)
   {
     myArguments = theArgs;
   }
 
   //! Adds the shape to the arguments.
-  //! @param theS [in] One of the argument shapes.
+  //! @param[in] theS  One of the argument shapes.
   void AddArgument(const TopoDS_Shape& theS)
   {
     myArguments.Append(theS);
@@ -176,13 +176,13 @@ public: //! @name Shape periodicity & repetition
   //! Makes the connected shape periodic.
   //! Repeated calls of this method overwrite the previous calls
   //! working with the basis connected shape.
-  //! @param theParams [in] Periodic options.
+  //! @param[in] theParams  Periodic options.
   Standard_EXPORT void MakePeriodic(const BOPAlgo_MakePeriodic::PeriodicityParams& theParams);
 
   //! Performs repetition of the periodic shape in specified direction
   //! required number of times.
-  //! @param theDirectionID [in] The direction's ID (0 for X, 1 for Y, 2 for Z);
-  //! @param theTimes [in] Requested number of repetitions (sign of the value defines
+  //! @param[in] theDirectionID  The direction's ID (0 for X, 1 for Y, 2 for Z);
+  //! @param[in] theTimes  Requested number of repetitions (sign of the value defines
   //!                      the side of the repetition direction (positive or negative)).
   Standard_EXPORT void RepeatShape(const Standard_Integer theDirectionID,
                                    const Standard_Integer theTimes);
@@ -202,7 +202,7 @@ public: //! @name Material transitions
 
   //! Returns the original shapes which images contain the
   //! the given shape with FORWARD orientation.
-  //! @param theS [in] The shape for which the materials are necessary.
+  //! @param[in] theS  The shape for which the materials are necessary.
   const TopTools_ListOfShape& MaterialsOnPositiveSide(const TopoDS_Shape& theS)
   {
     const TopTools_ListOfShape* pLM = myMaterials.Seek(theS.Oriented(TopAbs_FORWARD));
@@ -211,7 +211,7 @@ public: //! @name Material transitions
 
   //! Returns the original shapes which images contain the
   //! the given shape with REVERSED orientation.
-  //! @param theS [in] The shape for which the materials are necessary.
+  //! @param[in] theS  The shape for which the materials are necessary.
   const TopTools_ListOfShape& MaterialsOnNegativeSide(const TopoDS_Shape& theS)
   {
     const TopTools_ListOfShape* pLM = myMaterials.Seek(theS.Oriented(TopAbs_REVERSED));
@@ -228,14 +228,14 @@ public: //! @name History methods
   }
 
   //! Returns the list of shapes modified from the given shape.
-  //! @param theS [in] The shape for which the modified shapes are necessary.
+  //! @param[in] theS  The shape for which the modified shapes are necessary.
   const TopTools_ListOfShape& GetModified(const TopoDS_Shape& theS)
   {
     return (myHistory.IsNull() ? EmptyList() : myHistory->Modified(theS));
   }
 
   //! Returns the list of original shapes from which the current shape has been created.
-  //! @param theS [in] The shape for which the origins are necessary.
+  //! @param[in] theS  The shape for which the origins are necessary.
   const TopTools_ListOfShape& GetOrigins(const TopoDS_Shape& theS)
   {
     const TopTools_ListOfShape* pLOr = myOrigins.Seek(theS);

--- a/src/BOPAlgo/BOPAlgo_MakePeriodic.hxx
+++ b/src/BOPAlgo/BOPAlgo_MakePeriodic.hxx
@@ -138,7 +138,7 @@ public: //! @name Constructor
 public: //! @name Setting the shape to make it periodic
 
   //! Sets the shape to make it periodic.
-  //! @param theShape [in] The shape to make periodic.
+  //! @param[in] theShape  The shape to make periodic.
   void SetShape(const TopoDS_Shape& theShape)
   {
     myInputShape = theShape;
@@ -178,7 +178,7 @@ public: //! @name Definition of the structure to keep all periodicity parameters
 public: //! @name Setters/Getters for periodicity parameters structure
 
   //! Sets the periodicity parameters.
-  //! @param theParams [in] Periodicity parameters
+  //! @param[in] theParams  Periodicity parameters
   void SetPeriodicityParameters(const PeriodicityParams& theParams)
   {
     myPeriodicityParams = theParams;
@@ -197,9 +197,9 @@ public: //! @name Methods for setting/getting periodicity info using ID as a dir
   //! - 1 - Y direction;
   //! - 2 - Z direction.
   //!
-  //! @param theDirectionID [in] The direction's ID;
-  //! @param theIsPeriodic [in] Flag defining periodicity in given direction;
-  //! @param thePeriod [in] Required period in given direction.
+  //! @param[in] theDirectionID  The direction's ID;
+  //! @param[in] theIsPeriodic  Flag defining periodicity in given direction;
+  //! @param[in] thePeriod  Required period in given direction.
   void MakePeriodic(const Standard_Integer theDirectionID,
                     const Standard_Boolean theIsPeriodic,
                     const Standard_Real thePeriod = 0.0)
@@ -210,14 +210,14 @@ public: //! @name Methods for setting/getting periodicity info using ID as a dir
   }
 
   //! Returns the info about Periodicity of the shape in specified direction.
-  //! @param theDirectionID [in] The direction's ID.
+  //! @param[in] theDirectionID  The direction's ID.
   Standard_Boolean IsPeriodic(const Standard_Integer theDirectionID) const
   {
     return myPeriodicityParams.myPeriodic[ToDirectionID(theDirectionID)];
   }
 
   //! Returns the Period of the shape in specified direction.
-  //! @param theDirectionID [in] The direction's ID.
+  //! @param[in] theDirectionID  The direction's ID.
   Standard_Real Period(const Standard_Integer theDirectionID) const
   {
     Standard_Integer id = ToDirectionID(theDirectionID);
@@ -228,8 +228,8 @@ public: //! @name Methods for setting/getting periodicity info using ID as a dir
 public: //! @name Named methods for setting/getting info about shape's periodicity
 
   //! Sets the flag to make the shape periodic in X direction.
-  //! @param theIsPeriodic [in] Flag defining periodicity in X direction;
-  //! @param thePeriod [in] Required period in X direction.
+  //! @param[in] theIsPeriodic  Flag defining periodicity in X direction;
+  //! @param[in] thePeriod  Required period in X direction.
   void MakeXPeriodic(const Standard_Boolean theIsPeriodic,
                      const Standard_Real thePeriod = 0.0)
   {
@@ -243,8 +243,8 @@ public: //! @name Named methods for setting/getting info about shape's periodici
   Standard_Real XPeriod() const { return Period(0); }
 
   //! Sets the flag to make the shape periodic in Y direction.
-  //! @param theIsPeriodic [in] Flag defining periodicity in Y direction;
-  //! @param thePeriod [in] Required period in Y direction.
+  //! @param[in] theIsPeriodic  Flag defining periodicity in Y direction;
+  //! @param[in] thePeriod  Required period in Y direction.
   void MakeYPeriodic(const Standard_Boolean theIsPeriodic,
                      const Standard_Real thePeriod = 0.0)
   {
@@ -258,8 +258,8 @@ public: //! @name Named methods for setting/getting info about shape's periodici
   Standard_Real YPeriod() const { return Period(1); }
 
   //! Sets the flag to make the shape periodic in Z direction.
-  //! @param theIsPeriodic [in] Flag defining periodicity in Z direction;
-  //! @param thePeriod [in] Required period in Z direction.
+  //! @param[in] theIsPeriodic  Flag defining periodicity in Z direction;
+  //! @param[in] thePeriod  Required period in Z direction.
   void MakeZPeriodic(const Standard_Boolean theIsPeriodic,
                      const Standard_Real thePeriod = 0.0)
   {
@@ -288,9 +288,9 @@ public: //! @name Methods for setting/getting trimming info taking Direction ID 
   //!
   //! Before calling this method, the shape has to be set to be periodic in this direction.
   //!
-  //! @param theDirectionID [in] The direction's ID;
-  //! @param theIsTrimmed [in] The flag defining trimming of the shape in given direction;
-  //! @param theFirst [in] The first periodic parameter in the given direction.
+  //! @param[in] theDirectionID  The direction's ID;
+  //! @param[in] theIsTrimmed  The flag defining trimming of the shape in given direction;
+  //! @param[in] theFirst  The first periodic parameter in the given direction.
   void SetTrimmed(const Standard_Integer theDirectionID,
                   const Standard_Boolean theIsTrimmed,
                   const Standard_Real theFirst = 0.0)
@@ -304,14 +304,14 @@ public: //! @name Methods for setting/getting trimming info taking Direction ID 
   }
 
   //! Returns whether the input shape was trimmed in the specified direction.
-  //! @param theDirectionID [in] The direction's ID.
+  //! @param[in] theDirectionID  The direction's ID.
   Standard_Boolean IsInputTrimmed(const Standard_Integer theDirectionID) const
   {
     return myPeriodicityParams.myIsTrimmed[ToDirectionID(theDirectionID)];
   }
 
   //! Returns the first periodic parameter in the specified direction.
-  //! @param theDirectionID [in] The direction's ID.
+  //! @param[in] theDirectionID  The direction's ID.
   Standard_Real PeriodFirst(const Standard_Integer theDirectionID) const
   {
     Standard_Integer id = ToDirectionID(theDirectionID);
@@ -328,9 +328,9 @@ public: //! @name Named methods for setting/getting trimming info
   //!
   //! Before calling this method, the shape has to be set to be periodic in this direction.
   //!
-  //! @param theIsTrimmed [in] Flag defining whether the shape is already trimmed
+  //! @param[in] theIsTrimmed  Flag defining whether the shape is already trimmed
   //!                          in X direction to fit the X period;
-  //! @param theFirst [in] The first X periodic parameter.
+  //! @param[in] theFirst  The first X periodic parameter.
   void SetXTrimmed(const Standard_Boolean theIsTrimmed,
                    const Standard_Boolean theFirst = 0.0)
   {
@@ -356,9 +356,9 @@ public: //! @name Named methods for setting/getting trimming info
   //!
   //! Before calling this method, the shape has to be set to be periodic in this direction.
   //!
-  //! @param theIsTrimmed [in] Flag defining whether the shape is already trimmed
+  //! @param[in] theIsTrimmed  Flag defining whether the shape is already trimmed
   //!                          in Y direction to fit the Y period;
-  //! @param theFirst [in] The first Y periodic parameter.
+  //! @param[in] theFirst  The first Y periodic parameter.
   void SetYTrimmed(const Standard_Boolean theIsTrimmed,
                    const Standard_Boolean theFirst = 0.0)
   {
@@ -384,9 +384,9 @@ public: //! @name Named methods for setting/getting trimming info
   //!
   //! Before calling this method, the shape has to be set to be periodic in this direction.
   //!
-  //! @param theIsTrimmed [in] Flag defining whether the shape is already trimmed
+  //! @param[in] theIsTrimmed  Flag defining whether the shape is already trimmed
   //!                          in Z direction to fit the Z period;
-  //! @param theFirst [in] The first Z periodic parameter.
+  //! @param[in] theFirst  The first Z periodic parameter.
   void SetZTrimmed(const Standard_Boolean theIsTrimmed,
                    const Standard_Boolean theFirst = 0.0)
   {
@@ -419,8 +419,8 @@ public: //! @name Using the algorithm to repeat the shape
   //! be perform in negative direction.
   //! Makes the repeated shape a base for following repetitions.
   //!
-  //! @param theDirectionID [in] The direction's ID;
-  //! @param theTimes [in] Requested number of repetitions.
+  //! @param[in] theDirectionID  The direction's ID;
+  //! @param[in] theTimes  Requested number of repetitions.
   Standard_EXPORT const TopoDS_Shape& RepeatShape(const Standard_Integer theDirectionID,
                                                   const Standard_Integer theTimes);
 
@@ -429,7 +429,7 @@ public: //! @name Using the algorithm to repeat the shape
   //! perform in negative X direction.
   //! Makes the repeated shape a base for following repetitions.
   //!
-  //! @param theTimes [in] Requested number of repetitions.
+  //! @param[in] theTimes  Requested number of repetitions.
   const TopoDS_Shape& XRepeat(const Standard_Integer theTimes)
   {
     return RepeatShape(0, theTimes);
@@ -440,7 +440,7 @@ public: //! @name Using the algorithm to repeat the shape
   //! perform in negative Y direction.
   //! Makes the repeated shape a base for following repetitions.
   //!
-  //! @param theTimes [in] Requested number of repetitions.
+  //! @param[in] theTimes  Requested number of repetitions.
   const TopoDS_Shape& YRepeat(const Standard_Integer theTimes)
   {
     return RepeatShape(1, theTimes);
@@ -451,7 +451,7 @@ public: //! @name Using the algorithm to repeat the shape
   //! perform in negative Z direction.
   //! Makes the repeated shape a base for following repetitions.
   //!
-  //! @param theTimes [in] Requested number of repetitions.
+  //! @param[in] theTimes  Requested number of repetitions.
   const TopoDS_Shape& ZRepeat(const Standard_Integer theTimes)
   {
     return RepeatShape(2, theTimes);
@@ -490,7 +490,7 @@ public: //! @name Getting the identical shapes
   //! on the opposite periodic side.
   //! Returns empty list in case the shape has no twin.
   //!
-  //! @param theS [in] Shape to get the twins for.
+  //! @param[in] theS  Shape to get the twins for.
   const TopTools_ListOfShape& GetTwins(const TopoDS_Shape& theS) const
   {
     static TopTools_ListOfShape empty;
@@ -559,17 +559,17 @@ protected: //! @name Protected methods performing the operation
 
   //! Splits the shape by the given tools, copying the geometry of coinciding
   //! parts from the given tools to the split shape.
-  //! @param theTools [in] The tools to split the shape and take the geometry
+  //! @param[in] theTools  The tools to split the shape and take the geometry
   //!                      for coinciding parts.
-  //! @param theSplitShapeHistory [out] The history of shape split
-  //! @param theSplitToolsHistory [out] The history of tools modifications during the split
+  //! @param[out] theSplitShapeHistory  The history of shape split
+  //! @param[out] theSplitToolsHistory  The history of tools modifications during the split
   Standard_EXPORT void SplitShape(const TopTools_ListOfShape& theTools,
                                   Handle(BRepTools_History) theSplitShapeHistory = NULL,
                                   Handle(BRepTools_History) theSplitToolsHistory = NULL);
 
   //! Updates the map of twins after periodic shape repetition.
-  //! @param theTranslationHistory [in] The history of translation of the periodic shape.
-  //! @param theGluingHistory [in] The history of gluing of the repeated shapes.
+  //! @param[in] theTranslationHistory  The history of translation of the periodic shape.
+  //! @param[in] theGluingHistory  The history of gluing of the repeated shapes.
   Standard_EXPORT void UpdateTwins(const BRepTools_History& theTranslationHistory,
                                    const BRepTools_History& theGluingHistory);
 

--- a/src/BOPAlgo/BOPAlgo_RemoveFeatures.hxx
+++ b/src/BOPAlgo/BOPAlgo_RemoveFeatures.hxx
@@ -161,7 +161,7 @@ public: //! @name Constructors
 public: //! @name Setting input data for the algorithm
 
   //! Sets the shape for processing.
-  //! @param theShape [in] The shape to remove the faces from.
+  //! @param[in] theShape  The shape to remove the faces from.
   //!                      It should either be the SOLID, COMPSOLID or COMPOUND of Solids.
   void SetShape(const TopoDS_Shape& theShape)
   {
@@ -175,14 +175,14 @@ public: //! @name Setting input data for the algorithm
   }
 
   //! Adds the face to remove from the input shape.
-  //! @param theFace [in] The shape to extract the faces for removal.
+  //! @param[in] theFace  The shape to extract the faces for removal.
   void AddFaceToRemove(const TopoDS_Shape& theFace)
   {
     myFacesToRemove.Append(theFace);
   }
 
   //! Adds the faces to remove from the input shape.
-  //! @param theFaces [in] The list of shapes to extract the faces for removal.
+  //! @param[in] theFaces  The list of shapes to extract the faces for removal.
   void AddFacesToRemove(const TopTools_ListOfShape& theFaces)
   {
     TopTools_ListIteratorOfListOfShape it(theFaces);
@@ -238,14 +238,14 @@ protected: //! @name Protected methods performing the removal
   Standard_EXPORT void RemoveFeatures(const Message_ProgressRange& theRange);
 
   //! Remove the single feature from the shape.
-  //! @param theFeature [in] The feature to remove;
-  //! @param theSolids [in] The solids to be reconstructed after feature removal;
-  //! @param theFeatureFacesMap [in] The map of feature faces;
-  //! @param theHasAdjacentFaces [in] Shows whether the adjacent faces have been
+  //! @param[in] theFeature  The feature to remove;
+  //! @param[in] theSolids  The solids to be reconstructed after feature removal;
+  //! @param[in] theFeatureFacesMap  The map of feature faces;
+  //! @param[in] theHasAdjacentFaces  Shows whether the adjacent faces have been
   //!                                 found for the feature or not;
-  //! @param theAdjFaces [in] The reconstructed adjacent faces covering the feature;
-  //! @param theAdjFacesHistory [in] The history of the adjacent faces reconstruction;
-  //! @param theSolidsHistoryNeeded [in] Defines whether the history of solids
+  //! @param[in] theAdjFaces  The reconstructed adjacent faces covering the feature;
+  //! @param[in] theAdjFacesHistory  The history of the adjacent faces reconstruction;
+  //! @param[in] theSolidsHistoryNeeded  Defines whether the history of solids
   //!                                    modifications should be tracked or not.
   Standard_EXPORT void RemoveFeature(const TopoDS_Shape& theFeature,
                                      const TopTools_IndexedMapOfShape& theSolids,

--- a/src/BOPTools/BOPTools_AlgoTools.hxx
+++ b/src/BOPTools/BOPTools_AlgoTools.hxx
@@ -321,10 +321,10 @@ public: //! @name Choosing correct orientation for the split shape
   //! - 100 - bad types.
   //! In case of any error the method always returns FALSE.
   //!
-  //! @param theSplit [in] Split shape
-  //! @param theShape [in] Original shape
-  //! @param theContext [in] cached geometrical tools
-  //! @param theError [out] Error Status of the operation
+  //! @param[in] theSplit  Split shape
+  //! @param[in] theShape  Original shape
+  //! @param[in] theContext  cached geometrical tools
+  //! @param[out] theError  Error Status of the operation
   Standard_EXPORT static Standard_Boolean IsSplitToReverse(const TopoDS_Shape& theSplit,
                                                            const TopoDS_Shape& theShape,
                                                            const Handle(IntTools_Context)& theContext,
@@ -354,10 +354,10 @@ public: //! @name Choosing correct orientation for the split shape
   //! - 4 - unable to compute the normal for the original face.
   //! In case of any error the method always returns FALSE.
   //!
-  //! @param theSplit [in] Split face
-  //! @param theShape [in] Original face
-  //! @param theContext [in] cached geometrical tools
-  //! @param theError [out] Error Status of the operation
+  //! @param[in] theSplit  Split face
+  //! @param[in] theShape  Original face
+  //! @param[in] theContext  cached geometrical tools
+  //! @param[out] theError  Error Status of the operation
   Standard_EXPORT static Standard_Boolean IsSplitToReverse(const TopoDS_Face& theSplit,
                                                            const TopoDS_Face& theShape,
                                                            const Handle(IntTools_Context)& theContext,
@@ -379,10 +379,10 @@ public: //! @name Choosing correct orientation for the split shape
   //! - 4 - unable to compute the tangent vector for the original edge;
   //! In case of any error the method always returns FALSE.
   //!
-  //! @param theSplit [in] Split edge
-  //! @param theShape [in] Original edge
-  //! @param theContext [in] cached geometrical tools
-  //! @param theError [out] Error Status of the operation
+  //! @param[in] theSplit  Split edge
+  //! @param[in] theShape  Original edge
+  //! @param[in] theContext  cached geometrical tools
+  //! @param[out] theError  Error Status of the operation
   Standard_EXPORT static Standard_Boolean IsSplitToReverse(const TopoDS_Edge& theSplit,
                                                            const TopoDS_Edge& theShape,
                                                            const Handle(IntTools_Context)& theContext,

--- a/src/BRep/BRep_TFace.hxx
+++ b/src/BRep/BRep_TFace.hxx
@@ -92,8 +92,8 @@ public:
   Standard_EXPORT const Handle(Poly_Triangulation)& Triangulation (const Poly_MeshPurpose thePurpose = Poly_MeshPurpose_NONE) const;
 
   //! Sets input triangulation for this face.
-  //! @param theTriangulation [in] triangulation to be set
-  //! @param theToReset [in] flag to reset triangulations list to new list with only one input triangulation.
+  //! @param[in] theTriangulation  triangulation to be set
+  //! @param[in] theToReset  flag to reset triangulations list to new list with only one input triangulation.
   //! If theTriangulation is NULL internal list of triangulations will be cleared and active triangulation will be nullified.
   //! If theToReset is TRUE internal list of triangulations will be reset
   //! to new list with only one input triangulation that will be active.

--- a/src/BRep/BRep_Tool.hxx
+++ b/src/BRep/BRep_Tool.hxx
@@ -65,9 +65,9 @@ public:
   Standard_EXPORT static Handle(Geom_Surface) Surface (const TopoDS_Face& F);
 
   //! Returns the triangulation of the face according to the mesh purpose.
-  //! @param theFace [in] the input face to find triangulation.
-  //! @param theLocation [out] the face location.
-  //! @param theMeshPurpose [in] a mesh purpose to find appropriate triangulation (NONE by default).
+  //! @param[in] theFace  the input face to find triangulation.
+  //! @param[out] theLocation  the face location.
+  //! @param[in] theMeshPurpose  a mesh purpose to find appropriate triangulation (NONE by default).
   //! @return an active triangulation in case of NONE purpose,
   //!         the first triangulation appropriate for the input purpose,
   //!         just the first triangulation if none matching other criteria and input purpose is AnyFallback
@@ -76,8 +76,8 @@ public:
                                                                           const Poly_MeshPurpose theMeshPurpose = Poly_MeshPurpose_NONE);
 
   //! Returns all triangulations of the face.
-  //! @param theFace [in] the input face.
-  //! @param theLocation [out] the face location.
+  //! @param[in] theFace  the input face.
+  //! @param[out] theLocation  the face location.
   //! @return list of all available face triangulations.
   Standard_EXPORT static const Poly_ListOfTriangulation& Triangulations (const TopoDS_Face& theFace, TopLoc_Location& theLocation);
 
@@ -269,9 +269,9 @@ public:
   Standard_EXPORT static Standard_Real Tolerance (const TopoDS_Vertex& V);
   
   //! Finds the parameter of <theV> on <theE>.
-  //! @param theV [in] input vertex
-  //! @param theE [in] input edge
-  //! @param theParam  [out] calculated parameter on the curve
+  //! @param[in] theV  input vertex
+  //! @param[in] theE  input edge
+  //! @param[out] theParam   calculated parameter on the curve
   //! @return TRUE if done
   Standard_EXPORT static Standard_Boolean Parameter (const TopoDS_Vertex& theV,
 	                                                   const TopoDS_Edge& theE,

--- a/src/BRepAlgoAPI/BRepAlgoAPI_Check.hxx
+++ b/src/BRepAlgoAPI/BRepAlgoAPI_Check.hxx
@@ -60,12 +60,12 @@ public: //! @name Constructors
 
   //! Constructor for checking single shape.
   //!
-  //! @param theS [in] - the shape to check;
-  //! @param bTestSE [in] - flag which specifies whether to check the shape
+  //! @param[in] theS  - the shape to check;
+  //! @param[in] bTestSE  - flag which specifies whether to check the shape
   //!                       on small edges or not; by default it is set to TRUE;
-  //! @param bTestSI [in] - flag which specifies whether to check the shape
+  //! @param[in] bTestSI  - flag which specifies whether to check the shape
   //!                       on self-interference or not; by default it is set to TRUE;
-  //! @param theRange [in] - parameter to use progress indicator
+  //! @param[in] theRange  - parameter to use progress indicator
   Standard_EXPORT BRepAlgoAPI_Check(const TopoDS_Shape& theS,
                                     const Standard_Boolean bTestSE = Standard_True,
                                     const Standard_Boolean bTestSI = Standard_True,
@@ -76,15 +76,15 @@ public: //! @name Constructors
   //! the types of the given shapes will be checked on validity
   //! for Boolean operation of given type.
   //!
-  //! @param theS1 [in] - the first shape to check;
-  //! @param theS2 [in] - the second shape to check;
-  //! @param theOp [in] - the type of Boolean Operation for which the validity
+  //! @param[in] theS1  - the first shape to check;
+  //! @param[in] theS2  - the second shape to check;
+  //! @param[in] theOp  - the type of Boolean Operation for which the validity
   //!                     of given shapes should be checked.
-  //! @param bTestSE [in] - flag which specifies whether to check the shape
+  //! @param[in] bTestSE  - flag which specifies whether to check the shape
   //!                       on small edges or not; by default it is set to TRUE;
-  //! @param bTestSI [in] - flag which specifies whether to check the shape
+  //! @param[in] bTestSI  - flag which specifies whether to check the shape
   //!                       on self-interference or not; by default it is set to TRUE;
-  //! @param theRange [in] - parameter to use progress indicator
+  //! @param[in] theRange  - parameter to use progress indicator
   Standard_EXPORT BRepAlgoAPI_Check(const TopoDS_Shape& theS1,
                                     const TopoDS_Shape& theS2,
                                     const BOPAlgo_Operation theOp = BOPAlgo_UNKNOWN,
@@ -97,10 +97,10 @@ public: //! @name Initializing the algorithm
 
   //! Initializes the algorithm with single shape.
   //!
-  //! @param theS [in] - the shape to check;
-  //! @param bTestSE [in] - flag which specifies whether to check the shape
+  //! @param[in] theS  - the shape to check;
+  //! @param[in] bTestSE  - flag which specifies whether to check the shape
   //!                       on small edges or not; by default it is set to TRUE;
-  //! @param bTestSI [in] - flag which specifies whether to check the shape
+  //! @param[in] bTestSI  - flag which specifies whether to check the shape
   //!                       on self-interference or not; by default it is set to TRUE;
   void SetData(const TopoDS_Shape& theS,
                const Standard_Boolean bTestSE = Standard_True,
@@ -118,13 +118,13 @@ public: //! @name Initializing the algorithm
   //! the types of the given shapes will be checked on validity
   //! for Boolean operation of given type.
   //!
-  //! @param theS1 [in] - the first shape to check;
-  //! @param theS2 [in] - the second shape to check;
-  //! @param theOp [in] - the type of Boolean Operation for which the validity
+  //! @param[in] theS1  - the first shape to check;
+  //! @param[in] theS2  - the second shape to check;
+  //! @param[in] theOp  - the type of Boolean Operation for which the validity
   //!                     of given shapes should be checked.
-  //! @param bTestSE [in] - flag which specifies whether to check the shape
+  //! @param[in] bTestSE  - flag which specifies whether to check the shape
   //!                       on small edges or not; by default it is set to TRUE;
-  //! @param bTestSI [in] - flag which specifies whether to check the shape
+  //! @param[in] bTestSI  - flag which specifies whether to check the shape
   //!                       on self-interference or not; by default it is set to TRUE;
   void SetData(const TopoDS_Shape& theS1,
                const TopoDS_Shape& theS2,

--- a/src/BRepAlgoAPI/BRepAlgoAPI_Defeaturing.hxx
+++ b/src/BRepAlgoAPI/BRepAlgoAPI_Defeaturing.hxx
@@ -117,7 +117,7 @@ public: //! @name Constructors
 public: //! @name Setting input data for the algorithm
 
   //! Sets the shape for processing.
-  //! @param theShape [in] The shape to remove the features from.
+  //! @param[in] theShape  The shape to remove the features from.
   //!                      It should either be the SOLID, COMPSOLID or COMPOUND of Solids.
   void SetShape(const TopoDS_Shape& theShape)
   {
@@ -131,14 +131,14 @@ public: //! @name Setting input data for the algorithm
   }
 
   //! Adds the features to remove from the input shape.
-  //! @param theFace [in] The shape to extract the faces for removal.
+  //! @param[in] theFace  The shape to extract the faces for removal.
   void AddFaceToRemove(const TopoDS_Shape& theFace)
   {
     myFacesToRemove.Append(theFace);
   }
 
   //! Adds the faces to remove from the input shape.
-  //! @param theFaces [in] The list of shapes to extract the faces for removal.
+  //! @param[in] theFaces  The list of shapes to extract the faces for removal.
   void AddFacesToRemove(const TopTools_ListOfShape& theFaces)
   {
     TopTools_ListIteratorOfListOfShape it(theFaces);

--- a/src/BRepBuilderAPI/BRepBuilderAPI_MakeShapeOnMesh.hxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI_MakeShapeOnMesh.hxx
@@ -29,7 +29,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Ctor. Sets mesh to process.
-  //! @param theMesh [in] - Mesh to construct shape for.
+  //! @param[in] theMesh  - Mesh to construct shape for.
   BRepBuilderAPI_MakeShapeOnMesh(const Handle(Poly_Triangulation)& theMesh)
   : myMesh(theMesh)
   {}

--- a/src/BRepGProp/BRepGProp_Gauss.hxx
+++ b/src/BRepGProp/BRepGProp_Gauss.hxx
@@ -78,9 +78,9 @@ public: //! @name public API
   //! @param theLocation - location of the point or the plane;
   //! @param theCoeff - plane coefficients;
   //! @param theIsByPoint - flag of restricition (point/plane);
-  //! @param theOutMass[out] - mass (volume) of region;
-  //! @param theOutGravityCenter[out] - garvity center of region;
-  //! @param theOutInertia[out] - matrix of inertia;
+  //! @param[out] theOutMass - mass (volume) of region;
+  //! @param[out] theOutGravityCenter - garvity center of region;
+  //! @param[out] theOutInertia - matrix of inertia;
   Standard_EXPORT void Compute(
     const BRepGProp_Face&  theSurface,
     const gp_Pnt&          theLocation,
@@ -97,9 +97,9 @@ public: //! @name public API
   //! Error of the computation is not calculated.
   //! @param theSurface - bounding surface of the region;
   //! @param theLocation - surface location;
-  //! @param theOutMass[out] - mass (volume) of region;
-  //! @param theOutGravityCenter[out] - garvity center of region;
-  //! @param theOutInertia[out] - matrix of inertia;
+  //! @param[out] theOutMass - mass (volume) of region;
+  //! @param[out] theOutGravityCenter - garvity center of region;
+  //! @param[out] theOutInertia - matrix of inertia;
   Standard_EXPORT void Compute(
     const BRepGProp_Face&  theSurface,
     const gp_Pnt&          theLocation,
@@ -118,9 +118,9 @@ public: //! @name public API
   //! @param theLocation - location of the point or the plane;
   //! @param theCoeff - plane coefficients;
   //! @param theIsByPoint - flag of restricition (point/plane);
-  //! @param theOutMass[out] - mass (volume) of region;
-  //! @param theOutGravityCenter[out] - garvity center of region;
-  //! @param theOutInertia[out] - matrix of inertia;
+  //! @param[out] theOutMass - mass (volume) of region;
+  //! @param[out] theOutGravityCenter - garvity center of region;
+  //! @param[out] theOutInertia - matrix of inertia;
   Standard_EXPORT void Compute(
     BRepGProp_Face&        theSurface,
     BRepGProp_Domain&      theDomain,
@@ -139,9 +139,9 @@ public: //! @name public API
   //! @param theSurface - bounding surface of the region;
   //! @param theDomain - surface boundings;
   //! @param theLocation - surface location;
-  //! @param theOutMass[out] - mass (volume) of region;
-  //! @param theOutGravityCenter[out] - garvity center of region;
-  //! @param theOutInertia[out] - matrix of inertia;
+  //! @param[out] theOutMass - mass (volume) of region;
+  //! @param[out] theOutGravityCenter - garvity center of region;
+  //! @param[out] theOutInertia - matrix of inertia;
   Standard_EXPORT void Compute(
     BRepGProp_Face&        theSurface,
     BRepGProp_Domain&      theDomain,
@@ -160,9 +160,9 @@ public: //! @name public API
   //! @param theEps - maximal relative error of computed mass (volume) for face;
   //! @param theCoeff - plane coefficients;
   //! @param theIsByPoint - flag of restricition (point/plane);
-  //! @param theOutMass[out] - mass (volume) of region;
-  //! @param theOutGravityCenter[out] - garvity center of region;
-  //! @param theOutInertia[out] - matrix of inertia;
+  //! @param[out] theOutMass - mass (volume) of region;
+  //! @param[out] theOutGravityCenter - garvity center of region;
+  //! @param[out] theOutInertia - matrix of inertia;
   //! @return value of error which is calculated as
   //! Abs((M(i+1)-M(i))/M(i+1)), M(i+1) and M(i) are values
   //! for two successive steps of adaptive integration.
@@ -183,9 +183,9 @@ public: //! @name public API
   //! @param theDomain - surface boundings;
   //! @param theLocation - surface location;
   //! @param theEps - maximal relative error of computed mass (square) for face;
-  //! @param theOutMass[out] - mass (volume) of region;
-  //! @param theOutGravityCenter[out] - garvity center of region;
-  //! @param theOutInertia[out] - matrix of inertia;
+  //! @param[out] theOutMass - mass (volume) of region;
+  //! @param[out] theOutGravityCenter - garvity center of region;
+  //! @param[out] theOutInertia - matrix of inertia;
   //! @return value of error which is calculated as
   //! Abs((M(i+1)-M(i))/M(i+1)), M(i+1) and M(i) are values
   //! for two successive steps of adaptive integration.

--- a/src/BRepLib/BRepLib.hxx
+++ b/src/BRepLib/BRepLib.hxx
@@ -274,13 +274,13 @@ public:
 
 
   //! Enlarges the face on the given value.
-  //! @param theF [in] The face to extend
-  //! @param theExtVal [in] The extension value
-  //! @param theExtUMin [in] Defines whether to extend the face in UMin direction
-  //! @param theExtUMax [in] Defines whether to extend the face in UMax direction
-  //! @param theExtVMin [in] Defines whether to extend the face in VMin direction
-  //! @param theExtVMax [in] Defines whether to extend the face in VMax direction
-  //! @param theFExtended [in] The extended face
+  //! @param[in] theF  The face to extend
+  //! @param[in] theExtVal  The extension value
+  //! @param[in] theExtUMin  Defines whether to extend the face in UMin direction
+  //! @param[in] theExtUMax  Defines whether to extend the face in UMax direction
+  //! @param[in] theExtVMin  Defines whether to extend the face in VMin direction
+  //! @param[in] theExtVMax  Defines whether to extend the face in VMax direction
+  //! @param[in] theFExtended  The extended face
   Standard_EXPORT static void ExtendFace(const TopoDS_Face& theF,
                                          const Standard_Real theExtVal,
                                          const Standard_Boolean theExtUMin,

--- a/src/BRepMesh/BRepMesh_Deflection.hxx
+++ b/src/BRepMesh/BRepMesh_Deflection.hxx
@@ -56,12 +56,12 @@ public:
 
   //! Checks if the deflection of current polygonal representation
   //! is consistent with the required deflection.
-  //! @param theCurrent [in] Current deflection.
-  //! @param theRequired [in] Required deflection.
-  //! @param theAllowDecrease [in] Flag controlling the check. If decrease is allowed,
+  //! @param[in] theCurrent  Current deflection.
+  //! @param[in] theRequired  Required deflection.
+  //! @param[in] theAllowDecrease  Flag controlling the check. If decrease is allowed,
   //! to be consistent the current and required deflections should be approximately the same.
   //! If not allowed, the current deflection should be less than required.
-  //! @param theRatio [in] The ratio for comparison of the deflections (value from 0 to 1).
+  //! @param[in] theRatio  The ratio for comparison of the deflections (value from 0 to 1).
   Standard_EXPORT static Standard_Boolean IsConsistent (
     const Standard_Real theCurrent,
     const Standard_Real theRequired,

--- a/src/BRepMesh/BRepMesh_GeomTool.hxx
+++ b/src/BRepMesh/BRepMesh_GeomTool.hxx
@@ -110,9 +110,9 @@ public:
   //! @param theIndex index of discretization point.
   //! @param theIsoParam parameter on surface to be used as second coordinate 
   //! of resulting 2d point.
-  //! @param theParam[out] parameter of the point on the iso curve.
-  //! @param thePoint[out] discretization point.
-  //! @param theUV[out] discretization point in parametric space of the surface.
+  //! @param[out] theParam parameter of the point on the iso curve.
+  //! @param[out] thePoint discretization point.
+  //! @param[out] theUV discretization point in parametric space of the surface.
   //! @return TRUE on success, FALSE elsewhere.
   Standard_EXPORT Standard_Boolean Value(const Standard_Integer theIndex,
                                          const Standard_Real    theIsoParam,
@@ -123,9 +123,9 @@ public:
   //! Gets parameters of discretization point with the given index.
   //! @param theIndex index of discretization point.
   //! @param theSurface surface the curve is lying onto.
-  //! @param theParam[out] parameter of the point on the curve.
-  //! @param thePoint[out] discretization point.
-  //! @param theUV[out] discretization point in parametric space of the surface.
+  //! @param[out] theParam parameter of the point on the curve.
+  //! @param[out] thePoint discretization point.
+  //! @param[out] theUV discretization point in parametric space of the surface.
   //! @return TRUE on success, FALSE elsewhere.
   Standard_EXPORT Standard_Boolean Value(const Standard_Integer              theIndex,
                                          const Handle(BRepAdaptor_Surface)& theSurface,

--- a/src/BRepPrimAPI/BRepPrimAPI_MakeCone.hxx
+++ b/src/BRepPrimAPI/BRepPrimAPI_MakeCone.hxx
@@ -39,23 +39,23 @@ public:
 
 
   //! Make a cone.
-  //! @param R1 [in] cone bottom radius, may be null (z = 0)
-  //! @param R2 [in] cone top radius, may be null (z = H)
-  //! @param H  [in] cone height
+  //! @param[in] R1  cone bottom radius, may be null (z = 0)
+  //! @param[in] R2  cone top radius, may be null (z = H)
+  //! @param[in] H   cone height
   Standard_EXPORT BRepPrimAPI_MakeCone(const Standard_Real R1, const Standard_Real R2, const Standard_Real H);
 
   //! Make a cone.
-  //! @param R1    [in] cone bottom radius, may be null (z = 0)
-  //! @param R2    [in] cone top radius, may be null (z = H)
-  //! @param H     [in] cone height
-  //! @param angle [in] angle to create a part cone
+  //! @param[in] R1     cone bottom radius, may be null (z = 0)
+  //! @param[in] R2     cone top radius, may be null (z = H)
+  //! @param[in] H      cone height
+  //! @param[in] angle  angle to create a part cone
   Standard_EXPORT BRepPrimAPI_MakeCone(const Standard_Real R1, const Standard_Real R2, const Standard_Real H, const Standard_Real angle);
 
   //! Make a cone.
-  //! @param axes [in] coordinate system for the construction of the cone
-  //! @param R1   [in] cone bottom radius, may be null (z = 0)
-  //! @param R2   [in] cone top radius, may be null (z = H)
-  //! @param H    [in] cone height
+  //! @param[in] axes  coordinate system for the construction of the cone
+  //! @param[in] R1    cone bottom radius, may be null (z = 0)
+  //! @param[in] R2    cone top radius, may be null (z = H)
+  //! @param[in] H     cone height
   Standard_EXPORT BRepPrimAPI_MakeCone(const gp_Ax2& Axes, const Standard_Real R1, const Standard_Real R2, const Standard_Real H);
   
   //! Make a cone of height H radius R1 in the plane z =

--- a/src/BRepPrimAPI/BRepPrimAPI_MakeCylinder.hxx
+++ b/src/BRepPrimAPI/BRepPrimAPI_MakeCylinder.hxx
@@ -38,20 +38,20 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Make a cylinder.
-  //! @param R [in] cylinder radius
-  //! @param H [in] cylinder height
+  //! @param[in] R  cylinder radius
+  //! @param[in] H  cylinder height
   Standard_EXPORT BRepPrimAPI_MakeCylinder(const Standard_Real R, const Standard_Real H);
 
   //! Make a cylinder (part cylinder).
-  //! @param R     [in] cylinder radius
-  //! @param H     [in] cylinder height
-  //! @param Angle [in] defines the missing portion of the cylinder
+  //! @param[in] R      cylinder radius
+  //! @param[in] H      cylinder height
+  //! @param[in] Angle  defines the missing portion of the cylinder
   Standard_EXPORT BRepPrimAPI_MakeCylinder(const Standard_Real R, const Standard_Real H, const Standard_Real Angle);
 
   //! Make a cylinder of radius R and length H.
-  //! @param Axes [in] coordinate system for the construction of the cylinder
-  //! @param R    [in] cylinder radius
-  //! @param H    [in] cylinder height
+  //! @param[in] Axes  coordinate system for the construction of the cylinder
+  //! @param[in] R     cylinder radius
+  //! @param[in] H     cylinder height
   Standard_EXPORT BRepPrimAPI_MakeCylinder(const gp_Ax2& Axes, const Standard_Real R, const Standard_Real H);
 
   //! Make a cylinder   of  radius R  and  length H with

--- a/src/BRepPrimAPI/BRepPrimAPI_MakeSphere.hxx
+++ b/src/BRepPrimAPI/BRepPrimAPI_MakeSphere.hxx
@@ -39,69 +39,69 @@ public:
 
   
   //! Make a sphere.
-  //! @param R [in] sphere radius
+  //! @param[in] R  sphere radius
   Standard_EXPORT BRepPrimAPI_MakeSphere(const Standard_Real R);
 
   //! Make a sphere (spherical wedge).
-  //! @param R     [in] sphere radius
-  //! @param angle [in] angle between the radii lying within the bounding semidisks
+  //! @param[in] R      sphere radius
+  //! @param[in] angle  angle between the radii lying within the bounding semidisks
   Standard_EXPORT BRepPrimAPI_MakeSphere(const Standard_Real R, const Standard_Real angle);
 
   //! Make a sphere (spherical segment).
-  //! @param R [in] sphere radius
-  //! @param angle1 [in] first angle defining a spherical segment
-  //! @param angle2 [in] second angle defining a spherical segment
+  //! @param[in] R  sphere radius
+  //! @param[in] angle1  first angle defining a spherical segment
+  //! @param[in] angle2  second angle defining a spherical segment
   Standard_EXPORT BRepPrimAPI_MakeSphere(const Standard_Real R, const Standard_Real angle1, const Standard_Real angle2);
 
   //! Make a sphere (spherical segment).
-  //! @param R      [in] sphere radius
-  //! @param angle1 [in] first angle defining a spherical segment
-  //! @param angle2 [in] second angle defining a spherical segment
-  //! @param angle3 [in] angle between the radii lying within the bounding semidisks
+  //! @param[in] R       sphere radius
+  //! @param[in] angle1  first angle defining a spherical segment
+  //! @param[in] angle2  second angle defining a spherical segment
+  //! @param[in] angle3  angle between the radii lying within the bounding semidisks
   Standard_EXPORT BRepPrimAPI_MakeSphere(const Standard_Real R, const Standard_Real angle1, const Standard_Real angle2, const Standard_Real angle3);
 
   //! Make a sphere.
-  //! @param Center [in] sphere center coordinates
-  //! @param R      [in] sphere radius
+  //! @param[in] Center  sphere center coordinates
+  //! @param[in] R       sphere radius
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Pnt& Center, const Standard_Real R);
   
   //! Make a sphere (spherical wedge).
-  //! @param Center [in] sphere center coordinates
-  //! @param R      [in] sphere radius
-  //! @param angle  [in] angle between the radii lying within the bounding semidisks
+  //! @param[in] Center  sphere center coordinates
+  //! @param[in] R       sphere radius
+  //! @param[in] angle   angle between the radii lying within the bounding semidisks
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Pnt& Center, const Standard_Real R, const Standard_Real angle);
 
   //! Make a sphere (spherical segment).
-  //! @param Center [in] sphere center coordinates
-  //! @param R      [in] sphere radius
-  //! @param angle1 [in] first angle defining a spherical segment
-  //! @param angle2 [in] second angle defining a spherical segment
+  //! @param[in] Center  sphere center coordinates
+  //! @param[in] R       sphere radius
+  //! @param[in] angle1  first angle defining a spherical segment
+  //! @param[in] angle2  second angle defining a spherical segment
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Pnt& Center, const Standard_Real R, const Standard_Real angle1, const Standard_Real angle2);
 
   //! Make a sphere (spherical segment).
-  //! @param Center [in] sphere center coordinates
-  //! @param R      [in] sphere radius
-  //! @param angle1 [in] first angle defining a spherical segment
-  //! @param angle2 [in] second angle defining a spherical segment
-  //! @param angle3 [in] angle between the radii lying within the bounding semidisks
+  //! @param[in] Center  sphere center coordinates
+  //! @param[in] R       sphere radius
+  //! @param[in] angle1  first angle defining a spherical segment
+  //! @param[in] angle2  second angle defining a spherical segment
+  //! @param[in] angle3  angle between the radii lying within the bounding semidisks
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Pnt& Center, const Standard_Real R, const Standard_Real angle1, const Standard_Real angle2, const Standard_Real angle3);
 
   //! Make a sphere.
-  //! @param Axis [in] coordinate system for the construction of the sphere
-  //! @param R    [in] sphere radius
+  //! @param[in] Axis  coordinate system for the construction of the sphere
+  //! @param[in] R     sphere radius
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Ax2& Axis, const Standard_Real R);
 
   //! Make a sphere (spherical wedge).
-  //! @param Axis  [in] coordinate system for the construction of the sphere
-  //! @param R     [in] sphere radius
-  //! @param angle [in] angle between the radii lying within the bounding semidisks
+  //! @param[in] Axis   coordinate system for the construction of the sphere
+  //! @param[in] R      sphere radius
+  //! @param[in] angle  angle between the radii lying within the bounding semidisks
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Ax2& Axis, const Standard_Real R, const Standard_Real angle);
 
   //! Make a sphere (spherical segment).
-  //! @param Axis   [in] coordinate system for the construction of the sphere
-  //! @param R      [in] sphere radius
-  //! @param angle1 [in] first angle defining a spherical segment
-  //! @param angle2 [in] second angle defining a spherical segment
+  //! @param[in] Axis    coordinate system for the construction of the sphere
+  //! @param[in] R       sphere radius
+  //! @param[in] angle1  first angle defining a spherical segment
+  //! @param[in] angle2  second angle defining a spherical segment
   Standard_EXPORT BRepPrimAPI_MakeSphere(const gp_Ax2& Axis, const Standard_Real R, const Standard_Real angle1, const Standard_Real angle2);
 
   //! Make a sphere of radius R.

--- a/src/BRepPrimAPI/BRepPrimAPI_MakeTorus.hxx
+++ b/src/BRepPrimAPI/BRepPrimAPI_MakeTorus.hxx
@@ -39,50 +39,50 @@ public:
 
 
   //! Make a torus.
-  //! @param R1 [in] distance from the center of the pipe to the center of the torus
-  //! @param R2 [in] radius of the pipe
+  //! @param[in] R1  distance from the center of the pipe to the center of the torus
+  //! @param[in] R2  radius of the pipe
   Standard_EXPORT BRepPrimAPI_MakeTorus(const Standard_Real R1, const Standard_Real R2);
 
   //! Make a section of a torus.
-  //! @param R1    [in] distance from the center of the pipe to the center of the torus
-  //! @param R2    [in] radius of the pipe
-  //! @param angle [in] angle to create a torus pipe segment
+  //! @param[in] R1     distance from the center of the pipe to the center of the torus
+  //! @param[in] R2     radius of the pipe
+  //! @param[in] angle  angle to create a torus pipe segment
   Standard_EXPORT BRepPrimAPI_MakeTorus(const Standard_Real R1, const Standard_Real R2, const Standard_Real angle);
   
   //! Make  a torus with angles on the small circle.
-  //! @param R1     [in] distance from the center of the pipe to the center of the torus
-  //! @param R2     [in] radius of the pipe
-  //! @param angle1 [in] first  angle to create a torus ring segment
-  //! @param angle2 [in] second angle to create a torus ring segment
+  //! @param[in] R1      distance from the center of the pipe to the center of the torus
+  //! @param[in] R2      radius of the pipe
+  //! @param[in] angle1  first  angle to create a torus ring segment
+  //! @param[in] angle2  second angle to create a torus ring segment
   Standard_EXPORT BRepPrimAPI_MakeTorus(const Standard_Real R1, const Standard_Real R2, const Standard_Real angle1, const Standard_Real angle2);
   
   //! Make  a torus with angles on the small circle.
-  //! @param R1     [in] distance from the center of the pipe to the center of the torus
-  //! @param R2     [in] radius of the pipe
-  //! @param angle1 [in] first  angle to create a torus ring segment
-  //! @param angle2 [in] second angle to create a torus ring segment
-  //! @param angle  [in] angle to create a torus pipe segment
+  //! @param[in] R1      distance from the center of the pipe to the center of the torus
+  //! @param[in] R2      radius of the pipe
+  //! @param[in] angle1  first  angle to create a torus ring segment
+  //! @param[in] angle2  second angle to create a torus ring segment
+  //! @param[in] angle   angle to create a torus pipe segment
   Standard_EXPORT BRepPrimAPI_MakeTorus(const Standard_Real R1, const Standard_Real R2, const Standard_Real angle1, const Standard_Real angle2, const Standard_Real angle);
   
   //! Make a torus.
-  //! @param Axes [in] coordinate system for the construction of the sphere
-  //! @param R1   [in] distance from the center of the pipe to the center of the torus
-  //! @param R2   [in] radius of the pipe
+  //! @param[in] Axes  coordinate system for the construction of the sphere
+  //! @param[in] R1    distance from the center of the pipe to the center of the torus
+  //! @param[in] R2    radius of the pipe
   Standard_EXPORT BRepPrimAPI_MakeTorus(const gp_Ax2& Axes, const Standard_Real R1, const Standard_Real R2);
   
   //! Make a section of a torus.
-  //! @param Axes  [in] coordinate system for the construction of the sphere
-  //! @param R1    [in] distance from the center of the pipe to the center of the torus
-  //! @param R2    [in] radius of the pipe
-  //! @param angle [in] angle to create a torus pipe segment
+  //! @param[in] Axes   coordinate system for the construction of the sphere
+  //! @param[in] R1     distance from the center of the pipe to the center of the torus
+  //! @param[in] R2     radius of the pipe
+  //! @param[in] angle  angle to create a torus pipe segment
   Standard_EXPORT BRepPrimAPI_MakeTorus(const gp_Ax2& Axes, const Standard_Real R1, const Standard_Real R2, const Standard_Real angle);
   
   //! Make a torus.
-  //! @param Axes   [in] coordinate system for the construction of the sphere
-  //! @param R1     [in] distance from the center of the pipe to the center of the torus
-  //! @param R2     [in] radius of the pipe
-  //! @param angle1 [in] first  angle to create a torus ring segment
-  //! @param angle2 [in] second angle to create a torus ring segment
+  //! @param[in] Axes    coordinate system for the construction of the sphere
+  //! @param[in] R1      distance from the center of the pipe to the center of the torus
+  //! @param[in] R2      radius of the pipe
+  //! @param[in] angle1  first  angle to create a torus ring segment
+  //! @param[in] angle2  second angle to create a torus ring segment
   Standard_EXPORT BRepPrimAPI_MakeTorus(const gp_Ax2& Axes, const Standard_Real R1, const Standard_Real R2, const Standard_Real angle1, const Standard_Real angle2);
   
   //! Make a section of a torus of radii R1 R2.

--- a/src/BRepTools/BRepTools.hxx
+++ b/src/BRepTools/BRepTools.hxx
@@ -144,8 +144,8 @@ public:
   //! triangulations and polygons 3d of the edges.
   //! In case polygonal representation is the only available representation
   //! for the shape (shape does not have geometry) it is not removed.
-  //! @param theShape  [in] the shape to clean
-  //! @param theForce  [in] allows removing all polygonal representations from the shape,
+  //! @param[in] theShape   the shape to clean
+  //! @param[in] theForce   allows removing all polygonal representations from the shape,
   //!                       including polygons on triangulations irrelevant for the faces of the given shape.
   Standard_EXPORT static void Clean (const TopoDS_Shape& theShape, const Standard_Boolean theForce = Standard_False);
   
@@ -160,9 +160,9 @@ public:
 
   //! Verifies that each Face from the shape has got a triangulation with a deflection smaller or equal to specified one
   //! and the Edges a discretization on this triangulation.
-  //! @param theShape   [in] shape to verify
-  //! @param theLinDefl [in] maximum allowed linear deflection
-  //! @param theToCheckFreeEdges [in] if TRUE, then free Edges are required to have 3D polygon
+  //! @param[in] theShape    shape to verify
+  //! @param[in] theLinDefl  maximum allowed linear deflection
+  //! @param[in] theToCheckFreeEdges  if TRUE, then free Edges are required to have 3D polygon
   //! @return FALSE if input Shape contains Faces without triangulation,
   //!               or that triangulation has worse (greater) deflection than specified one,
   //!               or Edges in Shape lack polygons on triangulation
@@ -173,13 +173,13 @@ public:
 
   //! Loads triangulation data for each face of the shape
   //! from some deferred storage using specified shared input file system
-  //! @param theShape            [in] shape to load triangulations
-  //! @param theTriangulationIdx [in] index defining what triangulation should be loaded. Starts from 0.
+  //! @param[in] theShape             shape to load triangulations
+  //! @param[in] theTriangulationIdx  index defining what triangulation should be loaded. Starts from 0.
   //!        -1 is used in specific case to load currently already active triangulation.
   //!        If some face doesn't contain triangulation with this index, nothing will be loaded for it.
   //!        Exception will be thrown in case of invalid negative index
-  //! @param theToSetAsActive    [in] flag to activate triangulation after its loading
-  //! @param theFileSystem       [in] shared file system
+  //! @param[in] theToSetAsActive     flag to activate triangulation after its loading
+  //! @param[in] theFileSystem        shared file system
   //! @return TRUE if at least one triangulation is loaded.
   Standard_EXPORT static Standard_Boolean LoadTriangulation (const TopoDS_Shape& theShape,
                                                              const Standard_Integer theTriangulationIdx = -1,
@@ -187,8 +187,8 @@ public:
                                                              const Handle(OSD_FileSystem)& theFileSystem = Handle(OSD_FileSystem)());
 
   //! Releases triangulation data for each face of the shape if there is deferred storage to load it later
-  //! @param theShape            [in] shape to unload triangulations
-  //! @param theTriangulationIdx [in] index defining what triangulation should be unloaded. Starts from 0.
+  //! @param[in] theShape             shape to unload triangulations
+  //! @param[in] theTriangulationIdx  index defining what triangulation should be unloaded. Starts from 0.
   //!        -1 is used in specific case to unload currently already active triangulation.
   //!        If some face doesn't contain triangulation with this index, nothing will be unloaded for it.
   //!        Exception will be thrown in case of invalid negative index
@@ -198,10 +198,10 @@ public:
 
   //! Activates triangulation data for each face of the shape
   //! from some deferred storage using specified shared input file system
-  //! @param theShape              [in] shape to activate triangulations
-  //! @param theTriangulationIdx   [in] index defining what triangulation should be activated. Starts from 0.
+  //! @param[in] theShape               shape to activate triangulations
+  //! @param[in] theTriangulationIdx    index defining what triangulation should be activated. Starts from 0.
   //!        Exception will be thrown in case of invalid negative index
-  //! @param theToActivateStrictly [in] flag to activate exactly triangulation with defined theTriangulationIdx index.
+  //! @param[in] theToActivateStrictly  flag to activate exactly triangulation with defined theTriangulationIdx index.
   //!        In TRUE case if some face doesn't contain triangulation with this index, active triangulation
   //!        will not be changed for it. Else the last available triangulation will be activated.
   //! @return TRUE if at least one active triangulation was changed.
@@ -211,14 +211,14 @@ public:
 
   //! Loads all available triangulations for each face of the shape
   //! from some deferred storage using specified shared input file system
-  //! @param theShape      [in] shape to load triangulations
-  //! @param theFileSystem [in] shared file system
+  //! @param[in] theShape       shape to load triangulations
+  //! @param[in] theFileSystem  shared file system
   //! @return TRUE if at least one triangulation is loaded.
   Standard_EXPORT static Standard_Boolean LoadAllTriangulations (const TopoDS_Shape& theShape,
                                                                  const Handle(OSD_FileSystem)& theFileSystem = Handle(OSD_FileSystem)());
 
   //! Releases all available triangulations for each face of the shape if there is deferred storage to load them later
-  //! @param theShape      [in] shape to unload triangulations
+  //! @param[in] theShape       shape to unload triangulations
   //! @return TRUE if at least one triangulation is unloaded.
   Standard_EXPORT static Standard_Boolean UnloadAllTriangulations (const TopoDS_Shape& theShape);
 
@@ -255,8 +255,8 @@ public:
 
   //! Writes the shape to the stream in an ASCII format TopTools_FormatVersion_VERSION_1.
   //! This alias writes shape with triangulation data.
-  //! @param theShape [in]       the shape to write
-  //! @param theStream [in][out] the stream to output shape into
+  //! @param[in] theShape        the shape to write
+  //! @param[in][out] theStream  the stream to output shape into
   //! @param theRange            the range of progress indicator to fill in
   static void Write (const TopoDS_Shape& theShape,
                      Standard_OStream& theStream,
@@ -267,13 +267,13 @@ public:
   }
 
   //! Writes the shape to the stream in an ASCII format of specified version.
-  //! @param theShape [in]         the shape to write
-  //! @param theStream [in][out]   the stream to output shape into
-  //! @param theWithTriangles [in] flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
+  //! @param[in] theShape          the shape to write
+  //! @param[in][out] theStream    the stream to output shape into
+  //! @param[in] theWithTriangles  flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
   //!                              has no effect on triangulation-only geometry
-  //! @param theWithNormals [in]   flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
+  //! @param[in] theWithNormals    flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
   //!                              has no effect on triangulation-only geometry
-  //! @param theVersion [in]       the TopTools format version
+  //! @param[in] theVersion        the TopTools format version
   //! @param theProgress the range of progress indicator to fill in
   Standard_EXPORT static void Write (const TopoDS_Shape& theShape,
                                      Standard_OStream& theStream,
@@ -289,8 +289,8 @@ public:
 
   //! Writes the shape to the file in an ASCII format TopTools_FormatVersion_VERSION_1.
   //! This alias writes shape with triangulation data.
-  //! @param theShape [in] the shape to write
-  //! @param theFile [in]  the path to file to output shape into
+  //! @param[in] theShape  the shape to write
+  //! @param[in] theFile   the path to file to output shape into
   //! @param theProgress the range of progress indicator to fill in
   static Standard_Boolean Write (const TopoDS_Shape& theShape,
                                  const Standard_CString theFile,
@@ -301,13 +301,13 @@ public:
   }
 
   //! Writes the shape to the file in an ASCII format of specified version.
-  //! @param theShape [in]         the shape to write
-  //! @param theFile [in]          the path to file to output shape into
-  //! @param theWithTriangles [in] flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
+  //! @param[in] theShape          the shape to write
+  //! @param[in] theFile           the path to file to output shape into
+  //! @param[in] theWithTriangles  flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
   //!                              has no effect on triangulation-only geometry
-  //! @param theWithNormals [in]   flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
+  //! @param[in] theWithNormals    flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
   //!                              has no effect on triangulation-only geometry
-  //! @param theVersion [in]       the TopTools format version
+  //! @param[in] theVersion        the TopTools format version
   //! @param theProgress the range of progress indicator to fill in
   Standard_EXPORT static Standard_Boolean Write (const TopoDS_Shape& theShape,
                                                  const Standard_CString theFile,

--- a/src/BRepTools/BRepTools_History.hxx
+++ b/src/BRepTools/BRepTools_History.hxx
@@ -95,8 +95,8 @@ public: //! @name Constructors for History creation
 
   //! Template constructor for History creation from the algorithm having
   //! standard history methods such as IsDeleted(), Modified() and Generated().
-  //! @param theArguments [in] Arguments of the algorithm;
-  //! @param theAlgo [in] The algorithm.
+  //! @param[in] theArguments  Arguments of the algorithm;
+  //! @param[in] theAlgo  The algorithm.
   template <class TheAlgo>
   BRepTools_History(const TopTools_ListOfShape& theArguments,
                     TheAlgo& theAlgo)
@@ -216,8 +216,8 @@ public: //! A method to merge a next history to this history.
   //! Template method for merging history of the algorithm having standard
   //! history methods such as IsDeleted(), Modified() and Generated()
   //! into current history object.
-  //! @param theArguments [in] Arguments of the algorithm;
-  //! @param theAlgo [in] The algorithm.
+  //! @param[in] theArguments  Arguments of the algorithm;
+  //! @param[in] theAlgo  The algorithm.
   template<class TheAlgo>
   void Merge(const TopTools_ListOfShape& theArguments,
              TheAlgo& theAlgo)

--- a/src/BinTools/BinTools.hxx
+++ b/src/BinTools/BinTools.hxx
@@ -56,8 +56,8 @@ public:
 
   //! Writes the shape to the stream in binary format BinTools_FormatVersion_CURRENT.
   //! This alias writes shape with triangulation data.
-  //! @param theShape [in]       the shape to write
-  //! @param theStream [in][out] the stream to output shape into
+  //! @param[in] theShape        the shape to write
+  //! @param[in][out] theStream  the stream to output shape into
   //! @param theRange            the range of progress indicator to fill in
   static void Write (const TopoDS_Shape& theShape,
                      Standard_OStream& theStream,
@@ -68,13 +68,13 @@ public:
   }
 
   //! Writes the shape to the stream in binary format of specified version.
-  //! @param theShape [in]         the shape to write
-  //! @param theStream [in][out]   the stream to output shape into
-  //! @param theWithTriangles [in] flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
+  //! @param[in] theShape          the shape to write
+  //! @param[in][out] theStream    the stream to output shape into
+  //! @param[in] theWithTriangles  flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
   //!                              has no effect on triangulation-only geometry
-  //! @param theWithNormals [in]   flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
+  //! @param[in] theWithNormals    flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
   //!                              has no effect on triangulation-only geometry
-  //! @param theVersion [in]       the BinTools format version
+  //! @param[in] theVersion        the BinTools format version
   //! @param theRange              the range of progress indicator to fill in
   Standard_EXPORT static void Write(const TopoDS_Shape& theShape, Standard_OStream& theStream,
                                     const Standard_Boolean theWithTriangles,
@@ -87,8 +87,8 @@ public:
                                     const Message_ProgressRange& theRange = Message_ProgressRange());
 
   //! Writes the shape to the file in binary format BinTools_FormatVersion_CURRENT.
-  //! @param theShape [in] the shape to write
-  //! @param theFile [in]  the path to file to output shape into
+  //! @param[in] theShape  the shape to write
+  //! @param[in] theFile   the path to file to output shape into
   //! @param theRange      the range of progress indicator to fill in
   static Standard_Boolean Write (const TopoDS_Shape& theShape,
                                  const Standard_CString theFile,
@@ -99,13 +99,13 @@ public:
   }
 
   //! Writes the shape to the file in binary format of specified version.
-  //! @param theShape [in]         the shape to write
-  //! @param theFile [in]          the path to file to output shape into
-  //! @param theWithTriangles [in] flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
+  //! @param[in] theShape          the shape to write
+  //! @param[in] theFile           the path to file to output shape into
+  //! @param[in] theWithTriangles  flag which specifies whether to save shape with (TRUE) or without (FALSE) triangles;
   //!                              has no effect on triangulation-only geometry
-  //! @param theWithNormals [in]   flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
+  //! @param[in] theWithNormals    flag which specifies whether to save triangulation with (TRUE) or without (FALSE) normals;
   //!                              has no effect on triangulation-only geometry
-  //! @param theVersion [in]       the BinTools format version
+  //! @param[in] theVersion        the BinTools format version
   //! @param theRange              the range of progress indicator to fill in
   Standard_EXPORT static Standard_Boolean Write (const TopoDS_Shape& theShape,
                                                  const Standard_CString theFile,

--- a/src/BinTools/BinTools_ShapeSet.hxx
+++ b/src/BinTools/BinTools_ShapeSet.hxx
@@ -37,7 +37,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Builds an empty ShapeSet.
-  //! @param theWithTriangles [in] flag to write triangulation data
+  //! @param[in] theWithTriangles  flag to write triangulation data
   Standard_EXPORT BinTools_ShapeSet ();
 
   Standard_EXPORT virtual ~BinTools_ShapeSet();

--- a/src/DBRep/DBRep.hxx
+++ b/src/DBRep/DBRep.hxx
@@ -41,18 +41,18 @@ public:
   Standard_EXPORT static void Set (const Standard_CString Name, const TopoDS_Shape& S);
   
   //! Returns the shape in the variable.
-  //! @param theName [in] [out] variable name, or "." to pick up shape interactively (the picked name will be returned then)
-  //! @param theType [in]       shape type filter; function will return NULL if shape has different type
-  //! @param theToComplain [in] when TRUE, prints a message on cout if the variable is not set
+  //! @param[in][out] theName   variable name, or "." to pick up shape interactively (the picked name will be returned then)
+  //! @param[in] theType        shape type filter; function will return NULL if shape has different type
+  //! @param[in] theToComplain  when TRUE, prints a message on cout if the variable is not set
   static TopoDS_Shape Get (Standard_CString& theName, TopAbs_ShapeEnum theType = TopAbs_SHAPE, Standard_Boolean theToComplain = Standard_False)
   {
     return getShape (theName, theType, theToComplain);
   }
 
   //! Returns the shape in the variable.
-  //! @param theName [in] [out] variable name, or "." to pick up shape interactively (the picked name will be returned then)
-  //! @param theType [in]       shape type filter; function will return NULL if shape has different type
-  //! @param theToComplain [in] when TRUE, prints a message on cout if the variable is not set
+  //! @param[in][out] theName   variable name, or "." to pick up shape interactively (the picked name will be returned then)
+  //! @param[in] theType        shape type filter; function will return NULL if shape has different type
+  //! @param[in] theToComplain  when TRUE, prints a message on cout if the variable is not set
   static TopoDS_Shape Get (TCollection_AsciiString& theName, TopAbs_ShapeEnum theType = TopAbs_SHAPE, Standard_Boolean theToComplain = Standard_False)
   {
     Standard_CString aNamePtr = theName.ToCString();
@@ -65,9 +65,9 @@ public:
   }
 
   //! Returns the shape in the variable.
-  //! @param theName [in] variable name
-  //! @param theType [in] shape type filter; function will return NULL if shape has different type
-  //! @param theToComplain [in] when TRUE, prints a message on cout if the variable is not set
+  //! @param[in] theName  variable name
+  //! @param[in] theType  shape type filter; function will return NULL if shape has different type
+  //! @param[in] theToComplain  when TRUE, prints a message on cout if the variable is not set
   static TopoDS_Shape GetExisting (const TCollection_AsciiString& theName, TopAbs_ShapeEnum theType = TopAbs_SHAPE, Standard_Boolean theToComplain = Standard_False)
   {
     if (theName.Length() == 1
@@ -110,9 +110,9 @@ public:
 protected:
 
   //! Returns the shape in the variable.
-  //! @param theName [in] [out] variable name, or "." to pick up shape interactively (the picked name will be returned then)
-  //! @param theType [in]       shape type filter; function will return NULL if shape has different type
-  //! @param theToComplain [in] when TRUE, prints a message on cout if the variable is not set
+  //! @param[in][out] theName   variable name, or "." to pick up shape interactively (the picked name will be returned then)
+  //! @param[in] theType        shape type filter; function will return NULL if shape has different type
+  //! @param[in] theToComplain  when TRUE, prints a message on cout if the variable is not set
   Standard_EXPORT static TopoDS_Shape getShape (Standard_CString& theName,
                                                 TopAbs_ShapeEnum theType,
                                                 Standard_Boolean theToComplain);

--- a/src/DBRep/DBRep_DrawableShape.hxx
+++ b/src/DBRep/DBRep_DrawableShape.hxx
@@ -101,28 +101,28 @@ public:
 public:
 
   //! Auxiliary method computing nodal normals for presentation purposes.
-  //! @param theNormals [out] vector of computed normals (pair of points [from, to])
-  //! @param theFace    [in]  input face
-  //! @param theLength  [in]  normal length
+  //! @param[out] theNormals  vector of computed normals (pair of points [from, to])
+  //! @param[in] theFace      input face
+  //! @param[in] theLength    normal length
   //! @return FALSE if normals can not be computed
   Standard_EXPORT static Standard_Boolean addMeshNormals (NCollection_Vector<std::pair<gp_Pnt, gp_Pnt> >& theNormals,
                                                           const TopoDS_Face&  theFace,
                                                           const Standard_Real theLength);
 
   //! Auxiliary method computing nodal normals for presentation purposes.
-  //! @param theNormals [out] map of computed normals (grouped per Face)
-  //! @param theShape   [in]  input shape which will be exploded into Faces
-  //! @param theLength  [in]  normal length
+  //! @param[out] theNormals  map of computed normals (grouped per Face)
+  //! @param[in] theShape     input shape which will be exploded into Faces
+  //! @param[in] theLength    normal length
   Standard_EXPORT static void addMeshNormals (NCollection_DataMap<TopoDS_Face, NCollection_Vector<std::pair<gp_Pnt, gp_Pnt> > > & theNormals,
                                               const TopoDS_Shape& theShape,
                                               const Standard_Real theLength);
 
   //! Auxiliary method computing surface normals distributed within the Face for presentation purposes.
-  //! @param theNormals  [out] vector of computed normals (pair of points [from, to])
-  //! @param theFace     [in]  input face
-  //! @param theLength   [in]  normal length
-  //! @param theNbAlongU [in]  number along U
-  //! @param theNbAlongV [in]  number along V
+  //! @param[out] theNormals   vector of computed normals (pair of points [from, to])
+  //! @param[in] theFace       input face
+  //! @param[in] theLength     normal length
+  //! @param[in] theNbAlongU   number along U
+  //! @param[in] theNbAlongV   number along V
   //! @return FALSE if normals can not be computed
   Standard_EXPORT static Standard_Boolean addSurfaceNormals (NCollection_Vector<std::pair<gp_Pnt, gp_Pnt> >& theNormals,
                                                              const TopoDS_Face&     theFace,
@@ -131,11 +131,11 @@ public:
                                                              const Standard_Integer theNbAlongV);
 
   //! Auxiliary method computing surface normals distributed within the Face for presentation purposes.
-  //! @param theNormals  [out] map of computed normals (grouped per Face)
-  //! @param theShape    [in]  input shape which will be exploded into Faces
-  //! @param theLength   [in]  normal length
-  //! @param theNbAlongU [in]  number along U
-  //! @param theNbAlongV [in]  number along V
+  //! @param[out] theNormals   map of computed normals (grouped per Face)
+  //! @param[in] theShape      input shape which will be exploded into Faces
+  //! @param[in] theLength     normal length
+  //! @param[in] theNbAlongU   number along U
+  //! @param[in] theNbAlongV   number along V
   //! @return FALSE if normals can not be computed
   Standard_EXPORT static void addSurfaceNormals (NCollection_DataMap<TopoDS_Face, NCollection_Vector<std::pair<gp_Pnt, gp_Pnt> > >& theNormals,
                                                  const TopoDS_Shape&    theShape,

--- a/src/DE/DE_Provider.hxx
+++ b/src/DE/DE_Provider.hxx
@@ -59,7 +59,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Read was successful
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 const Handle(TDocStd_Document)& theDocument,
@@ -70,7 +70,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Write was successful
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const Handle(TDocStd_Document)& theDocument,
@@ -80,7 +80,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Read was successful
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 const Handle(TDocStd_Document)& theDocument,
@@ -89,7 +89,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Write was successful
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const Handle(TDocStd_Document)& theDocument,
@@ -99,7 +99,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Read was successful
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 TopoDS_Shape& theShape,
@@ -110,7 +110,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Write was successful
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const TopoDS_Shape& theShape,
@@ -120,7 +120,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Read was successful
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 TopoDS_Shape& theShape,
@@ -129,7 +129,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return True if Write was successful
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const TopoDS_Shape& theShape,

--- a/src/DE/DE_Wrapper.hxx
+++ b/src/DE/DE_Wrapper.hxx
@@ -79,7 +79,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                         const Handle(TDocStd_Document)& theDocument,
@@ -90,7 +90,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                          const Handle(TDocStd_Document)& theDocument,
@@ -100,7 +100,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                         const Handle(TDocStd_Document)& theDocument,
@@ -109,7 +109,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                          const Handle(TDocStd_Document)& theDocument,
@@ -119,7 +119,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                         TopoDS_Shape& theShape,
@@ -130,7 +130,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                          const TopoDS_Shape& theShape,
@@ -140,7 +140,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                         TopoDS_Shape& theShape,
@@ -149,7 +149,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                          const TopoDS_Shape& theShape,

--- a/src/DEBRepCascade/DEBRepCascade_Provider.hxx
+++ b/src/DEBRepCascade/DEBRepCascade_Provider.hxx
@@ -46,7 +46,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -57,7 +57,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -67,7 +67,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -76,7 +76,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -86,7 +86,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -97,7 +97,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -107,7 +107,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -116,7 +116,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/DEXCAFCascade/DEXCAFCascade_Provider.hxx
+++ b/src/DEXCAFCascade/DEXCAFCascade_Provider.hxx
@@ -46,7 +46,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -57,7 +57,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -67,7 +67,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -76,7 +76,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -86,7 +86,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -97,7 +97,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -107,7 +107,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -116,7 +116,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/Draw/Draw.hxx
+++ b/src/Draw/Draw.hxx
@@ -33,12 +33,12 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! (Re)Load a Draw Harness plugin.
-  //! @param theDI  [in] [out] Tcl interpretor to append loaded commands
-  //! @param theKey [in] plugin code name to be resolved in resource file
-  //! @param theResourceFileName   [in] description file name
-  //! @param theDefaultsDirectory  [in] default folder for looking description file
-  //! @param theUserDefaultsDirectory [in] user folder for looking description file
-  //! @param theIsVerbose [in] print verbose messages
+  //! @param[in][out] theDI    Tcl interpretor to append loaded commands
+  //! @param[in] theKey  plugin code name to be resolved in resource file
+  //! @param[in] theResourceFileName    description file name
+  //! @param[in] theDefaultsDirectory   default folder for looking description file
+  //! @param[in] theUserDefaultsDirectory  user folder for looking description file
+  //! @param[in] theIsVerbose  print verbose messages
   Standard_EXPORT static void Load (Draw_Interpretor& theDI,
                                     const TCollection_AsciiString& theKey,
                                     const TCollection_AsciiString& theResourceFileName,
@@ -128,9 +128,9 @@ public: //! @name argument parsing tools
   //!   }
   //! @endcode
   //!
-  //! @param theArgNb  [in] number of available arguments in theArgVec (array limits)
-  //! @param theArgVec [in] argument list
-  //! @param theColor [out] retrieved color
+  //! @param[in] theArgNb   number of available arguments in theArgVec (array limits)
+  //! @param[in] theArgVec  argument list
+  //! @param[out] theColor  retrieved color
   //! @return number of handled arguments (1, 2, 3 or 4) or 0 on syntax error
   static Standard_Integer ParseColor (const Standard_Integer   theArgNb,
                                       const char* const* const theArgVec,
@@ -140,9 +140,9 @@ public: //! @name argument parsing tools
   }
 
   //! Parses RGB color argument(s).
-  //! @param theArgNb  [in] number of available arguments in theArgVec (array limits)
-  //! @param theArgVec [in] argument list
-  //! @param theColor [out] retrieved color
+  //! @param[in] theArgNb   number of available arguments in theArgVec (array limits)
+  //! @param[in] theArgVec  argument list
+  //! @param[out] theColor  retrieved color
   //! @return number of handled arguments (1 or 3) or 0 on syntax error.
   static Standard_Integer ParseColor (const Standard_Integer   theArgNb,
                                       const char* const* const theArgVec,
@@ -177,8 +177,8 @@ public: //! @name argument parsing tools
   //!   }
   //! @endcode
   //!
-  //! @param theArg   [in] argument value
-  //! @param theIsOn [out] decoded Boolean flag
+  //! @param[in] theArg    argument value
+  //! @param[out] theIsOn  decoded Boolean flag
   //! @return FALSE on syntax error
   Standard_EXPORT static Standard_Boolean ParseOnOff (Standard_CString  theArg,
                                                       Standard_Boolean& theIsOn);
@@ -197,9 +197,9 @@ public: //! @name argument parsing tools
   //!   }
   //! @endcode
   //!
-  //! @param theArgsNb [in] overall number of arguments
-  //! @param theArgVec [in] vector of arguments
-  //! @param theArgIter [in] [out] argument position to parse
+  //! @param[in] theArgsNb  overall number of arguments
+  //! @param[in] theArgVec  vector of arguments
+  //! @param[in][out] theArgIter   argument position to parse
   //! @return flag value
   Standard_EXPORT static Standard_Boolean ParseOnOffIterator (Standard_Integer  theArgsNb,
                                                               const char**      theArgVec,
@@ -208,9 +208,9 @@ public: //! @name argument parsing tools
   //! Parses boolean argument at specified iterator position with optional on/off coming next.
   //! Similar to ParseOnOffIterator() but also reverses returned value if argument name starts with "no" prefix.
   //! E.g. if nominal argument is "cmd -usefeature [on|off|1|0]=on", then "-nousefeature" argument will return FALSE.
-  //! @param theArgsNb [in] overall number of arguments
-  //! @param theArgVec [in] vector of arguments
-  //! @param theArgIter [in] [out] argument position to parse
+  //! @param[in] theArgsNb  overall number of arguments
+  //! @param[in] theArgVec  vector of arguments
+  //! @param[in][out] theArgIter   argument position to parse
   //! @return flag value
   Standard_EXPORT static Standard_Boolean ParseOnOffNoIterator (Standard_Integer  theArgsNb,
                                                                 const char**      theArgVec,
@@ -256,8 +256,8 @@ public: //! @name methods loading standard command sets
 protected:
 
   //! Returns a variable value.
-  //! @param theName [in] [out] variable name, or "." to activate picking
-  //! @param theToAllowPick [in] when TRUE, "." name will activate picking
+  //! @param[in][out] theName   variable name, or "." to activate picking
+  //! @param[in] theToAllowPick  when TRUE, "." name will activate picking
   Standard_EXPORT static Handle(Draw_Drawable3D) getDrawable (Standard_CString& theName,
                                                               Standard_Boolean theToAllowPick);
 

--- a/src/Draw/Draw_Drawable3D.hxx
+++ b/src/Draw/Draw_Drawable3D.hxx
@@ -37,14 +37,14 @@ public:
   typedef Handle(Draw_Drawable3D)(*FactoryFunction_t)(Standard_IStream& theStream);
 
   //! Register factory for restoring drawable from stream (opposite to Draw_Drawable3D::Save()).
-  //! @param theType [in] class name
-  //! @param theFactory [in] factory function
+  //! @param[in] theType  class name
+  //! @param[in] theFactory  factory function
   Standard_EXPORT static void RegisterFactory (const Standard_CString theType,
                                                const FactoryFunction_t& theFactory);
 
   //! Restore drawable from stream (opposite to Draw_Drawable3D::Save()).
-  //! @param theType [in] class name
-  //! @param theStream [in] input stream
+  //! @param[in] theType  class name
+  //! @param[in] theStream  input stream
   //! @return restored drawable or NULL if factory is undefined for specified class
   Standard_EXPORT static Handle(Draw_Drawable3D) Restore (const Standard_CString theType,
                                                           Standard_IStream& theStream);

--- a/src/Draw/Draw_Window.hxx
+++ b/src/Draw/Draw_Window.hxx
@@ -204,11 +204,11 @@ public:
 protected:
 
   //! Main constructor.
-  //! @param theTitle  [in] window title
-  //! @param theXY     [in] top-left position
-  //! @param theSize   [in] window dimensions
-  //! @param theParent [in] optional native parent window
-  //! @param theWin    [in] optional native window
+  //! @param[in] theTitle   window title
+  //! @param[in] theXY      top-left position
+  //! @param[in] theSize    window dimensions
+  //! @param[in] theParent  optional native parent window
+  //! @param[in] theWin     optional native window
   Standard_EXPORT Draw_Window (const char* theTitle,
                                const NCollection_Vec2<int>& theXY,
                                const NCollection_Vec2<int>& theSize,

--- a/src/DsgPrs/DsgPrs_DatumPrs.hxx
+++ b/src/DsgPrs/DsgPrs_DatumPrs.hxx
@@ -31,9 +31,9 @@ public:
   //! The thihedron origin and axis directions are defined by theDatum coordinate system.
   //! DsgPrs_XYZAxisPresentation framework is used to create graphical primitives for each axis.
   //! Axes are marked with "X", "Y", "Z" text.
-  //! @param thePresentation [out] the modified presentation
-  //! @param theDatum [in] the source of trihedron position
-  //! @param theDrawer [in] the provider of display attributes
+  //! @param[out] thePresentation  the modified presentation
+  //! @param[in] theDatum  the source of trihedron position
+  //! @param[in] theDrawer  the provider of display attributes
   Standard_EXPORT static void Add (const Handle(Prs3d_Presentation)& thePresentation, const gp_Ax2& theDatum,
                                    const Handle(Prs3d_Drawer)& theDrawer);
 

--- a/src/Font/Font_FTFont.hxx
+++ b/src/Font/Font_FTFont.hxx
@@ -300,8 +300,8 @@ public:
 public:
 
   //! Computes outline contour for the symbol.
-  //! @param theUChar    [in] the character to be loaded as current one
-  //! @param theOutline  [out] outline contour
+  //! @param[in] theUChar     the character to be loaded as current one
+  //! @param[out] theOutline   outline contour
   //! @return true on success
   Standard_EXPORT const FT_Outline* renderGlyphOutline(const Standard_Utf32Char theChar);
 

--- a/src/Font/Font_FontMgr.hxx
+++ b/src/Font/Font_FontMgr.hxx
@@ -94,11 +94,11 @@ public:
   //! If the requested family name not found -> search for any font family with given aspect and height.
   //! If the font is still not found, returns any font available in the system.
   //! Returns NULL in case when the fonts are not found in the system.
-  //! @param theFontName    [in]       font family to find or alias name
-  //! @param theStrictLevel [in]       search strict level for using aliases and fallback
-  //! @param theFontAspect  [in] [out] font aspect to find (considered only if family name is not found);
+  //! @param[in] theFontName           font family to find or alias name
+  //! @param[in] theStrictLevel        search strict level for using aliases and fallback
+  //! @param[in][out] theFontAspect    font aspect to find (considered only if family name is not found);
   //!                                  can be modified if specified font alias refers to another style (compatibility with obsolete aliases)
-  //! @param theDoFailMsg   [in]       put error message on failure into default messenger
+  //! @param[in] theDoFailMsg          put error message on failure into default messenger
   Standard_EXPORT Handle(Font_SystemFont) FindFont (const TCollection_AsciiString& theFontName,
                                                     Font_StrictLevel theStrictLevel,
                                                     Font_FontAspect& theFontAspect,
@@ -113,8 +113,8 @@ public:
 
   //! Tries to find fallback font for specified Unicode subset.
   //! Returns NULL in case when fallback font is not found in the system.
-  //! @param theSubset     [in] Unicode subset
-  //! @param theFontAspect [in] font aspect to find
+  //! @param[in] theSubset      Unicode subset
+  //! @param[in] theFontAspect  font aspect to find
   Standard_EXPORT Handle(Font_SystemFont) FindFallbackFont (Font_UnicodeSubset theSubset,
                                                             Font_FontAspect theFontAspect) const;
 
@@ -153,12 +153,12 @@ public:
   void SetTraceAliases (Standard_Boolean theToTrace) { myToTraceAliases = theToTrace; }
 
   //! Return font names with defined aliases.
-  //! @param theAliases [out] alias names
+  //! @param[out] theAliases  alias names
   Standard_EXPORT void GetAllAliases (TColStd_SequenceOfHAsciiString& theAliases) const;
 
   //! Return aliases to specified font name.
-  //! @param theFontNames [out] font names associated with alias name
-  //! @param theAliasName [in]  alias name
+  //! @param[out] theFontNames  font names associated with alias name
+  //! @param[in] theAliasName   alias name
   Standard_EXPORT void GetFontAliases (TColStd_SequenceOfHAsciiString& theFontNames,
                                        const TCollection_AsciiString& theAliasName) const;
 
@@ -173,16 +173,16 @@ public:
   //! Aliases are defined "in advance", so that they could point to non-existing fonts,
   //! and they are resolved dynamically on request - first existing font is returned in case of multiple aliases to the same name.
   //!
-  //! @param theAliasName [in] alias name or name of another font to be used as alias
-  //! @param theFontName  [in] font to be used as substitution for alias
+  //! @param[in] theAliasName  alias name or name of another font to be used as alias
+  //! @param[in] theFontName   font to be used as substitution for alias
   //! @return FALSE if alias has been already registered
   Standard_EXPORT bool AddFontAlias (const TCollection_AsciiString& theAliasName,
                                      const TCollection_AsciiString& theFontName);
 
   //! Unregister font alias.
-  //! @param theAliasName [in] alias name or name of another font to be used as alias;
+  //! @param[in] theAliasName  alias name or name of another font to be used as alias;
   //!                          all aliases will be removed in case of empty name
-  //! @param theFontName  [in] font to be used as substitution for alias;
+  //! @param[in] theFontName   font to be used as substitution for alias;
   //!                          all fonts will be removed in case of empty name
   //! @return TRUE if alias has been removed
   Standard_EXPORT bool RemoveFontAlias (const TCollection_AsciiString& theAliasName,
@@ -231,7 +231,7 @@ private:
     Font_FontMap() {}
 
     //! Try finding font with specified parameters or the closest one.
-    //! @param theFontName [in] font family to find (or empty string if family name can be ignored)
+    //! @param[in] theFontName  font family to find (or empty string if family name can be ignored)
     //! @return best match font or NULL if not found
     Handle(Font_SystemFont) Find (const TCollection_AsciiString& theFontName) const;
   };

--- a/src/GCPnts/GCPnts_QuasiUniformAbscissa.hxx
+++ b/src/GCPnts/GCPnts_QuasiUniformAbscissa.hxx
@@ -69,55 +69,55 @@ public:
   //!     the package Geom2d (in the case of an Adaptor2d_Curve2d curve)
   //!     or a 3D curve from the package Geom (in the case of an Adaptor3d_Curve curve),
   //! -   and those required on the curve by the computation algorithm.
-  //! @param theC [in] input 3D curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
+  //! @param[in] theC  input 3D curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
   Standard_EXPORT GCPnts_QuasiUniformAbscissa (const Adaptor3d_Curve& theC,
                                                const Standard_Integer theNbPoints,
                                                const Standard_Real theU1, const Standard_Real theU2);
 
   //! Initialize the algorithms with 3D curve and target number of points.
-  //! @param theC [in] input 3D curve
-  //! @param theNbPoints [in] defines the number of desired points
+  //! @param[in] theC  input 3D curve
+  //! @param[in] theNbPoints  defines the number of desired points
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Integer theNbPoints);
 
   //! Initialize the algorithms with 3D curve, target number of points and curve parameter range.
-  //! @param theC [in] input 3D curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
+  //! @param[in] theC  input 3D curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Integer theNbPoints,
                                    const Standard_Real theU1, const Standard_Real theU2);
 
   //! Computes a uniform abscissa distribution of points on the 2D curve.
-  //! @param theC [in] input 2D curve
-  //! @param theNbPoints [in] defines the number of desired points
+  //! @param[in] theC  input 2D curve
+  //! @param[in] theNbPoints  defines the number of desired points
   Standard_EXPORT GCPnts_QuasiUniformAbscissa (const Adaptor2d_Curve2d& theC,
                                                const Standard_Integer theNbPoints);
 
   //! Computes a Uniform abscissa distribution of points on a part of the 2D curve.
-  //! @param theC [in] input 2D curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
+  //! @param[in] theC  input 2D curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
   Standard_EXPORT GCPnts_QuasiUniformAbscissa (const Adaptor2d_Curve2d& theC,
                                                const Standard_Integer theNbPoints,
                                                const Standard_Real theU1, const Standard_Real theU2);
 
   //! Initialize the algorithms with 2D curve and target number of points.
-  //! @param theC [in] input 2D curve
-  //! @param theNbPoints [in] defines the number of desired points
+  //! @param[in] theC  input 2D curve
+  //! @param[in] theNbPoints  defines the number of desired points
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Integer theNbPoints);
   
   //! Initialize the algorithms with 2D curve, target number of points and curve parameter range.
-  //! @param theC [in] input 2D curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
+  //! @param[in] theC  input 2D curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Integer theNbPoints,
                                    const Standard_Real theU1, const Standard_Real theU2);

--- a/src/GCPnts/GCPnts_TangentialDeflection.hxx
+++ b/src/GCPnts/GCPnts_TangentialDeflection.hxx
@@ -70,12 +70,12 @@ public:
   Standard_EXPORT GCPnts_TangentialDeflection();
 
   //! Constructor for 3D curve.
-  //! @param theC [in] 3d curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  3d curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT GCPnts_TangentialDeflection (const Adaptor3d_Curve& theC,
                                                const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
                                                const Standard_Integer theMinimumOfPoints = 2,
@@ -83,14 +83,14 @@ public:
                                                const Standard_Real theMinLen = 1.0e-7);
 
   //! Constructor for 3D curve with restricted range.
-  //! @param theC [in] 3d curve
-  //! @param theFirstParameter [in] first parameter on curve
-  //! @param theLastParameter  [in] last  parameter on curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTo  l [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  3d curve
+  //! @param[in] theFirstParameter  first parameter on curve
+  //! @param[in] theLastParameter   last  parameter on curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param theUTo  l[in]  tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT GCPnts_TangentialDeflection (const Adaptor3d_Curve& theC,
                                                const Standard_Real theFirstParameter, const Standard_Real theLastParameter,
                                                const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
@@ -99,12 +99,12 @@ public:
                                                const Standard_Real theMinLen = 1.0e-7);
 
   //! Constructor for 2D curve.
-  //! @param theC [in] 2d curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  2d curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT GCPnts_TangentialDeflection (const Adaptor2d_Curve2d& theC,
                                                const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
                                                const Standard_Integer theMinimumOfPoints = 2,
@@ -112,14 +112,14 @@ public:
                                                const Standard_Real theMinLen = 1.0e-7);
 
   //! Constructor for 2D curve with restricted range.
-  //! @param theC [in] 2d curve
-  //! @param theFirstParameter [in] first parameter on curve
-  //! @param theLastParameter  [in] last  parameter on curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  2d curve
+  //! @param[in] theFirstParameter  first parameter on curve
+  //! @param[in] theLastParameter   last  parameter on curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT GCPnts_TangentialDeflection (const Adaptor2d_Curve2d& theC,
                                                const Standard_Real theFirstParameter, const Standard_Real theLastParameter,
                                                const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
@@ -128,12 +128,12 @@ public:
                                                const Standard_Real theMinLen = 1.0e-7);
 
   //! Initialize algorithm for 3D curve.
-  //! @param theC [in] 3d curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  3d curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
                                    const Standard_Integer theMinimumOfPoints = 2,
@@ -141,14 +141,14 @@ public:
                                    const Standard_Real theMinLen = 1.0e-7);
 
   //! Initialize algorithm for 3D curve with restricted range.
-  //! @param theC [in] 3d curve
-  //! @param theFirstParameter [in] first parameter on curve
-  //! @param theLastParameter  [in] last  parameter on curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  3d curve
+  //! @param[in] theFirstParameter  first parameter on curve
+  //! @param[in] theLastParameter   last  parameter on curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Real theFirstParameter, const Standard_Real theLastParameter,
                                    const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
@@ -157,12 +157,12 @@ public:
                                    const Standard_Real theMinLen = 1.0e-7);
 
   //! Initialize algorithm for 2D curve.
-  //! @param theC [in] 2d curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  2d curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,
                                    const Standard_Integer theMinimumOfPoints = 2,
@@ -170,14 +170,14 @@ public:
                                    const Standard_Real theMinLen = 1.0e-7);
 
   //! Initialize algorithm for 2D curve with restricted range.
-  //! @param theC [in] 2d curve
-  //! @param theFirstParameter [in] first parameter on curve
-  //! @param theLastParameter  [in] last  parameter on curve
-  //! @param theAngularDeflection   [in] angular deflection in radians
-  //! @param theCurvatureDeflection [in] linear deflection
-  //! @param theMinimumOfPoints [in] minimum number of points
-  //! @param theUTol   [in] tolerance in curve parametric scope
-  //! @param theMinLen [in] minimal length
+  //! @param[in] theC  2d curve
+  //! @param[in] theFirstParameter  first parameter on curve
+  //! @param[in] theLastParameter   last  parameter on curve
+  //! @param[in] theAngularDeflection    angular deflection in radians
+  //! @param[in] theCurvatureDeflection  linear deflection
+  //! @param[in] theMinimumOfPoints  minimum number of points
+  //! @param[in] theUTol    tolerance in curve parametric scope
+  //! @param[in] theMinLen  minimal length
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Real theFirstParameter, const Standard_Real theLastParameter,
                                    const Standard_Real theAngularDeflection, const Standard_Real theCurvatureDeflection,

--- a/src/GCPnts/GCPnts_UniformAbscissa.hxx
+++ b/src/GCPnts/GCPnts_UniformAbscissa.hxx
@@ -35,20 +35,20 @@ public:
   Standard_EXPORT GCPnts_UniformAbscissa();
 
   //! Computes a uniform abscissa distribution of points on the 3D curve.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor3d_Curve& theC,
                                           const Standard_Real theAbscissa,
                                           const Standard_Real theToler = -1);
 
   //! Computes a Uniform abscissa distribution of points on a part of the 3D Curve.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor3d_Curve& theC,
                                           const Standard_Real theAbscissa,
@@ -56,20 +56,20 @@ public:
                                           const Standard_Real theToler = -1);
 
   //! Computes a uniform abscissa distribution of points on the 3D Curve.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor3d_Curve& theC,
                                           const Standard_Integer theNbPoints,
                                           const Standard_Real theToler = -1);
 
   //! Computes a Uniform abscissa distribution of points on a part of the 3D Curve.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor3d_Curve& theC,
                                           const Standard_Integer theNbPoints,
@@ -77,20 +77,20 @@ public:
                                           const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 3D curve, Abscissa, and Tolerance.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Real theAbscissa,
                                    const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 3D curve, Abscissa, Tolerance, and parameter range.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Real theAbscissa,
@@ -98,20 +98,20 @@ public:
                                    const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 3D curve, number of points, and Tolerance.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Integer theNbPoints,
                                    const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 3D curve, number of points, Tolerance, and parameter range.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor3d_Curve& theC,
                                    const Standard_Integer theNbPoints,
@@ -121,20 +121,20 @@ public:
 public:
 
   //! Computes a uniform abscissa distribution of points on the 2D curve.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor2d_Curve2d& theC,
                                           const Standard_Real theAbscissa,
                                           const Standard_Real theToler = -1);
 
   //! Computes a Uniform abscissa distribution of points on a part of the 2D Curve.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor2d_Curve2d& theC,
                                           const Standard_Real theAbscissa,
@@ -142,20 +142,20 @@ public:
                                           const Standard_Real theToler = -1);
 
   //! Computes a uniform abscissa distribution of points on the 2D Curve.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor2d_Curve2d& theC,
                                           const Standard_Integer theNbPoints,
                                           const Standard_Real theToler = -1);
 
   //! Computes a Uniform abscissa distribution of points on a part of the 2D Curve.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT GCPnts_UniformAbscissa (const Adaptor2d_Curve2d& theC,
                                           const Standard_Integer theNbPoints,
@@ -163,20 +163,20 @@ public:
                                           const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 2D curve, Abscissa, and Tolerance.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Real theAbscissa,
                                    const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 2D curve, Abscissa, Tolerance, and parameter range.
-  //! @param theC [in] input curve
-  //! @param theAbscissa [in] abscissa (distance between two consecutive points)
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theAbscissa  abscissa (distance between two consecutive points)
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Real theAbscissa,
@@ -184,20 +184,20 @@ public:
                                    const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 2D curve, number of points, and Tolerance.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Integer theNbPoints,
                                    const Standard_Real theToler = -1);
 
   //! Initialize the algorithms with 2D curve, number of points, Tolerance, and parameter range.
-  //! @param theC [in] input curve
-  //! @param theNbPoints [in] defines the number of desired points
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theToler [in] used for more precise calculation of curve length
+  //! @param[in] theC  input curve
+  //! @param[in] theNbPoints  defines the number of desired points
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theToler  used for more precise calculation of curve length
   //!                      (Precision::Confusion() by default)
   Standard_EXPORT void Initialize (const Adaptor2d_Curve2d& theC,
                                    const Standard_Integer theNbPoints,

--- a/src/GCPnts/GCPnts_UniformDeflection.hxx
+++ b/src/GCPnts/GCPnts_UniformDeflection.hxx
@@ -44,38 +44,38 @@ public:
   Standard_EXPORT GCPnts_UniformDeflection();
 
   //! Computes a uniform Deflection distribution of points on the curve.
-  //! @param theC [in] input 3D curve
-  //! @param theDeflection [in] target deflection
-  //! @param theWithControl [in] when TRUE, the algorithm controls the estimate deflection
+  //! @param[in] theC  input 3D curve
+  //! @param[in] theDeflection  target deflection
+  //! @param[in] theWithControl  when TRUE, the algorithm controls the estimate deflection
   Standard_EXPORT GCPnts_UniformDeflection (const Adaptor3d_Curve& theC,
                                             const Standard_Real theDeflection,
                                             const Standard_Boolean theWithControl = Standard_True);
 
   //! Computes a uniform Deflection distribution of points on the curve.
-  //! @param theC [in] input 2D curve
-  //! @param theDeflection [in] target deflection
-  //! @param theWithControl [in] when TRUE, the algorithm controls the estimate deflection
+  //! @param[in] theC  input 2D curve
+  //! @param[in] theDeflection  target deflection
+  //! @param[in] theWithControl  when TRUE, the algorithm controls the estimate deflection
   Standard_EXPORT GCPnts_UniformDeflection (const Adaptor2d_Curve2d& theC,
                                             const Standard_Real theDeflection,
                                             const Standard_Boolean theWithControl = Standard_True);
 
   //! Computes a Uniform Deflection distribution of points on a part of the curve.
-  //! @param theC [in] input 3D curve
-  //! @param theDeflection [in] target deflection
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theWithControl [in] when TRUE, the algorithm controls the estimate deflection
+  //! @param[in] theC  input 3D curve
+  //! @param[in] theDeflection  target deflection
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theWithControl  when TRUE, the algorithm controls the estimate deflection
   Standard_EXPORT GCPnts_UniformDeflection (const Adaptor3d_Curve& theC,
                                             const Standard_Real theDeflection,
                                             const Standard_Real theU1, const Standard_Real theU2,
                                             const Standard_Boolean theWithControl = Standard_True);
   
   //! Computes a Uniform Deflection distribution of points on a part of the curve.
-  //! @param theC [in] input 2D curve
-  //! @param theDeflection [in] target deflection
-  //! @param theU1 [in] first parameter on curve
-  //! @param theU2 [in] last  parameter on curve
-  //! @param theWithControl [in] when TRUE, the algorithm controls the estimate deflection
+  //! @param[in] theC  input 2D curve
+  //! @param[in] theDeflection  target deflection
+  //! @param[in] theU1  first parameter on curve
+  //! @param[in] theU2  last  parameter on curve
+  //! @param[in] theWithControl  when TRUE, the algorithm controls the estimate deflection
   Standard_EXPORT GCPnts_UniformDeflection (const Adaptor2d_Curve2d& theC,
                                             const Standard_Real theDeflection,
                                             const Standard_Real theU1, const Standard_Real theU2,

--- a/src/GeomLib/GeomLib.hxx
+++ b/src/GeomLib/GeomLib.hxx
@@ -155,13 +155,13 @@ public:
   Standard_EXPORT static void DensifyArray1OfReal (const Standard_Integer MinNumPoints, const TColStd_Array1OfReal& InParameters, Handle(TColStd_HArray1OfReal)& OutParameters);
   
   //! This method fuse intervals Interval1 and Interval2 with specified Confusion
-  //! @param Interval1 [in] first interval to fuse 
-  //! @param Interval2 [in] second interval to fuse
-  //! @param Confision [in] tolerance to compare intervals
-  //! @param IsAdjustToFirstInterval [in] flag to set method of fusion, if intervals are close
+  //! @param[in] Interval1  first interval to fuse 
+  //! @param[in] Interval2  second interval to fuse
+  //! @param[in] Confision  tolerance to compare intervals
+  //! @param[in] IsAdjustToFirstInterval  flag to set method of fusion, if intervals are close
   //!                               if false, intervals are fusing by half-division methdod
   //!                               if true, intervals are fusing by selecting value from Interval1
-  //! @param Fusion [out] output interval 
+  //! @param[out] Fusion  output interval 
   Standard_EXPORT static void FuseIntervals (const TColStd_Array1OfReal& Interval1, 
                                              const TColStd_Array1OfReal& Interval2, 
                                              TColStd_SequenceOfReal& Fusion,

--- a/src/Graphic3d/Graphic3d_ArrayOfPrimitives.hxx
+++ b/src/Graphic3d/Graphic3d_ArrayOfPrimitives.hxx
@@ -690,17 +690,17 @@ public: //! @name optional array of Indices/Edges for using shared Vertex data
   //! Add triangle strip into indexed triangulation array.
   //! N-2 triangles are added from N input nodes.
   //! Raises exception if array is not of type Graphic3d_TOPA_TRIANGLES.
-  //! @param theVertexLower [in] index of first node defining triangle strip
-  //! @param theVertexUpper [in] index of last  node defining triangle strip
+  //! @param[in] theVertexLower  index of first node defining triangle strip
+  //! @param[in] theVertexUpper  index of last  node defining triangle strip
   Standard_EXPORT void AddTriangleStripEdges (Standard_Integer theVertexLower,
                                               Standard_Integer theVertexUpper);
 
   //! Add triangle fan into indexed triangulation array.
   //! N-2 triangles are added from N input nodes (or N-1 with closed flag).
   //! Raises exception if array is not of type Graphic3d_TOPA_TRIANGLES.
-  //! @param theVertexLower [in] index of first node defining triangle fun (center)
-  //! @param theVertexUpper [in] index of last  node defining triangle fun
-  //! @param theToClose [in] close triangle fan (connect first and last points)
+  //! @param[in] theVertexLower  index of first node defining triangle fun (center)
+  //! @param[in] theVertexUpper  index of last  node defining triangle fun
+  //! @param[in] theToClose  close triangle fan (connect first and last points)
   Standard_EXPORT void AddTriangleFanEdges (Standard_Integer theVertexLower,
                                             Standard_Integer theVertexUpper,
                                             Standard_Boolean theToClose);
@@ -708,9 +708,9 @@ public: //! @name optional array of Indices/Edges for using shared Vertex data
   //! Add line strip (polyline) into indexed segments array.
   //! N-1 segments are added from N input nodes (or N with closed flag).
   //! Raises exception if array is not of type Graphic3d_TOPA_SEGMENTS.
-  //! @param theVertexLower [in] index of first node defining line strip fun (center)
-  //! @param theVertexUpper [in] index of last  node defining triangle fun
-  //! @param theToClose [in] close triangle fan (connect first and last points)
+  //! @param[in] theVertexLower  index of first node defining line strip fun (center)
+  //! @param[in] theVertexUpper  index of last  node defining triangle fun
+  //! @param[in] theToClose  close triangle fan (connect first and last points)
   Standard_EXPORT void AddPolylineEdges (Standard_Integer theVertexLower,
                                          Standard_Integer theVertexUpper,
                                          Standard_Boolean theToClose);

--- a/src/Graphic3d/Graphic3d_AspectText3d.hxx
+++ b/src/Graphic3d/Graphic3d_AspectText3d.hxx
@@ -32,12 +32,12 @@ public:
   Standard_EXPORT Graphic3d_AspectText3d();
 
   //! Creates a context table for text primitives defined with the specified values.
-  //! @param theColor [in] text color
-  //! @param theFont  [in] font family name or alias like Font_NOF_ASCII_MONO
-  //! @param theExpansionFactor [in] deprecated parameter, has no effect
-  //! @param theSpace [in] deprecated parameter, has no effect
-  //! @param theStyle [in] font style
-  //! @param theDisplayType [in] display mode
+  //! @param[in] theColor  text color
+  //! @param[in] theFont   font family name or alias like Font_NOF_ASCII_MONO
+  //! @param[in] theExpansionFactor  deprecated parameter, has no effect
+  //! @param[in] theSpace  deprecated parameter, has no effect
+  //! @param[in] theStyle  font style
+  //! @param[in] theDisplayType  display mode
   Standard_EXPORT Graphic3d_AspectText3d (const Quantity_Color& theColor,
                                           Standard_CString theFont,
                                           Standard_Real theExpansionFactor,

--- a/src/Graphic3d/Graphic3d_CView.hxx
+++ b/src/Graphic3d/Graphic3d_CView.hxx
@@ -272,24 +272,24 @@ public:
 
   //! Dumps the graphical contents of a shadowmap framebuffer into an image.
   //! @param theImage the image to store the shadow map.
-  //! @param theLightName [in] name of the light used to generate the shadow map.
+  //! @param[in] theLightName  name of the light used to generate the shadow map.
   virtual Standard_Boolean ShadowMapDump (Image_PixMap& theImage, const TCollection_AsciiString& theLightName) = 0;
 
   //! Marks BVH tree and the set of BVH primitives of correspondent priority list with id theLayerId as outdated.
   virtual void InvalidateBVHData (const Graphic3d_ZLayerId theLayerId) = 0;
 
   //! Add a layer to the view.
-  //! @param theNewLayerId [in] id of new layer, should be > 0 (negative values are reserved for default layers).
-  //! @param theSettings   [in] new layer settings
-  //! @param theLayerAfter [in] id of layer to append new layer before
+  //! @param[in] theNewLayerId  id of new layer, should be > 0 (negative values are reserved for default layers).
+  //! @param[in] theSettings    new layer settings
+  //! @param[in] theLayerAfter  id of layer to append new layer before
   virtual void InsertLayerBefore (const Graphic3d_ZLayerId theNewLayerId,
                                   const Graphic3d_ZLayerSettings& theSettings,
                                   const Graphic3d_ZLayerId theLayerAfter) = 0;
 
   //! Add a layer to the view.
-  //! @param theNewLayerId  [in] id of new layer, should be > 0 (negative values are reserved for default layers).
-  //! @param theSettings    [in] new layer settings
-  //! @param theLayerBefore [in] id of layer to append new layer after
+  //! @param[in] theNewLayerId   id of new layer, should be > 0 (negative values are reserved for default layers).
+  //! @param[in] theSettings     new layer settings
+  //! @param[in] theLayerBefore  id of layer to append new layer after
   virtual void InsertLayerAfter (const Graphic3d_ZLayerId theNewLayerId,
                                  const Graphic3d_ZLayerSettings& theSettings,
                                  const Graphic3d_ZLayerId theLayerBefore) = 0;
@@ -383,9 +383,9 @@ public:
   const Handle(Graphic3d_CubeMap)& IBLCubeMap() const { return myCubeMapIBL; }
 
   //! Sets image texture or environment cubemap as background.
-  //! @param theTextureMap [in] source to set a background;
+  //! @param[in] theTextureMap  source to set a background;
   //!                           should be either Graphic3d_Texture2D or Graphic3d_CubeMap
-  //! @param theToUpdatePBREnv [in] defines whether IBL maps will be generated or not
+  //! @param[in] theToUpdatePBREnv  defines whether IBL maps will be generated or not
   //!                               (see GeneratePBREnvironment())
   virtual void SetBackgroundImage (const Handle(Graphic3d_TextureMap)& theTextureMap,
                                    Standard_Boolean theToUpdatePBREnv = Standard_True) = 0;
@@ -497,7 +497,7 @@ public:
   void SetBaseXRCamera (const Handle(Graphic3d_Camera)& theCamera) { myBaseXRCamera = theCamera; }
 
   //! Convert XR pose to world space.
-  //! @param thePoseXR [in] transformation defined in VR local coordinate system,
+  //! @param[in] thePoseXR  transformation defined in VR local coordinate system,
   //!                       oriented as Y-up, X-right and -Z-forward
   //! @return transformation defining orientation of XR pose in world space
   gp_Trsf PoseXRToWorld (const gp_Trsf& thePoseXR) const
@@ -511,7 +511,7 @@ public:
   }
 
   //! Returns view direction in the world space based on XR pose.
-  //! @param thePoseXR [in] transformation defined in VR local coordinate system,
+  //! @param[in] thePoseXR  transformation defined in VR local coordinate system,
   //!                       oriented as Y-up, X-right and -Z-forward
   gp_Ax1 ViewAxisInWorld (const gp_Trsf& thePoseXR) const
   {
@@ -548,8 +548,8 @@ public: //! @name obsolete Graduated Trihedron functionality
   virtual void GraduatedTrihedronErase() {}
 
   //! Sets minimum and maximum points of scene bounding box for Graduated Trihedron stored in graphic view object.
-  //! @param theMin [in] the minimum point of scene.
-  //! @param theMax [in] the maximum point of scene.
+  //! @param[in] theMin  the minimum point of scene.
+  //! @param[in] theMax  the maximum point of scene.
   virtual void GraduatedTrihedronMinMaxValues (const Graphic3d_Vec3 theMin, const Graphic3d_Vec3 theMax)
   {
     (void )theMin;

--- a/src/Graphic3d/Graphic3d_Camera.hxx
+++ b/src/Graphic3d/Graphic3d_Camera.hxx
@@ -166,10 +166,10 @@ public:
   //! This transformation might be not in line with user expectations.
   //! In this case, application might define intermediate camera positions for interpolation or implement own interpolation logic.
   //!
-  //! @param theStart  [in] initial camera position
-  //! @param theEnd    [in] final   camera position
-  //! @param theT      [in] step between initial and final positions within [0,1] range
-  //! @param theCamera [out] interpolation result
+  //! @param[in] theStart   initial camera position
+  //! @param[in] theEnd     final   camera position
+  //! @param[in] theT       step between initial and final positions within [0,1] range
+  //! @param[out] theCamera  interpolation result
   Standard_EXPORT static void Interpolate (const Handle(Graphic3d_Camera)& theStart,
                                            const Handle(Graphic3d_Camera)& theEnd,
                                            const double theT,
@@ -186,7 +186,7 @@ public:
   Standard_EXPORT Graphic3d_Camera();
 
   //! Copy constructor.
-  //! @param theOther [in] the camera to copy from.
+  //! @param[in] theOther  the camera to copy from.
   Standard_EXPORT Graphic3d_Camera (const Handle(Graphic3d_Camera)& theOther);
 
   //! Initialize mapping related parameters from other camera handle.
@@ -196,7 +196,7 @@ public:
   Standard_EXPORT void CopyOrientationData (const Handle(Graphic3d_Camera)& theOtherCamera);
 
   //! Copy properties of another camera.
-  //! @param theOther [in] the camera to copy from.
+  //! @param[in] theOther  the camera to copy from.
   Standard_EXPORT void Copy (const Handle(Graphic3d_Camera)& theOther);
 
 //! @name Public camera properties
@@ -208,12 +208,12 @@ public:
 
   //! Sets camera look direction preserving the current Eye() position.
   //! WARNING! This method does NOT verify that the current Up() vector is orthogonal to the new Direction.
-  //! @param theDir [in] the direction.
+  //! @param[in] theDir  the direction.
   Standard_EXPORT void SetDirectionFromEye (const gp_Dir& theDir);
 
   //! Sets camera look direction and computes the new Eye position relative to current Center.
   //! WARNING! This method does NOT verify that the current Up() vector is orthogonal to the new Direction.
-  //! @param theDir [in] the direction.
+  //! @param[in] theDir  the direction.
   Standard_EXPORT void SetDirection (const gp_Dir& theDir);
 
   //! Get camera Up direction vector.
@@ -222,7 +222,7 @@ public:
 
   //! Sets camera Up direction vector, orthogonal to camera direction.
   //! WARNING! This method does NOT verify that the new Up vector is orthogonal to the current Direction().
-  //! @param theUp [in] the Up direction vector.
+  //! @param[in] theUp  the Up direction vector.
   //! @sa OrthogonalizeUp().
   Standard_EXPORT void SetUp (const gp_Dir& theUp);
 
@@ -244,20 +244,20 @@ public:
 
   //! Sets camera Eye position.
   //! Unlike SetEye(), this method only changes Eye point and preserves camera direction.
-  //! @param theEye [in] the location of camera's Eye.
+  //! @param[in] theEye  the location of camera's Eye.
   //! @sa SetEye()
   Standard_EXPORT void MoveEyeTo (const gp_Pnt& theEye);
 
   //! Sets camera Eye and Center positions.
-  //! @param theEye    [in] the location of camera's Eye
-  //! @param theCenter [in] the location of camera's Center
+  //! @param[in] theEye     the location of camera's Eye
+  //! @param[in] theCenter  the location of camera's Center
   Standard_EXPORT void SetEyeAndCenter (const gp_Pnt& theEye,
                                         const gp_Pnt& theCenter);
 
   //! Sets camera Eye position.
   //! WARNING! For backward compatibility reasons, this method also changes view direction,
   //! so that the new direction is computed from new Eye position to old Center position.
-  //! @param theEye [in] the location of camera's Eye.
+  //! @param[in] theEye  the location of camera's Eye.
   //! @sa MoveEyeTo(), SetEyeAndCenter()
   Standard_EXPORT void SetEye (const gp_Pnt& theEye);
 
@@ -272,7 +272,7 @@ public:
   //! Sets Center of the camera, e.g. the point where camera looks at.
   //! This methods changes camera direction, so that the new direction is computed
   //! from current Eye position to specified Center position.
-  //! @param theCenter [in] the point where the camera looks at.
+  //! @param[in] theCenter  the point where the camera looks at.
   Standard_EXPORT void SetCenter (const gp_Pnt& theCenter);
 
   //! Get distance of Eye from camera Center.
@@ -280,7 +280,7 @@ public:
   Standard_Real Distance() const { return myDistance; }
 
   //! Set distance of Eye from camera Center.
-  //! @param theDistance [in] the distance.
+  //! @param[in] theDistance  the distance.
   Standard_EXPORT void SetDistance (const Standard_Real theDistance);
 
   //! Get camera scale.
@@ -294,7 +294,7 @@ public:
   //! both dimensions assuming that the aspect is 1.0. The projection height
   //! and width are specified with the scale and correspondingly multiplied
   //! by the aspect.
-  //! @param theScale [in] the scale factor.
+  //! @param[in] theScale  the scale factor.
   Standard_EXPORT void SetScale (const Standard_Real theScale);
 
   //! Get camera axial scale.
@@ -302,7 +302,7 @@ public:
   const gp_XYZ& AxialScale() const { return myAxialScale; }
 
   //! Set camera axial scale.
-  //! @param theAxialScale [in] the axial scale vector.
+  //! @param[in] theAxialScale  the axial scale vector.
   Standard_EXPORT void SetAxialScale (const gp_XYZ& theAxialScale);
 
   //! Change camera projection type.
@@ -338,7 +338,7 @@ public:
 
   //! Set Field Of View (FOV) in y axis for perspective projection.
   //! Field of View in x axis is automatically scaled from view aspect ratio.
-  //! @param theFOVy [in] the FOV in degrees.
+  //! @param[in] theFOVy  the FOV in degrees.
   Standard_EXPORT void SetFOVy (const Standard_Real theFOVy);
 
   //! Get Field Of View (FOV) in y axis.
@@ -394,8 +394,8 @@ public:
   //! For perspective projection, only positive values are allowed.
   //! Program error exception is raised if non-positive values are
   //! specified for perspective projection or theZNear >= theZFar.
-  //! @param theZNear [in] the distance of the plane from the Eye.
-  //! @param theZFar [in] the distance of the plane from the Eye.
+  //! @param[in] theZNear  the distance of the plane from the Eye.
+  //! @param[in] theZFar  the distance of the plane from the Eye.
   Standard_EXPORT void SetZRange (const Standard_Real theZNear, const Standard_Real theZFar);
 
   //! Get the Near Z-clipping plane position.
@@ -427,7 +427,7 @@ public:
   }
 
   //! Changes width / height display ratio.
-  //! @param theAspect [in] the display ratio.
+  //! @param[in] theAspect  the display ratio.
   Standard_EXPORT void SetAspect (const Standard_Real theAspect);
 
   //! Get camera display ratio.
@@ -438,10 +438,10 @@ public:
   }
 
   //! Sets stereographic focus distance.
-  //! @param theType [in] the focus definition type. Focus can be defined
+  //! @param[in] theType  the focus definition type. Focus can be defined
   //! as absolute value or relatively to (as coefficient of) coefficient of
   //! camera focal length.
-  //! @param theZFocus [in] the focus absolute value or coefficient depending
+  //! @param[in] theZFocus  the focus absolute value or coefficient depending
   //! on the passed definition type.
   Standard_EXPORT void SetZFocus (const FocusType theType, const Standard_Real theZFocus);
 
@@ -461,9 +461,9 @@ public:
   }
 
   //! Sets Intraocular distance.
-  //! @param theType [in] the IOD definition type. IOD can be defined as
+  //! @param[in] theType  the IOD definition type. IOD can be defined as
   //! absolute value or relatively to (as coefficient of) camera focal length.
-  //! @param theIOD [in] the Intraocular distance.
+  //! @param[in] theIOD  the Intraocular distance.
   Standard_EXPORT void SetIOD (const IODType theType, const Standard_Real theIOD);
 
   //! Get Intraocular distance value.
@@ -496,7 +496,7 @@ public:
 
   //! Transform orientation components of the camera:
   //! Eye, Up and Center points.
-  //! @param theTrsf [in] the transformation to apply.
+  //! @param[in] theTrsf  the transformation to apply.
   Standard_EXPORT void Transform (const gp_Trsf& theTrsf);
 
   //! Calculate view plane size at center (target) point
@@ -509,7 +509,7 @@ public:
 
   //! Calculate view plane size at center point with specified Z offset
   //! and distance between ZFar and ZNear planes.
-  //! @param theZValue [in] the distance from the eye in eye-to-center direction
+  //! @param[in] theZValue  the distance from the eye in eye-to-center direction
   //! @return values in form of gp_Pnt (Width, Height, Depth).
   Standard_EXPORT gp_XYZ ViewDimensions (const Standard_Real theZValue) const;
 
@@ -537,12 +537,12 @@ public:
   //! The frustum planes are usually used as inputs for camera algorithms.
   //! Thus, if any changes to projection matrix calculation are necessary,
   //! the frustum planes calculation should be also touched.
-  //! @param theLeft [out] the frustum plane for left side of view.
-  //! @param theRight [out] the frustum plane for right side of view.
-  //! @param theBottom [out] the frustum plane for bottom side of view.
-  //! @param theTop [out] the frustum plane for top side of view.
-  //! @param theNear [out] the frustum plane for near side of view.
-  //! @param theFar [out] the frustum plane for far side of view.
+  //! @param[out] theLeft  the frustum plane for left side of view.
+  //! @param[out] theRight  the frustum plane for right side of view.
+  //! @param[out] theBottom  the frustum plane for bottom side of view.
+  //! @param[out] theTop  the frustum plane for top side of view.
+  //! @param[out] theNear  the frustum plane for near side of view.
+  //! @param[out] theFar  the frustum plane for far side of view.
   Standard_EXPORT void Frustum (gp_Pln& theLeft,
                                 gp_Pln& theRight,
                                 gp_Pln& theBottom,
@@ -555,37 +555,37 @@ public:
 
   //! Project point from world coordinate space to
   //! normalized device coordinates (mapping).
-  //! @param thePnt [in] the 3D point in WCS.
+  //! @param[in] thePnt  the 3D point in WCS.
   //! @return mapped point in NDC.
   Standard_EXPORT gp_Pnt Project (const gp_Pnt& thePnt) const;
 
   //! Unproject point from normalized device coordinates
   //! to world coordinate space.
-  //! @param thePnt [in] the NDC point.
+  //! @param[in] thePnt  the NDC point.
   //! @return 3D point in WCS.
   Standard_EXPORT gp_Pnt UnProject (const gp_Pnt& thePnt) const;
 
   //! Convert point from view coordinate space to
   //! projection coordinate space.
-  //! @param thePnt [in] the point in VCS.
+  //! @param[in] thePnt  the point in VCS.
   //! @return point in NDC.
   Standard_EXPORT gp_Pnt ConvertView2Proj (const gp_Pnt& thePnt) const;
 
   //! Convert point from projection coordinate space
   //! to view coordinate space.
-  //! @param thePnt [in] the point in NDC.
+  //! @param[in] thePnt  the point in NDC.
   //! @return point in VCS.
   Standard_EXPORT gp_Pnt ConvertProj2View (const gp_Pnt& thePnt) const;
 
   //! Convert point from world coordinate space to
   //! view coordinate space.
-  //! @param thePnt [in] the 3D point in WCS.
+  //! @param[in] thePnt  the 3D point in WCS.
   //! @return point in VCS.
   Standard_EXPORT gp_Pnt ConvertWorld2View (const gp_Pnt& thePnt) const;
 
   //! Convert point from view coordinate space to
   //! world coordinates.
-  //! @param thePnt [in] the 3D point in VCS.
+  //! @param[in] thePnt  the 3D point in VCS.
   //! @return point in WCS.
   Standard_EXPORT gp_Pnt ConvertView2World (const gp_Pnt& thePnt) const;
 
@@ -659,20 +659,20 @@ public:
 public:
 
   //! Get stereo projection matrices.
-  //! @param theProjL      [out] left  eye projection matrix
-  //! @param theHeadToEyeL [out] left  head to eye translation matrix
-  //! @param theProjR      [out] right eye projection matrix
-  //! @param theHeadToEyeR [out] right head to eye translation matrix
+  //! @param[out] theProjL       left  eye projection matrix
+  //! @param[out] theHeadToEyeL  left  head to eye translation matrix
+  //! @param[out] theProjR       right eye projection matrix
+  //! @param[out] theHeadToEyeR  right head to eye translation matrix
   Standard_EXPORT void StereoProjection (Graphic3d_Mat4d& theProjL,
                                          Graphic3d_Mat4d& theHeadToEyeL,
                                          Graphic3d_Mat4d& theProjR,
                                          Graphic3d_Mat4d& theHeadToEyeR) const;
 
   //! Get stereo projection matrices.
-  //! @param theProjL      [out] left  eye projection matrix
-  //! @param theHeadToEyeL [out] left  head to eye translation matrix
-  //! @param theProjR      [out] right eye projection matrix
-  //! @param theHeadToEyeR [out] right head to eye translation matrix
+  //! @param[out] theProjL       left  eye projection matrix
+  //! @param[out] theHeadToEyeL  left  head to eye translation matrix
+  //! @param[out] theProjR       right eye projection matrix
+  //! @param[out] theHeadToEyeR  right head to eye translation matrix
   Standard_EXPORT void StereoProjectionF (Graphic3d_Mat4& theProjL,
                                           Graphic3d_Mat4& theHeadToEyeL,
                                           Graphic3d_Mat4& theProjR,
@@ -693,10 +693,10 @@ public:
   bool IsCustomStereoProjection() const { return myIsCustomProjMatLR; }
 
   //! Set custom stereo projection matrices.
-  //! @param theProjL      [in] left  eye projection matrix
-  //! @param theHeadToEyeL [in] left  head to eye translation matrix
-  //! @param theProjR      [in] right eye projection matrix
-  //! @param theHeadToEyeR [in] right head to eye translation matrix
+  //! @param[in] theProjL       left  eye projection matrix
+  //! @param[in] theHeadToEyeL  left  head to eye translation matrix
+  //! @param[in] theProjR       right eye projection matrix
+  //! @param[in] theHeadToEyeR  right head to eye translation matrix
   Standard_EXPORT void SetCustomStereoProjection (const Graphic3d_Mat4d& theProjL,
                                                   const Graphic3d_Mat4d& theHeadToEyeL,
                                                   const Graphic3d_Mat4d& theProjR,
@@ -715,10 +715,10 @@ public:
 private:
 
   //! Get stereo projection matrices.
-  //! @param theProjL      [out] left  eye projection matrix
-  //! @param theHeadToEyeL [out] left  head to eye translation matrix
-  //! @param theProjR      [out] right eye projection matrix
-  //! @param theHeadToEyeR [out] right head to eye translation matrix
+  //! @param[out] theProjL       left  eye projection matrix
+  //! @param[out] theHeadToEyeL  left  head to eye translation matrix
+  //! @param[out] theProjR       right eye projection matrix
+  //! @param[out] theHeadToEyeR  right head to eye translation matrix
   template <typename Elem_t>
   Standard_EXPORT void stereoProjection (NCollection_Mat4<Elem_t>& theProjL,
                                          NCollection_Mat4<Elem_t>& theHeadToEyeL,
@@ -726,10 +726,10 @@ private:
                                          NCollection_Mat4<Elem_t>& theHeadToEyeR) const;
 
   //! Compute projection matrices.
-  //! @param theProjM [out] mono projection matrix
-  //! @param theProjL [out] left  eye projection matrix
-  //! @param theProjR [out] right eye projection matrix
-  //! @param theToAddHeadToEye [in] flag to pre-multiply head-to-eye translation
+  //! @param[out] theProjM  mono projection matrix
+  //! @param[out] theProjL  left  eye projection matrix
+  //! @param[out] theProjR  right eye projection matrix
+  //! @param[in] theToAddHeadToEye  flag to pre-multiply head-to-eye translation
   template <typename Elem_t>
   Standard_EXPORT void computeProjection (NCollection_Mat4<Elem_t>& theProjM,
                                           NCollection_Mat4<Elem_t>& theProjL,
@@ -737,7 +737,7 @@ private:
                                           bool theToAddHeadToEye) const;
 
   //! Compute projection matrices.
-  //! @param theMatrices [in] the matrices data container.
+  //! @param[in] theMatrices  the matrices data container.
   template <typename Elem_t>
   TransformMatrices<Elem_t>& UpdateProjection (TransformMatrices<Elem_t>& theMatrices) const
   {
@@ -750,7 +750,7 @@ private:
   }
 
   //! Compute orientation matrix.
-  //! @param theMatrices [in] the matrices data container.
+  //! @param[in] theMatrices  the matrices data container.
   template <typename Elem_t>
   Standard_EXPORT
     TransformMatrices<Elem_t>& UpdateOrientation (TransformMatrices<Elem_t>& theMatrices) const;
@@ -758,10 +758,10 @@ private:
 private:
 
   //! Compose orthographic projection matrix for the passed camera volume mapping.
-  //! @param theOutMx [out] the projection matrix
-  //! @param theLRBT [in] the left/right/bottom/top mapping (clipping) coordinates
-  //! @param theNear [in] the near mapping (clipping) coordinate
-  //! @param theFar [in] the far mapping (clipping) coordinate
+  //! @param[out] theOutMx  the projection matrix
+  //! @param[in] theLRBT  the left/right/bottom/top mapping (clipping) coordinates
+  //! @param[in] theNear  the near mapping (clipping) coordinate
+  //! @param[in] theFar  the far mapping (clipping) coordinate
   template <typename Elem_t>
   void orthoProj (NCollection_Mat4<Elem_t>& theOutMx,
                   const Aspect_FrustumLRBT<Elem_t>& theLRBT,
@@ -769,10 +769,10 @@ private:
                   const Elem_t theFar) const;
 
   //! Compose perspective projection matrix for the passed camera volume mapping.
-  //! @param theOutMx [out] the projection matrix
-  //! @param theLRBT [in] the left/right/bottom/top mapping (clipping) coordinates
-  //! @param theNear [in] the near mapping (clipping) coordinate
-  //! @param theFar [in] the far mapping (clipping) coordinate
+  //! @param[out] theOutMx  the projection matrix
+  //! @param[in] theLRBT  the left/right/bottom/top mapping (clipping) coordinates
+  //! @param[in] theNear  the near mapping (clipping) coordinate
+  //! @param[in] theFar  the far mapping (clipping) coordinate
   template <typename Elem_t>
   void perspectiveProj (NCollection_Mat4<Elem_t>& theOutMx,
                         const Aspect_FrustumLRBT<Elem_t>& theLRBT,
@@ -780,13 +780,13 @@ private:
                         const Elem_t theFar) const;
 
   //! Compose projection matrix for L/R stereo eyes.
-  //! @param theOutMx [out] the projection matrix
-  //! @param theLRBT [in] the left/right/bottom/top mapping (clipping) coordinates
-  //! @param theNear [in] the near mapping (clipping) coordinate
-  //! @param theFar [in] the far mapping (clipping) coordinate
-  //! @param theIOD [in] the Intraocular distance
-  //! @param theZFocus [in] the z coordinate of off-axis projection plane with zero parallax
-  //! @param theEyeIndex [in] choose between L/R eyes
+  //! @param[out] theOutMx  the projection matrix
+  //! @param[in] theLRBT  the left/right/bottom/top mapping (clipping) coordinates
+  //! @param[in] theNear  the near mapping (clipping) coordinate
+  //! @param[in] theFar  the far mapping (clipping) coordinate
+  //! @param[in] theIOD  the Intraocular distance
+  //! @param[in] theZFocus  the z coordinate of off-axis projection plane with zero parallax
+  //! @param[in] theEyeIndex  choose between L/R eyes
   template <typename Elem_t>
   void stereoEyeProj (NCollection_Mat4<Elem_t>& theOutMx,
                       const Aspect_FrustumLRBT<Elem_t>& theLRBT,
@@ -799,10 +799,10 @@ private:
   //! Construct "look at" orientation transformation.
   //! Reference point differs for perspective and ortho modes 
   //! (made for compatibility, to be improved..).
-  //! @param theEye [in] the eye coordinates in 3D space.
-  //! @param theFwdDir [in] view direction
-  //! @param theUpDir [in] the up direction vector.
-  //! @param theAxialScale [in] the axial scale vector.
+  //! @param[in] theEye  the eye coordinates in 3D space.
+  //! @param[in] theFwdDir  view direction
+  //! @param[in] theUpDir  the up direction vector.
+  //! @param[in] theAxialScale  the axial scale vector.
   //! @param theOutMx [in/out] the orientation matrix.
   template <typename Elem_t>
   static void

--- a/src/Graphic3d/Graphic3d_ClipPlane.hxx
+++ b/src/Graphic3d/Graphic3d_ClipPlane.hxx
@@ -59,27 +59,27 @@ public:
   Standard_EXPORT Graphic3d_ClipPlane();
 
   //! Copy constructor.
-  //! @param theOther [in] the copied plane.
+  //! @param[in] theOther  the copied plane.
   Standard_EXPORT Graphic3d_ClipPlane(const Graphic3d_ClipPlane& theOther);
 
   //! Construct clip plane for the passed equation.
   //! By default the plane is on, capping is turned off.
-  //! @param theEquation [in] the plane equation.
+  //! @param[in] theEquation  the plane equation.
   Standard_EXPORT Graphic3d_ClipPlane (const Graphic3d_Vec4d& theEquation);
 
   //! Construct clip plane from the passed geometrical definition.
   //! By default the plane is on, capping is turned off.
-  //! @param thePlane [in] the plane.
+  //! @param[in] thePlane  the plane.
   Standard_EXPORT Graphic3d_ClipPlane (const gp_Pln& thePlane);
 
   //! Set plane equation by its geometrical definition.
   //! The equation is specified in "world" coordinate system.
-  //! @param thePlane [in] the plane.
+  //! @param[in] thePlane  the plane.
   Standard_EXPORT void SetEquation (const gp_Pln& thePlane);
 
   //! Set 4-component equation vector for clipping plane.
   //! The equation is specified in "world" coordinate system.
-  //! @param theEquation [in] the XYZW (or "ABCD") equation vector.
+  //! @param[in] theEquation  the XYZW (or "ABCD") equation vector.
   Standard_EXPORT void SetEquation (const Graphic3d_Vec4d& theEquation);
 
   //! Get 4-component equation vector for clipping plane.
@@ -98,12 +98,12 @@ public:
   }
 
   //! Change state of the clipping plane.
-  //! @param theIsOn [in] the flag specifying whether the graphic driver
+  //! @param[in] theIsOn  the flag specifying whether the graphic driver
   //! clipping by this plane should be turned on or off.
   Standard_EXPORT void SetOn(const Standard_Boolean theIsOn);
 
   //! Change state of capping surface rendering.
-  //! @param theIsOn [in] the flag specifying whether the graphic driver should
+  //! @param[in] theIsOn  the flag specifying whether the graphic driver should
   //! perform rendering of capping surface produced by this plane. The graphic
   //! driver produces this surface for convex graphics by means of stencil-test
   //! and multi-pass rendering.
@@ -172,14 +172,14 @@ public: // @name user-defined graphical attributes
   Standard_EXPORT void SetCappingColor (const Quantity_Color& theColor);
 
   //! Set material for rendering capping surface.
-  //! @param theMat [in] the material.
+  //! @param[in] theMat  the material.
   Standard_EXPORT void SetCappingMaterial (const Graphic3d_MaterialAspect& theMat);
 
   //! @return capping material.
   const Graphic3d_MaterialAspect& CappingMaterial() const { return myAspect->FrontMaterial(); }
 
   //! Set texture to be applied on capping surface.
-  //! @param theTexture [in] the texture.
+  //! @param[in] theTexture  the texture.
   Standard_EXPORT void SetCappingTexture (const Handle(Graphic3d_TextureMap)& theTexture);
 
   //! @return capping texture map.
@@ -188,14 +188,14 @@ public: // @name user-defined graphical attributes
                                                               : Handle(Graphic3d_TextureMap)(); }
 
   //! Set hatch style (stipple) and turn hatching on.
-  //! @param theStyle [in] the hatch style.
+  //! @param[in] theStyle  the hatch style.
   Standard_EXPORT void SetCappingHatch (const Aspect_HatchStyle theStyle);
 
   //! @return hatching style.
   Aspect_HatchStyle CappingHatch() const { return (Aspect_HatchStyle)myAspect->HatchStyle()->HatchType(); }
 
   //! Set custom hatch style (stipple) and turn hatching on.
-  //! @param theStyle [in] the hatch pattern.
+  //! @param[in] theStyle  the hatch pattern.
   Standard_EXPORT void SetCappingCustomHatch (const Handle(Graphic3d_HatchStyle)& theStyle);
 
   //! @return hatching style.

--- a/src/Graphic3d/Graphic3d_CullingTool.hxx
+++ b/src/Graphic3d/Graphic3d_CullingTool.hxx
@@ -59,8 +59,8 @@ public:
   Standard_EXPORT Graphic3d_CullingTool();
 
   //! Retrieves view volume's planes equations and its vertices from projection and world-view matrices.
-  //! @param theCamera [in] camera definition
-  //! @param theModelWorld [in] optional object transformation for computing frustum in object local coordinate system
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theModelWorld  optional object transformation for computing frustum in object local coordinate system
   Standard_EXPORT void SetViewVolume (const Handle(Graphic3d_Camera)& theCamera,
                                       const Graphic3d_Mat4d& theModelWorld = Graphic3d_Mat4d());
 
@@ -81,10 +81,10 @@ public:
   Standard_EXPORT void CacheClipPtsProjections();
 
   //! Checks whether given AABB should be entirely culled or not.
-  //! @param theCtx    [in] culling properties
-  //! @param theMinPnt [in] maximum point of AABB
-  //! @param theMaxPnt [in] minimum point of AABB
-  //! @param theIsInside [out] flag indicating if AABB is fully inside; initial value should be set to TRUE
+  //! @param[in] theCtx     culling properties
+  //! @param[in] theMinPnt  maximum point of AABB
+  //! @param[in] theMaxPnt  minimum point of AABB
+  //! @param[out] theIsInside  flag indicating if AABB is fully inside; initial value should be set to TRUE
   //! @return TRUE if AABB is completely outside of view frustum or culled by size/distance;
   //!         FALSE in case of partial or complete overlap (use theIsInside to distinguish)
   bool IsCulled (const CullingContext& theCtx,
@@ -137,15 +137,15 @@ public:
 public:
 
   //! Calculates signed distance from plane to point.
-  //! @param theNormal [in] the plane's normal.
-  //! @param thePnt    [in]
+  //! @param[in] theNormal  the plane's normal.
+  //! @param[in] thePnt    
   Standard_EXPORT Standard_Real SignedPlanePointDistance (const Graphic3d_Vec4d& theNormal,
                                                           const Graphic3d_Vec4d& thePnt);
 
   //! Detects if AABB overlaps view volume using separating axis theorem (SAT).
-  //! @param theMinPnt   [in] maximum point of AABB
-  //! @param theMaxPnt   [in] minimum point of AABB
-  //! @param theIsInside [out] flag indicating if AABB is fully inside; initial value should be set to TRUE
+  //! @param[in] theMinPnt    maximum point of AABB
+  //! @param[in] theMaxPnt    minimum point of AABB
+  //! @param[out] theIsInside  flag indicating if AABB is fully inside; initial value should be set to TRUE
   //! @return TRUE if AABB is completely outside of view frustum;
   //!         FALSE in case of partial or complete overlap (use theIsInside to distinguish)
   //! @sa SelectMgr_Frustum::hasOverlap()
@@ -217,9 +217,9 @@ public:
   }
 
   //! Returns TRUE if given AABB should be discarded by distance culling criterion.
-  //! @param theMinPnt   [in] maximum point of AABB
-  //! @param theMaxPnt   [in] minimum point of AABB
-  //! @param theIsInside [out] flag indicating if AABB is fully inside; initial value should be set to TRUE
+  //! @param[in] theMinPnt    maximum point of AABB
+  //! @param[in] theMaxPnt    minimum point of AABB
+  //! @param[out] theIsInside  flag indicating if AABB is fully inside; initial value should be set to TRUE
   //! @return TRUE if AABB is completely behind culling distance;
   //!         FALSE in case of partial or complete overlap (use theIsInside to distinguish)
   bool IsTooDistant (const CullingContext&  theCtx,

--- a/src/Graphic3d/Graphic3d_GraphicDriver.hxx
+++ b/src/Graphic3d/Graphic3d_GraphicDriver.hxx
@@ -90,17 +90,17 @@ public:
 
   //! Adds a layer to all views.
   //! To add a structure to desired layer on display it is necessary to set the layer ID for the structure.
-  //! @param theNewLayerId [in] id of new layer, should be > 0 (negative values are reserved for default layers).
-  //! @param theSettings   [in] new layer settings
-  //! @param theLayerAfter [in] id of layer to append new layer before
+  //! @param[in] theNewLayerId  id of new layer, should be > 0 (negative values are reserved for default layers).
+  //! @param[in] theSettings    new layer settings
+  //! @param[in] theLayerAfter  id of layer to append new layer before
   Standard_EXPORT virtual void InsertLayerBefore (const Graphic3d_ZLayerId theNewLayerId,
                                                   const Graphic3d_ZLayerSettings& theSettings,
                                                   const Graphic3d_ZLayerId theLayerAfter) = 0;
 
   //! Adds a layer to all views.
-  //! @param theNewLayerId  [in] id of new layer, should be > 0 (negative values are reserved for default layers).
-  //! @param theSettings    [in] new layer settings
-  //! @param theLayerBefore [in] id of layer to append new layer after
+  //! @param[in] theNewLayerId   id of new layer, should be > 0 (negative values are reserved for default layers).
+  //! @param[in] theSettings     new layer settings
+  //! @param[in] theLayerBefore  id of layer to append new layer after
   Standard_EXPORT virtual void InsertLayerAfter (const Graphic3d_ZLayerId theNewLayerId,
                                                  const Graphic3d_ZLayerSettings& theSettings,
                                                  const Graphic3d_ZLayerId theLayerBefore) = 0;

--- a/src/Graphic3d/Graphic3d_GraphicDriverFactory.hxx
+++ b/src/Graphic3d/Graphic3d_GraphicDriverFactory.hxx
@@ -30,8 +30,8 @@ class Graphic3d_GraphicDriverFactory : public Standard_Transient
 public:
 
   //! Registers factory.
-  //! @param theFactory     [in] factory to register
-  //! @param theIsPreferred [in] add to the beginning of the list when TRUE, or add to the end otherwise
+  //! @param[in] theFactory      factory to register
+  //! @param[in] theIsPreferred  add to the beginning of the list when TRUE, or add to the end otherwise
   Standard_EXPORT static void RegisterFactory (const Handle(Graphic3d_GraphicDriverFactory)& theFactory,
                                                bool theIsPreferred = false);
 

--- a/src/Graphic3d/Graphic3d_MarkerImage.hxx
+++ b/src/Graphic3d/Graphic3d_MarkerImage.hxx
@@ -38,16 +38,16 @@ public:
 public:
 
   //! Constructor from existing pixmap.
-  //! @param theImage [in] source image
-  //! @param theImageAlpha [in] colorless image
+  //! @param[in] theImage  source image
+  //! @param[in] theImageAlpha  colorless image
   Standard_EXPORT Graphic3d_MarkerImage (const Handle(Image_PixMap)& theImage,
                                          const Handle(Image_PixMap)& theImageAlpha = Handle(Image_PixMap)());
 
   //! Creates marker image from array of bytes
   //! (method for compatibility with old markers definition).
-  //! @param theBitMap [in] source bitmap stored as array of bytes
-  //! @param theWidth  [in] number of bits in a row
-  //! @param theHeight [in] number of bits in a column
+  //! @param[in] theBitMap  source bitmap stored as array of bytes
+  //! @param[in] theWidth   number of bits in a row
+  //! @param[in] theHeight  number of bits in a column
   Standard_EXPORT Graphic3d_MarkerImage (const Handle(TColStd_HArray1OfByte)& theBitMap,
                                          const Standard_Integer theWidth,
                                          const Standard_Integer theHeight);
@@ -81,7 +81,7 @@ public:
   //! @param theAlphaValue pixels in the image that have alpha value greater than
   //!                      or equal to this parameter will be stored in bitmap as "1",
   //!                      others will be stored as "0"
-  //! @param theIsTopDown [in] flag indicating expected rows order in returned bitmap, which is bottom-up by default
+  //! @param[in] theIsTopDown  flag indicating expected rows order in returned bitmap, which is bottom-up by default
   Standard_EXPORT Handle(TColStd_HArray1OfByte) GetBitMapArray (const Standard_Real theAlphaValue = 0.5,
                                                                 const Standard_Boolean theIsTopDown = false) const;
 

--- a/src/Graphic3d/Graphic3d_MaterialAspect.hxx
+++ b/src/Graphic3d/Graphic3d_MaterialAspect.hxx
@@ -44,8 +44,8 @@ public:
   Standard_EXPORT static Graphic3d_TypeOfMaterial MaterialType (const Standard_Integer theRank);
 
   //! Finds the material for specified name.
-  //! @param theName [in]  name to find
-  //! @param theMat  [out] found material
+  //! @param[in] theName   name to find
+  //! @param[out] theMat   found material
   //! @return FALSE if name was unrecognized
   Standard_EXPORT static Standard_Boolean MaterialFromName (const Standard_CString theName,
                                                             Graphic3d_NameOfMaterial& theMat);

--- a/src/Graphic3d/Graphic3d_PBRMaterial.hxx
+++ b/src/Graphic3d/Graphic3d_PBRMaterial.hxx
@@ -108,20 +108,20 @@ public:
 
   //! Generates 2D look up table of scale and bias for fresnell zero coefficient.
   //! It is needed for calculation reflectance part of environment lighting.
-  //! @param [out] theLUT table storage (must be Image_Format_RGF).
-  //! @param [in] theNbIntegralSamples number of importance samples in hemisphere integral calculation for every table item.
+  //! @param[out]  theLUT table storage (must be Image_Format_RGF).
+  //! @param[in]  theNbIntegralSamples number of importance samples in hemisphere integral calculation for every table item.
   Standard_EXPORT static void GenerateEnvLUT (const Handle(Image_PixMap)& theLUT,
                                               unsigned int                theNbIntegralSamples = 1024);
 
   //! Compute material roughness from common material (specular color + shininess).
-  //! @param theSpecular [in] specular color
-  //! @param theShiness  [in] normalized shininess coefficient within [0..1] range
+  //! @param[in] theSpecular  specular color
+  //! @param[in] theShiness   normalized shininess coefficient within [0..1] range
   //! @return roughness within [0..1] range
   Standard_EXPORT static Standard_ShortReal RoughnessFromSpecular (const Quantity_Color& theSpecular,
                                                                    const Standard_Real theShiness);
 
   //! Compute material metallicity from common material (specular color).
-  //! @param theSpecular [in] specular color
+  //! @param[in] theSpecular  specular color
   //! @return metallicity within [0..1] range
   static Standard_ShortReal MetallicFromSpecular (const Quantity_Color& theSpecular)
   {

--- a/src/Graphic3d/Graphic3d_ShaderManager.hxx
+++ b/src/Graphic3d/Graphic3d_ShaderManager.hxx
@@ -104,8 +104,8 @@ public:
 protected:
 
   //! Generate map key for light sources configuration.
-  //! @param theLights [in] list of light sources
-  //! @param theHasShadowMap [in] flag indicating shadow maps usage
+  //! @param[in] theLights  list of light sources
+  //! @param[in] theHasShadowMap  flag indicating shadow maps usage
   Standard_EXPORT TCollection_AsciiString genLightKey (const Handle(Graphic3d_LightSet)& theLights,
                                                        const bool theHasShadowMap) const;
 
@@ -113,23 +113,23 @@ protected:
   Standard_EXPORT Handle(Graphic3d_ShaderProgram) getStdProgramFont() const;
 
   //! Prepare standard GLSL program without lighting.
-  //! @param theBits      [in] program bits
-  //! @param theIsOutline [in] draw silhouette
+  //! @param[in] theBits       program bits
+  //! @param[in] theIsOutline  draw silhouette
   Standard_EXPORT Handle(Graphic3d_ShaderProgram) getStdProgramUnlit (Standard_Integer theBits,
                                                                       Standard_Boolean theIsOutline = false) const;
 
   //! Prepare standard GLSL program with per-vertex lighting.
-  //! @param theLights [in] list of light sources
-  //! @param theBits   [in] program bits
+  //! @param[in] theLights  list of light sources
+  //! @param[in] theBits    program bits
   Standard_EXPORT Handle(Graphic3d_ShaderProgram) getStdProgramGouraud (const Handle(Graphic3d_LightSet)& theLights,
                                                                         Standard_Integer theBits) const;
 
   //! Prepare standard GLSL program with per-pixel lighting.
-  //! @param theLights [in] list of light sources
-  //! @param theBits   [in] program bits
-  //! @param theIsFlatNormal [in] when TRUE, the Vertex normals will be ignored and Face normal will be computed instead
-  //! @param theIsPBR  [in] when TRUE, the PBR pipeline will be activated
-  //! @param theNbShadowMaps [in] number of shadow maps
+  //! @param[in] theLights  list of light sources
+  //! @param[in] theBits    program bits
+  //! @param[in] theIsFlatNormal  when TRUE, the Vertex normals will be ignored and Face normal will be computed instead
+  //! @param[in] theIsPBR   when TRUE, the PBR pipeline will be activated
+  //! @param[in] theNbShadowMaps  number of shadow maps
   Standard_EXPORT Handle(Graphic3d_ShaderProgram) getStdProgramPhong (const Handle(Graphic3d_LightSet)& theLights,
                                                                       const Standard_Integer theBits,
                                                                       const Standard_Boolean theIsFlatNormal,
@@ -173,10 +173,10 @@ protected:
   Standard_EXPORT bool hasGlslBitwiseOps() const;
 
   //! Prepare GLSL version header.
-  //! @param theProgram [in] [out] program to set version header
-  //! @param theName [in] program id suffix
-  //! @param theBits [in] program bits
-  //! @param theUsesDerivates [in] program uses standard derivatives functions or not
+  //! @param[in][out] theProgram   program to set version header
+  //! @param[in] theName  program id suffix
+  //! @param[in] theBits  program bits
+  //! @param[in] theUsesDerivates  program uses standard derivatives functions or not
   //! @return filtered program bits with unsupported features disabled
   Standard_EXPORT Standard_Integer defaultGlslVersion (const Handle(Graphic3d_ShaderProgram)& theProgram,
                                                        const TCollection_AsciiString& theName,
@@ -184,9 +184,9 @@ protected:
                                                        bool theUsesDerivates = false) const;
 
   //! Prepare GLSL version header for OIT composition programs.
-  //! @param theProgram [in] [out] program to set version header
-  //! @param theName [in] program id suffix
-  //! @param theMsaa [in] multisampling flag
+  //! @param[in][out] theProgram   program to set version header
+  //! @param[in] theName  program id suffix
+  //! @param[in] theMsaa  multisampling flag
   Standard_EXPORT void defaultOitGlslVersion (const Handle(Graphic3d_ShaderProgram)& theProgram,
                                               const TCollection_AsciiString& theName,
                                               bool theMsaa) const;
@@ -199,12 +199,12 @@ protected:
                                                                  Standard_Integer theBits) const;
 
   //! Define computeLighting GLSL function depending on current lights configuration
-  //! @param theNbLights     [out] number of defined light sources
-  //! @param theLights       [in]  light sources list
-  //! @param theHasVertColor [in]  flag to use getVertColor() instead of Ambient and Diffuse components of active material
-  //! @param theIsPBR        [in]  flag to activate PBR pipeline
-  //! @param theHasTexColor  [in]  flag to include color texturing
-  //! @param theNbShadowMaps [in]  flag to include shadow map
+  //! @param[out] theNbLights      number of defined light sources
+  //! @param[in] theLights         light sources list
+  //! @param[in] theHasVertColor   flag to use getVertColor() instead of Ambient and Diffuse components of active material
+  //! @param[in] theIsPBR          flag to activate PBR pipeline
+  //! @param[in] theHasTexColor    flag to include color texturing
+  //! @param[in] theNbShadowMaps   flag to include shadow map
   Standard_EXPORT TCollection_AsciiString stdComputeLighting (Standard_Integer& theNbLights,
                                                               const Handle(Graphic3d_LightSet)& theLights,
                                                               Standard_Boolean  theHasVertColor,

--- a/src/Graphic3d/Graphic3d_Structure.hxx
+++ b/src/Graphic3d/Graphic3d_Structure.hxx
@@ -95,8 +95,8 @@ public:
   virtual void Erase() { erase(); }
   
   //! Highlights the structure in all the views with the given style
-  //! @param theStyle [in] the style (type of highlighting: box/color, color and opacity)
-  //! @param theToUpdateMgr [in] defines whether related computed structures will be
+  //! @param[in] theStyle  the style (type of highlighting: box/color, color and opacity)
+  //! @param[in] theToUpdateMgr  defines whether related computed structures will be
   //! highlighted via structure manager or not
   Standard_EXPORT void Highlight (const Handle(Graphic3d_PresentationAttributes)& theStyle, const Standard_Boolean theToUpdateMgr = Standard_True);
   
@@ -130,7 +130,7 @@ public:
   Graphic3d_ZLayerId GetZLayer() const { return myCStructure->ZLayer(); }
   
   //! Changes a sequence of clip planes slicing the structure on rendering.
-  //! @param thePlanes [in] the set of clip planes.
+  //! @param[in] thePlanes  the set of clip planes.
   void SetClipPlanes (const Handle(Graphic3d_SequenceOfHClipPlane)& thePlanes)
   {
     if (!myCStructure.IsNull()) { myCStructure->SetClipPlanes (thePlanes); }

--- a/src/Graphic3d/Graphic3d_TextureRoot.hxx
+++ b/src/Graphic3d/Graphic3d_TextureRoot.hxx
@@ -83,7 +83,7 @@ public:
 
   //! This method will be called by graphic driver each time when texture resource should be created.
   //! It is called in front of GetImage() for uploading compressed image formats natively supported by GPU.
-  //! @param theSupported [in] the list of supported compressed texture formats;
+  //! @param[in] theSupported  the list of supported compressed texture formats;
   //!                          returning image in unsupported format will result in texture upload failure
   //! @return compressed pixmap or NULL if image is not in supported compressed format
   Standard_EXPORT virtual Handle(Image_CompressedPixMap) GetCompressedImage (const Handle(Image_SupportedFormats)& theSupported);

--- a/src/Graphic3d/Graphic3d_TransformPers.hxx
+++ b/src/Graphic3d/Graphic3d_TransformPers.hxx
@@ -244,9 +244,9 @@ public:
 public:
 
   //! Find scale value based on the camera position and view dimensions
-  //! @param theCamera [in] camera definition
-  //! @param theViewportWidth [in] the width of viewport.
-  //! @param theViewportHeight [in] the height of viewport.
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theViewportWidth  the width of viewport.
+  //! @param[in] theViewportHeight  the height of viewport.
   virtual Standard_Real persistentScale (const Handle(Graphic3d_Camera)& theCamera,
                                          const Standard_Integer theViewportWidth,
                                          const Standard_Integer theViewportHeight) const
@@ -265,9 +265,9 @@ public:
   //! Create orientation matrix based on camera and view dimensions.
   //! Default implementation locks rotation by nullifying rotation component.
   //! Camera and view dimensions are not used, by default.
-  //! @param theCamera [in] camera definition
-  //! @param theViewportWidth [in] the width of viewport
-  //! @param theViewportHeight [in] the height of viewport
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theViewportWidth  the width of viewport
+  //! @param[in] theViewportHeight  the height of viewport
   virtual NCollection_Mat3<Standard_Real> persistentRotationMatrix (const Handle(Graphic3d_Camera)& theCamera,
                                                                     const Standard_Integer theViewportWidth,
                                                                     const Standard_Integer theViewportHeight) const
@@ -281,11 +281,11 @@ public:
   }
 
   //! Apply transformation to bounding box of presentation.
-  //! @param theCamera [in] camera definition
-  //! @param theProjection [in] the projection transformation matrix.
-  //! @param theWorldView [in] the world view transformation matrix.
-  //! @param theViewportWidth [in] the width of viewport (for 2d persistence).
-  //! @param theViewportHeight [in] the height of viewport (for 2d persistence).
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theProjection  the projection transformation matrix.
+  //! @param[in] theWorldView  the world view transformation matrix.
+  //! @param[in] theViewportWidth  the width of viewport (for 2d persistence).
+  //! @param[in] theViewportHeight  the height of viewport (for 2d persistence).
   //! @param theBoundingBox [in/out] the bounding box to transform.
   template<class T>
   void Apply (const Handle(Graphic3d_Camera)& theCamera,
@@ -296,11 +296,11 @@ public:
               Bnd_Box& theBoundingBox) const;
 
   //! Apply transformation to bounding box of presentation
-  //! @param theCamera [in] camera definition
-  //! @param theProjection [in] the projection transformation matrix.
-  //! @param theWorldView [in] the world view transformation matrix.
-  //! @param theViewportWidth [in] the width of viewport (for 2d persistence).
-  //! @param theViewportHeight [in] the height of viewport (for 2d persistence).
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theProjection  the projection transformation matrix.
+  //! @param[in] theWorldView  the world view transformation matrix.
+  //! @param[in] theViewportWidth  the width of viewport (for 2d persistence).
+  //! @param[in] theViewportHeight  the height of viewport (for 2d persistence).
   //! @param theBoundingBox [in/out] the bounding box to transform.
   template<class T>
   void Apply (const Handle(Graphic3d_Camera)& theCamera,
@@ -313,12 +313,12 @@ public:
   //! Compute transformation.
   //! Computed matrix can be applied to model world transformation
   //! of an object to implement effect of transformation persistence.
-  //! @param theCamera [in] camera definition
-  //! @param theProjection [in] the projection transformation matrix.
-  //! @param theWorldView [in] the world view transformation matrix.
-  //! @param theViewportWidth [in] the width of viewport (for 2d persistence).
-  //! @param theViewportHeight [in] the height of viewport (for 2d persistence).
-  //! @param theToApplyProjPers [in] if should apply projection persistence to matrix (for orthographic persistence).
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theProjection  the projection transformation matrix.
+  //! @param[in] theWorldView  the world view transformation matrix.
+  //! @param[in] theViewportWidth  the width of viewport (for 2d persistence).
+  //! @param[in] theViewportHeight  the height of viewport (for 2d persistence).
+  //! @param[in] theToApplyProjPers  if should apply projection persistence to matrix (for orthographic persistence).
   //! @return transformation matrix to be applied to model world transformation of an object.
   template<class T>
   NCollection_Mat4<T> Compute (const Handle(Graphic3d_Camera)& theCamera,
@@ -329,13 +329,13 @@ public:
                                const Standard_Boolean theToApplyProjPers = false) const;
 
   //! Apply transformation persistence on specified matrices.
-  //! @param theCamera [in] camera definition
-  //! @param theProjection [in] projection matrix to modify
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theProjection  projection matrix to modify
   //! @param theWorldView [in/out]  world-view matrix to modify
-  //! @param theViewportWidth [in]  viewport width
-  //! @param theViewportHeight [in] viewport height
-  //! @param theAnchor [in] if not NULL, overrides anchor point
-  //! @param theToApplyProjPers [in] if should apply projection persistence to matrix (for orthographic persistence).
+  //! @param[in] theViewportWidth   viewport width
+  //! @param[in] theViewportHeight  viewport height
+  //! @param[in] theAnchor  if not NULL, overrides anchor point
+  //! @param[in] theToApplyProjPers  if should apply projection persistence to matrix (for orthographic persistence).
   template<class T>
   void Apply (const Handle(Graphic3d_Camera)& theCamera,
               const NCollection_Mat4<T>& theProjection,
@@ -346,10 +346,10 @@ public:
               const Standard_Boolean theToApplyProjPers = true) const;
 
   //! Perform computations for applying transformation persistence on specified matrices.
-  //! @param theCamera [in] camera definition
-  //! @param theViewportWidth [in]  viewport width
-  //! @param theViewportHeight [in] viewport height
-  //! @param theAnchor [in] if not NULL, overrides anchor point
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theViewportWidth   viewport width
+  //! @param[in] theViewportHeight  viewport height
+  //! @param[in] theAnchor  if not NULL, overrides anchor point
   virtual NCollection_Mat4<Standard_Real> ComputeApply (Handle(Graphic3d_Camera)& theCamera,
                                                         const Standard_Integer theViewportWidth,
                                                         const Standard_Integer theViewportHeight,

--- a/src/Graphic3d/Graphic3d_TransformPersScaledAbove.hxx
+++ b/src/Graphic3d/Graphic3d_TransformPersScaledAbove.hxx
@@ -32,9 +32,9 @@ public:
 
   //! Find scale value based on the camera position and view dimensions
   //! If the camera scale value less than the persistence scale, zoom persistence is not applied.
-  //! @param theCamera [in] camera definition
-  //! @param theViewportWidth [in] the width of viewport.
-  //! @param theViewportHeight [in] the height of viewport.
+  //! @param[in] theCamera  camera definition
+  //! @param[in] theViewportWidth  the width of viewport.
+  //! @param[in] theViewportHeight  the height of viewport.
   Standard_EXPORT virtual Standard_Real persistentScale (const Handle(Graphic3d_Camera)& theCamera,
                                                          const Standard_Integer theViewportWidth,
                                                          const Standard_Integer theViewportHeight) const Standard_OVERRIDE;

--- a/src/Graphic3d/Graphic3d_WorldViewProjState.hxx
+++ b/src/Graphic3d/Graphic3d_WorldViewProjState.hxx
@@ -32,9 +32,9 @@ public:
   }
 
   //! Constructor for custom projector type.
-  //! @param theProjectionState [in] the projection state.
-  //! @param theWorldViewState [in] the world view state.
-  //! @param theCamera [in] the pointer to the class supplying projection and
+  //! @param[in] theProjectionState  the projection state.
+  //! @param[in] theWorldViewState  the world view state.
+  //! @param[in] theCamera  the pointer to the class supplying projection and
   //!                       world view matrices (camera).
   Graphic3d_WorldViewProjState (const Standard_Size theProjectionState,
                                 const Standard_Size theWorldViewState,

--- a/src/IGESCAFControl/IGESCAFControl_Provider.hxx
+++ b/src/IGESCAFControl/IGESCAFControl_Provider.hxx
@@ -47,7 +47,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -58,7 +58,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -68,7 +68,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -77,7 +77,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -87,7 +87,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -98,7 +98,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -108,7 +108,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -117,7 +117,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/IVtk/IVtk_IShapeData.hxx
+++ b/src/IVtk/IVtk_IShapeData.hxx
@@ -35,44 +35,44 @@ public:
   DEFINE_STANDARD_RTTIEXT(IVtk_IShapeData,IVtk_Interface)
 
   //! Insert a coordinate
-  //! @param [in] thePnt  point position
-  //! @param [in] theNorm point normal
+  //! @param[in]  thePnt  point position
+  //! @param[in]  theNorm point normal
   //! @return id of added point
   virtual IVtk_PointId InsertPoint (const gp_Pnt& thePnt,
                                     const NCollection_Vec3<float>& theNorm) = 0;
 
   //! Insert a vertex.
-  //! @param [in] theShapeID id of the sub-shape to which the vertex belongs.
-  //! @param [in] thePointId id of the point that defines the coordinates of the vertex
-  //! @param [in] theMeshType mesh type of the sub-shape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the sub-shape to which the vertex belongs.
+  //! @param[in]  thePointId id of the point that defines the coordinates of the vertex
+  //! @param[in]  theMeshType mesh type of the sub-shape (MT_Undefined by default)
   virtual void InsertVertex (const IVtk_IdType   theShapeID,
                              const IVtk_PointId  thePointId,
                              const IVtk_MeshType theMeshType = MT_Undefined) = 0;
 
   //! Insert a line.
-  //! @param [in] theShapeID id of the subshape to which the line belongs.
-  //! @param [in] thePointId1 id of the first point
-  //! @param [in] thePointId2 id of the second point
-  //! @param [in] theMeshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the subshape to which the line belongs.
+  //! @param[in]  thePointId1 id of the first point
+  //! @param[in]  thePointId2 id of the second point
+  //! @param[in]  theMeshType mesh type of the subshape (MT_Undefined by default)
   virtual void InsertLine (const IVtk_IdType   theShapeID,
                            const IVtk_PointId  thePointId1,
                            const IVtk_PointId  thePointId2,
                            const IVtk_MeshType theMeshType = MT_Undefined) = 0;
 
   //! Insert a poly-line.
-  //! @param [in] shapeID id of the subshape to which the polyline belongs.
-  //! @param [in] pointIds vector of point ids
-  //! @param [in] meshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  shapeID id of the subshape to which the polyline belongs.
+  //! @param[in]  pointIds vector of point ids
+  //! @param[in]  meshType mesh type of the subshape (MT_Undefined by default)
   virtual void InsertLine (const IVtk_IdType       theShapeID,
                            const IVtk_PointIdList* thePointIds,
                            const IVtk_MeshType     theMeshType = MT_Undefined) = 0;
 
   //! Insert a triangle
-  //! @param [in] theShapeID id of the subshape to which the triangle belongs.
-  //! @param [in] thePointId1 id of the first point
-  //! @param [in] thePointId2 id of the second point
-  //! @param [in] thePointId3 id of the third point
-  //! @param [in] theMeshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the subshape to which the triangle belongs.
+  //! @param[in]  thePointId1 id of the first point
+  //! @param[in]  thePointId2 id of the second point
+  //! @param[in]  thePointId3 id of the third point
+  //! @param[in]  theMeshType mesh type of the subshape (MT_Undefined by default)
   virtual void InsertTriangle (const IVtk_IdType   theShapeID,
                                const IVtk_PointId  thePointId1,
                                const IVtk_PointId  thePointId2,
@@ -82,9 +82,9 @@ public:
 public:
 
   //! Insert a coordinate
-  //! @param [in] theX X coordinate
-  //! @param [in] theY Y coordinate
-  //! @param [in] theZ Z coordinate
+  //! @param[in]  theX X coordinate
+  //! @param[in]  theY Y coordinate
+  //! @param[in]  theZ Z coordinate
   //! @return id of added point
   virtual IVtk_PointId InsertCoordinate (double theX, double theY, double theZ)
   {
@@ -92,7 +92,7 @@ public:
   }
 
   //! Insert a coordinate
-  //! @param [in] thePnt point position
+  //! @param[in]  thePnt point position
   //! @return id of added point
   IVtk_PointId InsertCoordinate (const gp_Pnt& thePnt)
   {

--- a/src/IVtk/IVtk_IShapeMesher.hxx
+++ b/src/IVtk/IVtk_IShapeMesher.hxx
@@ -32,8 +32,8 @@ public:
   virtual ~IVtk_IShapeMesher() { }
 
   //! Main entry point for building shape representation
-  //! @param [in] shape IShape to be meshed
-  //! @param [in] data IShapeData interface visualization data is passed to.
+  //! @param[in]  shape IShape to be meshed
+  //! @param[in]  data IShapeData interface visualization data is passed to.
   Standard_EXPORT void Build (const IVtk_IShape::Handle& theShape, const IVtk_IShapeData::Handle& theData);
 
   DEFINE_STANDARD_RTTIEXT(IVtk_IShapeMesher,IVtk_Interface)

--- a/src/IVtk/IVtk_IShapePickerAlgo.hxx
+++ b/src/IVtk/IVtk_IShapePickerAlgo.hxx
@@ -37,7 +37,7 @@ public:
   virtual int  NbPicked() = 0;
 
   //! Get activated selection modes for a shape.
-  //! @param [in] theShape a shape with activated selection mode(s)
+  //! @param[in]  theShape a shape with activated selection mode(s)
   //! @return list of active selection modes
   virtual IVtk_SelectionModeList GetSelectionModes (const IVtk_IShape::Handle& theShape) const = 0;
 
@@ -46,9 +46,9 @@ public: // @name Set selectable shapes and selection modes
   //! Activates/deactivates the given selection mode for the shape.
   //! If mode == SM_None, the shape becomes non-selectable and 
   //! is removed from the internal selection data.
-  //! @param [in] theShape Shape for which the selection mode should be activated
-  //! @param [in] theMode Selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theShape Shape for which the selection mode should be activated
+  //! @param[in]  theMode Selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   virtual void SetSelectionMode (const IVtk_IShape::Handle& theShape,
                                  const IVtk_SelectionMode theMode,
                                  const bool theIsTurnOn = true) = 0;
@@ -56,9 +56,9 @@ public: // @name Set selectable shapes and selection modes
   //! Activates/deactivates the given selection mode for the shape.
   //! If mode == SM_None, the shape becomes non-selectable and 
   //! is removed from the internal selection data.
-  //! @param [in] theShapes List of shapes for which the selection mode should be activated
-  //! @param [in] theMode Selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theShapes List of shapes for which the selection mode should be activated
+  //! @param[in]  theMode Selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   virtual void SetSelectionMode (const IVtk_ShapePtrList& theShapes,
                                  const IVtk_SelectionMode theMode,
                                  const bool theIsTurnOn = true) = 0;
@@ -80,8 +80,8 @@ public: // @name Obtain picking results
   //! is the first in the list)
   virtual const IVtk_ShapeIdList& ShapesPicked() const = 0;
 
-  //! @param [in] theId Top-level shape ID
-  //! @param [out] theShapeList the list of picked sub-shape IDs for the given top-level shape ID,
+  //! @param[in]  theId Top-level shape ID
+  //! @param[out]  theShapeList the list of picked sub-shape IDs for the given top-level shape ID,
   //! in the order of increasing depth (the ID of the sub-shape closest to the eye 
   //! is the first in the list)
   virtual void SubShapesPicked (const IVtk_IdType theId, IVtk_ShapeIdList& theShapeList) const = 0;

--- a/src/IVtk/IVtk_IView.hxx
+++ b/src/IVtk/IVtk_IView.hxx
@@ -86,8 +86,8 @@ public:
                              Standard_Boolean& theIsOrtho) const = 0;
 
   //! Converts 3D display coordinates into 3D world coordinates.
-  //! @param [in] theDisplayPnt 2d point of display coordinates
-  //! @param [out] theWorldPnt 3d point of world coordinates
+  //! @param[in]  theDisplayPnt 2d point of display coordinates
+  //! @param[out]  theWorldPnt 3d point of world coordinates
   //! @return true if conversion was successful, false otherwise
   virtual bool    DisplayToWorld (const gp_XY& theDisplayPnt, gp_XYZ& theWorldPnt) const = 0;
 

--- a/src/IVtkOCC/IVtkOCC_SelectableObject.hxx
+++ b/src/IVtkOCC/IVtkOCC_SelectableObject.hxx
@@ -34,7 +34,7 @@ public:
   typedef Handle(IVtkOCC_SelectableObject) Handle;
 
   //! Constructs a selectable object initialized by the given shape
-  //! @param [in] theShape Selectable shape
+  //! @param[in]  theShape Selectable shape
   IVtkOCC_SelectableObject (const IVtkOCC_Shape::Handle& theShape);
 
   //! Constructs uninitialized selectable object.
@@ -44,7 +44,7 @@ public:
   virtual ~IVtkOCC_SelectableObject();
 
   //! Sets the selectable shape
-  //! @param [in] theShape Selectable shape
+  //! @param[in]  theShape Selectable shape
   Standard_EXPORT void SetShape (const IVtkOCC_Shape::Handle& theShape);
 
   const IVtkOCC_Shape::Handle&  GetShape() const { return myShape; };
@@ -58,8 +58,8 @@ private:
 
   //! Internal method, computes selection data for viewer selector
   //! Inspired by AIS_Shape::ComputeSelection() from OCCT 6.5.1
-  //! @param [in] selection container for sensitive primitives
-  //! @param [in] mode Selection mode
+  //! @param[in]  selection container for sensitive primitives
+  //! @param[in]  mode Selection mode
   virtual void ComputeSelection (const Handle(SelectMgr_Selection)& theSelection,
                                  const Standard_Integer theMode) Standard_OVERRIDE;
 

--- a/src/IVtkOCC/IVtkOCC_Shape.hxx
+++ b/src/IVtkOCC/IVtkOCC_Shape.hxx
@@ -33,8 +33,8 @@ public:
   typedef Handle(IVtkOCC_Shape) Handle;
 
   //! Constructor for OCC IShape implementation.
-  //! @param theShape [in] shape to display
-  //! @param theDrawerLink [in] default attributes to link
+  //! @param[in] theShape  shape to display
+  //! @param[in] theDrawerLink  default attributes to link
   Standard_EXPORT IVtkOCC_Shape (const TopoDS_Shape& theShape,
                                  const Handle(Prs3d_Drawer)& theDrawerLink = Handle(Prs3d_Drawer)());
 
@@ -58,7 +58,7 @@ public:
   //! Returns unique ID of the given sub-shape within the top-level shape.
   //! Note that the sub-shape ID remains unchanged until the top-level is 
   //! modified by some operation.
-  //! @param [in] subShape sub-shape whose ID is returned
+  //! @param[in]  subShape sub-shape whose ID is returned
   //! @return local ID of the sub-shape.
   Standard_EXPORT IVtk_IdType GetSubShapeId (const TopoDS_Shape& theSubShape) const;
 
@@ -67,7 +67,7 @@ public:
 
   //! @brief Get a sub-shape by its local ID.
   //!
-  //! @param [in] id local ID of a sub-shape
+  //! @param[in]  id local ID of a sub-shape
   //! @return TopoDS_Shape& a sub-shape
   Standard_EXPORT const TopoDS_Shape& GetSubShape (const IVtk_IdType theId) const;
 
@@ -75,7 +75,7 @@ public:
   //! in a data field. This object internally caches selection data
   //! so it should be stored until the shape is no longer selectable.
   //! Note that the selectable object keeps a pointer to OccShape.
-  //! @param [in] selObj Handle to the selectable object
+  //! @param[in]  selObj Handle to the selectable object
   void SetSelectableObject (const Handle(SelectMgr_SelectableObject)& theSelObj)
   {
     mySelectable = theSelObj;

--- a/src/IVtkOCC/IVtkOCC_ShapeMesher.hxx
+++ b/src/IVtkOCC/IVtkOCC_ShapeMesher.hxx
@@ -105,9 +105,9 @@ private:
   //! Generates wireframe representation of the given TopoDS_Face object
   //! with help of OCCT algorithms. The resulting polylines are passed to IPolyData
   //! interface and associated with the given sub-shape ID.
-  //! @param [in] theFace TopoDS_Face object to build wireframe representation for
-  //! @param [in] theShapeId The face' sub-shape ID
-  //! @param [in] theDeflection curve deflection
+  //! @param[in]  theFace TopoDS_Face object to build wireframe representation for
+  //! @param[in]  theShapeId The face' sub-shape ID
+  //! @param[in]  theDeflection curve deflection
   void addWFFace (const TopoDS_Face&  theFace,
                   const IVtk_IdType   theShapeId,
                   const Standard_Real theDeflection);
@@ -116,8 +116,8 @@ private:
   //! starting from OCCT triangulation that should be created in advance. 
   //! The resulting triangles are passed to IPolyData
   //! interface and associated with the given sub-shape ID.
-  //! @param [in] theFace    TopoDS_Face object to build shaded representation for
-  //! @param [in] theShapeId the face' sub-shape ID
+  //! @param[in]  theFace    TopoDS_Face object to build shaded representation for
+  //! @param[in]  theShapeId the face' sub-shape ID
   //! @see IVtkOCC_ShapeMesher::meshShape, IVtkOCC_ShapeMesher::addEdge
   void addShadedFace (const TopoDS_Face&  theFace,
                       const IVtk_IdType   theShapeId);

--- a/src/IVtkOCC/IVtkOCC_ShapePickerAlgo.hxx
+++ b/src/IVtkOCC/IVtkOCC_ShapePickerAlgo.hxx
@@ -44,7 +44,7 @@ public:
   Standard_EXPORT virtual int  NbPicked() Standard_OVERRIDE;
 
   //! Get activated selection modes for a shape.
-  //! @param [in] theShape a shape with activated selection mode(s)
+  //! @param[in]  theShape a shape with activated selection mode(s)
   //! @return list of active selection modes
   Standard_EXPORT virtual IVtk_SelectionModeList 
     GetSelectionModes (const IVtk_IShape::Handle& theShape) const Standard_OVERRIDE;
@@ -54,9 +54,9 @@ public: //! @name Set selectable shapes and selection modes
   //! Activates/deactivates the given selection mode for the shape.
   //! If mode == SM_None, the shape becomes non-selectable and 
   //! is removed from the internal selection data.
-  //! @param [in] theShape Shape for which the selection mode should be activated
-  //! @param [in] theMode Selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theShape Shape for which the selection mode should be activated
+  //! @param[in]  theMode Selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   Standard_EXPORT virtual void SetSelectionMode (const IVtk_IShape::Handle& theShape,
                                                  const IVtk_SelectionMode theMode,
                                                  const bool theIsTurnOn = true) Standard_OVERRIDE;
@@ -64,9 +64,9 @@ public: //! @name Set selectable shapes and selection modes
   //! Activates/deactivates the given selection mode for the shape.
   //! If mode == SM_None, the shape becomes non-selectable and 
   //! is removed from the internal selection data.
-  //! @param [in] theShapes List of shapes for which the selection mode should be activated
-  //! @param [in] theMode Selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theShapes List of shapes for which the selection mode should be activated
+  //! @param[in]  theMode Selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   Standard_EXPORT virtual void SetSelectionMode (const IVtk_ShapePtrList& theShapes,
                                                  const IVtk_SelectionMode theMode,
                                                  const bool theIsTurnOn = true) Standard_OVERRIDE;
@@ -89,15 +89,15 @@ public: //! @name Obtain picking results
   //! is the first in the list)
   Standard_EXPORT virtual const IVtk_ShapeIdList& ShapesPicked() const Standard_OVERRIDE;
 
-  //! @param [in] theId Top-level shape ID
-  //! @param [out] theShapeList the list of picked sub-shape IDs for the given top-level shape ID,
+  //! @param[in]  theId Top-level shape ID
+  //! @param[out]  theShapeList the list of picked sub-shape IDs for the given top-level shape ID,
   //! in the order of increasing depth (the ID of the sub-shape closest to the eye 
   //! is the first in the list)
   Standard_EXPORT virtual void 
     SubShapesPicked (const IVtk_IdType theId, IVtk_ShapeIdList& theShapeList) const Standard_OVERRIDE;
 
   //! Remove selectable object from the picker (from internal maps).
-  //! @param [in] theShape the selectable shape
+  //! @param[in]  theShape the selectable shape
   Standard_EXPORT virtual void RemoveSelectableObject(const IVtk_IShape::Handle& theShape);
 
   //! Return topmost picked 3D point or (Inf, Inf, Inf) if undefined.

--- a/src/IVtkOCC/IVtkOCC_ViewerSelector.hxx
+++ b/src/IVtkOCC/IVtkOCC_ViewerSelector.hxx
@@ -33,15 +33,15 @@ public:
   virtual ~IVtkOCC_ViewerSelector();
 
   //! Implements point picking
-  //! @param [in] theXPix, theYPix Display coordinates of the point
-  //! @param [in] theView  ICamera interface to update the projection parameters.
+  //! @param[in]  theXPix, theYPix Display coordinates of the point
+  //! @param[in]  theView  ICamera interface to update the projection parameters.
   void Pick (const Standard_Integer    theXPix,
              const Standard_Integer    theYPix,
              const IVtk_IView::Handle& theView);
 
   //! Picking by rectangle
-  //! @param [in] theXMin, theYMin, theXMax, theYMax Rectangle coords
-  //! @param [in] theView ICamera interface to calculate projections
+  //! @param[in]  theXMin, theYMin, theXMax, theYMax Rectangle coords
+  //! @param[in]  theView ICamera interface to calculate projections
   void Pick (const Standard_Integer    theXMin,
              const Standard_Integer    theYMin,
              const Standard_Integer    theXMax,

--- a/src/IVtkTools/IVtkTools.hxx
+++ b/src/IVtkTools/IVtkTools.hxx
@@ -35,33 +35,33 @@ namespace IVtkTools
 
   //! Set a color for given type of sub-shapes.
   //! @param [in,out] theColorTable vtkLookupTable to set the color.
-  //! @param [in]  theColorRole type of sub-shapes to set the color.
-  //! @param [in]  theR red color component. Use [0,1] double values.
-  //! @param [in]  theG green color component. Use [0,1] double values.
-  //! @param [in]  theB blue color component. Use [0,1] double values.
-  //! @param [in]  theA the alpha value (the opacity) as a double between 0 and 1.
+  //! @param[in]   theColorRole type of sub-shapes to set the color.
+  //! @param[in]   theR red color component. Use [0,1] double values.
+  //! @param[in]   theG green color component. Use [0,1] double values.
+  //! @param[in]   theB blue color component. Use [0,1] double values.
+  //! @param[in]   theA the alpha value (the opacity) as a double between 0 and 1.
   Standard_EXPORT void SetLookupTableColor (vtkLookupTable* theColorTable, 
                                             const IVtk_MeshType theColorRole, 
                                             const double theR, const double theG, const double theB, 
                                             const double theA = 1);
 
   //! Get a color for given type of sub-shapes.
-  //! @param [in]  theColorTable vtkLookupTable to set the color.
-  //! @param [in]  theColorRole type of sub-shapes to set the color.
-  //! @param [out] theR red color component as a double between 0 and 1.
-  //! @param [out] theG green color component as a double between 0 and 1.
-  //! @param [out] theB blue color component as a double between 0 and 1.
+  //! @param[in]   theColorTable vtkLookupTable to set the color.
+  //! @param[in]   theColorRole type of sub-shapes to set the color.
+  //! @param[out]  theR red color component as a double between 0 and 1.
+  //! @param[out]  theG green color component as a double between 0 and 1.
+  //! @param[out]  theB blue color component as a double between 0 and 1.
   Standard_EXPORT void GetLookupTableColor (vtkLookupTable* theColorTable, 
                                             const IVtk_MeshType theColorRole, 
                                             double &theR, double &theG, double &theB);
 
   //! Get a color for given type of sub-shapes.
-  //! @param [in]  theColorTable vtkLookupTable to set the color.
-  //! @param [in]  theColorRole type of sub-shapes to set the color.
-  //! @param [out] theR red color component as a double between 0 and 1.
-  //! @param [out] theG green color component as a double between 0 and 1.
-  //! @param [out] theB blue color component as a double between 0 and 1.
-  //! @param [out] theA the alpha value (the opacity) as a double between 0 and 1.
+  //! @param[in]   theColorTable vtkLookupTable to set the color.
+  //! @param[in]   theColorRole type of sub-shapes to set the color.
+  //! @param[out]  theR red color component as a double between 0 and 1.
+  //! @param[out]  theG green color component as a double between 0 and 1.
+  //! @param[out]  theB blue color component as a double between 0 and 1.
+  //! @param[out]  theA the alpha value (the opacity) as a double between 0 and 1.
   Standard_EXPORT void GetLookupTableColor (vtkLookupTable* theColorTable, 
                                             const IVtk_MeshType theColorRole, 
                                             double &theR, double &theG, double &theB, 
@@ -72,7 +72,7 @@ namespace IVtkTools
 
   //! Set up the initial shape mapper parameters with user colors.
   //! @param [in,out] theMapper mapper to initialize
-  //! @param [in] theColorTable a table with user's colors definition
+  //! @param[in]  theColorTable a table with user's colors definition
   Standard_EXPORT void InitShapeMapper (vtkMapper* theMapper, 
                                         vtkLookupTable* theColorTable);
 

--- a/src/IVtkTools/IVtkTools_ShapeDataSource.hxx
+++ b/src/IVtkTools/IVtkTools_ShapeDataSource.hxx
@@ -46,7 +46,7 @@ public:
 public: //! @name Initialization
 
   //! Set the source OCCT shape.
-  //! @param theOccShape [in] OCCT shape wrapper.
+  //! @param[in] theOccShape  OCCT shape wrapper.
   void SetShape(const IVtkOCC_Shape::Handle& theOccShape);
 
   //! Get the source OCCT shape.
@@ -63,7 +63,7 @@ public: //! @name Data accessors
   IVtk_IdType GetId() const;
 
   //! Checks if the internal OccShape pointer is the same the argument.
-  //! @param [in] shape OccShape pointer to be checked.
+  //! @param[in]  shape OccShape pointer to be checked.
   //! @return true if the two OccShape instances are the same, and false otherwise.
   Standard_Boolean Contains (const IVtkOCC_Shape::Handle& theOccShape) const;
 
@@ -76,11 +76,11 @@ protected: //! @name Interface to override
   //! This is called by the superclass.
   //! This is the method you should override if you use this class as ancestor.
   //! Build output polygonal data set from the shape wrapper.
-  //! @param theRequest [in] information about data object.
+  //! @param[in] theRequest  information about data object.
   //! In current implementation it is ignored.
-  //! @param theInputVector [in] the input data. As adata source is the start
+  //! @param[in] theInputVector  the input data. As adata source is the start
   //! stage of the VTK pipeline, theInputVector is empty and not used (no input port).
-  //! @param theOutputVector [in] the pointer to output data, that is filled in this method.
+  //! @param[in] theOutputVector  the pointer to output data, that is filled in this method.
   virtual int RequestData(vtkInformation* theRequest,
                           vtkInformationVector** theInputVector,
                           vtkInformationVector* theOutputVector) Standard_OVERRIDE;
@@ -89,8 +89,8 @@ protected: //! @name Internals
 
   //! Transforms the passed polygonal data by the given OCCT transformation
   //! matrix.
-  //! @param theSource [in] source polygonal data to transform.
-  //! @param theTrsf [in] transformation to apply.
+  //! @param[in] theSource  source polygonal data to transform.
+  //! @param[in] theTrsf  transformation to apply.
   //! @return resulting polygonal data (transformed copy of source).
   vtkSmartPointer<vtkPolyData> transform (vtkPolyData* theSource, const gp_Trsf& theTrsf) const;
 

--- a/src/IVtkTools/IVtkTools_ShapePicker.hxx
+++ b/src/IVtkTools/IVtkTools_ShapePicker.hxx
@@ -67,38 +67,38 @@ public:
   //! Sets the renderer to be used by OCCT selection algorithm
   void SetRenderer (vtkRenderer* theRenderer);
   //! Sets area selection on/off
-  //! @param [in] theIsOn true if area selection is turned on, false otherwise.
+  //! @param[in]  theIsOn true if area selection is turned on, false otherwise.
   void SetAreaSelection (bool theIsOn);
 
   //! Get activated selection modes for a shape.
-  //! @param [in] theShape a shape with activated selection mode(s)
+  //! @param[in]  theShape a shape with activated selection mode(s)
   //! @return list of active selection modes
   IVtk_SelectionModeList GetSelectionModes (const IVtk_IShape::Handle& theShape) const;
 
   //! Get activated selection modes for a shape actor.
-  //! @param [in] theShapeActor an actor with activated selection mode(s)
+  //! @param[in]  theShapeActor an actor with activated selection mode(s)
   //! @return list of active selection modes
   IVtk_SelectionModeList GetSelectionModes (vtkActor* theShapeActor) const;
 
   //! Turn on/off a selection mode for a shape actor.
-  //! @param [in] theShape a shape to set a selection mode for
-  //! @param [in] theMode selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theShape a shape to set a selection mode for
+  //! @param[in]  theMode selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   void SetSelectionMode (const IVtk_IShape::Handle& theShape,
                          const IVtk_SelectionMode theMode,
                          const bool theIsTurnOn = true) const;
 
   //! Turn on/off a selection mode for a shape actor.
-  //! @param [in] theShapeActor shape presentation actor to set a selection mode for
-  //! @param [in] theMode selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theShapeActor shape presentation actor to set a selection mode for
+  //! @param[in]  theMode selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   void SetSelectionMode (vtkActor* theShapeActor,
                          const IVtk_SelectionMode theMode,
                          const bool theIsTurnOn = true) const;
 
   //! Sets the current selection mode for all visible shape objects.
-  //! @param [in] theMode selection mode to be activated
-  //! @param [in] theIsTurnOn Flag to turn on/off the selection mode
+  //! @param[in]  theMode selection mode to be activated
+  //! @param[in]  theIsTurnOn Flag to turn on/off the selection mode
   void SetSelectionMode (const IVtk_SelectionMode theMode,
                          const bool theIsTurnOn = true) const;
 
@@ -109,30 +109,30 @@ public:
   //! all OccShape objects found by the picking algorithm. e.g. all 
   //! shapes under the mouse cursor. Otherwise, ID of the shape closest to the eye
   //! is returned.
-  //! @param [in] theIsAll Get all selected shapes or just the only
+  //! @param[in]  theIsAll Get all selected shapes or just the only
   //!        top one is returned, has no effect during area selection.
   //! @return List of top-level shape IDs
   IVtk_ShapeIdList GetPickedShapesIds (bool theIsAll = false) const;
 
   //! Access to the list of sub-shapes ids picked. 
-  //! @param [in] theId top-level shape ID
-  //! @param [in] theIsAll Get all selected sub-shapes or just the 
+  //! @param[in]  theId top-level shape ID
+  //! @param[in]  theIsAll Get all selected sub-shapes or just the 
   //!        only top one is returned, has no effect during area selection.
   //! @return List of sub-shapes IDs
   IVtk_ShapeIdList GetPickedSubShapesIds (const IVtk_IdType theId, bool theIsAll = false) const;
 
   //! Access to the list of actors picked. 
-  //! @param [in] theIsAll Get all selected actors or just the only
+  //! @param[in]  theIsAll Get all selected actors or just the only
   //!         top one is returned, has no effect during area selection.
   //! @return List of actors IDs
   vtkSmartPointer<vtkActorCollection> GetPickedActors (bool theIsAll = false) const;
 
   //! Remove selectable object from the picker (from internal maps).
-  //! @param [in] theShape the selectable shape
+  //! @param[in]  theShape the selectable shape
   void RemoveSelectableObject(const IVtk_IShape::Handle& theShape);
 
   //! Remove selectable object from the picker (from internal maps).
-  //! @param [in] theShapeActor the shape presentation actor to be removed from the picker
+  //! @param[in]  theShapeActor the shape presentation actor to be removed from the picker
   void RemoveSelectableActor(vtkActor* theShapeActor);
 
 protected:
@@ -152,10 +152,10 @@ private: // not copyable
 
   //! Implementation of picking algorithm. 
   //! The coordinates accepted by this method are display (pixel) coordinates.
-  //! @param [in] pos contains the pick point (3 coordinates) or pick rectangle (6 coordinates)
+  //! @param[in]  pos contains the pick point (3 coordinates) or pick rectangle (6 coordinates)
   //! or polyline (array of 2d coordinates)
-  //! @param [in] renderer vtkRenderer object to be used (normally set in advance with setRenderer())
-  //! @param [in] nbPoints number of points for polyline case
+  //! @param[in]  renderer vtkRenderer object to be used (normally set in advance with setRenderer())
+  //! @param[in]  nbPoints number of points for polyline case
   //! @see IVtkTools_ShapePicker::setRenderer
   virtual void doPickImpl (double*, vtkRenderer* theRenderer, const int theNbPoints = -1);
 

--- a/src/IVtkVTK/IVtkVTK_ShapeData.hxx
+++ b/src/IVtkVTK/IVtkVTK_ShapeData.hxx
@@ -54,43 +54,43 @@ public:
   DEFINE_STANDARD_RTTIEXT(IVtkVTK_ShapeData,IVtk_IShapeData)
 
   //! Insert a coordinate
-  //! @param [in] thePnt  point position
-  //! @param [in] theNorm point normal
+  //! @param[in]  thePnt  point position
+  //! @param[in]  theNorm point normal
   //! @return id of added point
   Standard_EXPORT virtual IVtk_PointId InsertPoint (const gp_Pnt& thePnt,
                                                     const NCollection_Vec3<float>& theNorm) Standard_OVERRIDE;
 
   //! Insert a vertex.
-  //! @param [in] theShapeID id of the subshape to which the vertex belongs.
-  //! @param [in] thePointId id of the point that defines the coordinates of the vertex
-  //! @param [in] theMeshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the subshape to which the vertex belongs.
+  //! @param[in]  thePointId id of the point that defines the coordinates of the vertex
+  //! @param[in]  theMeshType mesh type of the subshape (MT_Undefined by default)
   Standard_EXPORT virtual void InsertVertex (const IVtk_IdType   theShapeID,
                                              const IVtk_PointId  thePointId,
                                              const IVtk_MeshType theMeshType) Standard_OVERRIDE;
 
   //! Insert a line.
-  //! @param [in] theShapeID id of the subshape to which the line belongs.
-  //! @param [in] thePointId1 id of the first point
-  //! @param [in] thePointId2 id of the second point
-  //! @param [in] theMeshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the subshape to which the line belongs.
+  //! @param[in]  thePointId1 id of the first point
+  //! @param[in]  thePointId2 id of the second point
+  //! @param[in]  theMeshType mesh type of the subshape (MT_Undefined by default)
   Standard_EXPORT virtual void InsertLine (const IVtk_IdType   theShapeID,
                                            const IVtk_PointId  thePointId1,
                                            const IVtk_PointId  thePointId2,
                                            const IVtk_MeshType theMeshType) Standard_OVERRIDE;
 
   //! Insert a poly-line.
-  //! @param [in] theShapeID id of the subshape to which the polyline belongs.
-  //! @param [in] thePointIds vector of point ids
-  //! @param [in] theMeshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the subshape to which the polyline belongs.
+  //! @param[in]  thePointIds vector of point ids
+  //! @param[in]  theMeshType mesh type of the subshape (MT_Undefined by default)
   Standard_EXPORT virtual void InsertLine (const IVtk_IdType       theShapeID, 
                                            const IVtk_PointIdList* thePointIds,
                                            const IVtk_MeshType     theMeshType) Standard_OVERRIDE;
   //! Insert a triangle
-  //! @param [in] theShapeID id of the subshape to which the triangle belongs.
-  //! @param [in] thePointId1 id of the first point
-  //! @param [in] thePointId2 id of the second point
-  //! @param [in] thePointId3 id of the third point
-  //! @param [in] theMeshType mesh type of the subshape (MT_Undefined by default)
+  //! @param[in]  theShapeID id of the subshape to which the triangle belongs.
+  //! @param[in]  thePointId1 id of the first point
+  //! @param[in]  thePointId2 id of the second point
+  //! @param[in]  thePointId3 id of the third point
+  //! @param[in]  theMeshType mesh type of the subshape (MT_Undefined by default)
   Standard_EXPORT virtual void InsertTriangle (const IVtk_IdType   theShapeID,
                                                const IVtk_PointId  thePointId1,
                                                const IVtk_PointId  thePointId2,

--- a/src/IVtkVTK/IVtkVTK_View.hxx
+++ b/src/IVtkVTK/IVtkVTK_View.hxx
@@ -94,8 +94,8 @@ public:
                                               Standard_Real& theHeight) const Standard_OVERRIDE;
 
   //! Converts 3D display coordinates into 3D world coordinates.
-  //! @param [in] theDisplayPnt 2d point of display coordinates
-  //! @param [out] theWorldPnt 3d point of world coordinates
+  //! @param[in]  theDisplayPnt 2d point of display coordinates
+  //! @param[out]  theWorldPnt 3d point of world coordinates
   //! @return true if conversion was successful, false otherwise
   Standard_EXPORT virtual bool DisplayToWorld (const gp_XY& theDisplayPnt, gp_XYZ& theWorldPnt) const Standard_OVERRIDE;
 

--- a/src/Image/Image_DDSParser.hxx
+++ b/src/Image/Image_DDSParser.hxx
@@ -25,11 +25,11 @@ class Image_DDSParser
 public:
 
   //! Load the face from DDS file.
-  //! @param theSupported [in] list of supported image formats
-  //! @param theFile      [in] file path
-  //! @param theFaceIndex [in] face index, within [0, Image_CompressedPixMap::NbFaces()) range;
+  //! @param[in] theSupported  list of supported image formats
+  //! @param[in] theFile       file path
+  //! @param[in] theFaceIndex  face index, within [0, Image_CompressedPixMap::NbFaces()) range;
   //!                          use -1 to skip reading the face data
-  //! @param theFileOffset [in] offset to the DDS data
+  //! @param[in] theFileOffset  offset to the DDS data
   //! @return loaded face or NULL if file cannot be read or not valid DDS file
   Standard_EXPORT static Handle(Image_CompressedPixMap) Load (const Handle(Image_SupportedFormats)& theSupported,
                                                               const TCollection_AsciiString& theFile,
@@ -37,9 +37,9 @@ public:
                                                               const int64_t theFileOffset = 0);
 
   //! Load the face from DDS file.
-  //! @param theSupported [in] list of supported image formats
-  //! @param theBuffer    [in] pre-loaded file data, should be at least of 128 bytes long defining DDS header.
-  //! @param theFaceIndex [in] face index, within [0, Image_CompressedPixMap::NbFaces()) range;
+  //! @param[in] theSupported  list of supported image formats
+  //! @param[in] theBuffer     pre-loaded file data, should be at least of 128 bytes long defining DDS header.
+  //! @param[in] theFaceIndex  face index, within [0, Image_CompressedPixMap::NbFaces()) range;
   //!                          use -1 to skip reading the face data
   //! @return loaded face or NULL if file cannot be read or not valid DDS file
   Standard_EXPORT static Handle(Image_CompressedPixMap) Load (const Handle(Image_SupportedFormats)& theSupported,

--- a/src/Image/Image_VideoRecorder.hxx
+++ b/src/Image/Image_VideoRecorder.hxx
@@ -85,8 +85,8 @@ public:
   Standard_EXPORT void Close();
 
   //! Open output stream - initialize recorder.
-  //! @param theFileName [in] video filename
-  //! @param theParams   [in] video parameters
+  //! @param[in] theFileName  video filename
+  //! @param[in] theParams    video parameters
   Standard_EXPORT Standard_Boolean Open (const char* theFileName,
                                          const Image_VideoParams& theParams);
 
@@ -109,8 +109,8 @@ protected:
   Standard_EXPORT TCollection_AsciiString formatAvError (const int theError) const;
 
   //! Append video stream.
-  //! theParams     [in] video parameters
-  //! theDefCodecId [in] identifier of codec managed by FFmpeg library (AVCodecID enum)
+  //! theParams[in]      video parameters
+  //! theDefCodecId[in]  identifier of codec managed by FFmpeg library (AVCodecID enum)
   Standard_EXPORT Standard_Boolean addVideoStream (const Image_VideoParams& theParams,
                                                    const Standard_Integer   theDefCodecId);
 

--- a/src/IntTools/IntTools_FaceFace.hxx
+++ b/src/IntTools/IntTools_FaceFace.hxx
@@ -76,7 +76,7 @@ public:
   Standard_EXPORT Standard_Boolean TangentFaces() const;
 
   //! Provides post-processing the result lines.
-  //! @param bToSplit [in] split the closed 3D-curves on parts when TRUE,
+  //! @param[in] bToSplit  split the closed 3D-curves on parts when TRUE,
   //!                      remain untouched otherwise
   Standard_EXPORT void PrepareLines3D (const Standard_Boolean bToSplit = Standard_True);
 

--- a/src/Media/Media_PlayerContext.hxx
+++ b/src/Media/Media_PlayerContext.hxx
@@ -36,16 +36,16 @@ class Media_PlayerContext : public Standard_Transient
 public:
 
   //! Dump first video frame.
-  //! @param theSrcVideo [in] path to the video
-  //! @param theMediaInfo [out] video description
+  //! @param[in] theSrcVideo  path to the video
+  //! @param[out] theMediaInfo  video description
   Standard_EXPORT static Handle(Media_Frame) DumpFirstFrame (const TCollection_AsciiString& theSrcVideo,
                                                              TCollection_AsciiString& theMediaInfo);
 
   //! Dump first video frame.
-  //! @param theSrcVideo [in] path to the video
-  //! @param theOutImage [in] path to make a screenshot
-  //! @param theMediaInfo [out] video description
-  //! @param theMaxSize [in] when positive - downscales image to specified size
+  //! @param[in] theSrcVideo  path to the video
+  //! @param[in] theOutImage  path to make a screenshot
+  //! @param[out] theMediaInfo  video description
+  //! @param[in] theMaxSize  when positive - downscales image to specified size
   Standard_EXPORT static bool DumpFirstFrame (const TCollection_AsciiString& theSrcVideo,
                                               const TCollection_AsciiString& theOutImage,
                                               TCollection_AsciiString& theMediaInfo,

--- a/src/MeshVS/MeshVS_Mesh.hxx
+++ b/src/MeshVS/MeshVS_Mesh.hxx
@@ -183,9 +183,9 @@ friend class MeshVS_PrsBuilder;
 protected:
 
   //! Stores all vertices that belong to one of the faces to the given map
-  //! @param theAllElements [in] the map of all mesh elements
-  //! @param theNbMaxFaceNodes [in] the maximum amount of nodes per face, retrieved from drawer
-  //! @param theSharedNodes [out] the result map of all vertices that belong to one face at least
+  //! @param[in] theAllElements  the map of all mesh elements
+  //! @param[in] theNbMaxFaceNodes  the maximum amount of nodes per face, retrieved from drawer
+  //! @param[out] theSharedNodes  the result map of all vertices that belong to one face at least
   Standard_EXPORT void scanFacesForSharedNodes (const TColStd_PackedMapOfInteger& theAllElements,
                                                 const Standard_Integer theNbMaxFaceNodes,
                                                 TColStd_PackedMapOfInteger& theSharedNodes) const;

--- a/src/Message/Message.hxx
+++ b/src/Message/Message.hxx
@@ -112,14 +112,14 @@ public:
   }
 
   //! Converts message metric to OSD memory info type.
-  //! @param theMetric [in] message metric
-  //! @param theMemInfo [out] filled memory info type
+  //! @param[in] theMetric  message metric
+  //! @param[out] theMemInfo  filled memory info type
   //! @return true if converted
   static Standard_EXPORT Standard_Boolean ToOSDMetric (const Message_MetricType theMetric, OSD_MemInfo::Counter& theMemInfo);
 
   //! Converts OSD memory info type to message metric.
   //! @param theMemInfo [int] memory info type
-  //! @param theMetric [out] filled message metric
+  //! @param[out] theMetric  filled message metric
   //! @return true if converted
   static Standard_EXPORT Standard_Boolean ToMessageMetric (const OSD_MemInfo::Counter theMemInfo, Message_MetricType& theMetric);
 

--- a/src/Message/Message_AttributeMeter.hxx
+++ b/src/Message/Message_AttributeMeter.hxx
@@ -37,31 +37,31 @@ public:
   Standard_EXPORT Message_AttributeMeter (const TCollection_AsciiString& theName = TCollection_AsciiString());
 
   //! Checks whether the attribute has values for the metric
-  //! @param theMetric [in] metric type
+  //! @param[in] theMetric  metric type
   //! @return true if the metric values exist in the attribute
   Standard_EXPORT Standard_Boolean HasMetric (const Message_MetricType& theMetric) const;
 
   //! Returns true when both values of the metric are set.
-  //! @param theMetric [in] metric type
+  //! @param[in] theMetric  metric type
   //! @return true if metric values are valid
   Standard_EXPORT Standard_Boolean IsMetricValid (const Message_MetricType& theMetric) const;
 
   //! Returns start value for the metric
-  //! @param theMetric [in] metric type
+  //! @param[in] theMetric  metric type
   //! @return real value
   Standard_EXPORT Standard_Real StartValue (const Message_MetricType& theMetric) const;
 
   //! Sets start values for the metric
-  //! @param theMetric [in] metric type
+  //! @param[in] theMetric  metric type
   Standard_EXPORT void SetStartValue (const Message_MetricType& theMetric, const Standard_Real theValue);
 
   //! Returns stop value for the metric
-  //! @param theMetric [in] metric type
+  //! @param[in] theMetric  metric type
   //! @return real value
   Standard_EXPORT Standard_Real StopValue (const Message_MetricType& theMetric) const;
 
   //! Sets stop values for the metric
-  //! @param theMetric [in] metric type
+  //! @param[in] theMetric  metric type
   Standard_EXPORT void SetStopValue (const Message_MetricType& theMetric, const Standard_Real theValue);
 
 public:

--- a/src/Message/Message_LazyProgressScope.hxx
+++ b/src/Message/Message_LazyProgressScope.hxx
@@ -28,11 +28,11 @@ class Message_LazyProgressScope : protected Message_ProgressScope
 public:
 
   //! Main constructor.
-  //! @param theRange [in] progress range to scope
-  //! @param theName  [in] name of this scope
-  //! @param theMax   [in] number of steps within this scope
-  //! @param thePatchStep [in] number of steps to update progress
-  //! @param theIsInf [in] infinite flag
+  //! @param[in] theRange  progress range to scope
+  //! @param[in] theName   name of this scope
+  //! @param[in] theMax    number of steps within this scope
+  //! @param[in] thePatchStep  number of steps to update progress
+  //! @param[in] theIsInf  infinite flag
   Message_LazyProgressScope (const Message_ProgressRange& theRange,
                              const char* theName,
                              const Standard_Real theMax,

--- a/src/Message/Message_ProgressScope.hxx
+++ b/src/Message/Message_ProgressScope.hxx
@@ -217,10 +217,10 @@ public: //! @name Preparation methods
   //! The topmost scope is created and owned by Message_ProgressIndicator
   //! and its pointer is contained in the Message_ProgressRange returned by the Start() method of progress indicator.
   //!
-  //! @param theRange [in][out] range to fill (will be disarmed)
-  //! @param theName  [in]      new scope name
-  //! @param theMax   [in]      number of steps in scope
-  //! @param isInfinite [in]    infinite flag
+  //! @param[in][out] theRange  range to fill (will be disarmed)
+  //! @param[in] theName        new scope name
+  //! @param[in] theMax         number of steps in scope
+  //! @param[in] isInfinite     infinite flag
   Message_ProgressScope (const Message_ProgressRange& theRange,
                          const TCollection_AsciiString& theName,
                          Standard_Real theMax,
@@ -233,10 +233,10 @@ public: //! @name Preparation methods
   //! The topmost scope is created and owned by Message_ProgressIndicator
   //! and its pointer is contained in the Message_ProgressRange returned by the Start() method of progress indicator.
   //!
-  //! @param theRange [in][out] range to fill (will be disarmed)
-  //! @param theName  [in]      new scope name constant (will be stored by pointer with no deep copy)
-  //! @param theMax   [in]      number of steps in scope
-  //! @param isInfinite [in]    infinite flag
+  //! @param[in][out] theRange  range to fill (will be disarmed)
+  //! @param[in] theName        new scope name constant (will be stored by pointer with no deep copy)
+  //! @param[in] theMax         number of steps in scope
+  //! @param[in] isInfinite     infinite flag
   template<size_t N>
   Message_ProgressScope (const Message_ProgressRange& theRange,
                          const char (&theName)[N],
@@ -250,10 +250,10 @@ public: //! @name Preparation methods
   //! The topmost scope is created and owned by Message_ProgressIndicator
   //! and its pointer is contained in the Message_ProgressRange returned by the Start() method of progress indicator.
   //!
-  //! @param theRange [in][out] range to fill (will be disarmed)
-  //! @param theName  [in]      empty scope name (only NULL is accepted as argument)
-  //! @param theMax   [in]      number of steps in scope
-  //! @param isInfinite [in]    infinite flag
+  //! @param[in][out] theRange  range to fill (will be disarmed)
+  //! @param[in] theName        empty scope name (only NULL is accepted as argument)
+  //! @param[in] theMax         number of steps in scope
+  //! @param[in] isInfinite     infinite flag
   Message_ProgressScope (const Message_ProgressRange& theRange,
                          const NullString* theName,
                          Standard_Real theMax,

--- a/src/NCollection/NCollection_DoubleMap.hxx
+++ b/src/NCollection/NCollection_DoubleMap.hxx
@@ -408,8 +408,8 @@ public:
   }
 
   //! Find the Key1 and return Key2 value (by copying its value).
-  //! @param [in]  theKey1 Key1 to find
-  //! @param [out] theKey2 Key2 to return
+  //! @param[in]   theKey1 Key1 to find
+  //! @param[out]  theKey2 Key2 to return
   //! @return TRUE if Key1 has been found
   Standard_Boolean Find1 (const TheKey1Type& theKey1,
                           TheKey2Type& theKey2) const
@@ -423,7 +423,7 @@ public:
   }
 
   //! Find the Key1 and return pointer to Key2 or NULL if Key1 is not bound.
-  //! @param [in]  theKey1 Key1 to find
+  //! @param[in]   theKey1 Key1 to find
   //! @return pointer to Key2 or NULL if Key1 is not found
   const TheKey2Type* Seek1 (const TheKey1Type& theKey1) const
   {
@@ -450,8 +450,8 @@ public:
   }
 
   //! Find the Key2 and return Key1 value (by copying its value).
-  //! @param [in]  theKey2 Key2 to find
-  //! @param [out] theKey1 Key1 to return
+  //! @param[in]   theKey2 Key2 to find
+  //! @param[out]  theKey1 Key1 to return
   //! @return TRUE if Key2 has been found
   Standard_Boolean Find2 (const TheKey2Type& theKey2,
                           TheKey1Type& theKey1) const
@@ -465,7 +465,7 @@ public:
   }
 
   //! Find the Key2 and return pointer to Key1 or NULL if not bound.
-  //! @param [in] theKey2 Key2 to find
+  //! @param[in]  theKey2 Key2 to find
   //! @return pointer to Key1 if Key2 has been found
   const TheKey1Type* Seek2 (const TheKey2Type& theKey2) const
   {

--- a/src/NCollection/NCollection_Lerp.hxx
+++ b/src/NCollection/NCollection_Lerp.hxx
@@ -57,7 +57,7 @@ public:
   //! Compute interpolated value between two values.
   //! @param theT normalized interpolation coefficient within [0, 1] range,
   //!             with 0 pointing to first value and 1 to the second value.
-  //! @param theResult [out] interpolated value
+  //! @param[out] theResult  interpolated value
   void Interpolate (double theT, T& theResult) const
   {
     theResult = (1.0 - theT) * myStart + theT * myEnd;

--- a/src/NCollection/NCollection_Mat3.hxx
+++ b/src/NCollection/NCollection_Mat3.hxx
@@ -57,8 +57,8 @@ public:
   }
 
   //! Get element at the specified row and column.
-  //! @param theRow [in] the row.to address.
-  //! @param theCol [in] the column to address.
+  //! @param[in] theRow  the row.to address.
+  //! @param[in] theCol  the column to address.
   //! @return the value of the addressed element.
   Element_t GetValue (const size_t theRow, const size_t theCol) const
   {
@@ -66,8 +66,8 @@ public:
   }
 
   //! Access element at the specified row and column.
-  //! @param theRow [in] the row.to access.
-  //! @param theCol [in] the column to access.
+  //! @param[in] theRow  the row.to access.
+  //! @param[in] theCol  the column to access.
   //! @return reference on the matrix element.
   Element_t& ChangeValue (const size_t theRow, const size_t theCol)
   {
@@ -75,9 +75,9 @@ public:
   }
 
   //! Set value for the element specified by row and columns.
-  //! @param theRow   [in] the row to change.
-  //! @param theCol   [in] the column to change.
-  //! @param theValue [in] the value to set.s
+  //! @param[in] theRow    the row to change.
+  //! @param[in] theCol    the column to change.
+  //! @param[in] theValue  the value to set.s
   void SetValue (const size_t    theRow,
                  const size_t    theCol,
                  const Element_t theValue)
@@ -98,8 +98,8 @@ public:
   }
 
   //! Change first 3 row values by the passed vector.
-  //! @param theRow [in] the row to change.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theRow  the row to change.
+  //! @param[in] theVec  the vector of values.
   void SetRow (const size_t theRow, const NCollection_Vec3<Element_t>& theVec)
   {
     SetValue (theRow, 0, theVec.x());
@@ -114,8 +114,8 @@ public:
   }
 
   //! Change first 3 column values by the passed vector.
-  //! @param theCol [in] the column to change.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theCol  the column to change.
+  //! @param[in] theVec  the vector of values.
   void SetColumn (const size_t theCol,
                   const NCollection_Vec3<Element_t>& theVec)
   {
@@ -182,7 +182,7 @@ public:
   Element_t*       ChangeData()       { return myMat; }
 
   //! Multiply by the vector (M * V).
-  //! @param theVec [in] the vector to multiply.
+  //! @param[in] theVec  the vector to multiply.
   NCollection_Vec3<Element_t> operator* (const NCollection_Vec3<Element_t>& theVec) const
   {
     return NCollection_Vec3<Element_t> (
@@ -192,8 +192,8 @@ public:
   }
 
   //! Compute matrix multiplication product: A * B.
-  //! @param theMatA [in] the matrix "A".
-  //! @param theMatB [in] the matrix "B".
+  //! @param[in] theMatA  the matrix "A".
+  //! @param[in] theMatB  the matrix "B".
   static NCollection_Mat3 Multiply (const NCollection_Mat3& theMatA,
                                     const NCollection_Mat3& theMatB)
   {
@@ -214,14 +214,14 @@ public:
   }
 
   //! Compute matrix multiplication.
-  //! @param theMat [in] the matrix to multiply.
+  //! @param[in] theMat  the matrix to multiply.
   void Multiply (const NCollection_Mat3& theMat)
   {
     *this = Multiply(*this, theMat);
   }
 
   //! Multiply by the another matrix.
-  //! @param theMat [in] the other matrix.
+  //! @param[in] theMat  the other matrix.
   NCollection_Mat3& operator*= (const NCollection_Mat3& theMat)
   {
     Multiply (theMat);
@@ -229,7 +229,7 @@ public:
   }
 
   //! Compute matrix multiplication product.
-  //! @param theMat [in] the other matrix.
+  //! @param[in] theMat  the other matrix.
   //! @return result of multiplication.
   Standard_NODISCARD NCollection_Mat3 operator* (const NCollection_Mat3& theMat) const
   {
@@ -237,7 +237,7 @@ public:
   }
 
   //! Compute matrix multiplication product.
-  //! @param theMat [in] the other matrix.
+  //! @param[in] theMat  the other matrix.
   //! @return result of multiplication.
   Standard_NODISCARD NCollection_Mat3 Multiplied (const NCollection_Mat3& theMat) const
   {
@@ -247,7 +247,7 @@ public:
   }
 
   //! Compute per-component multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   void Multiply (const Element_t theFactor)
   {
     for (size_t i = 0; i < 9; ++i)
@@ -257,7 +257,7 @@ public:
   }
 
   //! Compute per-element multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   NCollection_Mat3& operator*= (const Element_t theFactor)
   {
     Multiply (theFactor);
@@ -265,7 +265,7 @@ public:
   }
 
   //! Compute per-element multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   //! @return the result of multiplication.
   Standard_NODISCARD NCollection_Mat3 operator* (const Element_t theFactor) const
   {
@@ -273,7 +273,7 @@ public:
   }
 
   //! Compute per-element multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   //! @return the result of multiplication.
   Standard_NODISCARD NCollection_Mat3 Multiplied (const Element_t theFactor) const
   {
@@ -283,7 +283,7 @@ public:
   }
 
   //! Compute per-component division.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   void Divide (const Element_t theFactor)
   {
     for (size_t i = 0; i < 9; ++i)
@@ -293,7 +293,7 @@ public:
   }
 
   //! Per-component division.
-  //! @param theScalar [in] the scale factor.
+  //! @param[in] theScalar  the scale factor.
   NCollection_Mat3& operator/= (const Element_t theScalar)
   {
     Divide (theScalar);

--- a/src/NCollection/NCollection_Mat4.hxx
+++ b/src/NCollection/NCollection_Mat4.hxx
@@ -76,8 +76,8 @@ public:
   }
 
   //! Get element at the specified row and column.
-  //! @param theRow [in] the row to address.
-  //! @param theCol [in] the column to address.
+  //! @param[in] theRow  the row to address.
+  //! @param[in] theCol  the column to address.
   //! @return the value of the addressed element.
   Element_t GetValue (const size_t theRow, const size_t theCol) const
   {
@@ -85,8 +85,8 @@ public:
   }
 
   //! Access element at the specified row and column.
-  //! @param theRow [in] the row to access.
-  //! @param theCol [in] the column to access.
+  //! @param[in] theRow  the row to access.
+  //! @param[in] theCol  the column to access.
   //! @return reference on the matrix element.
   Element_t& ChangeValue (const size_t theRow, const size_t theCol)
   {
@@ -94,9 +94,9 @@ public:
   }
 
   //! Set value for the element specified by row and columns.
-  //! @param theRow   [in] the row to change.
-  //! @param theCol   [in] the column to change.
-  //! @param theValue [in] the value to set.
+  //! @param[in] theRow    the row to change.
+  //! @param[in] theCol    the column to change.
+  //! @param[in] theValue  the value to set.
   void SetValue (const size_t    theRow,
                  const size_t    theCol,
                  const Element_t theValue)
@@ -111,7 +111,7 @@ public:
   Element_t  operator() (const size_t theRow, const size_t theCol) const { return GetValue (theRow, theCol); }
 
   //! Get vector of elements for the specified row.
-  //! @param theRow [in] the row to access.
+  //! @param[in] theRow  the row to access.
   //! @return vector of elements.
   NCollection_Vec4<Element_t> GetRow (const size_t theRow) const
   {
@@ -122,8 +122,8 @@ public:
   }
 
   //! Change first 3 row values by the passed vector.
-  //! @param theRow [in] the row to change.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theRow  the row to change.
+  //! @param[in] theVec  the vector of values.
   void SetRow (const size_t theRow, const NCollection_Vec3<Element_t>& theVec)
   {
     SetValue (theRow, 0, theVec.x());
@@ -132,8 +132,8 @@ public:
   }
 
   //! Set row values by the passed 4 element vector.
-  //! @param theRow [in] the row to change.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theRow  the row to change.
+  //! @param[in] theVec  the vector of values.
   void SetRow (const size_t theRow, const NCollection_Vec4<Element_t>& theVec)
   {
     SetValue (theRow, 0, theVec.x());
@@ -143,7 +143,7 @@ public:
   }
 
   //! Get vector of elements for the specified column.
-  //! @param theCol [in] the column to access.
+  //! @param[in] theCol  the column to access.
   //! @return vector of elements.
   NCollection_Vec4<Element_t> GetColumn (const size_t theCol) const
   {
@@ -154,8 +154,8 @@ public:
   }
 
   //! Change first 3 column values by the passed vector.
-  //! @param theCol [in] the column to change.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theCol  the column to change.
+  //! @param[in] theVec  the vector of values.
   void SetColumn (const size_t theCol,
                   const NCollection_Vec3<Element_t>& theVec)
   {
@@ -165,8 +165,8 @@ public:
   }
 
   //! Set column values by the passed 4 element vector.
-  //! @param theCol [in] the column to change.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theCol  the column to change.
+  //! @param[in] theVec  the vector of values.
   void SetColumn (const size_t theCol,
                   const NCollection_Vec4<Element_t>& theVec)
   {
@@ -196,7 +196,7 @@ public:
   }
 
   //! Set diagonal elements of the matrix by the passed vector.
-  //! @param theVec [in] the vector of values.
+  //! @param[in] theVec  the vector of values.
   void SetDiagonal (const NCollection_Vec4<Element_t>& theVec)
   {
     SetValue (0, 0, theVec.x());
@@ -257,7 +257,7 @@ public:
   Element_t*       ChangeData()       { return myMat; }
 
   //! Multiply by the vector (M * V).
-  //! @param theVec [in] the vector to multiply.
+  //! @param[in] theVec  the vector to multiply.
   NCollection_Vec4<Element_t> operator* (const NCollection_Vec4<Element_t>& theVec) const
   {
     return NCollection_Vec4<Element_t> (
@@ -268,8 +268,8 @@ public:
   }
 
   //! Compute matrix multiplication product: A * B.
-  //! @param theMatA [in] the matrix "A".
-  //! @param theMatB [in] the matrix "B".
+  //! @param[in] theMatA  the matrix "A".
+  //! @param[in] theMatB  the matrix "B".
   static NCollection_Mat4 Multiply (const NCollection_Mat4& theMatA,
                                     const NCollection_Mat4& theMatB)
   {
@@ -290,14 +290,14 @@ public:
   }
 
   //! Compute matrix multiplication.
-  //! @param theMat [in] the matrix to multiply.
+  //! @param[in] theMat  the matrix to multiply.
   void Multiply (const NCollection_Mat4& theMat)
   {
     *this = Multiply(*this, theMat);
   }
 
   //! Multiply by the another matrix.
-  //! @param theMat [in] the other matrix.
+  //! @param[in] theMat  the other matrix.
   NCollection_Mat4& operator*= (const NCollection_Mat4& theMat)
   {
     Multiply (theMat);
@@ -305,7 +305,7 @@ public:
   }
 
   //! Compute matrix multiplication product.
-  //! @param theMat [in] the other matrix.
+  //! @param[in] theMat  the other matrix.
   //! @return result of multiplication.
   Standard_NODISCARD NCollection_Mat4 operator* (const NCollection_Mat4& theMat) const
   {
@@ -313,7 +313,7 @@ public:
   }
 
   //! Compute matrix multiplication product.
-  //! @param theMat [in] the other matrix.
+  //! @param[in] theMat  the other matrix.
   //! @return result of multiplication.
   Standard_NODISCARD NCollection_Mat4 Multiplied (const NCollection_Mat4& theMat) const
   {
@@ -323,7 +323,7 @@ public:
   }
 
   //! Compute per-component multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   void Multiply (const Element_t theFactor)
   {
     for (size_t i = 0; i < 16; ++i)
@@ -333,7 +333,7 @@ public:
   }
 
   //! Compute per-element multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   NCollection_Mat4& operator*= (const Element_t theFactor)
   {
     Multiply (theFactor);
@@ -341,7 +341,7 @@ public:
   }
 
   //! Compute per-element multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   //! @return the result of multiplication.
   Standard_NODISCARD NCollection_Mat4 operator* (const Element_t theFactor) const
   {
@@ -349,7 +349,7 @@ public:
   }
 
   //! Compute per-element multiplication.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   //! @return the result of multiplication.
   Standard_NODISCARD NCollection_Mat4 Multiplied (const Element_t theFactor) const
   {
@@ -359,7 +359,7 @@ public:
   }
 
   //! Compute per-component division.
-  //! @param theFactor [in] the scale factor.
+  //! @param[in] theFactor  the scale factor.
   void Divide (const Element_t theFactor)
   {
     for (size_t i = 0; i < 16; ++i)
@@ -369,7 +369,7 @@ public:
   }
 
   //! Per-component division.
-  //! @param theScalar [in] the scale factor.
+  //! @param[in] theScalar  the scale factor.
   NCollection_Mat4& operator/= (const Element_t theScalar)
   {
     Divide (theScalar);
@@ -459,7 +459,7 @@ public:
   Standard_NODISCARD NCollection_Mat4 operator-() const { return Negated(); }
 
   //! Translate the matrix on the passed vector.
-  //! @param theVec [in] the translation vector.
+  //! @param[in] theVec  the translation vector.
   void Translate (const NCollection_Vec3<Element_t>& theVec)
   {
     NCollection_Mat4 aTempMat;
@@ -486,8 +486,8 @@ public:
   }
 
   //! Compute inverted matrix.
-  //! @param theOutMx [out] the inverted matrix
-  //! @param theDet   [out] determinant of matrix
+  //! @param[out] theOutMx  the inverted matrix
+  //! @param[out] theDet    determinant of matrix
   //! @return true if reversion success
   bool Inverted (NCollection_Mat4<Element_t>& theOutMx, Element_t& theDet) const
   {
@@ -578,7 +578,7 @@ public:
   }
 
   //! Compute inverted matrix.
-  //! @param theOutMx [out] the inverted matrix
+  //! @param[out] theOutMx  the inverted matrix
   //! @return true if reversion success
   bool Inverted (NCollection_Mat4<Element_t>& theOutMx) const
   {

--- a/src/OSD/OSD_FileSystem.hxx
+++ b/src/OSD/OSD_FileSystem.hxx
@@ -50,11 +50,11 @@ public:
 
   //! Opens stream for specified file URL for reading operations (std::istream).
   //! Default implementation create a stream from file buffer returned by OSD_FileSystem::OpenFileBuffer().
-  //! @param theUrl       [in] path to open
-  //! @param theMode      [in] flags describing the requested input mode for the stream (std::ios_base::in will be implicitly added)
-  //! @param theOffset    [in] expected stream position from the beginning of the file (beginning of the stream by default);
+  //! @param[in] theUrl        path to open
+  //! @param[in] theMode       flags describing the requested input mode for the stream (std::ios_base::in will be implicitly added)
+  //! @param[in] theOffset     expected stream position from the beginning of the file (beginning of the stream by default);
   //!                          -1 would keep seek position undefined (in case of re-using theOldStream)
-  //! @param theOldStream [in] a pointer to existing stream pointing to theUrl to be reused (without re-opening)
+  //! @param[in] theOldStream  a pointer to existing stream pointing to theUrl to be reused (without re-opening)
   //! @return pointer to newly created opened stream, to theOldStream if it can be reused or NULL in case of failure.
   Standard_EXPORT virtual std::shared_ptr<std::istream> OpenIStream
                           (const TCollection_AsciiString& theUrl,
@@ -64,17 +64,17 @@ public:
 
   //! Opens stream for specified file URL for writing operations (std::ostream).
   //! Default implementation create a stream from file buffer returned by OSD_FileSystem::OpenFileBuffer().
-  //! @param theUrl       [in] path to open
-  //! @param theMode      [in] flags describing the requested output mode for the stream (std::ios_base::out will be implicitly added)
+  //! @param[in] theUrl        path to open
+  //! @param[in] theMode       flags describing the requested output mode for the stream (std::ios_base::out will be implicitly added)
   //! @return pointer to newly created opened stream or NULL in case of failure.
   Standard_EXPORT virtual std::shared_ptr<std::ostream> OpenOStream (const TCollection_AsciiString& theUrl,
                                                                      const std::ios_base::openmode theMode);
 
   //! Opens stream buffer for specified file URL.
-  //! @param theUrl        [in]  path to open
-  //! @param theMode       [in]  flags describing the requested input mode for the stream
-  //! @param theOffset     [in]  expected stream position from the beginning of the buffer (beginning of the stream buffer by default)
-  //! @param theOutBufSize [out] total buffer size (only if buffer is opened for read)
+  //! @param[in] theUrl          path to open
+  //! @param[in] theMode         flags describing the requested input mode for the stream
+  //! @param[in] theOffset       expected stream position from the beginning of the buffer (beginning of the stream buffer by default)
+  //! @param[out] theOutBufSize  total buffer size (only if buffer is opened for read)
   //! @return pointer to newly created opened stream buffer or NULL in case of failure.
   virtual std::shared_ptr<std::streambuf> OpenStreamBuffer (const TCollection_AsciiString& theUrl,
                                                             const std::ios_base::openmode theMode,

--- a/src/OSD/OSD_FileSystemSelector.hxx
+++ b/src/OSD/OSD_FileSystemSelector.hxx
@@ -28,8 +28,8 @@ public:
   OSD_FileSystemSelector() {}
 
   //! Registers file system within this selector.
-  //! @param theFileSystem  [in] file system to register
-  //! @param theIsPreferred [in] add to the beginning of the list when TRUE, or add to the end otherwise
+  //! @param[in] theFileSystem   file system to register
+  //! @param[in] theIsPreferred  add to the beginning of the list when TRUE, or add to the end otherwise
   Standard_EXPORT void AddProtocol (const Handle(OSD_FileSystem)& theFileSystem, bool theIsPreferred = false);
 
   //! Unregisters file system within this selector.

--- a/src/OSD/OSD_Path.hxx
+++ b/src/OSD/OSD_Path.hxx
@@ -208,9 +208,9 @@ public:
   //! Example: IN  theFilePath ='/media/cdrom/image.jpg'
   //!          OUT theFolder   ='/media/cdrom/'
   //!          OUT theFileName ='image.jpg'
-  //! @param theFilePath [in]  file path
-  //! @param theFolder   [out] folder path (with trailing separator)
-  //! @param theFileName [out] file name
+  //! @param[in] theFilePath   file path
+  //! @param[out] theFolder    folder path (with trailing separator)
+  //! @param[out] theFileName  file name
   Standard_EXPORT static void FolderAndFileFromPath (const TCollection_AsciiString& theFilePath,
                                                      TCollection_AsciiString&       theFolder,
                                                      TCollection_AsciiString&       theFileName);
@@ -220,9 +220,9 @@ public:
   //! Example: IN  theFilePath ='Image.sbs.JPG'
   //!          OUT theName     ='Image.sbs'
   //!          OUT theFileName ='jpg'
-  //! @param theFilePath  [in]  file path
-  //! @param theName      [out] file name without extension
-  //! @param theExtension [out] file extension in lower case and without dot
+  //! @param[in] theFilePath    file path
+  //! @param[out] theName       file name without extension
+  //! @param[out] theExtension  file extension in lower case and without dot
   Standard_EXPORT static void FileNameAndExtension (const TCollection_AsciiString& theFilePath,
                                                     TCollection_AsciiString&       theName,
                                                     TCollection_AsciiString&       theExtension);

--- a/src/OpenGl/OpenGl_Buffer.hxx
+++ b/src/OpenGl/OpenGl_Buffer.hxx
@@ -77,36 +77,36 @@ public:
   Standard_EXPORT virtual void Unbind (const Handle(OpenGl_Context)& theGlCtx) const;
 
   //! Notice that buffer object will be unbound after this call.
-  //! @param theComponentsNb [in] specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
-  //! @param theElemsNb      [in] elements count;
-  //! @param theData         [in] pointer to float data (vertices/normals etc.).
+  //! @param[in] theComponentsNb  specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
+  //! @param[in] theElemsNb       elements count;
+  //! @param[in] theData          pointer to float data (vertices/normals etc.).
   Standard_EXPORT bool Init (const Handle(OpenGl_Context)& theGlCtx,
                              const unsigned int     theComponentsNb,
                              const Standard_Integer theElemsNb,
                              const float*   theData);
 
   //! Notice that buffer object will be unbound after this call.
-  //! @param theComponentsNb [in] specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
-  //! @param theElemsNb      [in] elements count;
-  //! @param theData         [in] pointer to unsigned int data (indices etc.).
+  //! @param[in] theComponentsNb  specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
+  //! @param[in] theElemsNb       elements count;
+  //! @param[in] theData          pointer to unsigned int data (indices etc.).
   Standard_EXPORT bool Init (const Handle(OpenGl_Context)& theGlCtx,
                              const unsigned int     theComponentsNb,
                              const Standard_Integer theElemsNb,
                              const unsigned int* theData);
 
   //! Notice that buffer object will be unbound after this call.
-  //! @param theComponentsNb [in] specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
-  //! @param theElemsNb      [in] elements count;
-  //! @param theData         [in] pointer to unsigned short data (indices etc.).
+  //! @param[in] theComponentsNb  specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
+  //! @param[in] theElemsNb       elements count;
+  //! @param[in] theData          pointer to unsigned short data (indices etc.).
   Standard_EXPORT bool Init (const Handle(OpenGl_Context)& theGlCtx,
                              const unsigned int     theComponentsNb,
                              const Standard_Integer theElemsNb,
                              const unsigned short*  theData);
 
   //! Notice that buffer object will be unbound after this call.
-  //! @param theComponentsNb [in] specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
-  //! @param theElemsNb      [in] elements count;
-  //! @param theData         [in] pointer to Standard_Byte data (indices/colors etc.).
+  //! @param[in] theComponentsNb  specifies the number of components per generic vertex attribute; must be 1, 2, 3, or 4;
+  //! @param[in] theElemsNb       elements count;
+  //! @param[in] theData          pointer to Standard_Byte data (indices/colors etc.).
   Standard_EXPORT bool Init (const Handle(OpenGl_Context)& theGlCtx,
                              const unsigned int     theComponentsNb,
                              const Standard_Integer theElemsNb,
@@ -115,9 +115,9 @@ public:
   //! Notice that buffer object will be unbound after this call.
   //! Function replaces portion of data within this buffer object using glBufferSubData().
   //! The buffer object should be initialized before call.
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData     [in] pointer to float data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[in] theData      pointer to float data.
   Standard_EXPORT bool SubData (const Handle(OpenGl_Context)& theGlCtx,
                                 const Standard_Integer theElemFrom,
                                 const Standard_Integer theElemsNb,
@@ -126,9 +126,9 @@ public:
   //! Read back buffer sub-range.
   //! Notice that buffer object will be unbound after this call.
   //! Function reads portion of data from this buffer object using glGetBufferSubData().
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData    [out] destination pointer to float data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[out] theData     destination pointer to float data.
   Standard_EXPORT bool GetSubData (const Handle(OpenGl_Context)& theGlCtx,
                                    const Standard_Integer theElemFrom,
                                    const Standard_Integer theElemsNb,
@@ -137,9 +137,9 @@ public:
   //! Notice that buffer object will be unbound after this call.
   //! Function replaces portion of data within this buffer object using glBufferSubData().
   //! The buffer object should be initialized before call.
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData     [in] pointer to unsigned int data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[in] theData      pointer to unsigned int data.
   Standard_EXPORT bool SubData (const Handle(OpenGl_Context)& theGlCtx,
                                 const Standard_Integer theElemFrom,
                                 const Standard_Integer theElemsNb,
@@ -148,9 +148,9 @@ public:
   //! Read back buffer sub-range.
   //! Notice that buffer object will be unbound after this call.
   //! Function reads portion of data from this buffer object using glGetBufferSubData().
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData    [out] destination pointer to unsigned int data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[out] theData     destination pointer to unsigned int data.
   Standard_EXPORT bool GetSubData (const Handle(OpenGl_Context)& theGlCtx,
                                    const Standard_Integer theElemFrom,
                                    const Standard_Integer theElemsNb,
@@ -159,9 +159,9 @@ public:
   //! Notice that buffer object will be unbound after this call.
   //! Function replaces portion of data within this buffer object using glBufferSubData().
   //! The buffer object should be initialized before call.
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData     [in] pointer to unsigned short data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[in] theData      pointer to unsigned short data.
   Standard_EXPORT bool SubData (const Handle(OpenGl_Context)& theGlCtx,
                                 const Standard_Integer theElemFrom,
                                 const Standard_Integer theElemsNb,
@@ -170,9 +170,9 @@ public:
   //! Read back buffer sub-range.
   //! Notice that buffer object will be unbound after this call.
   //! Function reads portion of data from this buffer object using glGetBufferSubData().
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData    [out] destination pointer to unsigned short data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[out] theData     destination pointer to unsigned short data.
   Standard_EXPORT bool GetSubData (const Handle(OpenGl_Context)& theGlCtx,
                                    const Standard_Integer theElemFrom,
                                    const Standard_Integer theElemsNb,
@@ -181,9 +181,9 @@ public:
   //! Notice that buffer object will be unbound after this call.
   //! Function replaces portion of data within this buffer object using glBufferSubData().
   //! The buffer object should be initialized before call.
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData     [in] pointer to Standard_Byte data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[in] theData      pointer to Standard_Byte data.
   Standard_EXPORT bool SubData (const Handle(OpenGl_Context)& theGlCtx,
                                 const Standard_Integer theElemFrom,
                                 const Standard_Integer theElemsNb,
@@ -192,9 +192,9 @@ public:
   //! Read back buffer sub-range.
   //! Notice that buffer object will be unbound after this call.
   //! Function reads portion of data from this buffer object using glGetBufferSubData().
-  //! @param theElemFrom [in] element id from which replace buffer data (>=0);
-  //! @param theElemsNb  [in] elements count (theElemFrom + theElemsNb <= GetElemsNb());
-  //! @param theData    [out] destination pointer to Standard_Byte data.
+  //! @param[in] theElemFrom  element id from which replace buffer data (>=0);
+  //! @param[in] theElemsNb   elements count (theElemFrom + theElemsNb <= GetElemsNb());
+  //! @param[out] theData     destination pointer to Standard_Byte data.
   Standard_EXPORT bool GetSubData (const Handle(OpenGl_Context)& theGlCtx,
                                    const Standard_Integer theElemFrom,
                                    const Standard_Integer theElemsNb,
@@ -255,24 +255,24 @@ protected:
 
   //! Binds a buffer object to an indexed buffer target.
   //! Wrapper for glBindBufferBase().
-  //! @param theGlCtx [in] active OpenGL context
-  //! @param theIndex [in] index to bind
+  //! @param[in] theGlCtx  active OpenGL context
+  //! @param[in] theIndex  index to bind
   Standard_EXPORT void BindBufferBase (const Handle(OpenGl_Context)& theGlCtx,
                                        unsigned int theIndex);
 
   //! Unbinds a buffer object from an indexed buffer target.
   //! Wrapper for glBindBufferBase().
-  //! @param theGlCtx [in] active OpenGL context
-  //! @param theIndex [in] index to bind
+  //! @param[in] theGlCtx  active OpenGL context
+  //! @param[in] theIndex  index to bind
   Standard_EXPORT void UnbindBufferBase (const Handle(OpenGl_Context)& theGlCtx,
                                          unsigned int theIndex);
 
   //! Binds a buffer object to an indexed buffer target with specified offset and size.
   //! Wrapper for glBindBufferRange().
-  //! @param theGlCtx  [in] active OpenGL context
-  //! @param theIndex  [in] index to bind (@sa GL_MAX_UNIFORM_BUFFER_BINDINGS in case of uniform buffer)
-  //! @param theOffset [in] offset within the buffer (@sa GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT in case of uniform buffer)
-  //! @param theSize   [in] sub-section length starting from offset
+  //! @param[in] theGlCtx   active OpenGL context
+  //! @param[in] theIndex   index to bind (@sa GL_MAX_UNIFORM_BUFFER_BINDINGS in case of uniform buffer)
+  //! @param[in] theOffset  offset within the buffer (@sa GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT in case of uniform buffer)
+  //! @param[in] theSize    sub-section length starting from offset
   Standard_EXPORT void BindBufferRange (const Handle(OpenGl_Context)& theGlCtx,
                                         unsigned int   theIndex,
                                         const intptr_t theOffset,

--- a/src/OpenGl/OpenGl_CappingAlgo.hxx
+++ b/src/OpenGl/OpenGl_CappingAlgo.hxx
@@ -28,8 +28,8 @@ public:
 
   //! Draw capping surfaces by OpenGl for the clipping planes enabled in current context state.
   //! Depth buffer must be generated  for the passed groups.
-  //! @param theWorkspace [in] the GL workspace, context state
-  //! @param theStructure [in] the structure to be capped
+  //! @param[in] theWorkspace  the GL workspace, context state
+  //! @param[in] theStructure  the structure to be capped
   Standard_EXPORT static void RenderCapping (const Handle(OpenGl_Workspace)& theWorkspace,
                                              const OpenGl_Structure&         theStructure);
 

--- a/src/OpenGl/OpenGl_CappingPlaneResource.hxx
+++ b/src/OpenGl/OpenGl_CappingPlaneResource.hxx
@@ -38,20 +38,20 @@ public:
 
   //! Constructor.
   //! Create capping plane presentation associated to clipping plane data.
-  //! @param thePlane [in] the plane data.
+  //! @param[in] thePlane  the plane data.
   Standard_EXPORT OpenGl_CappingPlaneResource (const Handle(Graphic3d_ClipPlane)& thePlane);
 
   //! Destroy object.
   Standard_EXPORT virtual ~OpenGl_CappingPlaneResource();
 
   //! Update resource data in the passed context.
-  //! @param theContext   [in] the context
-  //! @param theObjAspect [in] object aspect
+  //! @param[in] theContext    the context
+  //! @param[in] theObjAspect  object aspect
   Standard_EXPORT void Update (const Handle(OpenGl_Context)& theContext,
                                const Handle(Graphic3d_Aspects)& theObjAspect);
 
   //! Release associated OpenGl resources.
-  //! @param theContext [in] the resource context.
+  //! @param[in] theContext  the resource context.
   Standard_EXPORT virtual void Release (OpenGl_Context* theContext) Standard_OVERRIDE;
 
   //! Returns estimated GPU memory usage - not implemented.

--- a/src/OpenGl/OpenGl_Clipping.hxx
+++ b/src/OpenGl/OpenGl_Clipping.hxx
@@ -140,7 +140,7 @@ protected: //! @name clipping state modification commands
                             const Standard_Integer theStartIndex);
 
   //! Remove the passed set of clipping planes from the context state.
-  //! @param thePlanes [in] the planes to remove from list.
+  //! @param[in] thePlanes  the planes to remove from list.
   Standard_EXPORT void remove (const Handle(Graphic3d_SequenceOfHClipPlane)& thePlanes,
                                const Standard_Integer theStartIndex);
 

--- a/src/OpenGl/OpenGl_Context.hxx
+++ b/src/OpenGl/OpenGl_Context.hxx
@@ -243,10 +243,10 @@ public:
   //!   aGlCtx->Init ((Aspect_Drawable )theXWindow, (Aspect_Display )theXDisp,  (Aspect_RenderingContext )theGlxCtx);
   //! @endcode
   //!
-  //! @param theSurface [in] surface / window          (EGLSurface | HWND  | GLXDrawable/Window)
-  //! @param theDisplay [in] display or device context (EGLDisplay | HDC   | Display*)
-  //! @param theContext [in] rendering context         (EGLContext | HGLRC | GLXContext | EAGLContext* | NSOpenGLContext*)
-  //! @param theIsCoreProfile [in] flag indicating that passed GL rendering context has been created with Core Profile
+  //! @param[in] theSurface  surface / window          (EGLSurface | HWND  | GLXDrawable/Window)
+  //! @param[in] theDisplay  display or device context (EGLDisplay | HDC   | Display*)
+  //! @param[in] theContext  rendering context         (EGLContext | HGLRC | GLXContext | EAGLContext* | NSOpenGLContext*)
+  //! @param[in] theIsCoreProfile  flag indicating that passed GL rendering context has been created with Core Profile
   //! @return false if OpenGL context can not be bound to specified surface
   Standard_EXPORT Standard_Boolean Init (const Aspect_Drawable         theSurface,
                                          const Aspect_Display          theDisplay,
@@ -296,9 +296,9 @@ public:
   //! Pointer to function retrieved from library is statically casted
   //! to requested type - there no way to check real signature of exported function.
   //! The context should be bound before call.
-  //! @param theLastFailFuncName [out] set to theFuncName in case of failure, unmodified on success
-  //! @param theFuncName [in] function name to find
-  //! @param theFuncPtr [out] retrieved function pointer
+  //! @param[out] theLastFailFuncName  set to theFuncName in case of failure, unmodified on success
+  //! @param[in] theFuncName  function name to find
+  //! @param[out] theFuncPtr  retrieved function pointer
   //! @return TRUE on success
   template <typename FuncType_t>
   Standard_Boolean FindProcVerbose (const char*& theLastFailFuncName,
@@ -834,8 +834,8 @@ public: //! @name methods to alter or retrieve current state
   }
 
   //! Bind specified texture set to current context, or unbind previous one when NULL specified.
-  //! @param theTextures [in] texture set to bind
-  //! @param theProgram  [in] program attributes; when not NULL,
+  //! @param[in] theTextures  texture set to bind
+  //! @param[in] theProgram   program attributes; when not NULL,
   //!                         mock textures will be bound to texture units expected by GLSL program, but undefined by texture set
   //! @return previous texture set
   Standard_EXPORT Handle(OpenGl_TextureSet) BindTextures (const Handle(OpenGl_TextureSet)& theTextures,
@@ -897,8 +897,8 @@ public: //! @name methods to alter or retrieve current state
   Standard_EXPORT void SetPointSpriteOrigin();
 
   //! Setup texture matrix to active GLSL program or to FFP global state using glMatrixMode (GL_TEXTURE).
-  //! @param theParams    [in] texture parameters
-  //! @param theIsTopDown [in] texture top-down flag
+  //! @param[in] theParams     texture parameters
+  //! @param[in] theIsTopDown  texture top-down flag
   Standard_EXPORT void SetTextureMatrix (const Handle(Graphic3d_TextureParams)& theParams,
                                          const Standard_Boolean theIsTopDown);
 

--- a/src/OpenGl/OpenGl_Element.hxx
+++ b/src/OpenGl/OpenGl_Element.hxx
@@ -68,8 +68,8 @@ public:
   Standard_EXPORT virtual void UpdateMemStats (Graphic3d_FrameStatsDataTmp& theStats) const;
 
   //! Increment draw calls statistics.
-  //! @param theStats [in] [out] frame counters to increment
-  //! @param theIsDetailed  [in] indicate detailed dump (more counters - number of triangles, points, etc.)
+  //! @param[in][out] theStats   frame counters to increment
+  //! @param[in] theIsDetailed   indicate detailed dump (more counters - number of triangles, points, etc.)
   Standard_EXPORT virtual void UpdateDrawStats (Graphic3d_FrameStatsDataTmp& theStats,
                                                  bool theIsDetailed) const;
 

--- a/src/OpenGl/OpenGl_Flipper.hxx
+++ b/src/OpenGl/OpenGl_Flipper.hxx
@@ -31,11 +31,11 @@ public:
 
   //! Construct rendering element to flip model-view matrix
   //! along the reference system to ensure up-Y, right-X orientation.
-  //! @param theReferenceSystem [in] the reference coordinate system.
+  //! @param[in] theReferenceSystem  the reference coordinate system.
   Standard_EXPORT OpenGl_Flipper (const gp_Ax2& theReferenceSystem);
 
   //! Set options for the element.
-  //! @param theIsEnabled [in] flag indicates whether the flipper
+  //! @param[in] theIsEnabled  flag indicates whether the flipper
   //! matrix modification should be set up or restored back.
   void SetOptions (const Standard_Boolean theIsEnabled) { myIsEnabled = theIsEnabled; }
 

--- a/src/OpenGl/OpenGl_GraduatedTrihedron.hxx
+++ b/src/OpenGl/OpenGl_GraduatedTrihedron.hxx
@@ -130,22 +130,22 @@ private:
 private:
 
   //! Initialize or update GL resources for rendering trihedron.
-  //! @param theContext [in] the GL context.
+  //! @param[in] theContext  the GL context.
   void initGlResources (const Handle(OpenGl_Context)& theContext) const;
 
   //! Gets normal of the view out of user.
-  //! @param theContext [in] OpenGL Context
-  //! @param theNormal [out] normal of the view out of user
+  //! @param[in] theContext  OpenGL Context
+  //! @param[out] theNormal  normal of the view out of user
   //! @return distance corresponding to 1 pixel
   Standard_ShortReal getNormal (const Handle(OpenGl_Context)& theContext,
                                 OpenGl_Vec3& theNormal) const;
 
   //! Gets distance to point (theX, theY, theZ) of bounding box along the normal
-  //! @param theNormal [in] normal of the view out of user
-  //! @param theCenter [in] geometry center of bounding box
-  //! @param theX [in] x of target point
-  //! @param theY [in] y of target point
-  //! @param theZ [in] z of terget point
+  //! @param[in] theNormal  normal of the view out of user
+  //! @param[in] theCenter  geometry center of bounding box
+  //! @param[in] theX  x of target point
+  //! @param[in] theY  y of target point
+  //! @param[in] theZ  z of terget point
   Standard_ShortReal getDistanceToCorner (const OpenGl_Vec3& theNormal,
                                           const OpenGl_Vec3& theCenter,
                                           const Standard_ShortReal theX,
@@ -153,14 +153,14 @@ private:
                                           const Standard_ShortReal theZ) const;
 
   //! Gets axes of grid
-  //! @param theCorners [in] the corners of grid
-  //! @param theGridAxes [out] grid axes, the base of graduated trihedron grid.
+  //! @param[in] theCorners  the corners of grid
+  //! @param[out] theGridAxes  grid axes, the base of graduated trihedron grid.
   Standard_ExtCharacter getGridAxes (const Standard_ShortReal theCorners[8],
                                      GridAxes& theGridAxes) const;
 
   //! Render line from the transformed primitive array myLine
-  //! @param theWorkspace [in] the OpenGl Workspace
-  //! @param theMat [in] theMat that contains base transformation and is used for applying
+  //! @param[in] theWorkspace  the OpenGl Workspace
+  //! @param[in] theMat  theMat that contains base transformation and is used for applying
   //!        translation and rotation
   //! @param thaTx the X for vector of translation
   //! @param thaTy the Y for vector of translation
@@ -173,10 +173,10 @@ private:
                    const Standard_ShortReal        theZt) const;
 
   //! Render grid lines perpendecular the axis of input index
-  //! @param theWorkspace [in] the OpenGl Workspace
-  //! @param theIndex [in] index of axis
-  //! @param theGridAxes [in] grid axes
-  //! @param theMat [in] theMat that contains base transformation and is used for applying
+  //! @param[in] theWorkspace  the OpenGl Workspace
+  //! @param[in] theIndex  index of axis
+  //! @param[in] theGridAxes  grid axes
+  //! @param[in] theMat  theMat that contains base transformation and is used for applying
   //!        translation and rotation
   void renderGridPlane (const Handle(OpenGl_Workspace)& theWorkspace,
                         const Standard_Integer& theIndex,
@@ -185,21 +185,21 @@ private:
 
 
   //! Render the axis of input index
-  //! @param theWorkspace [in] the OpenGl Workspace
-  //! @param theIndex [in] index of axis
-  //! @param theMat [in] theMat that contains base transformation and is used for applying
+  //! @param[in] theWorkspace  the OpenGl Workspace
+  //! @param[in] theIndex  index of axis
+  //! @param[in] theMat  theMat that contains base transformation and is used for applying
   //!        translation and rotation
   void renderAxis (const Handle(OpenGl_Workspace)& theWorkspace,
                    const Standard_Integer& theIndex,
                    const OpenGl_Mat4& theMat) const;
 
   //! Render grid labels, tickmark lines and labels
-  //! @param theWorkspace [in] the OpenGl Workspace
-  //! @param theMat [in] theMat that contains base transformation and is used for applying
+  //! @param[in] theWorkspace  the OpenGl Workspace
+  //! @param[in] theMat  theMat that contains base transformation and is used for applying
   //!        translation and rotation
-  //! @param theIndex [in] index of axis
-  //! @param theGridAxes [in] grid axes
-  //! @param theDpix [in] distance corresponding to 1 pixel
+  //! @param[in] theIndex  index of axis
+  //! @param[in] theGridAxes  grid axes
+  //! @param[in] theDpix  distance corresponding to 1 pixel
   void renderTickmarkLabels (const Handle(OpenGl_Workspace)& theWorkspace,
                              const OpenGl_Mat4& theMat,
                              const Standard_Integer theIndex,

--- a/src/OpenGl/OpenGl_Group.hxx
+++ b/src/OpenGl/OpenGl_Group.hxx
@@ -117,8 +117,8 @@ private:
   //! This method should be used for elements which can be used in scope of rendering algorithms.
   //! E.g. elements of groups during recursive rendering.
   //! If render filter is null, pure rendering is performed.
-  //! @param theWorkspace [in] the rendering workspace
-  //! @param theFilter    [in] the rendering filter to check whether the element should be rendered or not
+  //! @param[in] theWorkspace  the rendering workspace
+  //! @param[in] theFilter     the rendering filter to check whether the element should be rendered or not
   //! @return True if element passes the check and renders
   Standard_EXPORT bool renderFiltered (const Handle(OpenGl_Workspace)& theWorkspace,
                                        OpenGl_Element* theElement) const;

--- a/src/OpenGl/OpenGl_LayerList.hxx
+++ b/src/OpenGl/OpenGl_LayerList.hxx
@@ -187,11 +187,11 @@ protected:
   //! Additional accumulation framebuffer is used for blended order-independent
   //! transparency algorithm. It should support floating-point color components
   //! and share depth with main reading/drawing framebuffer.
-  //! @param theWorkspace [in] the currently used workspace for rendering.
+  //! @param[in] theWorkspace  the currently used workspace for rendering.
   //! @param theLayerIter [in/out] the current iterator of transparent layers to process.
-  //! @param theGlobalSettings [in] the set of global settings used for rendering.
-  //! @param theReadDrawFbo [in] the framebuffer for reading depth and writing final color.
-  //! @param theOitAccumFbo [in] the framebuffer for accumulating color and coverage for OIT process.
+  //! @param[in] theGlobalSettings  the set of global settings used for rendering.
+  //! @param[in] theReadDrawFbo  the framebuffer for reading depth and writing final color.
+  //! @param[in] theOitAccumFbo  the framebuffer for accumulating color and coverage for OIT process.
   Standard_EXPORT void renderTransparent (const Handle(OpenGl_Workspace)&   theWorkspace,
                                           OpenGl_LayerStack::iterator&      theLayerIter,
                                           const OpenGl_GlobalLayerSettings& theGlobalSettings,

--- a/src/OpenGl/OpenGl_Sampler.hxx
+++ b/src/OpenGl/OpenGl_Sampler.hxx
@@ -130,12 +130,12 @@ protected:
                                             Standard_Integer theValue);
 
   //! Apply sampler parameters.
-  //! @param theCtx     [in] active OpenGL context
-  //! @param theParams  [in] texture parameters to apply
-  //! @param theSampler [in] apply parameters to Texture object (NULL)
+  //! @param[in] theCtx      active OpenGL context
+  //! @param[in] theParams   texture parameters to apply
+  //! @param[in] theSampler  apply parameters to Texture object (NULL)
   //!                        or to specified Sampler object (non-NULL, sampler is not required to be bound)
-  //! @param theTarget  [in] OpenGL texture target
-  //! @param theMaxMipLevel [in] maximum mipmap level defined within the texture
+  //! @param[in] theTarget   OpenGL texture target
+  //! @param[in] theMaxMipLevel  maximum mipmap level defined within the texture
   Standard_EXPORT static void applySamplerParams (const Handle(OpenGl_Context)& theCtx,
                                                   const Handle(Graphic3d_TextureParams)& theParams,
                                                   OpenGl_Sampler* theSampler,

--- a/src/OpenGl/OpenGl_ShaderManager.hxx
+++ b/src/OpenGl/OpenGl_ShaderManager.hxx
@@ -74,9 +74,9 @@ public:
   }
 
   //! Creates new shader program or re-use shared instance.
-  //! @param theProxy    [IN]  program definition
-  //! @param theShareKey [OUT] sharing key
-  //! @param theProgram  [OUT] OpenGL program
+  //! @param[in] theProxy      program definition
+  //! @param[out] theShareKey  sharing key
+  //! @param[out] theProgram   OpenGL program
   //! @return true on success
   Standard_EXPORT Standard_Boolean Create (const Handle(Graphic3d_ShaderProgram)& theProxy,
                                            TCollection_AsciiString&               theShareKey,
@@ -185,8 +185,8 @@ public:
   }
 
   //! Bind program for FBO blit operation.
-  //! @param theNbSamples       [in] number of samples within source MSAA texture
-  //! @param theIsFallback_sRGB [in] flag indicating that destination buffer is not sRGB-ready
+  //! @param[in] theNbSamples        number of samples within source MSAA texture
+  //! @param theIsFallback_sRGB[in]  flag indicating that destination buffer is not sRGB-ready
   Standard_EXPORT Standard_Boolean BindFboBlitProgram (Standard_Integer theNbSamples,
                                                        Standard_Boolean theIsFallback_sRGB);
 
@@ -262,7 +262,7 @@ public:
                                                  const Handle(OpenGl_ShadowMapArray)& theShadowMaps);
 
   //! Updates state of OCCT light sources to dynamically enable/disable shadowmap.
-  //! @param theToCast [in] flag to enable/disable shadowmap
+  //! @param[in] theToCast  flag to enable/disable shadowmap
   //! @return previous flag state
   bool SetCastShadows (const bool theToCast)
   {
@@ -426,7 +426,7 @@ public:
   }
 
   //! Set the state of OIT rendering pass (only on state change).
-  //! @param theMode [in] flag indicating whether the special output should be written for OIT algorithm
+  //! @param[in] theMode  flag indicating whether the special output should be written for OIT algorithm
   void SetOitState (Graphic3d_RenderTransparentMethod theMode)
   {
     myOitState.Set (theMode, 0.0f);
@@ -434,7 +434,7 @@ public:
   }
 
   //! Set the state of weighed OIT rendering pass (only on state change).
-  //! @param theDepthFactor [in] the scalar factor of depth influence to the fragment's coverage
+  //! @param[in] theDepthFactor  the scalar factor of depth influence to the fragment's coverage
   void SetWeighedOitState (float theDepthFactor)
   {
     myOitState.Set (Graphic3d_RTM_BLEND_OIT, theDepthFactor);

--- a/src/OpenGl/OpenGl_ShaderStates.hxx
+++ b/src/OpenGl/OpenGl_ShaderStates.hxx
@@ -197,9 +197,9 @@ public:
   OpenGl_OitState() : myOitMode (Graphic3d_RTM_BLEND_UNORDERED), myDepthFactor (0.5f) {}
 
   //! Sets the uniform values.
-  //! @param theToEnableWrite [in] flag indicating whether color and coverage
+  //! @param[in] theToEnableWrite  flag indicating whether color and coverage
   //!  values for OIT processing should be written by shader program.
-  //! @param theDepthFactor [in] scalar factor [0-1] defining influence of depth
+  //! @param[in] theDepthFactor  scalar factor [0-1] defining influence of depth
   //!  component of a fragment to its final coverage coefficient.
   void Set (Graphic3d_RenderTransparentMethod theMode,
             const float theDepthFactor)

--- a/src/OpenGl/OpenGl_ShadowMap.hxx
+++ b/src/OpenGl/OpenGl_ShadowMap.hxx
@@ -74,8 +74,8 @@ public:
   void SetShadowMapBias (Standard_ShortReal theBias) { myShadowMapBias = theBias; }
 
   //! Compute camera.
-  //! @param theView   [in] active view
-  //! @param theOrigin [in] when not-NULL - displace shadow map camera to specified Z-Layer origin
+  //! @param[in] theView    active view
+  //! @param[in] theOrigin  when not-NULL - displace shadow map camera to specified Z-Layer origin
   Standard_EXPORT bool UpdateCamera (const Graphic3d_CView& theView,
                                      const gp_XYZ* theOrigin = NULL);
 

--- a/src/OpenGl/OpenGl_Texture.hxx
+++ b/src/OpenGl/OpenGl_Texture.hxx
@@ -212,11 +212,11 @@ public:
   virtual bool IsPointSprite() const { return false; }
 
   //! Auxiliary method for making an image dump from texture data.
-  //! @param theImage   [out] result image data (will be overridden)
-  //! @param theCtx      [in] active GL context
-  //! @param theTexUnit  [in] texture slot to use
-  //! @param theLevel    [in] mipmap level to dump
-  //! @param theCubeSide [in] cubemap side to dump within [0, 5] range
+  //! @param[out] theImage    result image data (will be overridden)
+  //! @param[in] theCtx       active GL context
+  //! @param[in] theTexUnit   texture slot to use
+  //! @param[in] theLevel     mipmap level to dump
+  //! @param[in] theCubeSide  cubemap side to dump within [0, 5] range
   //! @return FALSE on error
   Standard_EXPORT bool ImageDump (Image_PixMap& theImage,
                                   const Handle(OpenGl_Context)& theCtx,
@@ -299,12 +299,12 @@ public:
   //! Initializes 6 sides of cubemap.
   //! If theCubeMap is not NULL then size and format will be taken from it and corresponding arguments will be ignored.
   //! Otherwise this parameters will be taken from arguments.
-  //! @param theCtx         [in] active OpenGL context
-  //! @param theCubeMap     [in] cubemap definition, can be NULL
-  //! @param theSize        [in] cubemap dimensions
-  //! @param theFormat      [in] image format
-  //! @param theToGenMipmap [in] flag to generate mipmaped cubemap
-  //! @param theIsColorMap  [in] flag indicating cubemap storing color values
+  //! @param[in] theCtx          active OpenGL context
+  //! @param[in] theCubeMap      cubemap definition, can be NULL
+  //! @param[in] theSize         cubemap dimensions
+  //! @param[in] theFormat       image format
+  //! @param[in] theToGenMipmap  flag to generate mipmaped cubemap
+  //! @param[in] theIsColorMap   flag indicating cubemap storing color values
   Standard_EXPORT bool InitCubeMap (const Handle(OpenGl_Context)&    theCtx,
                                     const Handle(Graphic3d_CubeMap)& theCubeMap,
                                     Standard_Size    theSize,

--- a/src/OpenGl/OpenGl_TextureFormat.hxx
+++ b/src/OpenGl/OpenGl_TextureFormat.hxx
@@ -33,24 +33,24 @@ public:
   static OpenGl_TextureFormat Create();
 
   //! Find texture format suitable to specified image format.
-  //! @param theCtx [in] OpenGL context defining supported texture formats
-  //! @param theFormat [in] image format
-  //! @param theIsColorMap [in] flag indicating color nature of image (to select sRGB texture)
+  //! @param[in] theCtx  OpenGL context defining supported texture formats
+  //! @param[in] theFormat  image format
+  //! @param[in] theIsColorMap  flag indicating color nature of image (to select sRGB texture)
   //! @return found format or invalid format
   Standard_EXPORT static OpenGl_TextureFormat FindFormat (const Handle(OpenGl_Context)& theCtx,
                                                           Image_Format theFormat,
                                                           bool theIsColorMap);
 
   //! Find texture format suitable to specified internal (sized) texture format.
-  //! @param theCtx [in] OpenGL context defining supported texture formats
-  //! @param theSizedFormat [in] sized (internal) texture format (example: GL_RGBA8)
+  //! @param[in] theCtx  OpenGL context defining supported texture formats
+  //! @param[in] theSizedFormat  sized (internal) texture format (example: GL_RGBA8)
   //! @return found format or invalid format
   Standard_EXPORT static OpenGl_TextureFormat FindSizedFormat (const Handle(OpenGl_Context)& theCtx,
                                                                GLint theSizedFormat);
 
   //! Find texture format suitable to specified compressed texture format.
-  //! @param theCtx [in] OpenGL context defining supported texture formats
-  //! @param theFormat [in] compressed texture format
+  //! @param[in] theCtx  OpenGL context defining supported texture formats
+  //! @param[in] theFormat  compressed texture format
   //! @return found format or invalid format
   Standard_EXPORT static OpenGl_TextureFormat FindCompressedFormat (const Handle(OpenGl_Context)& theCtx,
                                                                     Image_CompressedFormat theFormat,

--- a/src/OpenGl/OpenGl_VertexBufferEditor.hxx
+++ b/src/OpenGl/OpenGl_VertexBufferEditor.hxx
@@ -39,15 +39,15 @@ class OpenGl_VertexBufferEditor
 public:
 
   //! Creates empty editor
-  //! theTmpBufferLength [in] temporary buffer length
+  //! theTmpBufferLength[in]  temporary buffer length
   explicit OpenGl_VertexBufferEditor (const Standard_Integer theTmpBufferLength = 0)
   : myElemFrom (0),
     myElemsNb (0),
     myTmpBuffer (0, theTmpBufferLength > 0 ? (theTmpBufferLength - 1) : 2047) {}
 
   //! Creates empty editor
-  //! theTmpBuffer       [in] pointer to temporary buffer
-  //! theTmpBufferLength [in] temporary buffer length
+  //! theTmpBuffer[in]        pointer to temporary buffer
+  //! theTmpBufferLength[in]  temporary buffer length
   OpenGl_VertexBufferEditor (theVec_t*              theTmpBuffer,
                              const Standard_Integer theTmpBufferLength)
   : myElemFrom (0),
@@ -55,8 +55,8 @@ public:
     myTmpBuffer (theTmpBuffer[0], 0, theTmpBufferLength - 1) {}
 
   //! Initialize editor for specified buffer object.
-  //! theGlCtx [in] bound OpenGL context to edit buffer object
-  //! theVbo   [in] buffer to edit
+  //! theGlCtx[in]  bound OpenGL context to edit buffer object
+  //! theVbo[in]    buffer to edit
   Standard_Boolean Init (const Handle(OpenGl_Context)& theGlCtx,
                          const Handle(OpenGl_Buffer)&  theVbo)
   {

--- a/src/OpenGl/OpenGl_View.hxx
+++ b/src/OpenGl/OpenGl_View.hxx
@@ -113,7 +113,7 @@ public:
 
   //! Dumps the graphical contents of a shadowmap framebuffer into an image.
   //! @param theImage the image to store the shadow map.
-  //! @param theLightName [in] name of the light used to generate the shadow map.
+  //! @param[in] theLightName  name of the light used to generate the shadow map.
   Standard_EXPORT virtual Standard_Boolean ShadowMapDump (Image_PixMap& theImage,
 	                                                      const TCollection_AsciiString& theLightName) Standard_OVERRIDE;
 
@@ -121,17 +121,17 @@ public:
   Standard_EXPORT virtual void InvalidateBVHData (const Graphic3d_ZLayerId theLayerId) Standard_OVERRIDE;
 
   //! Add a layer to the view.
-  //! @param theNewLayerId [in] id of new layer, should be > 0 (negative values are reserved for default layers).
-  //! @param theSettings   [in] new layer settings
-  //! @param theLayerAfter [in] id of layer to append new layer before
+  //! @param[in] theNewLayerId  id of new layer, should be > 0 (negative values are reserved for default layers).
+  //! @param[in] theSettings    new layer settings
+  //! @param[in] theLayerAfter  id of layer to append new layer before
   Standard_EXPORT virtual void InsertLayerBefore (const Graphic3d_ZLayerId theLayerId,
                                                   const Graphic3d_ZLayerSettings& theSettings,
                                                   const Graphic3d_ZLayerId theLayerAfter) Standard_OVERRIDE;
 
   //! Add a layer to the view.
-  //! @param theNewLayerId  [in] id of new layer, should be > 0 (negative values are reserved for default layers).
-  //! @param theSettings    [in] new layer settings
-  //! @param theLayerBefore [in] id of layer to append new layer after
+  //! @param[in] theNewLayerId   id of new layer, should be > 0 (negative values are reserved for default layers).
+  //! @param[in] theSettings     new layer settings
+  //! @param[in] theLayerBefore  id of layer to append new layer after
   Standard_EXPORT virtual void InsertLayerAfter (const Graphic3d_ZLayerId theNewLayerId,
                                                  const Graphic3d_ZLayerSettings& theSettings,
                                                  const Graphic3d_ZLayerId theLayerBefore) Standard_OVERRIDE;
@@ -198,9 +198,9 @@ public:
   Standard_EXPORT virtual void SetGradientBackground (const Aspect_GradientBackground& theBackground) Standard_OVERRIDE;
 
   //! Sets image texture or environment cubemap as background.
-  //! @param theTextureMap [in] source to set a background;
+  //! @param[in] theTextureMap  source to set a background;
   //!                           should be either Graphic3d_Texture2D or Graphic3d_CubeMap
-  //! @param theToUpdatePBREnv [in] defines whether IBL maps will be generated or not
+  //! @param[in] theToUpdatePBREnv  defines whether IBL maps will be generated or not
   //!                               (see GeneratePBREnvironment())
   Standard_EXPORT virtual void SetBackgroundImage (const Handle(Graphic3d_TextureMap)& theTextureMap,
                                                    Standard_Boolean theToUpdatePBREnv = Standard_True) Standard_OVERRIDE;
@@ -307,8 +307,8 @@ public: //! @name obsolete Graduated Trihedron functionality
   Standard_EXPORT virtual void GraduatedTrihedronErase() Standard_OVERRIDE;
 
   //! Sets minimum and maximum points of scene bounding box for Graduated Trihedron stored in graphic view object.
-  //! @param theMin [in] the minimum point of scene.
-  //! @param theMax [in] the maximum point of scene.
+  //! @param[in] theMin  the minimum point of scene.
+  //! @param[in] theMax  the maximum point of scene.
   Standard_EXPORT virtual void GraduatedTrihedronMinMaxValues (const Graphic3d_Vec3 theMin, const Graphic3d_Vec3 theMax) Standard_OVERRIDE;
 
 protected: //! @name Internal methods for managing GL resources
@@ -359,24 +359,24 @@ protected: //! @name low-level redrawing sub-routines
 protected: //! @name Rendering of GL graphics (with prepared drawing buffer).
 
   //! Renders the graphical contents of the view into the prepared shadowmap framebuffer.
-  //! @param theShadowMap [in] the framebuffer for rendering shadowmap.
+  //! @param[in] theShadowMap  the framebuffer for rendering shadowmap.
   Standard_EXPORT virtual void renderShadowMap (const Handle(OpenGl_ShadowMap)& theShadowMap);
 
   //! Renders the graphical contents of the view into the prepared window or framebuffer.
-  //! @param theProjection [in] the projection that should be used for rendering.
-  //! @param theReadDrawFbo [in] the framebuffer for rendering graphics.
-  //! @param theOitAccumFbo [in] the framebuffer for accumulating color and coverage for OIT process.
-  //! @param theToDrawImmediate [in] the flag indicates whether the rendering performs in immediate mode.
+  //! @param[in] theProjection  the projection that should be used for rendering.
+  //! @param[in] theReadDrawFbo  the framebuffer for rendering graphics.
+  //! @param[in] theOitAccumFbo  the framebuffer for accumulating color and coverage for OIT process.
+  //! @param[in] theToDrawImmediate  the flag indicates whether the rendering performs in immediate mode.
   Standard_EXPORT virtual void render (Graphic3d_Camera::Projection theProjection,
                                        OpenGl_FrameBuffer*          theReadDrawFbo,
                                        OpenGl_FrameBuffer*          theOitAccumFbo,
                                        const Standard_Boolean       theToDrawImmediate);
 
   //! Renders the graphical scene.
-  //! @param theProjection [in] the projection that is used for rendering.
-  //! @param theReadDrawFbo [in] the framebuffer for rendering graphics.
-  //! @param theOitAccumFbo [in] the framebuffer for accumulating color and coverage for OIT process.
-  //! @param theToDrawImmediate [in] the flag indicates whether the rendering performs in immediate mode.
+  //! @param[in] theProjection  the projection that is used for rendering.
+  //! @param[in] theReadDrawFbo  the framebuffer for rendering graphics.
+  //! @param[in] theOitAccumFbo  the framebuffer for accumulating color and coverage for OIT process.
+  //! @param[in] theToDrawImmediate  the flag indicates whether the rendering performs in immediate mode.
   Standard_EXPORT virtual void renderScene (Graphic3d_Camera::Projection theProjection,
                                             OpenGl_FrameBuffer*    theReadDrawFbo,
                                             OpenGl_FrameBuffer*    theOitAccumFbo,
@@ -387,10 +387,10 @@ protected: //! @name Rendering of GL graphics (with prepared drawing buffer).
                                                Graphic3d_Camera::Projection theProjection);
 
   //! Render set of structures presented in the view.
-  //! @param theProjection [in] the projection that is used for rendering.
-  //! @param theReadDrawFbo [in] the framebuffer for rendering graphics.
-  //! @param theOitAccumFbo [in] the framebuffer for accumulating color and coverage for OIT process.
-  //! @param theToDrawImmediate [in] the flag indicates whether the rendering performs in immediate mode.
+  //! @param[in] theProjection  the projection that is used for rendering.
+  //! @param[in] theReadDrawFbo  the framebuffer for rendering graphics.
+  //! @param[in] theOitAccumFbo  the framebuffer for accumulating color and coverage for OIT process.
+  //! @param[in] theToDrawImmediate  the flag indicates whether the rendering performs in immediate mode.
   Standard_EXPORT virtual void renderStructs (Graphic3d_Camera::Projection theProjection,
                                               OpenGl_FrameBuffer*    theReadDrawFbo,
                                               OpenGl_FrameBuffer*    theOitAccumFbo,

--- a/src/OpenGl/OpenGl_Workspace.hxx
+++ b/src/OpenGl/OpenGl_Workspace.hxx
@@ -170,8 +170,8 @@ public:
   void SetRenderFilter (Standard_Integer theFilter) { myRenderFilter = theFilter; }
 
   //! Checks whether the element can be rendered or not.
-  //! @param theElement [in] the element to check
-  //! @param theGroup   [in] the group containing the element
+  //! @param[in] theElement  the element to check
+  //! @param[in] theGroup    the group containing the element
   //! @return True if element can be rendered
   bool ShouldRender (const OpenGl_Element* theElement, const OpenGl_Group* theGroup);
 

--- a/src/Poly/Poly.hxx
+++ b/src/Poly/Poly.hxx
@@ -120,11 +120,11 @@ public:
   Standard_EXPORT static Standard_Real PointOnTriangle (const gp_XY& P1, const gp_XY& P2, const gp_XY& P3, const gp_XY& P, gp_XY& UV);
 
   //! Computes the intersection between axis and triangulation.
-  //! @param theTri  [in] input triangulation
-  //! @param theAxis [in] intersecting ray
-  //! @param theIsClosest [in] finds the closest intersection when TRUE, finds the farthest otherwise
-  //! @param theTriangle [out] intersected triangle
-  //! @param theDistance [out] distance along ray to intersection point
+  //! @param[in] theTri   input triangulation
+  //! @param[in] theAxis  intersecting ray
+  //! @param[in] theIsClosest  finds the closest intersection when TRUE, finds the farthest otherwise
+  //! @param[out] theTriangle  intersected triangle
+  //! @param[out] theDistance  distance along ray to intersection point
   //! @return TRUE if intersection takes place, FALSE otherwise.
   Standard_EXPORT static Standard_Boolean Intersect (const Handle(Poly_Triangulation)& theTri,
                                                      const gp_Ax1& theAxis,
@@ -133,12 +133,12 @@ public:
                                                      Standard_Real& theDistance);
 
   //! Computes the intersection between a triangle defined by three vertexes and a line.
-  //! @param theStart [in] picking ray origin
-  //! @param theDir   [in] picking ray direction
-  //! @param theV0    [in] first triangle node
-  //! @param theV1    [in] second triangle node
-  //! @param theV2    [in] third triangle node
-  //! @param theParam [out] param on line of the intersection point
+  //! @param[in] theStart  picking ray origin
+  //! @param[in] theDir    picking ray direction
+  //! @param[in] theV0     first triangle node
+  //! @param[in] theV1     second triangle node
+  //! @param[in] theV2     third triangle node
+  //! @param[out] theParam  param on line of the intersection point
   //! @return 1 if intersection was found, 0 otherwise.
   Standard_EXPORT static Standard_Integer IntersectTriLine  (const gp_XYZ& theStart,
                                                              const gp_Dir& theDir,

--- a/src/Poly/Poly_MergeNodesTool.hxx
+++ b/src/Poly/Poly_MergeNodesTool.hxx
@@ -260,9 +260,9 @@ private:
 
     //! Bind node to the map or find existing one.
     //! @param theIndex [in,out] index of new key to add, or index of existing key, if already bound
-    //! @param theIsOpposite [out] flag indicating that existing (already bound) node has opposite direction
-    //! @param thePos   [in] node position to add or find
-    //! @param theNorm  [in] element normal for equality check
+    //! @param[out] theIsOpposite  flag indicating that existing (already bound) node has opposite direction
+    //! @param[in] thePos    node position to add or find
+    //! @param[in] theNorm   element normal for equality check
     //! @return TRUE if node was not bound already
     Standard_EXPORT bool Bind (int&  theIndex,
                                bool& theIsOpposite,

--- a/src/Poly/Poly_Triangulation.hxx
+++ b/src/Poly/Poly_Triangulation.hxx
@@ -61,11 +61,11 @@ public:
   //! Constructs a triangulation from a set of triangles.
   //! The triangulation is initialized without a triangle or a node,
   //! but capable of containing specified number of nodes and triangles.
-  //! @param theNbNodes     [in] number of nodes to allocate
-  //! @param theNbTriangles [in] number of triangles to allocate
-  //! @param theHasUVNodes  [in] indicates whether 2D nodes will be associated with 3D ones,
+  //! @param[in] theNbNodes      number of nodes to allocate
+  //! @param[in] theNbTriangles  number of triangles to allocate
+  //! @param[in] theHasUVNodes   indicates whether 2D nodes will be associated with 3D ones,
   //!                            (i.e. to enable a 2D representation)
-  //! @param theHasNormals  [in] indicates whether normals will be given and associated with nodes
+  //! @param[in] theHasNormals   indicates whether normals will be given and associated with nodes
   Standard_EXPORT Poly_Triangulation (const Standard_Integer theNbNodes,
                                       const Standard_Integer theNbTriangles,
                                       const Standard_Boolean theHasUVNodes,
@@ -237,9 +237,9 @@ public:
   //! - input transformation theTrsf has no rotation part;
   //! - theIsAccurate is set to FALSE;
   //! - no triangulation data available (e.g. it is deferred and not loaded).
-  //! @param theBox [in] [out] bounding box to extend by this triangulation
-  //! @param theTrsf [in] optional transformation
-  //! @param theIsAccurate [in] when FALSE, allows using a cached min - max range of this triangulation
+  //! @param[in][out] theBox   bounding box to extend by this triangulation
+  //! @param[in] theTrsf  optional transformation
+  //! @param[in] theIsAccurate  when FALSE, allows using a cached min - max range of this triangulation
   //!                           even for non-identity transformation.
   //! @return FALSE if there is no any data to extend the passed box (no both triangulation and cached min - max range).
   Standard_EXPORT Standard_Boolean MinMax (Bnd_Box& theBox, const gp_Trsf& theTrsf, const bool theIsAccurate = false) const;
@@ -257,14 +257,14 @@ public:
   Standard_EXPORT void SetDoublePrecision (bool theIsDouble);
 
   //! Method resizing internal arrays of nodes (synchronously for all attributes).
-  //! @param theNbNodes   [in] new number of nodes
-  //! @param theToCopyOld [in] copy old nodes into the new array
+  //! @param[in] theNbNodes    new number of nodes
+  //! @param[in] theToCopyOld  copy old nodes into the new array
   Standard_EXPORT void ResizeNodes (Standard_Integer theNbNodes,
                                     Standard_Boolean theToCopyOld);
 
   //! Method resizing an internal array of triangles.
-  //! @param theNbTriangles [in] new number of triangles
-  //! @param theToCopyOld   [in] copy old triangles into the new array
+  //! @param[in] theNbTriangles  new number of triangles
+  //! @param[in] theToCopyOld    copy old triangles into the new array
   Standard_EXPORT void ResizeTriangles (Standard_Integer theNbTriangles,
                                         Standard_Boolean theToCopyOld);
 
@@ -385,7 +385,7 @@ protected:
   Standard_EXPORT void unsetCachedMinMax();
 
   //! Calculates bounding box of nodal data.
-  //! @param theTrsf [in] optional transformation.
+  //! @param[in] theTrsf  optional transformation.
   Standard_EXPORT virtual Bnd_Box computeBoundingBox (const gp_Trsf& theTrsf) const;
 
 protected:

--- a/src/Prs3d/Prs3d.hxx
+++ b/src/Prs3d/Prs3d.hxx
@@ -49,9 +49,9 @@ public:
   Standard_EXPORT static Standard_Boolean MatchSegment (const Standard_Real X, const Standard_Real Y, const Standard_Real Z, const Standard_Real aDistance, const gp_Pnt& p1, const gp_Pnt& p2, Standard_Real& dist);
 
   //! Computes the absolute deflection value based on relative deflection Prs3d_Drawer::DeviationCoefficient().
-  //! @param theBndMin [in] bounding box min corner
-  //! @param theBndMax [in] bounding box max corner
-  //! @param theDeviationCoefficient [in] relative deflection coefficient from Prs3d_Drawer::DeviationCoefficient()
+  //! @param[in] theBndMin  bounding box min corner
+  //! @param[in] theBndMax  bounding box max corner
+  //! @param[in] theDeviationCoefficient  relative deflection coefficient from Prs3d_Drawer::DeviationCoefficient()
   //! @return absolute deflection coefficient based on bounding box dimensions
   static Standard_Real GetDeflection (const Graphic3d_Vec3d& theBndMin,
                                       const Graphic3d_Vec3d& theBndMax,
@@ -62,9 +62,9 @@ public:
   }
 
   //! Computes the absolute deflection value based on relative deflection Prs3d_Drawer::DeviationCoefficient().
-  //! @param theBndBox [in] bounding box
-  //! @param theDeviationCoefficient [in] relative deflection coefficient from Prs3d_Drawer::DeviationCoefficient()
-  //! @param theMaximalChordialDeviation [in] absolute deflection coefficient from Prs3d_Drawer::MaximalChordialDeviation()
+  //! @param[in] theBndBox  bounding box
+  //! @param[in] theDeviationCoefficient  relative deflection coefficient from Prs3d_Drawer::DeviationCoefficient()
+  //! @param[in] theMaximalChordialDeviation  absolute deflection coefficient from Prs3d_Drawer::MaximalChordialDeviation()
   //! @return absolute deflection coefficient based on bounding box dimensions or theMaximalChordialDeviation if bounding box is Void or Infinite
   static Standard_Real GetDeflection (const Bnd_Box& theBndBox,
                                       const Standard_Real theDeviationCoefficient,
@@ -91,7 +91,7 @@ public:
   }
 
   //! Assembles array of primitives for sequence of polylines.
-  //! @param thePoints [in] the polylines sequence
+  //! @param[in] thePoints  the polylines sequence
   //! @return array of primitives
   Standard_EXPORT static Handle(Graphic3d_ArrayOfPrimitives) PrimitivesFromPolylines (const Prs3d_NListOfSequenceOfPnt& thePoints);
 
@@ -101,9 +101,9 @@ public:
                                                   Prs3d_NListOfSequenceOfPnt&       thePolylines);
 
   //! Add triangulation free edges into sequence of line segments.
-  //! @param theSegments [out] sequence of line segments to fill
-  //! @param thePolyTri   [in] triangulation to process
-  //! @param theLocation  [in] transformation to apply
+  //! @param[out] theSegments  sequence of line segments to fill
+  //! @param[in] thePolyTri    triangulation to process
+  //! @param[in] theLocation   transformation to apply
   Standard_EXPORT static void AddFreeEdges (TColgp_SequenceOfPnt& theSegments,
                                             const Handle(Poly_Triangulation)& thePolyTri,
                                             const gp_Trsf& theLocation);

--- a/src/Prs3d/Prs3d_BndBox.hxx
+++ b/src/Prs3d/Prs3d_BndBox.hxx
@@ -29,17 +29,17 @@ class Prs3d_BndBox : public Prs3d_Root
 public:
 
   //! Computes presentation of a bounding box.
-  //! @param thePresentation [in] the presentation.
-  //! @param theBndBox [in] the bounding box.
-  //! @param theDrawer [in] the drawer.
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theBndBox  the bounding box.
+  //! @param[in] theDrawer  the drawer.
   Standard_EXPORT static void Add (const Handle(Prs3d_Presentation)& thePresentation,
                                    const Bnd_Box& theBndBox,
                                    const Handle(Prs3d_Drawer)& theDrawer);
 
   //! Computes presentation of a bounding box.
-  //! @param thePresentation [in] the presentation.
-  //! @param theBndBox [in] the bounding box.
-  //! @param theDrawer [in] the drawer.
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theBndBox  the bounding box.
+  //! @param[in] theDrawer  the drawer.
   Standard_EXPORT static void Add (const Handle(Prs3d_Presentation)& thePresentation,
                                    const Bnd_OBB& theBndBox,
                                    const Handle(Prs3d_Drawer)& theDrawer);
@@ -47,7 +47,7 @@ public:
 public:
 
   //! Create primitive array with line segments for displaying a box.
-  //! @param theBox [in] the box to add
+  //! @param[in] theBox  the box to add
   static Handle(Graphic3d_ArrayOfSegments) FillSegments (const Bnd_OBB& theBox)
   {
     if (theBox.IsVoid())
@@ -61,7 +61,7 @@ public:
   }
 
   //! Create primitive array with line segments for displaying a box.
-  //! @param theBox [in] the box to add
+  //! @param[in] theBox  the box to add
   static Handle(Graphic3d_ArrayOfSegments) FillSegments (const Bnd_Box& theBox)
   {
     if (theBox.IsVoid())
@@ -75,9 +75,9 @@ public:
   }
 
   //! Create primitive array with line segments for displaying a box.
-  //! @param theSegments [in] [out] primitive array to be filled;
+  //! @param[in][out] theSegments   primitive array to be filled;
   //!                               should be at least 8 nodes and 24 edges in size
-  //! @param theBox [in] the box to add
+  //! @param[in] theBox  the box to add
   static void FillSegments (const Handle(Graphic3d_ArrayOfSegments)& theSegments, const Bnd_OBB& theBox)
   {
     if (!theBox.IsVoid())
@@ -89,9 +89,9 @@ public:
   }
 
   //! Create primitive array with line segments for displaying a box.
-  //! @param theSegments [in] [out] primitive array to be filled;
+  //! @param[in][out] theSegments   primitive array to be filled;
   //!                               should be at least 8 nodes and 24 edges in size
-  //! @param theBox [in] the box to add
+  //! @param[in] theBox  the box to add
   static void FillSegments (const Handle(Graphic3d_ArrayOfSegments)& theSegments, const Bnd_Box& theBox)
   {
     if (!theBox.IsVoid())
@@ -116,9 +116,9 @@ public:
 public:
 
   //! Create primitive array with line segments for displaying a box.
-  //! @param theSegments [in] [out] primitive array to be filled;
+  //! @param[in][out] theSegments   primitive array to be filled;
   //!                               should be at least 8 nodes and 24 edges in size
-  //! @param theBox [in] the box to add
+  //! @param[in] theBox  the box to add
   static void fillSegments (const Handle(Graphic3d_ArrayOfSegments)& theSegments, const gp_Pnt* theBox)
   {
     const Standard_Integer aFrom = theSegments->VertexNumber();

--- a/src/Prs3d/Prs3d_ToolCylinder.hxx
+++ b/src/Prs3d/Prs3d_ToolCylinder.hxx
@@ -24,12 +24,12 @@ class Prs3d_ToolCylinder : public Prs3d_ToolQuadric
 public:
 
   //! Generate primitives for 3D quadric surface and return a filled array.
-  //! @param theBottomRad [in] cylinder bottom radius
-  //! @param theTopRad    [in] cylinder top radius
-  //! @param theHeight    [in] cylinder height
-  //! @param theNbSlices  [in] number of slices within U parameter
-  //! @param theNbStacks  [in] number of stacks within V parameter
-  //! @param theTrsf      [in] optional transformation to apply
+  //! @param[in] theBottomRad  cylinder bottom radius
+  //! @param[in] theTopRad     cylinder top radius
+  //! @param[in] theHeight     cylinder height
+  //! @param[in] theNbSlices   number of slices within U parameter
+  //! @param[in] theNbStacks   number of stacks within V parameter
+  //! @param[in] theTrsf       optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theBottomRad,
                                                                     const Standard_Real    theTopRad,
@@ -40,11 +40,11 @@ public:
 public:
 
   //! Initializes the algorithm creating a cylinder.
-  //! @param theBottomRad [in] cylinder bottom radius
-  //! @param theTopRad    [in] cylinder top radius
-  //! @param theHeight    [in] cylinder height
-  //! @param theNbSlices  [in] number of slices within U parameter
-  //! @param theNbStacks  [in] number of stacks within V parameter
+  //! @param[in] theBottomRad  cylinder bottom radius
+  //! @param[in] theTopRad     cylinder top radius
+  //! @param[in] theHeight     cylinder height
+  //! @param[in] theNbSlices   number of slices within U parameter
+  //! @param[in] theNbStacks   number of stacks within V parameter
   Standard_EXPORT Prs3d_ToolCylinder (const Standard_Real    theBottomRad,
                                       const Standard_Real    theTopRad,
                                       const Standard_Real    theHeight,

--- a/src/Prs3d/Prs3d_ToolDisk.hxx
+++ b/src/Prs3d/Prs3d_ToolDisk.hxx
@@ -24,11 +24,11 @@ class Prs3d_ToolDisk : public Prs3d_ToolQuadric
 public:
 
   //! Generate primitives for 3D quadric surface.
-  //! @param theInnerRadius [in] inner disc radius
-  //! @param theOuterRadius [in] outer disc radius
-  //! @param theNbSlices    [in] number of slices within U parameter
-  //! @param theNbStacks    [in] number of stacks within V parameter
-  //! @param theTrsf        [in] optional transformation to apply
+  //! @param[in] theInnerRadius  inner disc radius
+  //! @param[in] theOuterRadius  outer disc radius
+  //! @param[in] theNbSlices     number of slices within U parameter
+  //! @param[in] theNbStacks     number of stacks within V parameter
+  //! @param[in] theTrsf         optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theInnerRadius,
                                                                     const Standard_Real    theOuterRadius,
@@ -38,18 +38,18 @@ public:
 public:
 
   //! Initializes the algorithm creating a disk.
-  //! @param theInnerRadius [in] inner disk radius
-  //! @param theOuterRadius [in] outer disk radius
-  //! @param theNbSlices    [in] number of slices within U parameter
-  //! @param theNbStacks    [in] number of stacks within V parameter
+  //! @param[in] theInnerRadius  inner disk radius
+  //! @param[in] theOuterRadius  outer disk radius
+  //! @param[in] theNbSlices     number of slices within U parameter
+  //! @param[in] theNbStacks     number of stacks within V parameter
   Standard_EXPORT Prs3d_ToolDisk (const Standard_Real    theInnerRadius,
                                   const Standard_Real    theOuterRadius,
                                   const Standard_Integer theNbSlices,
                                   const Standard_Integer theNbStacks);
 
   //! Set angle range in radians [0, 2*PI] by default.
-  //! @param theStartAngle [in] Start angle in counter clockwise order
-  //! @param theEndAngle   [in] End   angle in counter clockwise order
+  //! @param[in] theStartAngle  Start angle in counter clockwise order
+  //! @param[in] theEndAngle    End   angle in counter clockwise order
   void SetAngleRange (Standard_Real theStartAngle,
                       Standard_Real theEndAngle)
   {

--- a/src/Prs3d/Prs3d_ToolQuadric.hxx
+++ b/src/Prs3d/Prs3d_ToolQuadric.hxx
@@ -45,21 +45,21 @@ public:
 public:
 
   //! Generate primitives for 3D quadric surface presentation.
-  //! @param theTrsf [in] optional transformation to apply
+  //! @param[in] theTrsf  optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT Handle(Graphic3d_ArrayOfTriangles) CreateTriangulation (const gp_Trsf& theTrsf) const;
 
   //! Generate primitives for 3D quadric surface presentation.
-  //! @param theTrsf [in] optional transformation to apply
+  //! @param[in] theTrsf  optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT Handle(Poly_Triangulation) CreatePolyTriangulation (const gp_Trsf& theTrsf) const;
 
   //! Generate primitives for 3D quadric surface and fill the given array.
-  //! @param theArray [in][out] the array of vertices;
+  //! @param[in][out] theArray  the array of vertices;
   //!                           when NULL, function will create an indexed array;
   //!                           when not NULL, triangles will be appended to the end of array
   //!                           (will raise an exception if reserved array size is not large enough)
-  //! @param theTrsf [in] optional transformation to apply
+  //! @param[in] theTrsf  optional transformation to apply
   Standard_EXPORT void FillArray (Handle(Graphic3d_ArrayOfTriangles)& theArray,
                                   const gp_Trsf& theTrsf) const;
 
@@ -77,9 +77,9 @@ public:
 public:
 
   //! Generate primitives for 3D quadric surface presentation.
-  //! @param theArray [out] generated array of triangles
-  //! @param theTriangulation [out] generated triangulation
-  //! @param theTrsf [in] optional transformation to apply
+  //! @param[out] theArray  generated array of triangles
+  //! @param[out] theTriangulation  generated triangulation
+  //! @param[in] theTrsf  optional transformation to apply
   Standard_DEPRECATED("Deprecated method, CreateTriangulation() and CreatePolyTriangulation() should be used instead")
   Standard_EXPORT void FillArray (Handle(Graphic3d_ArrayOfTriangles)& theArray,
                                   Handle(Poly_Triangulation)& theTriangulation,

--- a/src/Prs3d/Prs3d_ToolSector.hxx
+++ b/src/Prs3d/Prs3d_ToolSector.hxx
@@ -24,10 +24,10 @@ class Prs3d_ToolSector : public Prs3d_ToolQuadric
 public:
 
   //! Generate primitives for 3D quadric surface.
-  //! @param theRadius   [in] sector radius
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
-  //! @param theTrsf     [in] optional transformation to apply
+  //! @param[in] theRadius    sector radius
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
+  //! @param[in] theTrsf      optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theRadius,
                                                                     const Standard_Integer theNbSlices,
@@ -36,9 +36,9 @@ public:
 public:
 
   //! Initializes the algorithm creating a sector (quadrant).
-  //! @param theRadius   [in] sector radius
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theRadius    sector radius
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Standard_EXPORT Prs3d_ToolSector (const Standard_Real    theRadius,
                                     const Standard_Integer theNbSlices,
                                     const Standard_Integer theNbStacks);

--- a/src/Prs3d/Prs3d_ToolSphere.hxx
+++ b/src/Prs3d/Prs3d_ToolSphere.hxx
@@ -24,10 +24,10 @@ class Prs3d_ToolSphere : public Prs3d_ToolQuadric
 public:
 
   //! Generate primitives for 3D quadric surface.
-  //! @param theRadius   [in] sphere radius
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
-  //! @param theTrsf     [in] optional transformation to apply
+  //! @param[in] theRadius    sphere radius
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
+  //! @param[in] theTrsf      optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theRadius,
                                                                     const Standard_Integer theNbSlices,
@@ -36,9 +36,9 @@ public:
 public:
 
   //! Initializes the algorithm creating a sphere.
-  //! @param theRadius   [in] sphere radius
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theRadius    sphere radius
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Standard_EXPORT Prs3d_ToolSphere (const Standard_Real    theRadius,
                                     const Standard_Integer theNbSlices,
                                     const Standard_Integer theNbStacks);

--- a/src/Prs3d/Prs3d_ToolTorus.hxx
+++ b/src/Prs3d/Prs3d_ToolTorus.hxx
@@ -24,11 +24,11 @@ class Prs3d_ToolTorus : public Prs3d_ToolQuadric
 public:
 
   //! Generate primitives for 3D quadric surface (complete torus).
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
-  //! @param theTrsf     [in] optional transformation to apply
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
+  //! @param[in] theTrsf      optional transformation to apply
   //! @return generated triangulation
   static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theMajorRad,
                                                     const Standard_Real    theMinorRad,
@@ -40,12 +40,12 @@ public:
   }
 
   //! Generate primitives for 3D quadric surface (torus segment).
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle    [in] angle to create a torus pipe segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
-  //! @param theTrsf     [in] optional transformation to apply
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle     angle to create a torus pipe segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
+  //! @param[in] theTrsf      optional transformation to apply
   //! @return generated triangulation
   static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theMajorRad,
                                                     const Standard_Real    theMinorRad,
@@ -58,13 +58,13 @@ public:
   }
 
   //! Generate primitives for 3D quadric surface (torus ring segment).
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle1   [in] first  angle to create a torus ring segment
-  //! @param theAngle2   [in] second angle to create a torus ring segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
-  //! @param theTrsf     [in] optional transformation to apply
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle1    first  angle to create a torus ring segment
+  //! @param[in] theAngle2    second angle to create a torus ring segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
+  //! @param[in] theTrsf      optional transformation to apply
   //! @return generated triangulation
   static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theMajorRad,
                                                     const Standard_Real    theMinorRad,
@@ -78,14 +78,14 @@ public:
   }
 
   //! Generate primitives for 3D quadric surface (segment of the torus ring segment).
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle1   [in] first  angle to create a torus ring segment
-  //! @param theAngle2   [in] second angle to create a torus ring segment
-  //! @param theAngle    [in] angle to create a torus pipe segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
-  //! @param theTrsf     [in] optional transformation to apply
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle1    first  angle to create a torus ring segment
+  //! @param[in] theAngle2    second angle to create a torus ring segment
+  //! @param[in] theAngle     angle to create a torus pipe segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
+  //! @param[in] theTrsf      optional transformation to apply
   //! @return generated triangulation
   Standard_EXPORT static Handle(Graphic3d_ArrayOfTriangles) Create (const Standard_Real    theMajorRad,
                                                                     const Standard_Real    theMinorRad,
@@ -99,10 +99,10 @@ public:
 public:
 
   //! Initializes the algorithm creating a complete torus.
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Prs3d_ToolTorus (const Standard_Real    theMajorRad,
                    const Standard_Real    theMinorRad,
                    const Standard_Integer theNbSlices,
@@ -112,11 +112,11 @@ public:
   }
 
   //! Initializes the algorithm creating a torus pipe segment.
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle    [in] angle to create a torus pipe segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle     angle to create a torus pipe segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Prs3d_ToolTorus (const Standard_Real    theMajorRad,
                    const Standard_Real    theMinorRad,
                    const Standard_Real    theAngle,
@@ -127,12 +127,12 @@ public:
   }
 
   //! Initializes the algorithm creating a torus ring segment.
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle1   [in] first  angle to create a torus ring segment
-  //! @param theAngle2   [in] second angle to create a torus ring segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle1    first  angle to create a torus ring segment
+  //! @param[in] theAngle2    second angle to create a torus ring segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Prs3d_ToolTorus (const Standard_Real    theMajorRad,
                    const Standard_Real    theMinorRad,
                    const Standard_Real    theAngle1,
@@ -144,13 +144,13 @@ public:
   }
 
   //! Initializes the algorithm creating a torus ring segment.
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle1   [in] first  angle to create a torus ring segment
-  //! @param theAngle2   [in] second angle to create a torus ring segment
-  //! @param theAngle    [in] angle to create a torus pipe segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle1    first  angle to create a torus ring segment
+  //! @param[in] theAngle2    second angle to create a torus ring segment
+  //! @param[in] theAngle     angle to create a torus pipe segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Prs3d_ToolTorus (const Standard_Real    theMajorRad,
                    const Standard_Real    theMinorRad,
                    const Standard_Real    theAngle1,
@@ -165,13 +165,13 @@ public:
 private:
 
   //! Initialisation
-  //! @param theMajorRad [in] distance from the center of the pipe to the center of the torus
-  //! @param theMinorRad [in] radius of the pipe
-  //! @param theAngle1   [in] first  angle to create a torus ring segment
-  //! @param theAngle2   [in] second angle to create a torus ring segment
-  //! @param theAngle    [in] angle to create a torus pipe segment
-  //! @param theNbSlices [in] number of slices within U parameter
-  //! @param theNbStacks [in] number of stacks within V parameter
+  //! @param[in] theMajorRad  distance from the center of the pipe to the center of the torus
+  //! @param[in] theMinorRad  radius of the pipe
+  //! @param[in] theAngle1    first  angle to create a torus ring segment
+  //! @param[in] theAngle2    second angle to create a torus ring segment
+  //! @param[in] theAngle     angle to create a torus pipe segment
+  //! @param[in] theNbSlices  number of slices within U parameter
+  //! @param[in] theNbStacks  number of stacks within V parameter
   Standard_EXPORT void init (const Standard_Real    theMajorRad,
                              const Standard_Real    theMinorRad,
                              const Standard_Real    theAngle1,

--- a/src/PrsDim/PrsDim.hxx
+++ b/src/PrsDim/PrsDim.hxx
@@ -118,7 +118,7 @@ public:
   Standard_EXPORT static void InitFaceLength (const TopoDS_Face& aFace, gp_Pln& aPlane, Handle(Geom_Surface)& aSurface, PrsDim_KindOfSurface& aSurfaceType, Standard_Real& anOffset);
   
   //! Finds attachment points on two curvilinear faces for length dimension.
-  //! @param thePlaneDir [in] the direction on the dimension plane to
+  //! @param[in] thePlaneDir  the direction on the dimension plane to
   //! compute the plane automatically. It will not be taken into account if
   //! plane is defined by user.
   Standard_EXPORT static void InitLengthBetweenCurvilinearFaces (const TopoDS_Face& theFirstFace, const TopoDS_Face& theSecondFace, Handle(Geom_Surface)& theFirstSurf, Handle(Geom_Surface)& theSecondSurf, gp_Pnt& theFirstAttach, gp_Pnt& theSecondAttach, gp_Dir& theDirOnPlane);

--- a/src/PrsDim/PrsDim_AngleDimension.hxx
+++ b/src/PrsDim/PrsDim_AngleDimension.hxx
@@ -64,41 +64,41 @@ public:
 
   //! Constructs minimum angle dimension between two linear edges (where possible).
   //! These two edges should be intersected by each other. Otherwise the geometry is not valid.
-  //! @param theFirstEdge [in] the first edge.
-  //! @param theSecondEdge [in] the second edge.
+  //! @param[in] theFirstEdge  the first edge.
+  //! @param[in] theSecondEdge  the second edge.
   Standard_EXPORT PrsDim_AngleDimension (const TopoDS_Edge& theFirstEdge,
                                          const TopoDS_Edge& theSecondEdge);
 
   //! Constructs the angle display object defined by three points.
-  //! @param theFirstPoint [in] the first point (point on first angle flyout).
-  //! @param theSecondPoint [in] the center point of angle dimension.
-  //! @param theThirdPoint [in] the second point (point on second angle flyout).
+  //! @param[in] theFirstPoint  the first point (point on first angle flyout).
+  //! @param[in] theSecondPoint  the center point of angle dimension.
+  //! @param[in] theThirdPoint  the second point (point on second angle flyout).
   Standard_EXPORT PrsDim_AngleDimension (const gp_Pnt& theFirstPoint,
                                          const gp_Pnt& theSecondPoint,
                                          const gp_Pnt& theThirdPoint);
 
   //! Constructs the angle display object defined by three vertices.
-  //! @param theFirstVertex [in] the first vertex (vertex for first angle flyout).
-  //! @param theSecondVertex [in] the center vertex of angle dimension.
-  //! @param theThirdPoint [in] the second vertex (vertex for second angle flyout).
+  //! @param[in] theFirstVertex  the first vertex (vertex for first angle flyout).
+  //! @param[in] theSecondVertex  the center vertex of angle dimension.
+  //! @param[in] theThirdPoint  the second vertex (vertex for second angle flyout).
   Standard_EXPORT PrsDim_AngleDimension (const TopoDS_Vertex& theFirstVertex,
                                          const TopoDS_Vertex& theSecondVertex,
                                          const TopoDS_Vertex& theThirdVertex);
 
   //! Constructs angle dimension for the cone face.
-  //! @param theCone [in] the conical face.
+  //! @param[in] theCone  the conical face.
   Standard_EXPORT PrsDim_AngleDimension (const TopoDS_Face& theCone);
 
   //! Constructs angle dimension between two planar faces.
-  //! @param theFirstFace [in] the first face.
-  //! @param theSecondFace [in] the second face.
+  //! @param[in] theFirstFace  the first face.
+  //! @param[in] theSecondFace  the second face.
   Standard_EXPORT PrsDim_AngleDimension (const TopoDS_Face& theFirstFace,
                                          const TopoDS_Face& theSecondFace);
 
   //! Constructs angle dimension between two planar faces.
-  //! @param theFirstFace [in] the first face.
-  //! @param theSecondFace [in] the second face.
-  //! @param thePoint [in] the point which the dimension plane should pass through.
+  //! @param[in] theFirstFace  the first face.
+  //! @param[in] theSecondFace  the second face.
+  //! @param[in] thePoint  the point which the dimension plane should pass through.
   //! This point can lay on the one of the faces or not.
   Standard_EXPORT PrsDim_AngleDimension (const TopoDS_Face& theFirstFace,
                                          const TopoDS_Face& theSecondFace,
@@ -128,41 +128,41 @@ public:
 
   //! Measures minimum angle dimension between two linear edges.
   //! These two edges should be intersected by each other. Otherwise the geometry is not valid.
-  //! @param theFirstEdge [in] the first edge.
-  //! @param theSecondEdge [in] the second edge.
+  //! @param[in] theFirstEdge  the first edge.
+  //! @param[in] theSecondEdge  the second edge.
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Edge& theFirstEdge,
                                             const TopoDS_Edge& theSecondEdge);
 
   //! Measures angle defined by three points.
-  //! @param theFirstPoint [in] the first point (point on first angle flyout).
-  //! @param theSecondPoint [in] the center point of angle dimension.
-  //! @param theThirdPoint [in] the second point (point on second angle flyout).
+  //! @param[in] theFirstPoint  the first point (point on first angle flyout).
+  //! @param[in] theSecondPoint  the center point of angle dimension.
+  //! @param[in] theThirdPoint  the second point (point on second angle flyout).
   Standard_EXPORT void SetMeasuredGeometry (const gp_Pnt& theFirstPoint,
                                             const gp_Pnt& theSecondPoint,
                                             const gp_Pnt& theThridPoint);
 
   //! Measures angle defined by three vertices.
-  //! @param theFirstVertex [in] the first vertex (vertex for first angle flyout).
-  //! @param theSecondVertex [in] the center vertex of angle dimension.
-  //! @param theThirdPoint [in] the second vertex (vertex for second angle flyout).
+  //! @param[in] theFirstVertex  the first vertex (vertex for first angle flyout).
+  //! @param[in] theSecondVertex  the center vertex of angle dimension.
+  //! @param[in] theThirdPoint  the second vertex (vertex for second angle flyout).
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Vertex& theFirstVertex,
                                             const TopoDS_Vertex& theSecondVertex,
                                             const TopoDS_Vertex& theThirdVertex);
 
   //! Measures angle of conical face.
-  //! @param theCone [in] the shape to measure.
+  //! @param[in] theCone  the shape to measure.
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Face& theCone);
 
   //! Measures angle between two planar faces.
-  //! @param theFirstFace [in] the first face.
-  //! @param theSecondFace [in] the second face..
+  //! @param[in] theFirstFace  the first face.
+  //! @param[in] theSecondFace  the second face..
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Face& theFirstFace,
                                             const TopoDS_Face& theSecondFace);
 
   //! Measures angle between two planar faces.
-  //! @param theFirstFace [in] the first face.
-  //! @param theSecondFace [in] the second face.
-  //! @param thePoint [in] the point which the dimension plane should pass through.
+  //! @param[in] theFirstFace  the first face.
+  //! @param[in] theSecondFace  the second face.
+  //! @param[in] thePoint  the point which the dimension plane should pass through.
   //! This point can lay on the one of the faces or not.
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Face& theFirstFace,
                                             const TopoDS_Face& theSecondFace,
@@ -189,14 +189,14 @@ public:
   Standard_EXPORT virtual gp_Pnt GetTextPosition () const Standard_OVERRIDE;
 
   //! Sets angle type.
-  //! @param theType [in] the type value.
+  //! @param[in] theType  the type value.
   void SetType (const PrsDim_TypeOfAngle theType) { myType = theType; }
 
   //! @return the current angle type.
   PrsDim_TypeOfAngle GetType() const { return myType; }
 
   //! Sets visible arrows type
-  //! @param theType [in] the type of visibility of arrows.
+  //! @param[in] theType  the type of visibility of arrows.
   void SetArrowsVisibility (const PrsDim_TypeOfAngleArrowVisibility& theType) { myArrowsVisibility = theType; }
 
   //! @return the type of visibility of arrows.
@@ -212,21 +212,21 @@ protected:
   //! Based on this normal angle arc, arrows and extensions are constructed.
   gp_Dir GetNormalForMinAngle() const;
 
-  //! @param theFirstAttach [in] the first attachment point.
-  //! @param theSecondAttach [in] the second attachment point.
-  //! @param theCenter [in] the center point (center point of the angle).  
+  //! @param[in] theFirstAttach  the first attachment point.
+  //! @param[in] theSecondAttach  the second attachment point.
+  //! @param[in] theCenter  the center point (center point of the angle).  
   //! @return the center of the dimension arc (the main dimension line in case of angle). 
   Standard_EXPORT gp_Pnt GetCenterOnArc (const gp_Pnt& theFirstAttach,
                                          const gp_Pnt& theSecondAttach,
                                          const gp_Pnt& theCenter) const;
 
   //! Draws main dimension line (arc).
-  //! @param thePresentation [in] the dimension presentation.
-  //! @param theFirstAttach [in] the first attachment point.
-  //! @param theSecondAttach [in] the second attachment point.
-  //! @param theCenter [in] the center point (center point of the angle).
-  //! @param theRadius [in] the radius of the dimension arc.
-  //! @param theMode [in] the display mode.
+  //! @param[in] thePresentation  the dimension presentation.
+  //! @param[in] theFirstAttach  the first attachment point.
+  //! @param[in] theSecondAttach  the second attachment point.
+  //! @param[in] theCenter  the center point (center point of the angle).
+  //! @param[in] theRadius  the radius of the dimension arc.
+  //! @param[in] theMode  the display mode.
   Standard_EXPORT void DrawArc (const Handle(Prs3d_Presentation)& thePresentation,
                                 const gp_Pnt& theFirstAttach,
                                 const gp_Pnt& theSecondAttach,
@@ -235,14 +235,14 @@ protected:
                                 const Standard_Integer theMode);
 
   //! Draws main dimension line (arc) with text.
-  //! @param thePresentation [in] the dimension presentation.
-  //! @param theFirstAttach [in] the first attachment point.
-  //! @param theSecondAttach [in] the second attachment point.
-  //! @param theCenter [in] the center point (center point of the angle).
-  //! @param theText [in] the text label string.
-  //! @param theTextWidth [in] the text label width. 
-  //! @param theMode [in] the display mode.
-  //! @param theLabelPosition [in] the text label vertical and horizontal positioning option
+  //! @param[in] thePresentation  the dimension presentation.
+  //! @param[in] theFirstAttach  the first attachment point.
+  //! @param[in] theSecondAttach  the second attachment point.
+  //! @param[in] theCenter  the center point (center point of the angle).
+  //! @param[in] theText  the text label string.
+  //! @param[in] theTextWidth  the text label width. 
+  //! @param[in] theMode  the display mode.
+  //! @param[in] theLabelPosition  the text label vertical and horizontal positioning option
   //! respectively to the main dimension line. 
   Standard_EXPORT void DrawArcWithText (const Handle(Prs3d_Presentation)& thePresentation,
                                         const gp_Pnt& theFirstAttach,
@@ -256,10 +256,10 @@ protected:
   //! Fits text alignment relatively to the dimension line;
   //! it computes the value of label position and arrow orientation
   //! according set in the aspect and dimension properties.
-  //! @param theHorizontalTextPos [in] the horizontal alignment for text position.
-  //! @param theLabelPosition [out] the label position, contains bits that defines
+  //! @param[in] theHorizontalTextPos  the horizontal alignment for text position.
+  //! @param[out] theLabelPosition  the label position, contains bits that defines
   //! vertical and horizontal alignment. (for internal usage in count text position).
-  //! @param theIsArrowExternal [out] is the arrows external,
+  //! @param[out] theIsArrowExternal  is the arrows external,
   //! if arrow orientation in the dimension aspect is Prs3d_DAO_Fit, it fits arrow
   //! orientation automatically.
   Standard_EXPORT void FitTextAlignment (const Prs3d_DimensionTextHorizontalPosition& theHorizontalTextPos,
@@ -268,10 +268,10 @@ protected:
 
   //! Adjusts aspect parameters according the text position:
   //! extension size, vertical text alignment and flyout.
-  //! @param theTextPos [in] the user defined 3d point of text position.
-  //! @param theExtensionSize [out] the adjusted extension size.
-  //! @param theAlignment [out] the horizontal label alignment.
-  //! @param theFlyout [out] the adjusted value of flyout.
+  //! @param[in] theTextPos  the user defined 3d point of text position.
+  //! @param[out] theExtensionSize  the adjusted extension size.
+  //! @param[out] theAlignment  the horizontal label alignment.
+  //! @param[out] theFlyout  the adjusted value of flyout.
   Standard_EXPORT void AdjustParameters (const gp_Pnt& theTextPos,
                                          Standard_Real& theExtensionSize,
                                          Prs3d_DimensionTextHorizontalPosition& theAlignment,
@@ -308,7 +308,7 @@ protected:
   Standard_EXPORT Standard_Boolean InitTwoFacesAngle();
 
   //! Init angular dimension to measure angle between two planar faces.
-  //! @param thePointOnFirstFace [in] the point which the dimension plane should pass through.
+  //! @param[in] thePointOnFirstFace  the point which the dimension plane should pass through.
   //! This point can lay on the one of the faces or not.
   //! It will be projected on the first face and this point will be set
   //! as the first point attach point.

--- a/src/PrsDim/PrsDim_DiameterDimension.hxx
+++ b/src/PrsDim/PrsDim_DiameterDimension.hxx
@@ -55,25 +55,25 @@ class PrsDim_DiameterDimension : public PrsDim_Dimension
 public:
 
   //! Construct diameter dimension for the circle.
-  //! @param theCircle [in] the circle to measure.
+  //! @param[in] theCircle  the circle to measure.
   Standard_EXPORT PrsDim_DiameterDimension (const gp_Circ& theCircle);
 
   //! Construct diameter dimension for the circle and orient it correspondingly
   //! to the passed plane.
-  //! @param theCircle [in] the circle to measure.
-  //! @param thePlane [in] the plane defining preferred orientation
+  //! @param[in] theCircle  the circle to measure.
+  //! @param[in] thePlane  the plane defining preferred orientation
   //!        for dimension.
   Standard_EXPORT PrsDim_DiameterDimension (const gp_Circ& theCircle,
                                             const gp_Pln& thePlane);
 
   //! Construct diameter on the passed shape, if applicable.
-  //! @param theShape [in] the shape to measure.
+  //! @param[in] theShape  the shape to measure.
   Standard_EXPORT PrsDim_DiameterDimension (const TopoDS_Shape& theShape);
 
   //! Construct diameter on the passed shape, if applicable - and
   //! define the preferred plane to orient the dimension.
-  //! @param theShape [in] the shape to measure.
-  //! @param thePlane [in] the plane defining preferred orientation
+  //! @param[in] theShape  the shape to measure.
+  //! @param[in] thePlane  the plane defining preferred orientation
   //!        for dimension.
   Standard_EXPORT PrsDim_DiameterDimension (const TopoDS_Shape& theShape,
                                             const gp_Pln& thePlane);
@@ -96,13 +96,13 @@ public:
   //! on the circle to attach the dimension lines to.
   //! The dimension will become invalid if the diameter of the circle
   //! is less than Precision::Confusion().
-  //! @param theCircle [in] the circle to measure.
+  //! @param[in] theCircle  the circle to measure.
   Standard_EXPORT void SetMeasuredGeometry (const gp_Circ& theCircle);
 
   //! Measure diameter on the passed shape, if applicable.
   //! The dimension will become invalid if the passed shape is not
   //! measurable or if measured diameter value is less than Precision::Confusion().
-  //! @param theShape [in] the shape to measure.
+  //! @param[in] theShape  the shape to measure.
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Shape& theShape);
 
   //! @return the display units string.
@@ -150,9 +150,9 @@ protected:
   //! Program error exception is raised if the dimension plane "x" direction 
   //! is orthogonal to plane (the "impossible" case). The passed dimension plane
   //! is the one specially computed to locate dimension presentation in circle.
-  //! @param theCircle [in] the circle.
-  //! @param theFirstPnt [out] the first point.
-  //! @param theSecondPnt [out] the second point.
+  //! @param[in] theCircle  the circle.
+  //! @param[out] theFirstPnt  the first point.
+  //! @param[out] theSecondPnt  the second point.
   Standard_EXPORT void ComputeSidePoints (const gp_Circ& theCircle,
                                           gp_Pnt& theFirstPnt,
                                           gp_Pnt& theSecondPnt);

--- a/src/PrsDim/PrsDim_Dimension.hxx
+++ b/src/PrsDim/PrsDim_Dimension.hxx
@@ -218,7 +218,7 @@ public:
 public:
 
   //! Constructor with default parameters values.
-  //! @param theType [in] the type of dimension.
+  //! @param[in] theType  the type of dimension.
   Standard_EXPORT PrsDim_Dimension (const PrsDim_KindOfDimension theType);
 
   //! Gets dimension measurement value. If the value to display is not
@@ -240,12 +240,12 @@ public:
   //! Sets user-defined dimension value.
   //! The user-defined dimension value is specified in model space,
   //! and affect by unit conversion during the display.
-  //! @param theValue [in] the user-defined value to display.
+  //! @param[in] theValue  the user-defined value to display.
   Standard_EXPORT void SetCustomValue (const Standard_Real theValue);
 
   //! Sets user-defined dimension value.
   //! Unit conversion during the display is not applied.
-  //! @param theValue [in] the user-defined value to display.
+  //! @param[in] theValue  the user-defined value to display.
   Standard_EXPORT void SetCustomValue (const TCollection_ExtendedString& theValue);
 
   //! Gets user-defined dimension value.
@@ -286,7 +286,7 @@ public:
   //! Fixes the absolute text position and adjusts flyout, plane and text alignment
   //! according to it. Updates presentation if the text position is valid.
   //! ATTENTION! It does not change vertical text alignment.
-  //! @param theTextPos [in] the point of text position.
+  //! @param[in] theTextPos  the point of text position.
   virtual void SetTextPosition (const gp_Pnt& /*theTextPos*/) { }
 
   //! Computes absolute text position from dimension parameters
@@ -388,22 +388,22 @@ protected:
   Standard_EXPORT Standard_Real ValueToDisplayUnits() const;
 
   //! Get formatted value string and its model space width.
-  //! @param theWidth [out] the model space with of the string.
+  //! @param[out] theWidth  the model space with of the string.
   //! @return formatted dimension value string.
   Standard_EXPORT TCollection_ExtendedString GetValueString (Standard_Real& theWidth) const;
 
   //! Performs drawing of 2d or 3d arrows on the working plane
-  //! @param theLocation [in] the location of the arrow tip.
-  //! @param theDirection [in] the direction from the tip to the bottom of the arrow.
+  //! @param[in] theLocation  the location of the arrow tip.
+  //! @param[in] theDirection  the direction from the tip to the bottom of the arrow.
   Standard_EXPORT void DrawArrow (const Handle(Prs3d_Presentation)& thePresentation,
                                   const gp_Pnt& theLocation,
                                   const gp_Dir& theDirection);
 
   //! Performs drawing of 2d or 3d text on the working plane
-  //! @param theTextPos [in] the position of the text label.
-  //! @param theTestDir [in] the direction of the text label.
-  //! @param theText [in] the text label string.
-  //! @param theLabelPosition [in] the text label vertical and horizontal positioning option
+  //! @param[in] theTextPos  the position of the text label.
+  //! @param[in] theTestDir  the direction of the text label.
+  //! @param[in] theText  the text label string.
+  //! @param[in] theLabelPosition  the text label vertical and horizontal positioning option
   //! respectively to the main dimension line. 
   //! @return text width relative to the dimension working plane. For 2d text this value will be zero.
   Standard_EXPORT void drawText (const Handle(Prs3d_Presentation)& thePresentation,
@@ -413,14 +413,14 @@ protected:
                                  const Standard_Integer theLabelPosition);
 
   //! Performs computing of dimension linear extension with text
-  //! @param thePresentation [in] the presentation to fill with graphical primitives.
-  //! @param theExtensionSize [in] the size of extension line.
-  //! @param theExtensionStart [in] the point where extension line connects to dimension.
-  //! @param theExtensionDir [in] the direction of extension line.
-  //! @param theLabelString [in] the string with value.
-  //! @param theLabelWidth [in] the geometrical width computed for value string.
-  //! @param theMode [in] the display mode.
-  //! @param theLabelPosition [in] position flags for the text label.
+  //! @param[in] thePresentation  the presentation to fill with graphical primitives.
+  //! @param[in] theExtensionSize  the size of extension line.
+  //! @param[in] theExtensionStart  the point where extension line connects to dimension.
+  //! @param[in] theExtensionDir  the direction of extension line.
+  //! @param[in] theLabelString  the string with value.
+  //! @param[in] theLabelWidth  the geometrical width computed for value string.
+  //! @param[in] theMode  the display mode.
+  //! @param[in] theLabelPosition  position flags for the text label.
   Standard_EXPORT void DrawExtension (const Handle(Prs3d_Presentation)& thePresentation,
                                       const Standard_Real theExtensionSize,
                                       const gp_Pnt& theExtensionStart,
@@ -433,11 +433,11 @@ protected:
   //! Performs computing of linear dimension (for length, diameter, radius and so on).
   //! Please note that this method uses base dimension properties, like working plane
   //! flyout length, drawer attributes.
-  //! @param thePresentation [in] the presentation to fill with primitives.
-  //! @param theMode [in] the presentation compute mode.
-  //! @param theFirstPoint [in] the first attach point of linear dimension.
-  //! @param theSecondPoint [in] the second attach point of linear dimension.
-  //! @param theIsOneSide [in] specifies whether the dimension has only one flyout line.
+  //! @param[in] thePresentation  the presentation to fill with primitives.
+  //! @param[in] theMode  the presentation compute mode.
+  //! @param[in] theFirstPoint  the first attach point of linear dimension.
+  //! @param[in] theSecondPoint  the second attach point of linear dimension.
+  //! @param[in] theIsOneSide  specifies whether the dimension has only one flyout line.
   Standard_EXPORT void DrawLinearDimension (const Handle(Prs3d_Presentation)& thePresentation,
                                             const Standard_Integer theMode,
                                             const gp_Pnt& theFirstPoint,
@@ -445,19 +445,19 @@ protected:
                                             const Standard_Boolean theIsOneSide = Standard_False);
 
   //! Computes points bounded the flyout line for linear dimension.
-  //! @param theFirstPoint [in] the first attach point of linear dimension.
-  //! @param theSecondPoint [in] the second attach point of linear dimension.
-  //! @param theLineBegPoint [out] the first attach point of linear dimension.
-  //! @param theLineEndPoint [out] the second attach point of linear dimension.
+  //! @param[in] theFirstPoint  the first attach point of linear dimension.
+  //! @param[in] theSecondPoint  the second attach point of linear dimension.
+  //! @param[out] theLineBegPoint  the first attach point of linear dimension.
+  //! @param[out] theLineEndPoint  the second attach point of linear dimension.
   Standard_EXPORT virtual void ComputeFlyoutLinePoints (const gp_Pnt& theFirstPoint, const gp_Pnt& theSecondPoint,
                                                         gp_Pnt& theLineBegPoint, gp_Pnt& theLineEndPoint);
 
   //! Compute selection sensitives for linear dimension flyout lines (length, diameter, radius).
   //! Please note that this method uses base dimension properties: working plane and flyout length.
-  //! @param theSelection [in] the selection structure to fill with selection primitives.
-  //! @param theOwner [in] the selection entity owner.
-  //! @param theFirstPoint [in] the first attach point of linear dimension.
-  //! @param theSecondPoint [in] the second attach point of linear dimension.
+  //! @param[in] theSelection  the selection structure to fill with selection primitives.
+  //! @param[in] theOwner  the selection entity owner.
+  //! @param[in] theFirstPoint  the first attach point of linear dimension.
+  //! @param[in] theSecondPoint  the second attach point of linear dimension.
   Standard_EXPORT void ComputeLinearFlyouts (const Handle(SelectMgr_Selection)& theSelection,
                                              const Handle(SelectMgr_EntityOwner)& theOwner,
                                              const gp_Pnt& theFirstPoint,
@@ -466,10 +466,10 @@ protected:
 
   //! Performs initialization of circle and middle arc point from the passed
   //! shape which is assumed to contain circular geometry.
-  //! @param theShape [in] the shape to explore.
-  //! @param theCircle [out] the circle geometry.
-  //! @param theMiddleArcPoint [out] the middle point of the arc.
-  //! @param theIsClosed [out] returns TRUE if the geometry is closed circle.
+  //! @param[in] theShape  the shape to explore.
+  //! @param[out] theCircle  the circle geometry.
+  //! @param[out] theMiddleArcPoint  the middle point of the arc.
+  //! @param[out] theIsClosed  returns TRUE if the geometry is closed circle.
   //! @return TRUE if the circle is successfully returned from the input shape.
   Standard_EXPORT Standard_Boolean InitCircularDimension (const TopoDS_Shape& theShape,
                                                           gp_Circ& theCircle,
@@ -477,13 +477,13 @@ protected:
                                                           Standard_Boolean& theIsClosed);
  
   //! Produce points for triangular arrow face.
-  //! @param thePeakPnt [in] the arrow peak position.
-  //! @param theDirection [in] the arrow direction.
-  //! @param thePlane [in] the face plane.
-  //! @param theArrowLength [in] the length of arrow.
-  //! @param theArrowAngle [in] the angle of arrow.
-  //! @param theSidePnt1 [out] the first side point.
-  //! @param theSidePnt2 [out] the second side point.
+  //! @param[in] thePeakPnt  the arrow peak position.
+  //! @param[in] theDirection  the arrow direction.
+  //! @param[in] thePlane  the face plane.
+  //! @param[in] theArrowLength  the length of arrow.
+  //! @param[in] theArrowAngle  the angle of arrow.
+  //! @param[out] theSidePnt1  the first side point.
+  //! @param[out] theSidePnt2  the second side point.
   Standard_EXPORT void PointsForArrow (const gp_Pnt& thePeakPnt,
                                        const gp_Dir& theDirection,
                                        const gp_Dir& thePlane,
@@ -499,13 +499,13 @@ protected:
                                                    const Standard_Boolean theIsOneSide = Standard_False) const;
 
   //! Fits text alignment relatively to the dimension line.
-  //! @param theFirstPoint [in] the first attachment point.
-  //! @param theSecondPoint [in] the second attachment point.
-  //! @param theIsOneSide [in] is the arrow displayed only on the one side of the dimension.
-  //! @param theHorizontalTextPos [in] the text horizontal position (alignment).
-  //! @param theLabelPosition [out] the label position, contains bits that defines
+  //! @param[in] theFirstPoint  the first attachment point.
+  //! @param[in] theSecondPoint  the second attachment point.
+  //! @param[in] theIsOneSide  is the arrow displayed only on the one side of the dimension.
+  //! @param[in] theHorizontalTextPos  the text horizontal position (alignment).
+  //! @param[out] theLabelPosition  the label position, contains bits that defines
   //! vertical and horizontal alignment. (for internal usage in count text position)
-  //! @param theIsArrowExternal [out] is the arrows external,
+  //! @param[out] theIsArrowExternal  is the arrows external,
   //! if arrow orientation in the dimension aspect is Prs3d_DAO_Fit, it fits arrow
   //! orientation automatically.
   Standard_EXPORT void FitTextAlignmentForLinear (const gp_Pnt& theFirstPoint,
@@ -517,14 +517,14 @@ protected:
 
   //! Adjusts aspect parameters according the text position:
   //! extension size, vertical text alignment and flyout.
-  //! @param theTextPos [in] the user defined 3d point of text position
-  //! @param theFirstPoint [in] the first point of linear measurement.
-  //! @param theSecondPoint [in] the second point of linear measurement.
-  //! @param theExtensionSize [out] the adjusted extension size
-  //! @param theAlignment [out] the horizontal label alignment.
-  //! @param theFlyout [out] the adjusted value of flyout.
-  //! @param thePlane [out] the new plane that contains theTextPos and attachment points.
-  //! @param theIsPlaneOld [out] shows if new plane is computed.
+  //! @param[in] theTextPos  the user defined 3d point of text position
+  //! @param[in] theFirstPoint  the first point of linear measurement.
+  //! @param[in] theSecondPoint  the second point of linear measurement.
+  //! @param[out] theExtensionSize  the adjusted extension size
+  //! @param[out] theAlignment  the horizontal label alignment.
+  //! @param[out] theFlyout  the adjusted value of flyout.
+  //! @param[out] thePlane  the new plane that contains theTextPos and attachment points.
+  //! @param[out] theIsPlaneOld  shows if new plane is computed.
   Standard_EXPORT Standard_Boolean AdjustParametersForLinear (const gp_Pnt& theTextPos,
                                                               const gp_Pnt& theFirstPoint,
                                                               const gp_Pnt& theSecondPoint,
@@ -537,10 +537,10 @@ protected:
 protected: //! @name Static auxilliary methods for geometry extraction
 
   //! If it is possible extracts circle from planar face.
-  //! @param theFace        [in] the planar face
-  //! @param theCurve       [out] the circular curve
-  //! @param theFirstPoint  [out] the point of the first parameter of the circlular curve
-  //! @param theSecondPoint [out] the point of the last parameter of the circlular curve
+  //! @param[in] theFace         the planar face
+  //! @param[out] theCurve        the circular curve
+  //! @param[out] theFirstPoint   the point of the first parameter of the circlular curve
+  //! @param[out] theSecondPoint  the point of the last parameter of the circlular curve
   //! @return TRUE in case of successful circle extraction
   static Standard_Boolean CircleFromPlanarFace (const TopoDS_Face&  theFace,
                                                 Handle(Geom_Curve)& theCurve,
@@ -548,10 +548,10 @@ protected: //! @name Static auxilliary methods for geometry extraction
                                                 gp_Pnt&             theLastPoint);
 
   //! If it is possible extracts circle from the edge.
-  //! @param theEdge        [in] input edge to extract circle from
-  //! @param theCircle      [out] circle
-  //! @param theFirstPoint  [out] the point of the first parameter of the circlular curve
-  //! @param theSecondPoint [out] the point of the last parameter of the circlular curve
+  //! @param[in] theEdge         input edge to extract circle from
+  //! @param[out] theCircle       circle
+  //! @param[out] theFirstPoint   the point of the first parameter of the circlular curve
+  //! @param[out] theSecondPoint  the point of the last parameter of the circlular curve
   //! @return TRUE in case of successful circle extraction.
   static Standard_Boolean CircleFromEdge (const TopoDS_Edge& theEdge,
                                           gp_Circ&           theCircle,
@@ -562,7 +562,7 @@ protected: //! @name Behavior to implement
 
   //! Override this method to check if user-defined plane
   //! is valid for the dimension geometry.
-  //! @param thePlane [in] the working plane for positioning every
+  //! @param[in] thePlane  the working plane for positioning every
   //! dimension in the application.
   //! @return true is the plane is suitable for building dimension
   //! with computed dimension geometry.
@@ -584,8 +584,8 @@ protected: //! @name Behavior to implement
 
 
   //! Base procedure of computing selection (based on selection geometry data).
-  //! @param theSelection [in] the selection structure to will with primitives.
-  //! @param theMode [in] the selection mode.
+  //! @param[in] theSelection  the selection structure to will with primitives.
+  //! @param[in] theMode  the selection mode.
   Standard_EXPORT virtual void ComputeSelection (const Handle(SelectMgr_Selection)& theSelection,
                                                  const Standard_Integer theMode) Standard_OVERRIDE;
 
@@ -619,7 +619,7 @@ protected: //! @name Selection geometry
   public:
 
     //! Clear geometry of sensitives for the specified compute mode.
-    //! @param theMode [in] the compute mode to clear.
+    //! @param[in] theMode  the compute mode to clear.
     void Clear (const Standard_Integer theMode)
     {
       if (theMode == ComputeMode_All || theMode == ComputeMode_Line)

--- a/src/PrsDim/PrsDim_LengthDimension.hxx
+++ b/src/PrsDim/PrsDim_LengthDimension.hxx
@@ -52,38 +52,38 @@ public:
 
   //! Construct length dimension between face and edge.
   //! Here dimension can be built without user-defined plane.
-  //! @param theFace [in] the face (first shape).
-  //! @param theEdge [in] the edge (second shape).
+  //! @param[in] theFace  the face (first shape).
+  //! @param[in] theEdge  the edge (second shape).
   Standard_EXPORT PrsDim_LengthDimension (const TopoDS_Face& theFace,
                                           const TopoDS_Edge& theEdge);
 
   //! Construct length dimension between two faces.
-  //! @param theFirstFace [in] the first face (first shape).
-  //! @param theSecondFace [in] the second face (second shape).
+  //! @param[in] theFirstFace  the first face (first shape).
+  //! @param[in] theSecondFace  the second face (second shape).
   Standard_EXPORT PrsDim_LengthDimension (const TopoDS_Face& theFirstFace,
                                           const TopoDS_Face& theSecondFace);
 
   //! Construct length dimension between two points in
   //! the specified plane.
-  //! @param theFirstPoint [in] the first point.
-  //! @param theSecondPoint [in] the second point.
-  //! @param thePlane [in] the plane to orient dimension.
+  //! @param[in] theFirstPoint  the first point.
+  //! @param[in] theSecondPoint  the second point.
+  //! @param[in] thePlane  the plane to orient dimension.
   Standard_EXPORT PrsDim_LengthDimension (const gp_Pnt& theFirstPoint,
                                           const gp_Pnt& theSecondPoint,
                                           const gp_Pln& thePlane);
 
   //! Construct length dimension between two arbitrary shapes in
   //! the specified plane.
-  //! @param theFirstShape [in] the first shape.
-  //! @param theSecondShape [in] the second shape.
-  //! @param thePlane [in] the plane to orient dimension.
+  //! @param[in] theFirstShape  the first shape.
+  //! @param[in] theSecondShape  the second shape.
+  //! @param[in] thePlane  the plane to orient dimension.
   Standard_EXPORT PrsDim_LengthDimension (const TopoDS_Shape& theFirstShape,
                                           const TopoDS_Shape& theSecondShape,
                                           const gp_Pln& thePlane);
 
   //! Construct length dimension of linear edge.
-  //! @param theEdge [in] the edge to measure.
-  //! @param thePlane [in] the plane to orient dimension.
+  //! @param[in] theEdge  the edge to measure.
+  //! @param[in] thePlane  the plane to orient dimension.
   Standard_EXPORT PrsDim_LengthDimension (const TopoDS_Edge& theEdge,
                                           const gp_Pln& thePlane);
 
@@ -106,9 +106,9 @@ public:
   //! Measure distance between two points.
   //! The dimension will become invalid if the new distance between
   //! attachment points is less than Precision::Confusion().
-  //! @param theFirstPoint [in] the first point.
-  //! @param theSecondPoint [in] the second point.
-  //! @param thePlane [in] the user-defined plane
+  //! @param[in] theFirstPoint  the first point.
+  //! @param[in] theSecondPoint  the second point.
+  //! @param[in] thePlane  the user-defined plane
   Standard_EXPORT void SetMeasuredGeometry (const gp_Pnt& theFirstPoint,
                                             const gp_Pnt& theSecondPoint,
                                             const gp_Pln& thePlane);
@@ -116,31 +116,31 @@ public:
   //! Measure length of edge.
   //! The dimension will become invalid if the new length of edge
   //! is less than Precision::Confusion().
-  //! @param theEdge [in] the edge to measure.
-  //! @param thePlane [in] the user-defined plane
+  //! @param[in] theEdge  the edge to measure.
+  //! @param[in] thePlane  the user-defined plane
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Edge& theEdge,
                                             const gp_Pln& thePlane);
 
   //! Measure distance between two faces.
   //! The dimension will become invalid if the distance can not
   //! be measured or it is less than Precision::Confusion().
-  //! @param theFirstFace [in] the first face (first shape).
-  //! @param theSecondFace [in] the second face (second shape).
+  //! @param[in] theFirstFace  the first face (first shape).
+  //! @param[in] theSecondFace  the second face (second shape).
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Face& theFirstFace,
                                             const TopoDS_Face& theSecondFace);
 
   //! Measure distance between face and edge.
   //! The dimension will become invalid if the distance can not
   //! be measured or it is less than Precision::Confusion().
-  //! @param theFace [in] the face (first shape).
-  //! @param theEdge [in] the edge (second shape).
+  //! @param[in] theFace  the face (first shape).
+  //! @param[in] theEdge  the edge (second shape).
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Face& theFace,
                                             const TopoDS_Edge& theEdge);
 
   //! Measure distance between generic pair of shapes (edges, vertices, length),
   //! where measuring is applicable.
-  //! @param theFirstShape [in] the first shape.
-  //! @param theSecondShape [in] the second shape.
+  //! @param[in] theFirstShape  the first shape.
+  //! @param[in] theSecondShape  the second shape.
   Standard_EXPORT void SetMeasuredShapes (const TopoDS_Shape& theFirstShape,
                                           const TopoDS_Shape& theSecondShape);
 
@@ -161,8 +161,8 @@ public:
   //! Set custom direction for dimension. If it is not set, the direction is obtained
   //! from the measured geometry (e.g. line between points of dimension)
   //! The direction does not change flyout direction of dimension.
-  //! @param theDirection [in] the dimension direction.
-  //! @param theUseDirection [in] boolean value if custom direction should be used.
+  //! @param[in] theDirection  the dimension direction.
+  //! @param[in] theUseDirection  boolean value if custom direction should be used.
   Standard_EXPORT void SetDirection (const gp_Dir& theDirection, const Standard_Boolean theUseDirection = Standard_True);
 
 protected:
@@ -184,10 +184,10 @@ protected:
   //! Computes points bounded the flyout line for linear dimension.
   //! Direction of flyout line equal to the custom direction of dimension if defined or
   //! parallel to the main direction line
-  //! @param theFirstPoint [in] the first attach point of linear dimension.
-  //! @param theSecondPoint [in] the second attach point of linear dimension.
-  //! @param theLineBegPoint [out] the first attach point of linear dimension.
-  //! @param theLineEndPoint [out] the second attach point of linear dimension.
+  //! @param[in] theFirstPoint  the first attach point of linear dimension.
+  //! @param[in] theSecondPoint  the second attach point of linear dimension.
+  //! @param[out] theLineBegPoint  the first attach point of linear dimension.
+  //! @param[out] theLineEndPoint  the second attach point of linear dimension.
   Standard_EXPORT virtual void ComputeFlyoutLinePoints (const gp_Pnt& theFirstPoint, const gp_Pnt& theSecondPoint,
                                                         gp_Pnt& theLineBegPoint, gp_Pnt& theLineEndPoint) Standard_OVERRIDE;
 
@@ -197,8 +197,8 @@ protected:
 protected:
 
   //! Checks that distance between two points is valid.
-  //! @param theFirstPoint [in] the first point.
-  //! @param theSecondPoint [in] the second point.
+  //! @param[in] theFirstPoint  the first point.
+  //! @param[in] theSecondPoint  the second point.
   Standard_EXPORT Standard_Boolean IsValidPoints (const gp_Pnt& theFirstPoint,
                                                   const gp_Pnt& theSecondPoint) const;
 
@@ -209,7 +209,7 @@ protected:
   //! Auxiliary method for InitTwoShapesPoints()
   //! in case of the distance between edge and vertex.
   //! Finds the point on the edge that is the closest one to <theVertex>.
-  //! @param theEdgeDir [out] is the direction on the edge to build automatic plane.
+  //! @param[out] theEdgeDir  is the direction on the edge to build automatic plane.
   Standard_EXPORT Standard_Boolean InitEdgeVertexLength (const TopoDS_Edge& theEdge,
                                                          const TopoDS_Vertex& theVertex,
                                                          gp_Dir& theEdgeDir,
@@ -221,7 +221,7 @@ protected:
   //! Find the second attachment point which belongs to <theFace>
   //! Iterate over the edges of the face and find the closest point according
   //! to found point on edge.
-  //! @param theEdgeDir [out] is the direction on the edge to build automatic plane.
+  //! @param[out] theEdgeDir  is the direction on the edge to build automatic plane.
   Standard_EXPORT Standard_Boolean InitEdgeFaceLength (const TopoDS_Edge& theEdge,
                                                        const TopoDS_Face& theFace,
                                                        gp_Dir& theEdgeDir);

--- a/src/PrsDim/PrsDim_RadiusDimension.hxx
+++ b/src/PrsDim/PrsDim_RadiusDimension.hxx
@@ -43,19 +43,19 @@ class PrsDim_RadiusDimension : public PrsDim_Dimension
 public:
 
   //! Create radius dimension for the circle geometry.
-  //! @param theCircle [in] the circle to measure.
+  //! @param[in] theCircle  the circle to measure.
   Standard_EXPORT PrsDim_RadiusDimension (const gp_Circ& theCircle);
 
   //! Create radius dimension for the circle geometry and define its
   //! orientation by location of the first point on that circle.
-  //! @param theCircle [in] the circle to measure.
-  //! @param theAnchorPoint [in] the point to define the position
+  //! @param[in] theCircle  the circle to measure.
+  //! @param[in] theAnchorPoint  the point to define the position
   //!        of the dimension attachment on the circle.
   Standard_EXPORT PrsDim_RadiusDimension (const gp_Circ& theCircle,
                                          const gp_Pnt& theAnchorPoint);
 
   //! Create radius dimension for the arbitrary shape (if possible).
-  //! @param theShape [in] the shape to measure.
+  //! @param[in] theShape  the shape to measure.
   Standard_EXPORT PrsDim_RadiusDimension (const TopoDS_Shape& theShape);
 
 public:
@@ -74,16 +74,16 @@ public:
   //! Measure radius of the circle.
   //! The dimension will become invalid if the radius of the circle
   //! is less than Precision::Confusion().
-  //! @param theCircle [in] the circle to measure.
+  //! @param[in] theCircle  the circle to measure.
   void SetMeasuredGeometry (const gp_Circ& theCircle) { SetMeasuredGeometry (theCircle, gp_Pnt(), Standard_False); }
 
   //! Measure radius of the circle and orient the dimension so
   //! the dimension lines attaches to anchor point on the circle.
   //! The dimension will become invalid if the radius of the circle
   //! is less than Precision::Confusion().
-  //! @param theCircle [in] the circle to measure.
-  //! @param theAnchorPoint [in] the point to attach the dimension lines, should be on the circle
-  //! @param theHasAnchor   [in] should be set TRUE if theAnchorPoint should be used
+  //! @param[in] theCircle  the circle to measure.
+  //! @param[in] theAnchorPoint  the point to attach the dimension lines, should be on the circle
+  //! @param[in] theHasAnchor    should be set TRUE if theAnchorPoint should be used
   Standard_EXPORT void SetMeasuredGeometry (const gp_Circ& theCircle,
                                             const gp_Pnt& theAnchorPoint,
                                             const Standard_Boolean theHasAnchor = Standard_True);
@@ -91,15 +91,15 @@ public:
   //! Measure radius on the passed shape, if applicable.
   //! The dimension will become invalid if the passed shape is not
   //! measurable or if measured diameter value is less than Precision::Confusion().
-  //! @param theShape [in] the shape to measure.
+  //! @param[in] theShape  the shape to measure.
   void SetMeasuredGeometry (const TopoDS_Shape& theShape) { SetMeasuredGeometry (theShape, gp_Pnt(), Standard_False); }
 
   //! Measure radius on the passed shape, if applicable.
   //! The dimension will become invalid if the passed shape is not
   //! measurable or if measured diameter value is less than Precision::Confusion().
-  //! @param theShape [in] the shape to measure.
-  //! @param theAnchorPoint [in] the point to attach the dimension lines, should be on the circle
-  //! @param theHasAnchor   [in] should be set TRUE if theAnchorPoint should be used
+  //! @param[in] theShape  the shape to measure.
+  //! @param[in] theAnchorPoint  the point to attach the dimension lines, should be on the circle
+  //! @param[in] theHasAnchor    should be set TRUE if theAnchorPoint should be used
   Standard_EXPORT void SetMeasuredGeometry (const TopoDS_Shape& theShape,
                                             const gp_Pnt& theAnchorPoint,
                                             const Standard_Boolean theHasAnchor = Standard_True);

--- a/src/PrsMgr/PrsMgr_PresentableObject.hxx
+++ b/src/PrsMgr/PrsMgr_PresentableObject.hxx
@@ -287,11 +287,11 @@ public: //! @name clipping planes
   //! Besides of this, some planes can be already set in view where the object
   //! is shown: the number of these planes should be subtracted from limit
   //! to predict the maximum possible number of object clipping planes.
-  //! @param thePlane [in] the clip plane to be appended to map of clip planes.
+  //! @param[in] thePlane  the clip plane to be appended to map of clip planes.
   Standard_EXPORT virtual void AddClipPlane (const Handle(Graphic3d_ClipPlane)& thePlane);
 
   //! Removes previously added clip plane.
-  //! @param thePlane [in] the clip plane to be removed from map of clip planes.
+  //! @param[in] thePlane  the clip plane to be removed from map of clip planes.
   Standard_EXPORT virtual void RemoveClipPlane (const Handle(Graphic3d_ClipPlane)& thePlane);
 
 public: //! @name parent/children properties
@@ -355,9 +355,9 @@ protected: //! @name interface methods
   //! Each of the views in the viewer and every modification such as rotation, for example, entails recalculation.
   //! Default implementation throws Standard_NotImplemented exception
   //! Warning! The transformation must be applied to the object before computation.
-  //! @param theProjector [in] view orientation
-  //! @param theTrsf [in] additional transformation, or NULL if undefined
-  //! @param thePrs  [in] presentation to fill
+  //! @param[in] theProjector  view orientation
+  //! @param[in] theTrsf  additional transformation, or NULL if undefined
+  //! @param[in] thePrs   presentation to fill
   Standard_EXPORT virtual void computeHLR (const Handle(Graphic3d_Camera)& theProjector,
                                            const Handle(TopLoc_Datum3D)& theTrsf,
                                            const Handle(Prs3d_Presentation)& thePrs);

--- a/src/Quantity/Quantity_Color.hxx
+++ b/src/Quantity/Quantity_Color.hxx
@@ -237,8 +237,8 @@ public:
   //! So the output is formatted as 0x00RRGGBB.
   //! Note that this unpacking does NOT involve non-linear sRGB -> linear RGB conversion,
   //! as would be usually expected for RGB color packed into 4 bytes.
-  //! @param theColor [in] color to convert
-  //! @param theARGB [out] result color encoded as integer
+  //! @param[in] theColor  color to convert
+  //! @param[out] theARGB  result color encoded as integer
   static void Color2argb (const Quantity_Color& theColor,
                           Standard_Integer& theARGB)
   {

--- a/src/RWGltf/RWGltf_CafWriter.hxx
+++ b/src/RWGltf/RWGltf_CafWriter.hxx
@@ -53,8 +53,8 @@ public:
   };
 
   //! Main constructor.
-  //! @param theFile     [in] path to output glTF file
-  //! @param theIsBinary [in] flag to write into binary glTF format (.glb)
+  //! @param[in] theFile      path to output glTF file
+  //! @param[in] theIsBinary  flag to write into binary glTF format (.glb)
   Standard_EXPORT RWGltf_CafWriter (const TCollection_AsciiString& theFile,
                                     Standard_Boolean theIsBinary);
 
@@ -140,14 +140,14 @@ public:
 
   //! Write glTF file and associated binary file.
   //! Triangulation data should be precomputed within shapes!
-  //! @param theDocument    [in] input document
-  //! @param theRootLabels  [in] list of root shapes to export
-  //! @param theLabelFilter [in] optional filter with document nodes to export,
+  //! @param[in] theDocument     input document
+  //! @param[in] theRootLabels   list of root shapes to export
+  //! @param[in] theLabelFilter  optional filter with document nodes to export,
   //!                            with keys defined by XCAFPrs_DocumentExplorer::DefineChildId() and filled recursively
   //!                            (leaves and parent assembly nodes at all levels);
   //!                            when not NULL, all nodes not included into the map will be ignored
-  //! @param theFileInfo    [in] map with file metadata to put into glTF header section
-  //! @param theProgress    [in] optional progress indicator
+  //! @param[in] theFileInfo     map with file metadata to put into glTF header section
+  //! @param[in] theProgress     optional progress indicator
   //! @return FALSE on file writing failure
   Standard_EXPORT virtual bool Perform (const Handle(TDocStd_Document)& theDocument,
                                         const TDF_LabelSequence& theRootLabels,
@@ -157,9 +157,9 @@ public:
 
   //! Write glTF file and associated binary file.
   //! Triangulation data should be precomputed within shapes!
-  //! @param theDocument    [in] input document
-  //! @param theFileInfo    [in] map with file metadata to put into glTF header section
-  //! @param theProgress    [in] optional progress indicator
+  //! @param[in] theDocument     input document
+  //! @param[in] theFileInfo     map with file metadata to put into glTF header section
+  //! @param[in] theProgress     optional progress indicator
   //! @return FALSE on file writing failure
   Standard_EXPORT virtual bool Perform (const Handle(TDocStd_Document)& theDocument,
                                         const TColStd_IndexedDataMapOfStringString& theFileInfo,
@@ -169,10 +169,10 @@ protected:
 
   //! Write binary data file with triangulation data.
   //! Triangulation data should be precomputed within shapes!
-  //! @param theDocument    [in] input document
-  //! @param theRootLabels  [in] list of root shapes to export
-  //! @param theLabelFilter [in] optional filter with document nodes to export
-  //! @param theProgress    [in] optional progress indicator
+  //! @param[in] theDocument     input document
+  //! @param[in] theRootLabels   list of root shapes to export
+  //! @param[in] theLabelFilter  optional filter with document nodes to export
+  //! @param[in] theProgress     optional progress indicator
   //! @return FALSE on file writing failure
   Standard_EXPORT virtual bool writeBinData (const Handle(TDocStd_Document)& theDocument,
                                              const TDF_LabelSequence& theRootLabels,
@@ -180,11 +180,11 @@ protected:
                                              const Message_ProgressRange& theProgress);
 
   //! Write JSON file with glTF structure (should be called after writeBinData()).
-  //! @param theDocument    [in] input document
-  //! @param theRootLabels  [in] list of root shapes to export
-  //! @param theLabelFilter [in] optional filter with document nodes to export
-  //! @param theFileInfo    [in] map with file metadata to put into glTF header section
-  //! @param theProgress    [in] optional progress indicator
+  //! @param[in] theDocument     input document
+  //! @param[in] theRootLabels   list of root shapes to export
+  //! @param[in] theLabelFilter  optional filter with document nodes to export
+  //! @param[in] theFileInfo     map with file metadata to put into glTF header section
+  //! @param[in] theProgress     optional progress indicator
   //! @return FALSE on file writing failure
   Standard_EXPORT virtual bool writeJson (const Handle(TDocStd_Document)& theDocument,
                                           const TDF_LabelSequence& theRootLabels,
@@ -206,11 +206,11 @@ protected:
                                                               const TDF_Label& theRefLabel) const;
 
   //! Write mesh nodes into binary file.
-  //! @param theGltfFace [out] glTF face definition
-  //! @param theBinFile  [out] output file to write into
-  //! @param theFaceIter [in]  current face to write
-  //! @param theAccessorNb [in] [out] last accessor index
-  //! @param theMesh [in] [out] mesh
+  //! @param[out] theGltfFace  glTF face definition
+  //! @param[out] theBinFile   output file to write into
+  //! @param[in] theFaceIter   current face to write
+  //! @param[in][out] theAccessorNb   last accessor index
+  //! @param[in][out] theMesh   mesh
   Standard_EXPORT virtual void saveNodes (RWGltf_GltfFace& theGltfFace,
                                           std::ostream& theBinFile,
                                           const RWMesh_FaceIterator& theFaceIter,
@@ -218,11 +218,11 @@ protected:
                                           const std::shared_ptr<RWGltf_CafWriter::Mesh>& theMesh) const;
 
   //! Write mesh normals into binary file.
-  //! @param theGltfFace [out] glTF face definition
-  //! @param theBinFile  [out] output file to write into
-  //! @param theFaceIter [in]  current face to write
-  //! @param theAccessorNb [in] [out] last accessor index
-  //! @param theMesh [in] [out] mesh
+  //! @param[out] theGltfFace  glTF face definition
+  //! @param[out] theBinFile   output file to write into
+  //! @param[in] theFaceIter   current face to write
+  //! @param[in][out] theAccessorNb   last accessor index
+  //! @param[in][out] theMesh   mesh
   Standard_EXPORT virtual void saveNormals (RWGltf_GltfFace& theGltfFace,
                                             std::ostream& theBinFile,
                                             RWMesh_FaceIterator& theFaceIter,
@@ -230,11 +230,11 @@ protected:
                                             const std::shared_ptr<RWGltf_CafWriter::Mesh>& theMesh) const;
 
   //! Write mesh texture UV coordinates into binary file.
-  //! @param theGltfFace [out] glTF face definition
-  //! @param theBinFile  [out] output file to write into
-  //! @param theFaceIter [in]  current face to write
-  //! @param theAccessorNb [in] [out] last accessor index
-  //! @param theMesh [in] [out] mesh
+  //! @param[out] theGltfFace  glTF face definition
+  //! @param[out] theBinFile   output file to write into
+  //! @param[in] theFaceIter   current face to write
+  //! @param[in][out] theAccessorNb   last accessor index
+  //! @param[in][out] theMesh   mesh
   Standard_EXPORT virtual void saveTextCoords (RWGltf_GltfFace& theGltfFace,
                                                std::ostream& theBinFile,
                                                const RWMesh_FaceIterator& theFaceIter,
@@ -242,11 +242,11 @@ protected:
                                                const std::shared_ptr<RWGltf_CafWriter::Mesh>& theMesh) const;
 
   //! Write mesh indexes into binary file.
-  //! @param theGltfFace [out] glTF face definition
-  //! @param theBinFile  [out] output file to write into
-  //! @param theFaceIter [in]  current face to write
-  //! @param theAccessorNb [in] [out] last accessor index
-  //! @param theMesh [in] [out] mesh
+  //! @param[out] theGltfFace  glTF face definition
+  //! @param[out] theBinFile   output file to write into
+  //! @param[in] theFaceIter   current face to write
+  //! @param[in][out] theAccessorNb   last accessor index
+  //! @param[in][out] theMesh   mesh
   Standard_EXPORT virtual void saveIndices (RWGltf_GltfFace& theGltfFace,
                                             std::ostream& theBinFile,
                                             const RWMesh_FaceIterator& theFaceIter,
@@ -256,36 +256,36 @@ protected:
 protected:
 
   //! Write bufferView for vertex positions within RWGltf_GltfRootElement_Accessors section
-  //! @param theGltfFace [in] face definition to write
+  //! @param[in] theGltfFace  face definition to write
   Standard_EXPORT virtual void writePositions (const RWGltf_GltfFace& theGltfFace);
 
   //! Write bufferView for vertex normals within RWGltf_GltfRootElement_Accessors section
-  //! @param theGltfFace [in] face definition to write
+  //! @param[in] theGltfFace  face definition to write
   Standard_EXPORT virtual void writeNormals (const RWGltf_GltfFace& theGltfFace);
 
   //! Write bufferView for vertex texture coordinates within RWGltf_GltfRootElement_Accessors section
-  //! @param theGltfFace [in] face definition to write
+  //! @param[in] theGltfFace  face definition to write
   Standard_EXPORT virtual void writeTextCoords (const RWGltf_GltfFace& theGltfFace);
 
   //! Write bufferView for triangle indexes within RWGltf_GltfRootElement_Accessors section.
-  //! @param theGltfFace [in] face definition to write
+  //! @param[in] theGltfFace  face definition to write
   Standard_EXPORT virtual void writeIndices (const RWGltf_GltfFace& theGltfFace);
 
 protected:
 
   //! Write RWGltf_GltfRootElement_Accessors section.
-  //! @param theSceneNodeMap [in] ordered map of scene nodes
+  //! @param[in] theSceneNodeMap  ordered map of scene nodes
   Standard_EXPORT virtual void writeAccessors (const RWGltf_GltfSceneNodeMap& theSceneNodeMap);
 
   //! Write RWGltf_GltfRootElement_Animations section (reserved).
   Standard_EXPORT virtual void writeAnimations();
 
   //! Write RWGltf_GltfRootElement_Asset section.
-  //! @param theFileInfo [in] optional metadata to write into file header
+  //! @param[in] theFileInfo  optional metadata to write into file header
   Standard_EXPORT virtual void writeAsset (const TColStd_IndexedDataMapOfStringString& theFileInfo);
 
   //! Write RWGltf_GltfRootElement_BufferViews section.
-  //! @param theBinDataBufferId [in] index of binary buffer with vertex data
+  //! @param[in] theBinDataBufferId  index of binary buffer with vertex data
   Standard_EXPORT virtual void writeBufferViews (const Standard_Integer theBinDataBufferId);
 
   //! Write RWGltf_GltfRootElement_Buffers section.
@@ -295,18 +295,18 @@ protected:
   Standard_EXPORT virtual void writeExtensions();
 
   //! Write RWGltf_GltfRootElement_Images section.
-  //! @param theSceneNodeMap [in] ordered map of scene nodes
-  //! @param theMaterialMap [out] map of materials, filled with image files used by textures
+  //! @param[in] theSceneNodeMap  ordered map of scene nodes
+  //! @param[out] theMaterialMap  map of materials, filled with image files used by textures
   Standard_EXPORT virtual void writeImages (const RWGltf_GltfSceneNodeMap& theSceneNodeMap);
 
   //! Write RWGltf_GltfRootElement_Materials section.
-  //! @param theSceneNodeMap [in] ordered map of scene nodes
-  //! @param theMaterialMap [out] map of materials, filled with materials
+  //! @param[in] theSceneNodeMap  ordered map of scene nodes
+  //! @param[out] theMaterialMap  map of materials, filled with materials
   Standard_EXPORT virtual void writeMaterials (const RWGltf_GltfSceneNodeMap& theSceneNodeMap);
 
   //! Write RWGltf_GltfRootElement_Meshes section.
-  //! @param theSceneNodeMap [in] ordered map of scene nodes
-  //! @param theMaterialMap  [in] map of materials
+  //! @param[in] theSceneNodeMap  ordered map of scene nodes
+  //! @param[in] theMaterialMap   map of materials
   Standard_EXPORT virtual void writeMeshes (const RWGltf_GltfSceneNodeMap& theSceneNodeMap);
 
   //! Write a primitive array to RWGltf_GltfRootElement_Meshes section.
@@ -320,11 +320,11 @@ protected:
                                                bool& theToStartPrims);
 
   //! Write RWGltf_GltfRootElement_Nodes section.
-  //! @param theDocument     [in] input document
-  //! @param theRootLabels   [in] list of root shapes to export
-  //! @param theLabelFilter  [in] optional filter with document nodes to export
-  //! @param theSceneNodeMap [in] ordered map of scene nodes
-  //! @param theSceneRootNodeInds [out] sequence of scene nodes pointing to root shapes (to be used for writeScenes())
+  //! @param[in] theDocument      input document
+  //! @param[in] theRootLabels    list of root shapes to export
+  //! @param[in] theLabelFilter   optional filter with document nodes to export
+  //! @param[in] theSceneNodeMap  ordered map of scene nodes
+  //! @param[out] theSceneRootNodeInds  sequence of scene nodes pointing to root shapes (to be used for writeScenes())
   Standard_EXPORT virtual void writeNodes (const Handle(TDocStd_Document)&  theDocument,
                                            const TDF_LabelSequence&         theRootLabels,
                                            const TColStd_MapOfAsciiString*  theLabelFilter,
@@ -335,23 +335,23 @@ protected:
   Standard_EXPORT virtual void writeSamplers();
 
   //! Write RWGltf_GltfRootElement_Scene section.
-  //! @param theDefSceneId [in] index of default scene (0)
+  //! @param[in] theDefSceneId  index of default scene (0)
   Standard_EXPORT virtual void writeScene (const Standard_Integer theDefSceneId);
 
   //! Write RWGltf_GltfRootElement_Scenes section.
-  //! @param theSceneRootNodeInds [in] sequence of scene nodes pointing to root shapes
+  //! @param[in] theSceneRootNodeInds  sequence of scene nodes pointing to root shapes
   Standard_EXPORT virtual void writeScenes (const NCollection_Sequence<Standard_Integer>& theSceneRootNodeInds);
 
   //! Write RWGltf_GltfRootElement_Skins section (reserved).
   Standard_EXPORT virtual void writeSkins();
 
   //! Write RWGltf_GltfRootElement_Textures section.
-  //! @param theSceneNodeMap [in] ordered map of scene nodes
-  //! @param theMaterialMap [out] map of materials, filled with textures
+  //! @param[in] theSceneNodeMap  ordered map of scene nodes
+  //! @param[out] theMaterialMap  map of materials, filled with textures
   Standard_EXPORT virtual void writeTextures (const RWGltf_GltfSceneNodeMap& theSceneNodeMap);
 
   //! Write nodes.extras section with key-value attributes.
-  //! @param theNamedData [in] attributes map to process.
+  //! @param[in] theNamedData  attributes map to process.
   Standard_EXPORT virtual void writeExtrasAttributes(const Handle(TDataStd_NamedData)& theNamedData);
 
 protected:

--- a/src/RWGltf/RWGltf_GltfMaterialMap.hxx
+++ b/src/RWGltf/RWGltf_GltfMaterialMap.hxx
@@ -35,8 +35,8 @@ public:
 public:
 
   //! Add material images into GLB stream.
-  //! @param theBinFile [in] [out] output file stream
-  //! @param theStyle   [in] material images to add
+  //! @param[in][out] theBinFile   output file stream
+  //! @param[in] theStyle    material images to add
   Standard_EXPORT void AddGlbImages (std::ostream& theBinFile,
                                      const XCAFPrs_Style& theStyle);
 
@@ -84,8 +84,8 @@ protected:
                                  Standard_Boolean& theIsStarted);
 
   //! Add texture image into GLB stream.
-  //! @param theBinFile [in] [out] output file stream
-  //! @param theTexture [in] texture image to add
+  //! @param[in][out] theBinFile   output file stream
+  //! @param[in] theTexture  texture image to add
   Standard_EXPORT void addGlbImage (std::ostream& theBinFile,
                                     const Handle(Image_Texture)& theTexture);
 

--- a/src/RWGltf/RWGltf_Provider.hxx
+++ b/src/RWGltf/RWGltf_Provider.hxx
@@ -48,7 +48,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const  Handle(TDocStd_Document)& theDocument,
@@ -59,7 +59,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -69,7 +69,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -78,7 +78,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -88,7 +88,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -99,7 +99,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -109,7 +109,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -118,7 +118,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/RWMesh/RWMesh_MaterialMap.hxx
+++ b/src/RWMesh/RWMesh_MaterialMap.hxx
@@ -58,9 +58,9 @@ public:
   Standard_EXPORT virtual bool CreateTextureFolder();
 
   //! Copy and rename texture file to the new location.
-  //! @param theResTexture [out] result texture file path (relative to the model)
-  //! @param theTexture [in] original texture
-  //! @param theKey [in] material key
+  //! @param[out] theResTexture  result texture file path (relative to the model)
+  //! @param[in] theTexture  original texture
+  //! @param[in] theKey  material key
   Standard_EXPORT virtual bool CopyTexture (TCollection_AsciiString& theResTexture,
                                             const Handle(Image_Texture)& theTexture,
                                             const TCollection_AsciiString& theKey);

--- a/src/RWMesh/RWMesh_TriangulationReader.hxx
+++ b/src/RWMesh/RWMesh_TriangulationReader.hxx
@@ -143,9 +143,9 @@ protected:
 protected: //! @name interface for filling triangulation data
 
   //! Resizes array of position nodes to specified size.
-  //! @param theMesh [in] triangulation to be modified
-  //! @param theNbNodes [in] nodes number
-  //! @param theToCopyData [in] copy old nodes into new array
+  //! @param[in] theMesh  triangulation to be modified
+  //! @param[in] theNbNodes  nodes number
+  //! @param[in] theToCopyData  copy old nodes into new array
   //! @return TRUE in case of success operation
   virtual bool setNbPositionNodes (const Handle(Poly_Triangulation)& theMesh,
                                    Standard_Integer theNbNodes,
@@ -160,9 +160,9 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Sets node position.
-  //! @param theMesh [in] triangulation to be modified
-  //! @param theIndex [in] node index starting from 1
-  //! @param thePnt [in] node position
+  //! @param[in] theMesh  triangulation to be modified
+  //! @param[in] theIndex  node index starting from 1
+  //! @param[in] thePnt  node position
   virtual void setNodePosition (const Handle(Poly_Triangulation)& theMesh,
                                 Standard_Integer theIndex,
                                 const gp_Pnt& thePnt) const
@@ -171,8 +171,8 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Resizes array of UV nodes to specified size.
-  //! @param theMesh [in] triangulation to be modified
-  //! @param theNbNodes [in] nodes number
+  //! @param[in] theMesh  triangulation to be modified
+  //! @param[in] theNbNodes  nodes number
   //! @return TRUE in case of success operation
   virtual bool setNbUVNodes (const Handle(Poly_Triangulation)& theMesh,
                              Standard_Integer theNbNodes) const
@@ -187,9 +187,9 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Sets node UV texture coordinates.
-  //! @param theMesh [in] triangulation to be modified
-  //! @param theIndex [in] node index starting from 1
-  //! @param theUV [in] node UV coordinates
+  //! @param[in] theMesh  triangulation to be modified
+  //! @param[in] theIndex  node index starting from 1
+  //! @param[in] theUV  node UV coordinates
   virtual void setNodeUV (const Handle(Poly_Triangulation)& theMesh,
                           Standard_Integer theIndex,
                           const gp_Pnt2d& theUV) const
@@ -198,8 +198,8 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Resizes array of nodes normals to specified size.
-  //! @param theMesh [in] triangulation to be modified
-  //! @param theNbNodes [in] nodes number
+  //! @param[in] theMesh  triangulation to be modified
+  //! @param[in] theNbNodes  nodes number
   //! @return TRUE in case of success operation
   virtual bool setNbNormalNodes (const Handle(Poly_Triangulation)& theMesh,
                                  Standard_Integer theNbNodes) const
@@ -214,7 +214,7 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Sets node normal.
-  //! @param theMesh [in] triangulation to be modified
+  //! @param[in] theMesh  triangulation to be modified
   //! @param theIndex  node index starting from 1
   //! @param theNormal node normal vector
   virtual void setNodeNormal (const Handle(Poly_Triangulation)& theMesh,
@@ -225,9 +225,9 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Resizes array of triangles to specified size.
-  //! @param theMesh [in] triangulation to be modified
-  //! @param theNbTris [in] elements number
-  //! @param theToCopyData [in] copy old triangles into new array
+  //! @param[in] theMesh  triangulation to be modified
+  //! @param[in] theNbTris  elements number
+  //! @param[in] theToCopyData  copy old triangles into new array
   //! @return TRUE in case of success operation
   virtual bool setNbTriangles (const Handle(Poly_Triangulation)& theMesh,
                                Standard_Integer theNbTris,
@@ -242,7 +242,7 @@ protected: //! @name interface for filling triangulation data
   }
 
   //! Adds triangle element.
-  //! @param theMesh [in] triangulation to be modified
+  //! @param[in] theMesh  triangulation to be modified
   //! @param theIndex    triangle index starting from 1
   //! @param theTriangle triangle nodes starting from 1
   //! @return 0 if node indexes are out of range,

--- a/src/RWObj/RWObj_CafWriter.hxx
+++ b/src/RWObj/RWObj_CafWriter.hxx
@@ -38,7 +38,7 @@ class RWObj_CafWriter : public Standard_Transient
 public:
 
   //! Main constructor.
-  //! @param theFile [in] path to output OBJ file
+  //! @param[in] theFile  path to output OBJ file
   Standard_EXPORT RWObj_CafWriter (const TCollection_AsciiString& theFile);
 
   //! Destructor.
@@ -61,14 +61,14 @@ public:
 
   //! Write OBJ file and associated MTL material file.
   //! Triangulation data should be precomputed within shapes!
-  //! @param theDocument    [in] input document
-  //! @param theRootLabels  [in] list of root shapes to export
-  //! @param theLabelFilter [in] optional filter with document nodes to export,
+  //! @param[in] theDocument     input document
+  //! @param[in] theRootLabels   list of root shapes to export
+  //! @param[in] theLabelFilter  optional filter with document nodes to export,
   //!                            with keys defined by XCAFPrs_DocumentExplorer::DefineChildId() and filled recursively
   //!                            (leaves and parent assembly nodes at all levels);
   //!                            when not NULL, all nodes not included into the map will be ignored
-  //! @param theFileInfo    [in] map with file metadata to put into OBJ header section
-  //! @param theProgress    [in] optional progress indicator
+  //! @param[in] theFileInfo     map with file metadata to put into OBJ header section
+  //! @param[in] theProgress     optional progress indicator
   //! @return FALSE on file writing failure
   Standard_EXPORT virtual bool Perform (const Handle(TDocStd_Document)& theDocument,
                                         const TDF_LabelSequence& theRootLabels,
@@ -78,9 +78,9 @@ public:
 
   //! Write OBJ file and associated MTL material file.
   //! Triangulation data should be precomputed within shapes!
-  //! @param theDocument    [in] input document
-  //! @param theFileInfo    [in] map with file metadata to put into glTF header section
-  //! @param theProgress    [in] optional progress indicator
+  //! @param[in] theDocument     input document
+  //! @param[in] theFileInfo     map with file metadata to put into glTF header section
+  //! @param[in] theProgress     optional progress indicator
   //! @return FALSE on file writing failure
   Standard_EXPORT virtual bool Perform (const Handle(TDocStd_Document)& theDocument,
                                         const TColStd_IndexedDataMapOfStringString& theFileInfo,
@@ -92,11 +92,11 @@ protected:
   Standard_EXPORT virtual Standard_Boolean toSkipFaceMesh (const RWMesh_FaceIterator& theFaceIter);
 
   //! Collect face triangulation info.
-  //! @param theFace [in] face to process
-  //! @param theNbNodes [in] [out] overall number of triangulation nodes (should be appended)
-  //! @param theNbElems [in] [out] overall number of triangulation elements (should be appended)
-  //! @param theNbProgressSteps [in] [out] overall number of progress steps (should be appended)
-  //! @param theToCreateMatFile [in] [out] flag to create material file or not (should be appended)
+  //! @param[in] theFace  face to process
+  //! @param[in][out] theNbNodes   overall number of triangulation nodes (should be appended)
+  //! @param[in][out] theNbElems   overall number of triangulation elements (should be appended)
+  //! @param[in][out] theNbProgressSteps   overall number of progress steps (should be appended)
+  //! @param[in][out] theToCreateMatFile   flag to create material file or not (should be appended)
   Standard_EXPORT virtual void addFaceInfo (const RWMesh_FaceIterator& theFace,
                                             Standard_Integer& theNbNodes,
                                             Standard_Integer& theNbElems,
@@ -104,13 +104,13 @@ protected:
                                             Standard_Boolean& theToCreateMatFile);
 
   //! Write the shape.
-  //! @param theWriter  [in] OBJ writer context
-  //! @param theMatMgr  [in] OBJ material map
-  //! @param thePSentry [in] progress sentry
-  //! @param theLabel   [in] document label to process
-  //! @param theParentTrsf  [in] parent node transformation
-  //! @param theParentStyle [in] parent node style
-  //! @param theName    [in] node name
+  //! @param[in] theWriter   OBJ writer context
+  //! @param[in] theMatMgr   OBJ material map
+  //! @param[in] thePSentry  progress sentry
+  //! @param[in] theLabel    document label to process
+  //! @param[in] theParentTrsf   parent node transformation
+  //! @param[in] theParentStyle  parent node style
+  //! @param[in] theName     node name
   Standard_EXPORT virtual bool writeShape (RWObj_ObjWriterContext&        theWriter,
                                            RWObj_ObjMaterialMap&          theMatMgr,
                                            Message_LazyProgressScope&     thePSentry,
@@ -120,36 +120,36 @@ protected:
                                            const TCollection_AsciiString& theName);
 
   //! Write face triangle vertex positions.
-  //! @param theWriter  [in] OBJ writer context
-  //! @param thePSentry [in] progress sentry
-  //! @param theFace    [in] current face
+  //! @param[in] theWriter   OBJ writer context
+  //! @param[in] thePSentry  progress sentry
+  //! @param[in] theFace     current face
   //! @return FALSE on writing file error
   Standard_EXPORT virtual bool writePositions (RWObj_ObjWriterContext&    theWriter,
                                                Message_LazyProgressScope& thePSentry,
                                                const RWMesh_FaceIterator& theFace);
 
   //! Write face triangle vertex normals.
-  //! @param theWriter  [in] OBJ writer context
-  //! @param thePSentry [in] progress sentry
-  //! @param theFace    [in] current face
+  //! @param[in] theWriter   OBJ writer context
+  //! @param[in] thePSentry  progress sentry
+  //! @param[in] theFace     current face
   //! @return FALSE on writing file error
   Standard_EXPORT virtual bool writeNormals (RWObj_ObjWriterContext&    theWriter,
                                              Message_LazyProgressScope& thePSentry,
                                              const RWMesh_FaceIterator& theFace);
 
   //! Write face triangle vertex texture coordinates.
-  //! @param theWriter  [in] OBJ writer context
-  //! @param thePSentry [in] progress sentry
-  //! @param theFace    [in] current face
+  //! @param[in] theWriter   OBJ writer context
+  //! @param[in] thePSentry  progress sentry
+  //! @param[in] theFace     current face
   //! @return FALSE on writing file error
   Standard_EXPORT virtual bool writeTextCoords (RWObj_ObjWriterContext&    theWriter,
                                                 Message_LazyProgressScope& thePSentry,
                                                 const RWMesh_FaceIterator& theFace);
 
   //! Write face triangles indices.
-  //! @param theWriter  [in] OBJ writer context
-  //! @param thePSentry [in] progress sentry
-  //! @param theFace    [in] current face
+  //! @param[in] theWriter   OBJ writer context
+  //! @param[in] thePSentry  progress sentry
+  //! @param[in] theFace     current face
   //! @return FALSE on writing file error
   Standard_EXPORT virtual bool writeIndices (RWObj_ObjWriterContext&    theWriter,
                                              Message_LazyProgressScope& thePSentry,

--- a/src/RWObj/RWObj_Provider.hxx
+++ b/src/RWObj/RWObj_Provider.hxx
@@ -46,7 +46,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -57,7 +57,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -67,7 +67,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -76,7 +76,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -86,7 +86,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -97,7 +97,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -107,7 +107,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -116,7 +116,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/RWPly/RWPly_Provider.hxx
+++ b/src/RWPly/RWPly_Provider.hxx
@@ -46,7 +46,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -56,7 +56,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -66,7 +66,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -76,7 +76,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/RWStl/RWStl_Provider.hxx
+++ b/src/RWStl/RWStl_Provider.hxx
@@ -46,7 +46,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 const Handle(TDocStd_Document)& theDocument,
@@ -57,7 +57,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const Handle(TDocStd_Document)& theDocument,
@@ -67,7 +67,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 const Handle(TDocStd_Document)& theDocument,
@@ -76,7 +76,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const Handle(TDocStd_Document)& theDocument,
@@ -86,7 +86,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 TopoDS_Shape& theShape,
@@ -97,7 +97,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const TopoDS_Shape& theShape,
@@ -107,7 +107,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Read(const TCollection_AsciiString& thePath,
                                                 TopoDS_Shape& theShape,
@@ -116,7 +116,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual Standard_Boolean Write(const TCollection_AsciiString& thePath,
                                                  const TopoDS_Shape& theShape,

--- a/src/Resource/Resource_Manager.hxx
+++ b/src/Resource/Resource_Manager.hxx
@@ -57,10 +57,10 @@ public:
   Standard_EXPORT Resource_Manager();
 
   //! Create a Resource manager.
-  //! @param theName [in] description file name
-  //! @param theDefaultsDirectory  [in] default folder for looking description file
-  //! @param theUserDefaultsDirectory [in] user folder for looking description file
-  //! @param theIsVerbose [in] print verbose messages
+  //! @param[in] theName  description file name
+  //! @param[in] theDefaultsDirectory   default folder for looking description file
+  //! @param[in] theUserDefaultsDirectory  user folder for looking description file
+  //! @param[in] theIsVerbose  print verbose messages
   Standard_EXPORT Resource_Manager (const TCollection_AsciiString& theName,
                                     const TCollection_AsciiString& theDefaultsDirectory,
                                     const TCollection_AsciiString& theUserDefaultsDirectory,

--- a/src/Resource/Resource_Unicode.hxx
+++ b/src/Resource/Resource_Unicode.hxx
@@ -111,9 +111,9 @@ public:
   }
 
   //! Converts the non-ASCII C string in specified format to the Unicode string of extended characters.
-  //! @param theFormat  [in] source encoding
-  //! @param theFromStr [in] text to convert
-  //! @param theToStr  [out] destination string
+  //! @param[in] theFormat   source encoding
+  //! @param[in] theFromStr  text to convert
+  //! @param[out] theToStr   destination string
   Standard_EXPORT static void ConvertFormatToUnicode (const Resource_FormatType theFormat,
                                                       const Standard_CString theFromStr,
                                                       TCollection_ExtendedString& theToStr);
@@ -121,19 +121,19 @@ public:
   //! Converts the Unicode string of extended characters to the non-ASCII string according to specified format.
   //! You need more than twice the length of the source string to complete the conversion.
   //! The function returns true if conversion is complete, i.e. the maximum number of characters is not reached before the end of conversion.
-  //! @param theFormat  [in] destination encoding
-  //! @param theFromStr [in] text to convert
-  //! @param theToStr  [out] destination buffer
-  //! @param theMaxSize [in] destination buffer length
+  //! @param[in] theFormat   destination encoding
+  //! @param[in] theFromStr  text to convert
+  //! @param[out] theToStr   destination buffer
+  //! @param[in] theMaxSize  destination buffer length
   Standard_EXPORT static Standard_Boolean ConvertUnicodeToFormat (const Resource_FormatType theFormat,
                                                                   const TCollection_ExtendedString& theFromStr,
                                                                   Standard_PCharacter& theToStr,
                                                                   const Standard_Integer theMaxSize);
 
   //! Converts the Unicode string of extended characters to the non-ASCII string according to the format returned by the function GetFormat.
-  //! @param theFromStr [in] text to convert
-  //! @param theToStr  [out] destination buffer
-  //! @param theMaxSize [in] destination buffer length
+  //! @param[in] theFromStr  text to convert
+  //! @param[out] theToStr   destination buffer
+  //! @param[in] theMaxSize  destination buffer length
   static Standard_Boolean ConvertUnicodeToFormat (const TCollection_ExtendedString& theFromStr,
                                                   Standard_PCharacter& theToStr,
                                                   const Standard_Integer theMaxSize)

--- a/src/STEPCAFControl/STEPCAFControl_Provider.hxx
+++ b/src/STEPCAFControl/STEPCAFControl_Provider.hxx
@@ -47,7 +47,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -58,7 +58,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -68,7 +68,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -77,7 +77,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -87,7 +87,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -98,7 +98,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -108,7 +108,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -117,7 +117,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/STEPCAFControl/STEPCAFControl_Reader.hxx
+++ b/src/STEPCAFControl/STEPCAFControl_Reader.hxx
@@ -81,21 +81,21 @@ public:
 
   //! Loads a file and returns the read status
   //! Provided for use like single-file reader.
-  //! @param theFileName [in] file to open
+  //! @param[in] theFileName  file to open
   //! @return read status
   Standard_EXPORT IFSelect_ReturnStatus ReadFile (const Standard_CString theFileName);
 
   //! Loads a file and returns the read status
   //! Provided for use like single-file reader.
-  //! @param theFileName [in] file to open
-  //! @param theParams [in] default configuration parameters
+  //! @param[in] theFileName  file to open
+  //! @param[in] theParams  default configuration parameters
   //! @return read status
   Standard_EXPORT IFSelect_ReturnStatus ReadFile(const Standard_CString theFileName,
                                                  const StepData_ConfParameters& theParams);
 
   //! Loads a file from stream and returns the read status.
-  //! @param theName [in] auxiliary stream name
-  //! @param theIStream [in] stream to read from
+  //! @param[in] theName  auxiliary stream name
+  //! @param[in] theIStream  stream to read from
   //! @return read status
   Standard_EXPORT IFSelect_ReturnStatus ReadStream (const Standard_CString theName,
                                                     std::istream& theIStream);

--- a/src/Select3D/Select3D_SensitiveSet.hxx
+++ b/src/Select3D/Select3D_SensitiveSet.hxx
@@ -115,10 +115,10 @@ protected:
                                             Standard_Boolean theToCheckAllInside);
 
   //! Checks whether the entity with index theIdx (partially) overlaps the current selecting volume.
-  //! @param thePickResult [OUT] picking result, should update minimum depth
-  //! @param theMgr [IN] selection manager
-  //! @param theElemIdx [IN] element index within BVH tree to check
-  //! @param theIsFullInside [IN] when TRUE indicates that entire BVH node is already inside selection volume (in case of rectangle selection);
+  //! @param[out] thePickResult  picking result, should update minimum depth
+  //! @param[in] theMgr  selection manager
+  //! @param[in] theElemIdx  element index within BVH tree to check
+  //! @param[in] theIsFullInside  when TRUE indicates that entire BVH node is already inside selection volume (in case of rectangle selection);
   //!                             in this case algorithm might skip checking the element and just register it as detected
   virtual Standard_Boolean overlapsElement (SelectBasics_PickResult& thePickResult,
                                             SelectBasics_SelectingVolumeManager& theMgr,
@@ -126,9 +126,9 @@ protected:
                                             Standard_Boolean theIsFullInside) = 0;
 
   //! Checks whether the entity with index theIdx is (fully) inside the current selecting volume
-  //! @param theMgr [IN] selection manager
-  //! @param theElemIdx [IN] element index within BVH tree to check
-  //! @param theIsFullInside [IN] when TRUE indicates that entire BVH node is already inside selection volume (in case of rectangle selection);
+  //! @param[in] theMgr  selection manager
+  //! @param[in] theElemIdx  element index within BVH tree to check
+  //! @param[in] theIsFullInside  when TRUE indicates that entire BVH node is already inside selection volume (in case of rectangle selection);
   //!                             in this case algorithm might skip checking the element and just register it as detected
   virtual Standard_Boolean elementIsInside (SelectBasics_SelectingVolumeManager& theMgr,
                                             Standard_Integer theElemIdx,
@@ -142,8 +142,8 @@ protected:
   //! @param theFirstElem index of the first element
   //! @param theLastElem index of the last element
   //! @param theIsFullInside when TRUE indicates that entire BVH node is already inside selection volume
-  //! @param thePickResult [OUT] picking result (for picking by ray)
-  //! @param theMatchesNb [OUT] number of processed elements
+  //! @param[out] thePickResult  picking result (for picking by ray)
+  //! @param[out] theMatchesNb  number of processed elements
   //! @return FALSE if some element is outside the selection volume (if IsOverlapAllowed is FALSE); TRUE otherwise
   Standard_EXPORT Standard_Boolean processElements (SelectBasics_SelectingVolumeManager& theMgr,
                                                     Standard_Integer theFirstElem,

--- a/src/Select3D/Select3D_SensitiveTriangulation.hxx
+++ b/src/Select3D/Select3D_SensitiveTriangulation.hxx
@@ -52,13 +52,13 @@ public:
 public:
 
   //! Get last detected triangle.
-  //! @param theTriangle [out] triangle node indexes
+  //! @param[out] theTriangle  triangle node indexes
   //! @return TRUE if defined
   Standard_EXPORT bool LastDetectedTriangle (Poly_Triangle& theTriangle) const;
 
   //! Get last detected triangle.
-  //! @param theTriangle [out] triangle node indexes
-  //! @param theTriNodes [out] triangle nodes (with pre-applied transformation)
+  //! @param[out] theTriangle  triangle node indexes
+  //! @param[out] theTriNodes  triangle nodes (with pre-applied transformation)
   //! @return TRUE if defined
   Standard_EXPORT bool LastDetectedTriangle (Poly_Triangle& theTriangle,
                                              gp_Pnt theTriNodes[3]) const;

--- a/src/SelectMgr/SelectMgr_BaseIntersector.hxx
+++ b/src/SelectMgr/SelectMgr_BaseIntersector.hxx
@@ -61,17 +61,17 @@ public:
   Standard_EXPORT virtual void SetPixelTolerance (const Standard_Integer theTol);
 
   //! Note that this method does not perform any checks on type of the frustum.
-  //! @param theScaleFactor [in] scale factor for new intersector or negative value if undefined;
+  //! @param[in] theScaleFactor  scale factor for new intersector or negative value if undefined;
   //!                            IMPORTANT: scaling makes sense only for scalable ::IsScalable() intersectors (built on a single point)!
-  //! @param theTrsf [in] transformation for new intersector or gp_Identity if undefined
-  //! @param theBuilder [in] an optional argument that represents corresponding settings for re-constructing transformed frustum from scratch;
+  //! @param[in] theTrsf  transformation for new intersector or gp_Identity if undefined
+  //! @param[in] theBuilder  an optional argument that represents corresponding settings for re-constructing transformed frustum from scratch;
   //!                        could be NULL if reconstruction is not expected furthermore
   //! @return a copy of the frustum resized according to the scale factor given and transforms it using the matrix given
   virtual Handle(SelectMgr_BaseIntersector) ScaleAndTransform (const Standard_Integer theScaleFactor,
                                                                const gp_GTrsf& theTrsf,
                                                                const Handle(SelectMgr_FrustumBuilder)& theBuilder) const = 0;
 
-  //! @param theBuilder [in] argument that represents corresponding settings for re-constructing transformed frustum from scratch;
+  //! @param[in] theBuilder  argument that represents corresponding settings for re-constructing transformed frustum from scratch;
   //!                        should NOT be NULL.
   //! @return a copy of the frustum with the input builder assigned
   virtual Handle(SelectMgr_BaseIntersector) CopyWithBuilder (const Handle(SelectMgr_FrustumBuilder)& theBuilder) const = 0;

--- a/src/SelectMgr/SelectMgr_EntityOwner.hxx
+++ b/src/SelectMgr/SelectMgr_EntityOwner.hxx
@@ -137,7 +137,7 @@ public:
   Standard_Boolean IsSelected() const { return myIsSelected; }
 
   //! Set the state of the owner.
-  //! @param theIsSelected [in] shows if owner is selected.
+  //! @param[in] theIsSelected  shows if owner is selected.
   void SetSelected (const Standard_Boolean theIsSelected) { myIsSelected = theIsSelected; }
 
   //! If the object needs to be selected, it returns true.

--- a/src/SelectMgr/SelectMgr_RectangularFrustum.hxx
+++ b/src/SelectMgr/SelectMgr_RectangularFrustum.hxx
@@ -101,7 +101,7 @@ public:
 
   //! Returns a copy of the frustum using the given frustum builder configuration.
   //! Returned frustum should be re-constructed before being used.
-  //! @param theBuilder [in] argument that represents corresponding settings for re-constructing transformed frustum from scratch;
+  //! @param[in] theBuilder  argument that represents corresponding settings for re-constructing transformed frustum from scratch;
   //!                        should NOT be NULL.
   //! @return a copy of the frustum with the input builder assigned
   Standard_EXPORT virtual Handle(SelectMgr_BaseIntersector) CopyWithBuilder (const Handle(SelectMgr_FrustumBuilder)& theBuilder) const Standard_OVERRIDE;

--- a/src/SelectMgr/SelectMgr_SelectingVolumeManager.hxx
+++ b/src/SelectMgr/SelectMgr_SelectingVolumeManager.hxx
@@ -225,9 +225,9 @@ public:
 
   //! Valid for point selection only!
   //! Computes depth range for clipping planes.
-  //! @param theViewPlanes  [in] global view planes
-  //! @param theObjPlanes   [in] object planes
-  //! @param theWorldSelMgr [in] selection volume in world space for computing clipping plane ranges
+  //! @param[in] theViewPlanes   global view planes
+  //! @param[in] theObjPlanes    object planes
+  //! @param[in] theWorldSelMgr  selection volume in world space for computing clipping plane ranges
   Standard_EXPORT void SetViewClipping (const Handle(Graphic3d_SequenceOfHClipPlane)& theViewPlanes,
                                         const Handle(Graphic3d_SequenceOfHClipPlane)& theObjPlanes,
                                         const SelectMgr_SelectingVolumeManager* theWorldSelMgr);

--- a/src/SelectMgr/SelectMgr_TriangularFrustum.hxx
+++ b/src/SelectMgr/SelectMgr_TriangularFrustum.hxx
@@ -57,7 +57,7 @@ public:
 
   //! Returns a copy of the frustum using the given frustum builder configuration.
   //! Returned frustum should be re-constructed before being used.
-  //! @param theBuilder [in] argument that represents corresponding settings for re-constructing transformed frustum from scratch;
+  //! @param[in] theBuilder  argument that represents corresponding settings for re-constructing transformed frustum from scratch;
   //!                        should NOT be NULL.
   //! @return a copy of the frustum with the input builder assigned
   Standard_EXPORT virtual Handle(SelectMgr_BaseIntersector) CopyWithBuilder (const Handle(SelectMgr_FrustumBuilder)& theBuilder) const Standard_OVERRIDE;

--- a/src/SelectMgr/SelectMgr_TriangularFrustumSet.hxx
+++ b/src/SelectMgr/SelectMgr_TriangularFrustumSet.hxx
@@ -64,7 +64,7 @@ public:
 
   //! Returns a copy of the frustum using the given frustum builder configuration.
   //! Returned frustum should be re-constructed before being used.
-  //! @param theBuilder [in] argument that represents corresponding settings for re-constructing transformed frustum from scratch;
+  //! @param[in] theBuilder  argument that represents corresponding settings for re-constructing transformed frustum from scratch;
   //!                        should NOT be NULL.
   //! @return a copy of the frustum with the input builder assigned
   Standard_EXPORT virtual Handle(SelectMgr_BaseIntersector) CopyWithBuilder (const Handle(SelectMgr_FrustumBuilder)& theBuilder) const Standard_OVERRIDE;

--- a/src/SelectMgr/SelectMgr_ViewerSelector.hxx
+++ b/src/SelectMgr/SelectMgr_ViewerSelector.hxx
@@ -126,8 +126,8 @@ public:
   Standard_Real DepthTolerance() const { return myDepthTolerance; }
 
   //! Set the tolerance for considering two entities having a similar depth (distance from eye to entity).
-  //! @param theType [in] type of tolerance value
-  //! @param theTolerance [in] tolerance value in 3D scale (SelectMgr_TypeOfDepthTolerance_Uniform)
+  //! @param[in] theType  type of tolerance value
+  //! @param[in] theTolerance  tolerance value in 3D scale (SelectMgr_TypeOfDepthTolerance_Uniform)
   //!                          or in pixels (SelectMgr_TypeOfDepthTolerance_UniformPixels);
   //!                          value is ignored in case of SelectMgr_TypeOfDepthTolerance_SensitivityFactor
   void SetDepthTolerance (SelectMgr_TypeOfDepthTolerance theType,
@@ -325,10 +325,10 @@ protected:
 
   //! Internal function that checks if there is possible overlap between some entity of selectable object theObject and
   //! current selecting volume.
-  //! @param theObject [in] the selectable object for traversal.
-  //! @param theMgr [in] the (un)transformed copy of the selecting volume manager representing active selection frustum.
-  //! @param theCamera, theProjectionMat, theWorldViewMat [in] the source camera and matrices for theMgr given.
-  //! @param theWinSize [in] viewport (window) dimensions for evaluating 
+  //! @param[in] theObject  the selectable object for traversal.
+  //! @param[in] theMgr  the (un)transformed copy of the selecting volume manager representing active selection frustum.
+  //! @param theCamera, theProjectionMat, theWorldViewMat[in]  the source camera and matrices for theMgr given.
+  //! @param[in] theWinSize  viewport (window) dimensions for evaluating 
   //!        object's transformation persistence.
   Standard_EXPORT void traverseObject (const Handle(SelectMgr_SelectableObject)& theObject,
                                        const SelectMgr_SelectingVolumeManager& theMgr,

--- a/src/Standard/Standard.hxx
+++ b/src/Standard/Standard.hxx
@@ -101,12 +101,12 @@ public:
   //!   and no stack will be provided if this or companion libraries (SymSrv.dll, SrcSrv.dll, etc.) will not be found;
   //!   .pdb symbols should be provided on Windows platform to retrieve a meaningful stack;
   //!   only x86_64 CPU architecture is currently implemented.
-  //! @param theBuffer [in] [out] message buffer to extend
-  //! @param theBufferSize [in] message buffer size
-  //! @param theNbTraces [in] maximum number of stack traces
-  //! @param theContext [in] optional platform-dependent frame context;
+  //! @param[in][out] theBuffer   message buffer to extend
+  //! @param[in] theBufferSize  message buffer size
+  //! @param[in] theNbTraces  maximum number of stack traces
+  //! @param[in] theContext  optional platform-dependent frame context;
   //!                        in case of DbgHelp (Windows) should be a pointer to CONTEXT
-  //! @param theNbTopSkip [in] number of traces on top of the stack to skip
+  //! @param[in] theNbTopSkip  number of traces on top of the stack to skip
   //! @return TRUE on success
   Standard_EXPORT static Standard_Boolean StackTrace (char* theBuffer,
                                                       const int theBufferSize,

--- a/src/Standard/Standard_CString.hxx
+++ b/src/Standard/Standard_CString.hxx
@@ -68,9 +68,9 @@ Standard_EXPORT int Sprintf (char* theBuffer, const char* theFormat, ...);
 //! Equivalent of standard C function vsprintf() that always uses C locale.
 //! Note that this function does not check buffer bounds and should be used with precaution measures
 //! (only with format fitting into the buffer of known size).
-//! @param theBuffer  [in] [out] string buffer to fill
-//! @param theFormat  [in] format to apply
-//! @param theArgList [in] argument list for specified format
+//! @param[in][out] theBuffer    string buffer to fill
+//! @param[in] theFormat   format to apply
+//! @param[in] theArgList  argument list for specified format
 //! @return the total number of characters written, or a negative number on error
 Standard_EXPORT int Vsprintf (char* theBuffer, const char* theFormat, va_list theArgList);
 

--- a/src/Standard/Standard_Dump.hxx
+++ b/src/Standard/Standard_Dump.hxx
@@ -327,7 +327,7 @@ public:
   //! The sublevel value might be processed later using the same method.
   //!
   //! @param theStreamStr stream value
-  //! @param theKeyToValues [out] container of split values. It contains key to value and position of the value in the stream text
+  //! @param[out] theKeyToValues  container of split values. It contains key to value and position of the value in the stream text
   Standard_EXPORT static Standard_Boolean SplitJson (const TCollection_AsciiString& theStreamStr,
                                                      NCollection_IndexedDataMap<TCollection_AsciiString, Standard_DumpValue>& theKeyToValues);
 
@@ -365,7 +365,7 @@ public:
                                                                  const bool isShortInfo = true);
 
   //! Append into output value: "Name": { Field }
-  //! @param theOStream [out] stream to be fill with values
+  //! @param[out] theOStream  stream to be fill with values
   //! @param theKey a source value
   //! @param theField stream value
   Standard_EXPORT static void DumpKeyToClass (Standard_OStream& theOStream,
@@ -373,13 +373,13 @@ public:
                                               const TCollection_AsciiString& theField);
 
   //! Unite values in one value using template: "value_1", "value_2", ..., "value_n"
-  //! @param theOStream [out] stream to be fill with values
-  //! @param theCount   [in]  number of values
+  //! @param[out] theOStream  stream to be fill with values
+  //! @param[in] theCount     number of values
   Standard_EXPORT static void DumpCharacterValues (Standard_OStream& theOStream, int theCount, ...);
 
   //! Unite values in one value using template: value_1, value_2, ..., value_n
-  //! @param theOStream [out] stream to be fill with values
-  //! @param theCount   [in]  number of values
+  //! @param[out] theOStream  stream to be fill with values
+  //! @param[in] theCount     number of values
   Standard_EXPORT static void DumpRealValues (Standard_OStream& theOStream, int theCount, ...);
 
   //! Check whether the parameter name is equal to the name in the stream at position

--- a/src/Standard/Standard_Failure.hxx
+++ b/src/Standard/Standard_Failure.hxx
@@ -38,12 +38,12 @@ public:
   Standard_EXPORT Standard_Failure (const Standard_Failure& f);
 
   //! Creates a status object of type "Failure".
-  //! @param theDesc [in] exception description
+  //! @param[in] theDesc  exception description
   Standard_EXPORT Standard_Failure (const Standard_CString theDesc);
 
   //! Creates a status object of type "Failure" with stack trace.
-  //! @param theDesc [in] exception description
-  //! @param theStackTrace [in] associated stack trace
+  //! @param[in] theDesc  exception description
+  //! @param[in] theStackTrace  associated stack trace
   Standard_EXPORT Standard_Failure (const Standard_CString theDesc,
                                     const Standard_CString theStackTrace);
 

--- a/src/Standard/Standard_ReadBuffer.hxx
+++ b/src/Standard/Standard_ReadBuffer.hxx
@@ -39,9 +39,9 @@ public:
   }
 
   //! Initialize the buffer.
-  //! @param theDataLen  [in] the full length of input data to read from stream.
-  //! @param theChunkLen [in] the length of single chunk to read
-  //! @param theIsPartialPayload [in] when FALSE, theDataLen will be automatically aligned to the multiple of theChunkLen;
+  //! @param[in] theDataLen   the full length of input data to read from stream.
+  //! @param[in] theChunkLen  the length of single chunk to read
+  //! @param[in] theIsPartialPayload  when FALSE, theDataLen will be automatically aligned to the multiple of theChunkLen;
   //!                                 when TRUE, last chunk will be read from stream exactly till theDataLen
   //!                                 allowing portion of chunk to be uninitialized (useful for interleaved data)
   void Init (int64_t theDataLen,

--- a/src/Standard/Standard_ReadLineBuffer.hxx
+++ b/src/Standard/Standard_ReadLineBuffer.hxx
@@ -54,7 +54,7 @@ public:
   //!         (in case of NULL result theStream should be checked externally to identify the presence of errors).
   //!          Empty lines will be returned also with zero length.
   //! @param theStream [inout] - the stream to read from.
-  //! @param theLineLength [out] - output parameter defined length of returned line.
+  //! @param[out] theLineLength  - output parameter defined length of returned line.
   template<typename Stream_T>
   const char* ReadLine (Stream_T& theStream,
                         size_t& theLineLength)
@@ -68,8 +68,8 @@ public:
   //!         (in case of NULL result theStream should be checked externally to identify the presence of errors).
   //!          Empty lines will be returned also with zero length.
   //! @param theStream [inout] - the stream to read from.
-  //! @param theLineLength [out] - output parameter defined length of returned line.
-  //! @param theReadData   [out] - output parameter defined the number of elements successfully read from the stream during this call,
+  //! @param[out] theLineLength  - output parameter defined length of returned line.
+  //! @param[out] theReadData    - output parameter defined the number of elements successfully read from the stream during this call,
   //!                              it can be zero if no data was read and the line is taken from the buffer.
   template<typename Stream_T>
   const char* ReadLine (Stream_T& theStream,
@@ -261,8 +261,8 @@ public:
   bool ToPutGapInMultiline() const { return myToPutGapInMultiline; }
 
   //! Sets or unsets the multi-line mode.
-  //! @param theMultilineMode [in] multiline mode flag
-  //! @param theToPutGap      [in] put gap space while connecting lines (no gap otherwise)
+  //! @param[in] theMultilineMode  multiline mode flag
+  //! @param[in] theToPutGap       put gap space while connecting lines (no gap otherwise)
   void SetMultilineMode (bool theMultilineMode,
                          bool theToPutGap = true)
   {

--- a/src/StdPrs/StdPrs_Isolines.hxx
+++ b/src/StdPrs/StdPrs_Isolines.hxx
@@ -40,10 +40,10 @@ public:
   //! This method chooses proper version of isoline builder algorithm : on triangulation
   //! or surface depending on the flag passed from Prs3d_Drawer attributes.
   //! This method is a default way to display isolines for a given TopoDS face.
-  //! @param thePresentation [in] the presentation.
-  //! @param theFace [in] the face.
-  //! @param theDrawer [in] the display settings.
-  //! @param theDeflection [in] the deflection for isolines-on-surface version.
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theFace  the face.
+  //! @param[in] theDrawer  the display settings.
+  //! @param[in] theDeflection  the deflection for isolines-on-surface version.
   inline static void Add (const Handle(Prs3d_Presentation)& thePresentation,
                           const TopoDS_Face&                theFace,
                           const Handle(Prs3d_Drawer)&       theDrawer,
@@ -63,9 +63,9 @@ public:
   //! This method chooses proper version of isoline builder algorithm : on triangulation
   //! or surface depending on the flag passed from Prs3d_Drawer attributes.
   //! This method is a default way to display isolines for a given TopoDS face.
-  //! @param theFace [in] the face.
-  //! @param theDrawer [in] the display settings.
-  //! @param theDeflection [in] the deflection for isolines-on-surface version.
+  //! @param[in] theFace  the face.
+  //! @param[in] theDrawer  the display settings.
+  //! @param[in] theDeflection  the deflection for isolines-on-surface version.
   static void Add (const TopoDS_Face&          theFace,
                    const Handle(Prs3d_Drawer)& theDrawer,
                    const Standard_Real         theDeflection,
@@ -83,35 +83,35 @@ public:
   }
 
   //! Computes isolines on triangulation and adds them to a presentation.
-  //! @param thePresentation [in] the presentation.
-  //! @param theFace [in] the face.
-  //! @param theDrawer [in] the display settings.
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theFace  the face.
+  //! @param[in] theDrawer  the display settings.
   Standard_EXPORT static void AddOnTriangulation (const Handle(Prs3d_Presentation)& thePresentation,
                                                   const TopoDS_Face&                theFace,
                                                   const Handle(Prs3d_Drawer)&       theDrawer);
 
   //! Computes isolines on triangulation.
-  //! @param theFace [in] the face.
-  //! @param theDrawer [in] the display settings.
-  //! @param theUPolylines [out] the sequence of result polylines
-  //! @param theVPolylines [out] the sequence of result polylines
+  //! @param[in] theFace  the face.
+  //! @param[in] theDrawer  the display settings.
+  //! @param[out] theUPolylines  the sequence of result polylines
+  //! @param[out] theVPolylines  the sequence of result polylines
   Standard_EXPORT static void AddOnTriangulation (const TopoDS_Face&          theFace,
                                                   const Handle(Prs3d_Drawer)& theDrawer,
                                                   Prs3d_NListOfSequenceOfPnt& theUPolylines,
                                                   Prs3d_NListOfSequenceOfPnt& theVPolylines);
 
   //! Computes isolines on triangulation and adds them to a presentation.
-  //! @param thePresentation [in] the presentation.
-  //! @param theTriangulation [in] the triangulation.
-  //! @param theSurface [in] the definition of triangulated surface. The surface
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theTriangulation  the triangulation.
+  //! @param[in] theSurface  the definition of triangulated surface. The surface
   //!        adapter is used to precisely evaluate isoline points using surface
   //!        law and fit them on triangulation. If NULL is passed, the method will
   //!        use linear interpolation of triangle node's UV coordinates to evaluate
   //!        isoline points.
-  //! @param theLocation [in] the location transformation defined for triangulation (surface).
-  //! @param theDrawer [in] the display settings.
-  //! @param theUIsoParams [in] the parameters of u isolines to compute.
-  //! @param theVIsoParams [in] the parameters of v isolines to compute.
+  //! @param[in] theLocation  the location transformation defined for triangulation (surface).
+  //! @param[in] theDrawer  the display settings.
+  //! @param[in] theUIsoParams  the parameters of u isolines to compute.
+  //! @param[in] theVIsoParams  the parameters of v isolines to compute.
   Standard_EXPORT static void AddOnTriangulation (const Handle(Prs3d_Presentation)& thePresentation,
                                                   const Handle(Poly_Triangulation)& theTriangulation,
                                                   const Handle(Geom_Surface)&       theSurface,
@@ -121,21 +121,21 @@ public:
                                                   const TColStd_SequenceOfReal&     theVIsoParams);
 
   //! Computes isolines on surface and adds them to presentation.
-  //! @param thePresentation [in] the presentation.
-  //! @param theFace [in] the face.
-  //! @param theDrawer [in] the display settings.
-  //! @param theDeflection [in] the deflection value.
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theFace  the face.
+  //! @param[in] theDrawer  the display settings.
+  //! @param[in] theDeflection  the deflection value.
   Standard_EXPORT static void AddOnSurface (const Handle(Prs3d_Presentation)& thePresentation,
                                             const TopoDS_Face&                theFace,
                                             const Handle(Prs3d_Drawer)&       theDrawer,
                                             const Standard_Real               theDeflection);
 
   //! Computes isolines on surface and adds them to presentation.
-  //! @param theFace [in] the face
-  //! @param theDrawer [in] the display settings
-  //! @param theDeflection [in] the deflection value
-  //! @param theUPolylines [out] the sequence of result polylines
-  //! @param theVPolylines [out] the sequence of result polylines
+  //! @param[in] theFace  the face
+  //! @param[in] theDrawer  the display settings
+  //! @param[in] theDeflection  the deflection value
+  //! @param[out] theUPolylines  the sequence of result polylines
+  //! @param[out] theVPolylines  the sequence of result polylines
   Standard_EXPORT static void AddOnSurface (const TopoDS_Face&          theFace,
                                             const Handle(Prs3d_Drawer)& theDrawer,
                                             const Standard_Real         theDeflection,
@@ -143,12 +143,12 @@ public:
                                             Prs3d_NListOfSequenceOfPnt& theVPolylines);
 
   //! Computes isolines on surface and adds them to presentation.
-  //! @param thePresentation [in] the presentation.
-  //! @param theSurface [in] the surface.
-  //! @param theDrawer [in] the display settings.
-  //! @param theDeflection [in] the deflection value.
-  //! @param theUIsoParams [in] the parameters of u isolines to compute.
-  //! @param theVIsoParams [in] the parameters of v isolines to compute.
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theSurface  the surface.
+  //! @param[in] theDrawer  the display settings.
+  //! @param[in] theDeflection  the deflection value.
+  //! @param[in] theUIsoParams  the parameters of u isolines to compute.
+  //! @param[in] theVIsoParams  the parameters of v isolines to compute.
   Standard_EXPORT static void AddOnSurface (const Handle(Prs3d_Presentation)&   thePresentation,
                                             const Handle(BRepAdaptor_Surface)& theSurface,
                                             const Handle(Prs3d_Drawer)&         theDrawer,
@@ -157,16 +157,16 @@ public:
                                             const TColStd_SequenceOfReal&       theVIsoParams);
 
   //! Evaluate sequence of parameters for drawing uv isolines for a given face.
-  //! @param theFace [in] the face.
-  //! @param theNbIsoU [in] the number of u isolines.
-  //! @param theNbIsoV [in] the number of v isolines.
-  //! @param theUVLimit [in] the u, v parameter value limit.
-  //! @param theUIsoParams [out] the sequence of u isoline parameters.
-  //! @param theVIsoParams [out] the sequence of v isoline parameters.
-  //! @param theUmin [out] the lower U boundary of  theFace.
-  //! @param theUmax [out] the upper U boundary of  theFace.
-  //! @param theVmin [out] the lower V boundary of  theFace.
-  //! @param theVmax [out] the upper V boundary of  theFace.
+  //! @param[in] theFace  the face.
+  //! @param[in] theNbIsoU  the number of u isolines.
+  //! @param[in] theNbIsoV  the number of v isolines.
+  //! @param[in] theUVLimit  the u, v parameter value limit.
+  //! @param[out] theUIsoParams  the sequence of u isoline parameters.
+  //! @param[out] theVIsoParams  the sequence of v isoline parameters.
+  //! @param[out] theUmin  the lower U boundary of  theFace.
+  //! @param[out] theUmax  the upper U boundary of  theFace.
+  //! @param[out] theVmin  the lower V boundary of  theFace.
+  //! @param[out] theVmax  the upper V boundary of  theFace.
   Standard_EXPORT static void UVIsoParameters (const TopoDS_Face&      theFace,
                                                const Standard_Integer  theNbIsoU,
                                                const Standard_Integer  theNbIsoV,
@@ -206,13 +206,13 @@ public:
 private:
 
   //! Computes isolines on surface.
-  //! @param theSurface [in] the surface
-  //! @param theDrawer [in] the display settings
-  //! @param theDeflection [in] the deflection value
-  //! @param theUIsoParams [in] the parameters of u isolines to compute
-  //! @param theVIsoParams [in] the parameters of v isolines to compute
-  //! @param theUPolylines [out] the sequence of result polylines
-  //! @param theVPolylines [out] the sequence of result polylines
+  //! @param[in] theSurface  the surface
+  //! @param[in] theDrawer  the display settings
+  //! @param[in] theDeflection  the deflection value
+  //! @param[in] theUIsoParams  the parameters of u isolines to compute
+  //! @param[in] theVIsoParams  the parameters of v isolines to compute
+  //! @param[out] theUPolylines  the sequence of result polylines
+  //! @param[out] theVPolylines  the sequence of result polylines
   Standard_EXPORT static void addOnSurface (const Handle(BRepAdaptor_Surface)& theSurface,
                                             const Handle(Prs3d_Drawer)&         theDrawer,
                                             const Standard_Real                 theDeflection,
@@ -222,19 +222,19 @@ private:
                                             Prs3d_NListOfSequenceOfPnt&         theVPolylines);
 
   //! Computes isolines on triangulation.
-  //! @param thePresentation [in] the presentation
-  //! @param theTriangulation [in] the triangulation
-  //! @param theSurface [in] the definition of triangulated surface. The surface
+  //! @param[in] thePresentation  the presentation
+  //! @param[in] theTriangulation  the triangulation
+  //! @param[in] theSurface  the definition of triangulated surface. The surface
   //!        adapter is used to precisely evaluate isoline points using surface
   //!        law and fit them on triangulation. If NULL is passed, the method will
   //!        use linear interpolation of triangle node's UV coordinates to evaluate
   //!        isoline points
-  //! @param theLocation [in] the location transformation defined for triangulation (surface)
-  //! @param theDrawer [in] the display settings
-  //! @param theUIsoParams [in] the parameters of u isolines to compute
-  //! @param theVIsoParams [in] the parameters of v isolines to compute
-  //! @param theUPolylines [out] the sequence of result polylines
-  //! @param theVPolylines [out] the sequence of result polylines
+  //! @param[in] theLocation  the location transformation defined for triangulation (surface)
+  //! @param[in] theDrawer  the display settings
+  //! @param[in] theUIsoParams  the parameters of u isolines to compute
+  //! @param[in] theVIsoParams  the parameters of v isolines to compute
+  //! @param[out] theUPolylines  the sequence of result polylines
+  //! @param[out] theVPolylines  the sequence of result polylines
   Standard_EXPORT static void addOnTriangulation (const Handle(Poly_Triangulation)& theTriangulation,
                                                   const Handle(Geom_Surface)&       theSurface,
                                                   const TopLoc_Location&            theLocation,
@@ -244,12 +244,12 @@ private:
                                                   Prs3d_NListOfSequenceOfPnt&       theVPolylines);
 
   //! Find isoline segment on a triangle.
-  //! @param theSurface [in] the surface.
-  //! @param theIsU     [in] when true than U isoline is specified, V isoline otherwise
-  //! @param theIsoline [in] the isoline in uv coordinates.
-  //! @param theNodesXYZ [in] the XYZ coordinates of triangle nodes.
-  //! @param theNodesUV [in] the UV coordinates of triangle nodes.
-  //! @param theSegment [out] the XYZ points of crossed triangle's links.
+  //! @param[in] theSurface  the surface.
+  //! @param[in] theIsU      when true than U isoline is specified, V isoline otherwise
+  //! @param[in] theIsoline  the isoline in uv coordinates.
+  //! @param[in] theNodesXYZ  the XYZ coordinates of triangle nodes.
+  //! @param[in] theNodesUV  the UV coordinates of triangle nodes.
+  //! @param[out] theSegment  the XYZ points of crossed triangle's links.
   //!                         with U cross point parameter for V isoline
   //!                         or V parameters for U isoline (depending on theIsU)
   //! @return TRUE if the isoline passes through the triangle.

--- a/src/StdPrs/StdPrs_ShadedShape.hxx
+++ b/src/StdPrs/StdPrs_ShadedShape.hxx
@@ -61,7 +61,7 @@ public:
 public:
 
   //! Create primitive array with triangles for specified shape.
-  //! @param theShape [in] the shape with precomputed triangulation
+  //! @param[in] theShape  the shape with precomputed triangulation
   static Handle(Graphic3d_ArrayOfTriangles) FillTriangles (const TopoDS_Shape& theShape)
   {
     gp_Pnt2d aDummy;

--- a/src/StdPrs/StdPrs_ToolTriangulatedShape.hxx
+++ b/src/StdPrs/StdPrs_ToolTriangulatedShape.hxx
@@ -47,14 +47,14 @@ public:
                                                       const Handle(Prs3d_Drawer)& theDrawer);
 
   //! Checks whether the shape is properly triangulated for a given display settings.
-  //! @param theShape [in] the shape.
-  //! @param theDrawer [in] the display settings.
+  //! @param[in] theShape  the shape.
+  //! @param[in] theDrawer  the display settings.
   Standard_EXPORT static Standard_Boolean IsTessellated (const TopoDS_Shape& theShape,
                                                          const Handle(Prs3d_Drawer)& theDrawer);
 
   //! Validates triangulation within the shape and performs tessellation if necessary.
-  //! @param theShape [in] the shape.
-  //! @param theDrawer [in] the display settings.
+  //! @param[in] theShape  the shape.
+  //! @param[in] theDrawer  the display settings.
   //! @return true if tessellation was recomputed and false otherwise.
   Standard_EXPORT static Standard_Boolean Tessellate (const TopoDS_Shape& theShape,
                                                       const Handle(Prs3d_Drawer)& theDrawer);
@@ -63,9 +63,9 @@ public:
   //! function will compare actual coefficients with previous values and will clear triangulation on their change
   //! (regardless actual tessellation quality).
   //! Function is placed here for compatibility reasons - new code should avoid using IsAutoTriangulation().
-  //! @param theShape  [in] the shape
-  //! @param theDrawer [in] the display settings
-  //! @param theToResetCoeff [in] updates coefficients in theDrawer to actual state to avoid redundant recomputations
+  //! @param[in] theShape   the shape
+  //! @param[in] theDrawer  the display settings
+  //! @param[in] theToResetCoeff  updates coefficients in theDrawer to actual state to avoid redundant recomputations
   Standard_EXPORT static void ClearOnOwnDeflectionChange (const TopoDS_Shape& theShape,
                                                           const Handle(Prs3d_Drawer)& theDrawer,
                                                           const Standard_Boolean theToResetCoeff);

--- a/src/StdPrs/StdPrs_WFShape.hxx
+++ b/src/StdPrs/StdPrs_WFShape.hxx
@@ -31,50 +31,50 @@ class StdPrs_WFShape : public Prs3d_Root
 public:
 
   //! Computes wireframe presentation of a shape.
-  //! @param thePresentation [in] the presentation.
-  //! @param theShape [in] the shape.
-  //! @param theDrawer [in] the draw settings.
-  //! @param theIsParallel [in] perform algorithm using multiple threads
+  //! @param[in] thePresentation  the presentation.
+  //! @param[in] theShape  the shape.
+  //! @param[in] theDrawer  the draw settings.
+  //! @param[in] theIsParallel  perform algorithm using multiple threads
   Standard_EXPORT static void Add (const Handle(Prs3d_Presentation)& thePresentation,
                                    const TopoDS_Shape& theShape,
                                    const Handle(Prs3d_Drawer)& theDrawer,
                                    Standard_Boolean theIsParallel = Standard_False);
 
   //! Compute free and boundary edges on a triangulation of each face in the given shape.
-  //! @param theShape              [in] the list of triangulated faces
-  //! @param theToExcludeGeometric [in] flag indicating that Faces with defined Surface should be skipped
+  //! @param[in] theShape               the list of triangulated faces
+  //! @param[in] theToExcludeGeometric  flag indicating that Faces with defined Surface should be skipped
   Standard_EXPORT static Handle(Graphic3d_ArrayOfPrimitives) AddEdgesOnTriangulation (const TopoDS_Shape&    theShape,
                                                                                       const Standard_Boolean theToExcludeGeometric = Standard_True);
 
   //! Compute free and boundary edges on a triangulation of each face in the given shape.
-  //! @param theSegments           [in] the sequence of points defining segments
-  //! @param theShape              [in] the list of triangulated faces
-  //! @param theToExcludeGeometric [in] flag indicating that Faces with defined Surface should be skipped
+  //! @param[in] theSegments            the sequence of points defining segments
+  //! @param[in] theShape               the list of triangulated faces
+  //! @param[in] theToExcludeGeometric  flag indicating that Faces with defined Surface should be skipped
   Standard_EXPORT static void AddEdgesOnTriangulation (TColgp_SequenceOfPnt&  theSegments,
                                                        const TopoDS_Shape&    theShape,
                                                        const Standard_Boolean theToExcludeGeometric = Standard_True);
 
   //! Compute all edges (wire, free, unfree) and put them into single primitive array.
-  //! @param theShape [in] the shape
-  //! @param theDrawer [in] the drawer settings (deviation angle and maximal parameter value)
+  //! @param[in] theShape  the shape
+  //! @param[in] theDrawer  the drawer settings (deviation angle and maximal parameter value)
   Standard_EXPORT static Handle(Graphic3d_ArrayOfPrimitives) AddAllEdges (const TopoDS_Shape& theShape,
                                                                           const Handle(Prs3d_Drawer)& theDrawer);
 
   //! Compute vertex presentation for a shape.
-  //! @param theShape [in] the shape
-  //! @param theVertexMode [in] vertex filter
+  //! @param[in] theShape  the shape
+  //! @param[in] theVertexMode  vertex filter
   Standard_EXPORT static Handle(Graphic3d_ArrayOfPoints) AddVertexes (const TopoDS_Shape& theShape,
                                                                       Prs3d_VertexDrawMode theVertexMode);
 
 private:
 
   //! Compute edge presentations for a shape.
-  //! @param theShape [in] the shape
-  //! @param theDrawer [in] the drawer settings (deviation angle and maximal parameter value)
-  //! @param theShapeDeflection [in] the deflection for the wireframe shape
-  //! @param theWire [out] output polylines for lonely wires
-  //! @param theFree [out] output polylines for free edges
-  //! @param theUnFree [out] output polylines for non-free edges
+  //! @param[in] theShape  the shape
+  //! @param[in] theDrawer  the drawer settings (deviation angle and maximal parameter value)
+  //! @param[in] theShapeDeflection  the deflection for the wireframe shape
+  //! @param[out] theWire  output polylines for lonely wires
+  //! @param[out] theFree  output polylines for free edges
+  //! @param[out] theUnFree  output polylines for non-free edges
   Standard_EXPORT static void addEdges (const TopoDS_Shape& theShape,
                                         const Handle(Prs3d_Drawer)& theDrawer,
                                         Standard_Real theShapeDeflection,
@@ -83,10 +83,10 @@ private:
                                         Prs3d_NListOfSequenceOfPnt* theUnFree);
 
   //! Compute edge presentations for a shape.
-  //! @param theEdges [in] the list of edges
-  //! @param theDrawer [in] the drawer settings (deviation angle and maximal parameter value)
-  //! @param theShapeDeflection [in] the deflection for the wireframe shape
-  //! @param thePolylines [out] output polylines
+  //! @param[in] theEdges  the list of edges
+  //! @param[in] theDrawer  the drawer settings (deviation angle and maximal parameter value)
+  //! @param[in] theShapeDeflection  the deflection for the wireframe shape
+  //! @param[out] thePolylines  output polylines
   static void addEdges (const TopTools_ListOfShape& theEdges,
                         const Handle(Prs3d_Drawer)& theDrawer,
                         const Standard_Real         theShapeDeflection,

--- a/src/TCollection/TCollection_AsciiString.hxx
+++ b/src/TCollection/TCollection_AsciiString.hxx
@@ -438,7 +438,7 @@ Standard_Boolean operator > (const TCollection_AsciiString& other) const
   Standard_EXPORT Standard_Boolean IsIntegerValue() const;
   
   //! Returns True if the AsciiString starts with some characters that can be interpreted as integer or real value.
-  //! @param theToCheckFull [in] when TRUE, checks if entire string defines a real value;
+  //! @param[in] theToCheckFull  when TRUE, checks if entire string defines a real value;
   //!                            otherwise checks if string starts with a real value
   //! Note: an integer value is considered to be a real value as well.
   Standard_EXPORT Standard_Boolean IsRealValue (Standard_Boolean theToCheckFull = Standard_False) const;

--- a/src/TDataStd/TDataStd_NamedData.hxx
+++ b/src/TDataStd/TDataStd_NamedData.hxx
@@ -148,8 +148,8 @@ public:
   Standard_EXPORT const Handle(TColStd_HArray1OfInteger)& GetArrayOfIntegers (const TCollection_ExtendedString& theName);
 
   //! Defines a named array of integer values.
-  //! @param theName [in] key
-  //! @param theArrayOfIntegers [in] new value, overrides existing (passed array will be copied by value!)
+  //! @param[in] theName  key
+  //! @param[in] theArrayOfIntegers  new value, overrides existing (passed array will be copied by value!)
   void SetArrayOfIntegers (const TCollection_ExtendedString& theName,
                            const Handle(TColStd_HArray1OfInteger)& theArrayOfIntegers)
   {
@@ -226,7 +226,7 @@ public: //! @name late-load deferred data interface
 
   //! Load data from deferred storage, without calling Backup().
   //! As result, the content of the object will be overridden by data from deferred storage (which is normally read-only).
-  //! @param theToKeepDeferred [in] when TRUE, the link to deferred storage will be preserved
+  //! @param[in] theToKeepDeferred  when TRUE, the link to deferred storage will be preserved
   //!                               so that it will be possible calling UnloadDeferredData() afterwards for releasing memory
   //! @return FALSE if deferred storage is unavailable or deferred data has been already loaded
   virtual Standard_Boolean LoadDeferredData (Standard_Boolean theToKeepDeferred = false)

--- a/src/V3d/V3d_Trihedron.hxx
+++ b/src/V3d/V3d_Trihedron.hxx
@@ -81,7 +81,7 @@ public:
   Standard_EXPORT void SetNbFacets (const Standard_Integer theNbFacets);
 
   //! Return text aspect for specified axis.
-  //! @param theAxis [in] axis index
+  //! @param[in] theAxis  axis index
   //! @return text aspect
   const Handle(Prs3d_TextAspect)& LabelAspect (V3d_TypeOfAxe theAxis) const { return myTextAspects[theAxis]; }
 
@@ -94,7 +94,7 @@ public:
   Standard_EXPORT void SetLabelsColor (const Quantity_Color& theColor);
 
   //! Return shading aspect for specified axis.
-  //! @param theAxis [in] axis index
+  //! @param[in] theAxis  axis index
   //! @return shading aspect
   const Handle(Prs3d_ShadingAspect)& ArrowAspect (V3d_TypeOfAxe theAxis) const { return myArrowShadingAspects[theAxis]; }
 
@@ -107,7 +107,7 @@ public:
   const Handle(Prs3d_ShadingAspect)& OriginAspect() const { return mySphereShadingAspect; }
 
   //! Return axis text.
-  //! @param theAxis [in] axis index
+  //! @param[in] theAxis  axis index
   //! @return text of the label
   const TCollection_AsciiString& Label (V3d_TypeOfAxe theAxis) const { return myLabels[theAxis]; }
 

--- a/src/V3d/V3d_View.hxx
+++ b/src/V3d/V3d_View.hxx
@@ -152,7 +152,7 @@ public:
   //! The auto z-fit has extra parameters which can controlled from application level
   //! to ensure that the size of viewing volume will be sufficiently large to cover
   //! the depth of unmanaged objects, for example, transformation persistent ones.
-  //! @param theScaleFactor [in] the scale factor for Z-range.
+  //! @param[in] theScaleFactor  the scale factor for Z-range.
   //! The range between Z-min, Z-max projection volume planes
   //! evaluated by z fitting method will be scaled using this coefficient.
   //! Program error exception is thrown if negative or zero value
@@ -465,10 +465,10 @@ public:
   //! view projection. Can be used to perform interactive panning operation.
   //! In that case the DXv, DXy parameters specify panning relative to the
   //! point where the operation is started.
-  //! @param theDXv [in] the relative panning on "x" axis of view projection, in view space coordinates.
-  //! @param theDYv [in] the relative panning on "y" axis of view projection, in view space coordinates.
-  //! @param theZoomFactor [in] the zooming factor.
-  //! @param theToStart [in] pass TRUE when starting panning to remember view
+  //! @param[in] theDXv  the relative panning on "x" axis of view projection, in view space coordinates.
+  //! @param[in] theDYv  the relative panning on "y" axis of view projection, in view space coordinates.
+  //! @param[in] theZoomFactor  the zooming factor.
+  //! @param[in] theToStart  pass TRUE when starting panning to remember view
   //! state prior to panning for relative arguments. If panning is started,
   //! passing {0, 0} for {theDXv, theDYv} will return view to initial state.
   //! Performs update of view.
@@ -478,8 +478,8 @@ public:
   //! {Xp, Yp} pixel coordinates relative to the bottom-left corner of
   //! screen. To calculate pixel coordinates for any point from world
   //! coordinate space, it can be projected using "Project".
-  //! @param theXp [in] the x coordinate.
-  //! @param theYp [in] the y coordinate.
+  //! @param[in] theXp  the x coordinate.
+  //! @param[in] theYp  the y coordinate.
   Standard_EXPORT void SetCenter (const Standard_Integer theXp, const Standard_Integer theYp);
 
   //! Defines the view projection size in its maximum dimension,
@@ -518,17 +518,17 @@ public:
   //! The Z clipping range (depth range) is fitted if AutoZFit flag is TRUE.
   //! Throws program error exception if margin coefficient is < 0 or >= 1.
   //! Updates the view.
-  //! @param theMargin [in] the margin coefficient for view borders.
-  //! @param theToUpdate [in] flag to perform view update.
+  //! @param[in] theMargin  the margin coefficient for view borders.
+  //! @param[in] theToUpdate  flag to perform view update.
   Standard_EXPORT void FitAll (const Standard_Real theMargin = 0.01, const Standard_Boolean theToUpdate = Standard_True);
 
   //! Adjust view parameters to fit the displayed scene, respecting height / width ratio
   //! according to the custom bounding box given.
   //! Throws program error exception if margin coefficient is < 0 or >= 1.
   //! Updates the view.
-  //! @param theBox [in] the custom bounding box to fit.
-  //! @param theMargin [in] the margin coefficient for view borders.
-  //! @param theToUpdate [in] flag to perform view update.
+  //! @param[in] theBox  the custom bounding box to fit.
+  //! @param[in] theMargin  the margin coefficient for view borders.
+  //! @param[in] theToUpdate  flag to perform view update.
   Standard_EXPORT void FitAll (const Bnd_Box& theBox, const Standard_Real theMargin = 0.01, const Standard_Boolean theToUpdate = Standard_True);
 
   //! Adjusts the viewing volume so as not to clip the displayed objects by front and back
@@ -546,10 +546,10 @@ public:
   //! Centers the defined PIXEL window so that it occupies
   //! the maximum space while respecting the initial height/width ratio.
   //! NOTE than the original Z size of the view is NOT modified.
-  //! @param theMinXp [in] pixel coordinates of minimal corner on x screen axis.
-  //! @param theMinYp [in] pixel coordinates of minimal corner on y screen axis.
-  //! @param theMaxXp [in] pixel coordinates of maximal corner on x screen axis.
-  //! @param theMaxYp [in] pixel coordinates of maximal corner on y screen axis.
+  //! @param[in] theMinXp  pixel coordinates of minimal corner on x screen axis.
+  //! @param[in] theMinYp  pixel coordinates of minimal corner on y screen axis.
+  //! @param[in] theMaxXp  pixel coordinates of maximal corner on x screen axis.
+  //! @param[in] theMaxYp  pixel coordinates of maximal corner on y screen axis.
   Standard_EXPORT void WindowFit (const Standard_Integer theMinXp, const Standard_Integer theMinYp, const Standard_Integer theMaxXp, const Standard_Integer theMaxYp);
 
   //! Saves the current view mapping. This will be the
@@ -739,10 +739,10 @@ public:
   //! view projection. Can be used to perform interactive panning operation.
   //! In that case the DXp, DXp parameters specify panning relative to the
   //! point where the operation is started.
-  //! @param theDXp [in] the relative panning on "x" axis of view projection, in pixels.
-  //! @param theDYp [in] the relative panning on "y" axis of view projection, in pixels.
-  //! @param theZoomFactor [in] the zooming factor.
-  //! @param theToStart [in] pass TRUE when starting panning to remember view
+  //! @param[in] theDXp  the relative panning on "x" axis of view projection, in pixels.
+  //! @param[in] theDYp  the relative panning on "y" axis of view projection, in pixels.
+  //! @param[in] theZoomFactor  the zooming factor.
+  //! @param[in] theToStart  pass TRUE when starting panning to remember view
   //! state prior to panning for relative arguments. Passing 0 for relative
   //! panning parameter should return view panning to initial state.
   //! Performs update of view.
@@ -750,15 +750,15 @@ public:
 
   //! Zoom the view according to a zoom factor computed
   //! from the distance between the 2 mouse position.
-  //! @param theXp1 [in] the x coordinate of first mouse position, in pixels.
-  //! @param theYp1 [in] the y coordinate of first mouse position, in pixels.
-  //! @param theXp2 [in] the x coordinate of second mouse position, in pixels.
-  //! @param theYp2 [in] the y coordinate of second mouse position, in pixels.
+  //! @param[in] theXp1  the x coordinate of first mouse position, in pixels.
+  //! @param[in] theYp1  the y coordinate of first mouse position, in pixels.
+  //! @param[in] theXp2  the x coordinate of second mouse position, in pixels.
+  //! @param[in] theYp2  the y coordinate of second mouse position, in pixels.
   Standard_EXPORT void Zoom (const Standard_Integer theXp1, const Standard_Integer theYp1, const Standard_Integer theXp2, const Standard_Integer theYp2);
 
   //! Defines starting point for ZoomAtPoint view operation.
-  //! @param theXp [in] the x mouse coordinate, in pixels.
-  //! @param theYp [in] the y mouse coordinate, in pixels.
+  //! @param[in] theXp  the x mouse coordinate, in pixels.
+  //! @param[in] theYp  the y mouse coordinate, in pixels.
   Standard_EXPORT void StartZoomAtPoint (const Standard_Integer theXp, const Standard_Integer theYp);
 
   //! Zooms the model at a pixel defined by the method StartZoomAtPoint().
@@ -808,12 +808,12 @@ public:
   }
 
   //! Transform camera eye, center and scale to fit in the passed bounding box specified in WCS.
-  //! @param theCamera [in] the camera
-  //! @param theBox    [in] the bounding box
-  //! @param theMargin [in] the margin coefficient for view borders
-  //! @param theResolution [in] the minimum size of projection of bounding box in Xv or Yv direction when it considered to be a thin plane or point (without a volume);
+  //! @param[in] theCamera  the camera
+  //! @param[in] theBox     the bounding box
+  //! @param[in] theMargin  the margin coefficient for view borders
+  //! @param[in] theResolution  the minimum size of projection of bounding box in Xv or Yv direction when it considered to be a thin plane or point (without a volume);
   //!                           in this case only the center of camera is adjusted
-  //! @param theToEnlargeIfLine [in] when TRUE - in cases when the whole bounding box projected into thin line going along Z-axis of screen,
+  //! @param[in] theToEnlargeIfLine  when TRUE - in cases when the whole bounding box projected into thin line going along Z-axis of screen,
   //!                                the view plane is enlarged such thatwe see the whole line on rotation, otherwise only the center of camera is adjusted.
   //! @return TRUE if the fit all operation can be done
   Standard_EXPORT Standard_Boolean FitMinMax (const Handle(Graphic3d_Camera)& theCamera,
@@ -884,11 +884,11 @@ public:
   //! rendering space to convex volume. Number of supported clip planes can be consulted
   //! by PlaneLimit method of associated Graphic3d_GraphicDriver.
   //! Please be aware that the planes which exceed the limit are ignored during rendering.
-  //! @param thePlane [in] the clip plane to be added to view.
+  //! @param[in] thePlane  the clip plane to be added to view.
   Standard_EXPORT virtual void AddClipPlane (const Handle(Graphic3d_ClipPlane)& thePlane);
 
   //! Removes clip plane from the view.
-  //! @param thePlane [in] the clip plane to be removed from view.
+  //! @param[in] thePlane  the clip plane to be removed from view.
   Standard_EXPORT virtual void RemoveClipPlane (const Handle(Graphic3d_ClipPlane)& thePlane);
 
   //! Get clip planes.
@@ -901,7 +901,7 @@ public:
   //! clip planes can be consulted by InquirePlaneLimit method of
   //! Graphic3d_GraphicDriver. Please be aware that the planes that
   //! exceed the limit are ignored during rendering.
-  //! @param thePlanes [in] the clip planes to set.
+  //! @param[in] thePlanes  the clip planes to set.
   Standard_EXPORT void SetClipPlanes (const Handle(Graphic3d_SequenceOfHClipPlane)& thePlanes);
 
   //! Returns the MAX number of clipping planes associated to the view.
@@ -1006,8 +1006,8 @@ protected:
   //! Scales camera to fit the view frame of defined width and height
   //! keeping the aspect. For orthogonal camera the method changes scale,
   //! for perspective adjusts Eye location about the Center point.
-  //! @param theSizeXv [in] size of viewport frame on "x" axis.
-  //! @param theSizeYv [in] size of viewport frame on "y" axis.
+  //! @param[in] theSizeXv  size of viewport frame on "x" axis.
+  //! @param[in] theSizeYv  size of viewport frame on "y" axis.
   Standard_EXPORT void Scale (const Handle(Graphic3d_Camera)& theCamera, const Standard_Real theSizeXv, const Standard_Real theSizeYv) const;
 
   Standard_EXPORT void Translate (const Handle(Graphic3d_Camera)& theCamera, const Standard_Real theDXv, const Standard_Real theDYv) const;

--- a/src/V3d/V3d_Viewer.hxx
+++ b/src/V3d/V3d_Viewer.hxx
@@ -169,8 +169,8 @@ public:
   //! Add a new top-level Z layer to all managed views and get its ID as <theLayerId> value.
   //! The Z layers are controlled entirely by viewer, it is not possible to add a layer to a particular view.
   //! Custom layers will be inserted before Graphic3d_ZLayerId_Top (e.g. between Graphic3d_ZLayerId_Default and before Graphic3d_ZLayerId_Top).
-  //! @param theLayerId [out] id of created layer
-  //! @param theSettings [in] new layer settings
+  //! @param[out] theLayerId  id of created layer
+  //! @param[in] theSettings  new layer settings
   //! @return FALSE if the layer can not be created
   Standard_Boolean AddZLayer (Graphic3d_ZLayerId& theLayerId,
                               const Graphic3d_ZLayerSettings& theSettings = Graphic3d_ZLayerSettings())
@@ -182,9 +182,9 @@ public:
   //! The Z layers are controlled entirely by viewer, it is not possible to add a layer to a particular view.
   //! Layer rendering order is defined by its position in list (altered by theLayerAfter)
   //! and IsImmediate() flag (all layers with IsImmediate() flag are drawn afterwards);
-  //! @param theNewLayerId [out] id of created layer; layer id is arbitrary and does not depend on layer position in the list
-  //! @param theSettings    [in] new layer settings
-  //! @param theLayerAfter  [in] id of layer to append new layer before
+  //! @param[out] theNewLayerId  id of created layer; layer id is arbitrary and does not depend on layer position in the list
+  //! @param[in] theSettings     new layer settings
+  //! @param[in] theLayerAfter   id of layer to append new layer before
   //! @return FALSE if the layer can not be created
   Standard_EXPORT Standard_Boolean InsertLayerBefore (Graphic3d_ZLayerId& theNewLayerId,
                                                       const Graphic3d_ZLayerSettings& theSettings,
@@ -194,9 +194,9 @@ public:
   //! The Z layers are controlled entirely by viewer, it is not possible to add a layer to a particular view.
   //! Layer rendering order is defined by its position in list (altered by theLayerAfter)
   //! and IsImmediate() flag (all layers with IsImmediate() flag are drawn afterwards);
-  //! @param theNewLayerId [out] id of created layer; layer id is arbitrary and does not depend on layer position in the list
-  //! @param theSettings    [in] new layer settings
-  //! @param theLayerBefore [in] id of layer to append new layer after
+  //! @param[out] theNewLayerId  id of created layer; layer id is arbitrary and does not depend on layer position in the list
+  //! @param[in] theSettings     new layer settings
+  //! @param[in] theLayerBefore  id of layer to append new layer after
   //! @return FALSE if the layer can not be created
   Standard_EXPORT Standard_Boolean InsertLayerAfter (Graphic3d_ZLayerId& theNewLayerId,
                                                      const Graphic3d_ZLayerSettings& theSettings,

--- a/src/ViewerTest/ViewerTest.hxx
+++ b/src/ViewerTest/ViewerTest.hxx
@@ -223,8 +223,8 @@ public:
                                                              Graphic3d_TypeOfShadingModel& theModel);
 
   //! Parses ZLayer name.
-  //! @param theArg [in] layer name or enumeration alias
-  //! @param theLayer [out] layer index
+  //! @param[in] theArg  layer name or enumeration alias
+  //! @param[out] theLayer  layer index
   //! @return TRUE if layer has been identified, note that Graphic3d_ZLayerId_UNKNOWN is also valid value
   static Standard_Boolean ParseZLayerName (Standard_CString theArg,
                                            Graphic3d_ZLayerId& theLayer)
@@ -233,8 +233,8 @@ public:
   }
 
   //! Parses ZLayer name.
-  //! @param theArg [in] layer name, enumeration alias or index (of existing Layer)
-  //! @param theLayer [out] layer index
+  //! @param[in] theArg  layer name, enumeration alias or index (of existing Layer)
+  //! @param[out] theLayer  layer index
   //! @return TRUE if layer has been identified, note that Graphic3d_ZLayerId_UNKNOWN is also valid value
   static Standard_Boolean ParseZLayer (Standard_CString theArg,
                                        Graphic3d_ZLayerId& theLayer)
@@ -273,9 +273,9 @@ public: //! @name deprecated methods
 private:
 
   //! Parses ZLayer name.
-  //! @param theArg [in] layer name, enumeration alias or index (of existing Layer)
-  //! @param theToAllowInteger [in] when TRUE, the argument will be checked for existing layer index
-  //! @param theLayer [out] layer index
+  //! @param[in] theArg  layer name, enumeration alias or index (of existing Layer)
+  //! @param[in] theToAllowInteger  when TRUE, the argument will be checked for existing layer index
+  //! @param[out] theLayer  layer index
   //! @return TRUE if layer has been identified, note that Graphic3d_ZLayerId_UNKNOWN is also valid value
   Standard_EXPORT static Standard_Boolean parseZLayer (Standard_CString theArg,
                                                        Standard_Boolean theToAllowInteger,

--- a/src/Vrml/Vrml_Provider.hxx
+++ b/src/Vrml/Vrml_Provider.hxx
@@ -46,7 +46,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -57,7 +57,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -67,7 +67,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theDocument document to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     const Handle(TDocStd_Document)& theDocument,
@@ -76,7 +76,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theDocument document to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const Handle(TDocStd_Document)& theDocument,
@@ -86,7 +86,7 @@ public:
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -97,7 +97,7 @@ public:
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
   //! @param[in] theWS current work session
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,
@@ -107,7 +107,7 @@ public:
   //! Reads a CAD file, according internal configuration
   //! @param[in] thePath path to the import CAD file
   //! @param[out] theShape shape to save result
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Read operation has ended correctly
   Standard_EXPORT virtual bool Read(const TCollection_AsciiString& thePath,
                                     TopoDS_Shape& theShape,
@@ -116,7 +116,7 @@ public:
   //! Writes a CAD file, according internal configuration
   //! @param[in] thePath path to the export CAD file
   //! @param[out] theShape shape to export
-  //! @param theProgress[in] progress indicator
+  //! @param[in] theProgress progress indicator
   //! @return true if Write operation has ended correctly
   Standard_EXPORT virtual bool Write(const TCollection_AsciiString& thePath,
                                      const TopoDS_Shape& theShape,

--- a/src/WNT/WNT_HIDSpaceMouse.hxx
+++ b/src/WNT/WNT_HIDSpaceMouse.hxx
@@ -109,8 +109,8 @@ public:
   }
 
   //! Return new translation values.
-  //! @param theIsIdle [out] flag indicating idle state (no translation)
-  //! @param theIsQuadric [in] flag to apply non-linear scale factor
+  //! @param[out] theIsIdle  flag indicating idle state (no translation)
+  //! @param[in] theIsQuadric  flag to apply non-linear scale factor
   //! @return vector of 3 elements defining translation values within [-1..1] range, 0 meaning idle,
   //!         .x defining left/right slide, .y defining forward/backward and .z defining up/down slide.
   Standard_EXPORT Graphic3d_Vec3d Translation (bool& theIsIdle,
@@ -124,8 +124,8 @@ public:
   }
 
   //! Return new rotation values.
-  //! @param theIsIdle [out] flag indicating idle state (no rotation)
-  //! @param theIsQuadric [in] flag to apply non-linear scale factor
+  //! @param[out] theIsIdle  flag indicating idle state (no rotation)
+  //! @param[in] theIsQuadric  flag to apply non-linear scale factor
   //! @return vector of 3 elements defining rotation values within [-1..1] range, 0 meaning idle,
   //!         .x defining tilt, .y defining roll and .z defining spin.
   Standard_EXPORT Graphic3d_Vec3d Rotation (bool& theIsIdle,

--- a/src/WNT/WNT_Window.hxx
+++ b/src/WNT/WNT_Window.hxx
@@ -82,7 +82,7 @@ public:
   
   //! Opens a window according to the map mode.
   //! This method is specific to Windows NT.
-  //! @param theMapMode [in] can be one of SW_xxx constants defined in <windows.h>
+  //! @param[in] theMapMode  can be one of SW_xxx constants defined in <windows.h>
   Standard_EXPORT void Map (const Standard_Integer theMapMode) const;
 
   //! Closes the window <me>.
@@ -143,13 +143,13 @@ public:
   };
 
   //! RegisterRawInputDevices() wrapper.
-  //! @param theRawDeviceMask [in] mask of RawInputMask flags
+  //! @param[in] theRawDeviceMask  mask of RawInputMask flags
   //! @return number of actually registered device types
   Standard_EXPORT int RegisterRawInputDevices (unsigned int theRawDeviceMask);
 
   //! Process a single window message.
-  //! @param theListener [in][out] listener to redirect message
-  //! @param theMsg [in][out] message to process
+  //! @param[in][out] theListener  listener to redirect message
+  //! @param[in][out] theMsg  message to process
   //! @return TRUE if message has been processed
   Standard_EXPORT virtual bool ProcessMessage (Aspect_WindowInputListener& theListener,
                                                MSG& theMsg);

--- a/src/XCAFDoc/XCAFDoc_AssemblyGraph.hxx
+++ b/src/XCAFDoc/XCAFDoc_AssemblyGraph.hxx
@@ -59,8 +59,8 @@ public:
 
     //! \brief Accepting the assembly graph and starting node to iterate.
     //! Iteration starts from the specified node.
-    //! \param [in] theGraph - assembly graph to iterate.
-    //! \param [in] theNode  - graph node ID.
+    //! \param[in]  theGraph - assembly graph to iterate.
+    //! \param[in]  theNode  - graph node ID.
     Standard_EXPORT Iterator(const Handle(XCAFDoc_AssemblyGraph)& theGraph,
                              const Standard_Integer               theNode = 1);
 
@@ -94,14 +94,14 @@ public:
 
   //! \brief Constructs graph from XCAF document.
   //! Construction of a formal graph will be done immediately.
-  //! \param [in] theDoc - document to iterate.
+  //! \param[in]  theDoc - document to iterate.
   Standard_EXPORT XCAFDoc_AssemblyGraph(const Handle(TDocStd_Document)& theDoc);
 
   //! \brief Constructs graph from XCAF label.
   //! Construction of a formal graph will be done immediately. The specified
   //! label is used as a starting position.
-  //! \param [in] theDoc   - document to iterate.
-  //! \param [in] theLabel - starting position.
+  //! \param[in]  theDoc   - document to iterate.
+  //! \param[in]  theLabel - starting position.
   Standard_EXPORT XCAFDoc_AssemblyGraph(const TDF_Label& theLabel);
 
   //! \return Document shape tool.
@@ -118,14 +118,14 @@ public:
   }
 
   //! \brief Checks whether the assembly graph contains (n1, n2) directed link.
-  //! \param [in] theNode1 - one-based ID of the first node.
-  //! \param [in] theNode2 - one-based ID of the second node.
+  //! \param[in]  theNode1 - one-based ID of the first node.
+  //! \param[in]  theNode2 - one-based ID of the second node.
   //! \return true/false.
   Standard_EXPORT Standard_Boolean IsDirectLink(const Standard_Integer theNode1,
                                                 const Standard_Integer theNode2) const;
 
   //! \brief Checks whether direct children exist for the given node.
-  //! \param [in] theNode - one-based node ID.
+  //! \param[in]  theNode - one-based node ID.
   //! \return true/false.
   Standard_Boolean HasChildren(const Standard_Integer theNode) const
   {
@@ -133,7 +133,7 @@ public:
   }
 
   //! \brief Returns IDs of child nodes for the given node.
-  //! \param [in] theNode - one-based node ID.
+  //! \param[in]  theNode - one-based node ID.
   //! \return set of child IDs.
   const TColStd_PackedMapOfInteger& GetChildren(const Standard_Integer theNode) const
   {
@@ -141,13 +141,13 @@ public:
   }
 
   //! \brief Returns the node type from \ref NodeType enum.
-  //! \param [in] theNode - one-based node ID.
+  //! \param[in]  theNode - one-based node ID.
   //! \return node type.
   //! \sa NodeType
   Standard_EXPORT NodeType GetNodeType(const Standard_Integer theNode) const;
 
   //! \brief returns object ID by node ID.
-  //! \param [in] theNode - one-based node ID.
+  //! \param[in]  theNode - one-based node ID.
   //! \return persistent ID.
   const TDF_Label& GetNode(const Standard_Integer theNode) const
   {
@@ -180,27 +180,27 @@ public:
   Standard_EXPORT Standard_Integer NbLinks() const;
 
   //! Returns quantity of part usage occurrences.
-  //! \param [in] theNode - one-based part ID.
+  //! \param[in]  theNode - one-based part ID.
   //! \return usage occurrence quantity.
   Standard_EXPORT Standard_Integer NbOccurrences(const Standard_Integer theNode) const;
 
 private:
 
   //! Builds graph out of OCAF XDE structure.
-  //! \param [in] theLabel - optional starting position.
+  //! \param[in]  theLabel - optional starting position.
   Standard_EXPORT void buildGraph(const TDF_Label& theLabel);
 
   //! Adds components for the given parent to the graph structure.
-  //! \param [in] theParent   - OCAF label of the parent object.
-  //! \param [in] theParentId - ID of the already registered node representing
+  //! \param[in]  theParent   - OCAF label of the parent object.
+  //! \param[in]  theParentId - ID of the already registered node representing
   //!                           the parent object in the assembly graph
   //!                           being populated.
   Standard_EXPORT void addComponents(const TDF_Label&       theParent,
                                      const Standard_Integer theParentId);
 
   //! Adds node into the graph.
-  //! \param [in] theLabel    - label at insertion level.
-  //! \param [in] theParentId - parent one-based node IDS.
+  //! \param[in]  theLabel    - label at insertion level.
+  //! \param[in]  theParentId - parent one-based node IDS.
   //! \return one-based internal ID of the node.
   Standard_EXPORT Standard_Integer addNode(const TDF_Label&       theLabel,
                                            const Standard_Integer theParentId);

--- a/src/XCAFDoc/XCAFDoc_AssemblyItemId.hxx
+++ b/src/XCAFDoc/XCAFDoc_AssemblyItemId.hxx
@@ -32,22 +32,22 @@ public:
 
   //! Constructs an item ID from a list of strings, where every 
   //! string is a label entry.
-  //! \param [in] thePath - list of label entries.
+  //! \param[in]  thePath - list of label entries.
   Standard_EXPORT XCAFDoc_AssemblyItemId(const TColStd_ListOfAsciiString& thePath);
 
   //! Constructs an item ID from a formatted path, where label entries
   //! are separated by '/' symbol.
-  //! \param [in] theString - formatted full path.
+  //! \param[in]  theString - formatted full path.
   Standard_EXPORT XCAFDoc_AssemblyItemId(const TCollection_AsciiString& theString);
 
   //! Initializes the item ID from a list of strings, where every 
   //! string is a label entry.
-  //! \param [in] thePath - list of label entries.
+  //! \param[in]  thePath - list of label entries.
   Standard_EXPORT void Init(const TColStd_ListOfAsciiString& thePath);
 
   //! Initializes the item ID from a formatted path, where label entries
   //! are separated by '/' symbol.
-  //! \param [in] theString - formatted full path.
+  //! \param[in]  theString - formatted full path.
   Standard_EXPORT void Init(const TCollection_AsciiString& theString);
 
   //! Returns true if the full path is empty, otherwise - false.
@@ -57,17 +57,17 @@ public:
   Standard_EXPORT void Nullify();
 
   //! Checks if this item is a child of the given item.
-  //! \param [in] theOther - potentially ancestor item.
+  //! \param[in]  theOther - potentially ancestor item.
   //! \return true if the item is a child of theOther item, otherwise - false.
   Standard_EXPORT Standard_Boolean IsChild(const XCAFDoc_AssemblyItemId& theOther) const;
 
   //! Checks if this item is a direct child of the given item.
-  //! \param [in] theOther - potentially parent item.
+  //! \param[in]  theOther - potentially parent item.
   //! \return true if the item is a direct child of theOther item, otherwise - false.
   Standard_EXPORT Standard_Boolean IsDirectChild(const XCAFDoc_AssemblyItemId& theOther) const;
 
   //! Checks for item IDs equality.
-  //! \param [in] theOther - the item ID to check equality with.
+  //! \param[in]  theOther - the item ID to check equality with.
   //! \return true if this ID is equal to theOther, otherwise - false.
   Standard_EXPORT Standard_Boolean IsEqual(const XCAFDoc_AssemblyItemId& theOther) const;
 

--- a/src/XCAFDoc/XCAFDoc_AssemblyItemRef.hxx
+++ b/src/XCAFDoc/XCAFDoc_AssemblyItemRef.hxx
@@ -43,25 +43,25 @@ public:
   //! @{
 
   //! Create (if not exist) a reference to an assembly item.
-  //! \param [in] theLabel  - label to add the attribute.
-  //! \param [in] theItemId - assembly item ID.
+  //! \param[in]  theLabel  - label to add the attribute.
+  //! \param[in]  theItemId - assembly item ID.
   //! \return A handle to the attribute instance.
   Standard_EXPORT static Handle(XCAFDoc_AssemblyItemRef) Set(const TDF_Label&              theLabel,
                                                              const XCAFDoc_AssemblyItemId& theItemId);
 
   //! Create (if not exist) a reference to an assembly item's label attribute.
-  //! \param [in] theLabel  - label to add the attribute.
-  //! \param [in] theItemId - assembly item ID.
-  //! \param [in] theGUID   - assembly item's label attribute ID.
+  //! \param[in]  theLabel  - label to add the attribute.
+  //! \param[in]  theItemId - assembly item ID.
+  //! \param[in]  theGUID   - assembly item's label attribute ID.
   //! \return A handle to the attribute instance.
   Standard_EXPORT static Handle(XCAFDoc_AssemblyItemRef) Set(const TDF_Label&              theLabel,
                                                              const XCAFDoc_AssemblyItemId& theItemId,
                                                              const Standard_GUID&          theGUID);
 
   //! Create (if not exist) a reference to an assembly item's subshape.
-  //! \param [in] theLabel      - label to add the attribute.
-  //! \param [in] theItemId     - assembly item ID.
-  //! \param [in] theShapeIndex - assembly item's subshape index.
+  //! \param[in]  theLabel      - label to add the attribute.
+  //! \param[in]  theItemId     - assembly item ID.
+  //! \param[in]  theShapeIndex - assembly item's subshape index.
   //! \return A handle to the attribute instance.
   Standard_EXPORT static Handle(XCAFDoc_AssemblyItemRef) Set(const TDF_Label&              theLabel,
                                                              const XCAFDoc_AssemblyItemId& theItemId,

--- a/src/XCAFDoc/XCAFDoc_AssemblyIterator.hxx
+++ b/src/XCAFDoc/XCAFDoc_AssemblyIterator.hxx
@@ -28,14 +28,14 @@ class XCAFDoc_AssemblyIterator
 public:
 
   //! Constructs iterator starting from assembly roots.
-  //! \param [in]      theDoc   - document to iterate.
+  //! \param[in]       theDoc   - document to iterate.
   //! \param [in, opt] theLevel - max level of hierarchy to reach (INT_MAX is for no limit).
   Standard_EXPORT XCAFDoc_AssemblyIterator(const Handle(TDocStd_Document)& theDoc,
                                            const Standard_Integer          theLevel = INT_MAX);
 
   //! Constructs iterator starting from the specified position in the assembly tree.
-  //! \param [in]      theDoc   - document to iterate.
-  //! \param [in]      theRoot  - assembly item to start iterating from.
+  //! \param[in]       theDoc   - document to iterate.
+  //! \param[in]       theRoot  - assembly item to start iterating from.
   //! \param [in, opt] theLevel - max level of hierarchy to reach (INT_MAX is for no limit).
   Standard_EXPORT XCAFDoc_AssemblyIterator(const Handle(TDocStd_Document)& theDoc,
                                            const XCAFDoc_AssemblyItemId&   theRoot,

--- a/src/XCAFDoc/XCAFDoc_AssemblyTool.hxx
+++ b/src/XCAFDoc/XCAFDoc_AssemblyTool.hxx
@@ -41,8 +41,8 @@ public:
   //!   return Standard_True;
   //! }
   //! ~~~~~
-  //! \param [in] theIterator - starting position in the assembly tree.
-  //! \param [in] theFunc     - user function called for each assembly tree node.
+  //! \param[in]  theIterator - starting position in the assembly tree.
+  //! \param[in]  theFunc     - user function called for each assembly tree node.
   template <typename Func>
   static void Traverse(XCAFDoc_AssemblyIterator theIterator,
                        Func                     theFunc)
@@ -69,10 +69,10 @@ public:
   //! ~~~~~
   //! User function theFunc takes the assembly graph passed for traversing, current
   //! graph node ID and returns true/false to continue/break.
-  //! \param [in] theGraph  - assembly graph.
-  //! \param [in] theFilter - user filtering function called for each assembly graph node.
-  //! \param [in] theFunc   - user function called for accepted assembly graph node.
-  //! \param [in] theNode   - starting positive one-based graph node ID.
+  //! \param[in]  theGraph  - assembly graph.
+  //! \param[in]  theFilter - user filtering function called for each assembly graph node.
+  //! \param[in]  theFunc   - user function called for accepted assembly graph node.
+  //! \param[in]  theNode   - starting positive one-based graph node ID.
   template <typename Func, typename Filter>
   static void Traverse(const Handle(XCAFDoc_AssemblyGraph)& theGraph,
                        Filter                               theFilter,

--- a/src/XCAFDoc/XCAFDoc_Note.hxx
+++ b/src/XCAFDoc/XCAFDoc_Note.hxx
@@ -38,8 +38,8 @@ public:
   Standard_EXPORT static Handle(XCAFDoc_Note) Get(const TDF_Label& theLabel);
 
   //! Sets the user name and the timestamp of the note.
-  //! \param [in] theUserName  - the user associated with the note.
-  //! \param [in] theTimeStamp - timestamp of the note.
+  //! \param[in]  theUserName  - the user associated with the note.
+  //! \param[in]  theTimeStamp - timestamp of the note.
   //! \return A handle to the attribute instance.
   Standard_EXPORT void Set(const TCollection_ExtendedString& theUserName,
                            const TCollection_ExtendedString& theTimeStamp);

--- a/src/XCAFDoc/XCAFDoc_NoteBalloon.hxx
+++ b/src/XCAFDoc/XCAFDoc_NoteBalloon.hxx
@@ -31,10 +31,10 @@ public:
   Standard_EXPORT static Handle(XCAFDoc_NoteBalloon) Get(const TDF_Label& theLabel);
 
   //! Create (if not exist) a comment note on the given label.
-  //! \param [in] theLabel     - note label.
-  //! \param [in] theUserName  - the name of the user, who created the note.
-  //! \param [in] theTimeStamp - creation timestamp of the note.
-  //! \param [in] theComment   - comment text.
+  //! \param[in]  theLabel     - note label.
+  //! \param[in]  theUserName  - the name of the user, who created the note.
+  //! \param[in]  theTimeStamp - creation timestamp of the note.
+  //! \param[in]  theComment   - comment text.
   Standard_EXPORT static Handle(XCAFDoc_NoteBalloon) Set(const TDF_Label&                  theLabel,
                                                          const TCollection_ExtendedString& theUserName,
                                                          const TCollection_ExtendedString& theTimeStamp,

--- a/src/XCAFDoc/XCAFDoc_NoteBinData.hxx
+++ b/src/XCAFDoc/XCAFDoc_NoteBinData.hxx
@@ -37,12 +37,12 @@ public:
   //! @{
 
   //! Create (if not exist) a binary note with data loaded from a binary file.
-  //! \param [in] theLabel     - label to add the attribute.
-  //! \param [in] theUserName  - the name of the user, who created the note.
-  //! \param [in] theTimeStamp - creation timestamp of the note.
-  //! \param [in] theTitle     - file title.
-  //! \param [in] theMIMEtype  - MIME type of the file.
-  //! \param [in] theFile      - input binary file.
+  //! \param[in]  theLabel     - label to add the attribute.
+  //! \param[in]  theUserName  - the name of the user, who created the note.
+  //! \param[in]  theTimeStamp - creation timestamp of the note.
+  //! \param[in]  theTitle     - file title.
+  //! \param[in]  theMIMEtype  - MIME type of the file.
+  //! \param[in]  theFile      - input binary file.
   //! \return A handle to the attribute instance.
   Standard_EXPORT static Handle(XCAFDoc_NoteBinData) Set(const TDF_Label&                  theLabel,
                                                          const TCollection_ExtendedString& theUserName,
@@ -52,12 +52,12 @@ public:
                                                          OSD_File&                         theFile);
 
   //! Create (if not exist) a binary note byte data array.
-  //! \param [in] theLabel     - label to add the attribute.
-  //! \param [in] theUserName  - the name of the user, who created the note.
-  //! \param [in] theTimeStamp - creation timestamp of the note.
-  //! \param [in] theTitle     - data title.
-  //! \param [in] theMIMEtype  - MIME type of data.
-  //! \param [in] theData      - byte data array.
+  //! \param[in]  theLabel     - label to add the attribute.
+  //! \param[in]  theUserName  - the name of the user, who created the note.
+  //! \param[in]  theTimeStamp - creation timestamp of the note.
+  //! \param[in]  theTitle     - data title.
+  //! \param[in]  theMIMEtype  - MIME type of data.
+  //! \param[in]  theData      - byte data array.
   //! \return A handle to the attribute instance.
   Standard_EXPORT static Handle(XCAFDoc_NoteBinData) Set(const TDF_Label&                     theLabel,
                                                          const TCollection_ExtendedString&    theUserName,
@@ -75,17 +75,17 @@ public:
   //! @{
 
   //! Sets title, MIME type and data from a binary file.
-  //! \param [in] theTitle     - file title.
-  //! \param [in] theMIMEtype  - MIME type of the file.
-  //! \param [in] theFile      - input binary file.
+  //! \param[in]  theTitle     - file title.
+  //! \param[in]  theMIMEtype  - MIME type of the file.
+  //! \param[in]  theFile      - input binary file.
   Standard_EXPORT Standard_Boolean Set(const TCollection_ExtendedString& theTitle,
                                        const TCollection_AsciiString&    theMIMEtype,
                                        OSD_File&                         theFile);
 
   //! Sets title, MIME type and data from a byte array.
-  //! \param [in] theTitle     - data title.
-  //! \param [in] theMIMEtype  - MIME type of data.
-  //! \param [in] theData      - byte data array.
+  //! \param[in]  theTitle     - data title.
+  //! \param[in]  theMIMEtype  - MIME type of data.
+  //! \param[in]  theData      - byte data array.
   Standard_EXPORT void Set(const TCollection_ExtendedString&    theTitle,
                            const TCollection_AsciiString&       theMIMEtype,
                            const Handle(TColStd_HArray1OfByte)& theData);

--- a/src/XCAFDoc/XCAFDoc_NoteComment.hxx
+++ b/src/XCAFDoc/XCAFDoc_NoteComment.hxx
@@ -31,10 +31,10 @@ public:
   Standard_EXPORT static Handle(XCAFDoc_NoteComment) Get(const TDF_Label& theLabel);
 
   //! Create (if not exist) a comment note on the given label.
-  //! \param [in] theLabel     - note label.
-  //! \param [in] theUserName  - the name of the user, who created the note.
-  //! \param [in] theTimeStamp - creation timestamp of the note.
-  //! \param [in] theComment   - comment text.
+  //! \param[in]  theLabel     - note label.
+  //! \param[in]  theUserName  - the name of the user, who created the note.
+  //! \param[in]  theTimeStamp - creation timestamp of the note.
+  //! \param[in]  theComment   - comment text.
   Standard_EXPORT static Handle(XCAFDoc_NoteComment) Set(const TDF_Label&                  theLabel,
                                                          const TCollection_ExtendedString& theUserName,
                                                          const TCollection_ExtendedString& theTimeStamp,

--- a/src/XCAFDoc/XCAFDoc_NotesTool.hxx
+++ b/src/XCAFDoc/XCAFDoc_NotesTool.hxx
@@ -101,21 +101,21 @@ public:
 
   //! Returns all labels from the notes hive.
   //! The label sequence isn't cleared beforehand.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[out]  theNoteLabels - sequence of labels.
   Standard_EXPORT void GetNotes(TDF_LabelSequence& theNoteLabels) const;
 
   //! Returns all labels from the annotated items hive.
   //! The label sequence isn't cleared beforehand.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[out]  theNoteLabels - sequence of labels.
   Standard_EXPORT void GetAnnotatedItems(TDF_LabelSequence& theLabels) const;
 
   //! Checks if the given assembly item is annotated.
-  //! \param [in] theItemId - assembly item ID.
+  //! \param[in]  theItemId - assembly item ID.
   //! \return true if the item is annotated, otherwise - false.
   Standard_EXPORT Standard_Boolean IsAnnotatedItem(const XCAFDoc_AssemblyItemId& theItemId) const;
 
   //! Checks if the given labeled item is annotated.
-  //! \param [in] theItemLabel - item label.
+  //! \param[in]  theItemLabel - item label.
   //! \return true if the item is annotated, otherwise - false.
   Standard_EXPORT Standard_Boolean IsAnnotatedItem(const TDF_Label& theItemLabel) const;
 
@@ -123,39 +123,39 @@ public:
   //! @{
 
   //! Finds a label of the given assembly item ID in the annotated items hive.
-  //! \param [in] theItemId - assembly item ID.
+  //! \param[in]  theItemId - assembly item ID.
   //! \return annotated item label if it is found, otherwise - null label.
   Standard_EXPORT TDF_Label FindAnnotatedItem(const XCAFDoc_AssemblyItemId& theItemId) const;
 
   //! Finds a label of the given labeled item in the annotated items hive.
-  //! \param [in] theItemLabel - item label.
+  //! \param[in]  theItemLabel - item label.
   //! \return annotated item label if it is found, otherwise - null label.
   Standard_EXPORT TDF_Label FindAnnotatedItem(const TDF_Label& theItemLabel) const;
 
   //! Finds a label of the given assembly item's attribute in the annotated items hive.
-  //! \param [in] theItemId - assembly item ID.
-  //! \param [in] theGUID   - assembly item's attribute GUID.
+  //! \param[in]  theItemId - assembly item ID.
+  //! \param[in]  theGUID   - assembly item's attribute GUID.
   //! \return annotated item label if it is found, otherwise - null label.
   Standard_EXPORT TDF_Label FindAnnotatedItemAttr(const XCAFDoc_AssemblyItemId& theItemId,
                                                   const Standard_GUID&          theGUID) const;
 
   //! Finds a label of the given labeled item's attribute in the annotated items hive.
-  //! \param [in] theItemLabel - item label.
-  //! \param [in] theGUID      - item's attribute GUID.
+  //! \param[in]  theItemLabel - item label.
+  //! \param[in]  theGUID      - item's attribute GUID.
   //! \return annotated item label if it is found, otherwise - null label.
   Standard_EXPORT TDF_Label FindAnnotatedItemAttr(const TDF_Label&     theItemLabel,
                                                   const Standard_GUID& theGUID) const;
 
   //! Finds a label of the given assembly item's subshape in the annotated items hive.
-  //! \param [in] theItemId        - assembly item ID.
-  //! \param [in] theSubshapeIndex - assembly item's subshape index.
+  //! \param[in]  theItemId        - assembly item ID.
+  //! \param[in]  theSubshapeIndex - assembly item's subshape index.
   //! \return annotated item label if it is found, otherwise - null label.
   Standard_EXPORT TDF_Label FindAnnotatedItemSubshape(const XCAFDoc_AssemblyItemId& theItemId,
                                                       Standard_Integer              theSubshapeIndex) const;
 
   //! Finds a label of the given labeled item's subshape in the annotated items hive.
-  //! \param [in] theItemLabel     - item label.
-  //! \param [in] theSubshapeIndex - labeled item's subshape index.
+  //! \param[in]  theItemLabel     - item label.
+  //! \param[in]  theSubshapeIndex - labeled item's subshape index.
   //! \return annotated item label if it is found, otherwise - null label.
   Standard_EXPORT TDF_Label FindAnnotatedItemSubshape(const TDF_Label& theItemLabel,
                                                       Standard_Integer theSubshapeIndex) const;
@@ -168,9 +168,9 @@ public:
   //! Create a new comment note.
   //! Creates a new label under the notes hive and attaches \ref XCAFDoc_NoteComment 
   //! attribute (derived ftom \ref XCAFDoc_Note).
-  //! \param [in] theUserName  - the user associated with the note.
-  //! \param [in] theTimeStamp - timestamp of the note.
-  //! \param [in] theComment   - textual comment.
+  //! \param[in]  theUserName  - the user associated with the note.
+  //! \param[in]  theTimeStamp - timestamp of the note.
+  //! \param[in]  theComment   - textual comment.
   //! \return a handle to the base note attribute.
   Standard_EXPORT Handle(XCAFDoc_Note) CreateComment(const TCollection_ExtendedString& theUserName,
                                                      const TCollection_ExtendedString& theTimeStamp,
@@ -179,9 +179,9 @@ public:
   //! Create a new 'balloon' note.
   //! Creates a new label under the notes hive and attaches \ref XCAFDoc_NoteBalloon 
   //! attribute (derived ftom \ref XCAFDoc_Note).
-  //! \param [in] theUserName  - the user associated with the note.
-  //! \param [in] theTimeStamp - timestamp of the note.
-  //! \param [in] theComment   - textual comment.
+  //! \param[in]  theUserName  - the user associated with the note.
+  //! \param[in]  theTimeStamp - timestamp of the note.
+  //! \param[in]  theComment   - textual comment.
   //! \return a handle to the base note attribute.
   Standard_EXPORT Handle(XCAFDoc_Note) CreateBalloon(const TCollection_ExtendedString& theUserName,
                                                      const TCollection_ExtendedString& theTimeStamp,
@@ -190,11 +190,11 @@ public:
   //! Create a new note with data loaded from a binary file.
   //! Creates a new label under the notes hive and attaches \ref XCAFDoc_NoteComment 
   //! attribute (derived ftom \ref XCAFDoc_Note).
-  //! \param [in] theUserName  - the user associated with the note.
-  //! \param [in] theTimeStamp - timestamp of the note.
-  //! \param [in] theTitle     - file title.
-  //! \param [in] theMIMEtype  - MIME type of the file.
-  //! \param [in] theFile      - input binary file.
+  //! \param[in]  theUserName  - the user associated with the note.
+  //! \param[in]  theTimeStamp - timestamp of the note.
+  //! \param[in]  theTitle     - file title.
+  //! \param[in]  theMIMEtype  - MIME type of the file.
+  //! \param[in]  theFile      - input binary file.
   //! \return a handle to the base note attribute.
   Standard_EXPORT Handle(XCAFDoc_Note) CreateBinData(const TCollection_ExtendedString& theUserName,
                                                      const TCollection_ExtendedString& theTimeStamp,
@@ -205,11 +205,11 @@ public:
   //! Create a new note with data loaded from a byte data array.
   //! Creates a new label under the notes hive and attaches \ref XCAFDoc_NoteComment 
   //! attribute (derived ftom \ref XCAFDoc_Note).
-  //! \param [in] theUserName  - the user associated with the note.
-  //! \param [in] theTimeStamp - timestamp of the note.
-  //! \param [in] theTitle     - data title.
-  //! \param [in] theMIMEtype  - MIME type of the file.
-  //! \param [in] theData      - byte data array.
+  //! \param[in]  theUserName  - the user associated with the note.
+  //! \param[in]  theTimeStamp - timestamp of the note.
+  //! \param[in]  theTitle     - data title.
+  //! \param[in]  theMIMEtype  - MIME type of the file.
+  //! \param[in]  theData      - byte data array.
   //! \return a handle to the base note attribute.
   Standard_EXPORT Handle(XCAFDoc_Note) CreateBinData(const TCollection_ExtendedString&    theUserName,
                                                      const TCollection_ExtendedString&    theTimeStamp,
@@ -225,8 +225,8 @@ public:
   //! Gets all note labels of the assembly item.
   //! Notes linked to item's subshapes or attributes aren't
   //! taken into account. The label sequence isn't cleared beforehand.
-  //! \param [in] theItemId      - assembly item ID.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[in]  theItemId      - assembly item ID.
+  //! \param[out]  theNoteLabels - sequence of labels.
   //! \return number of added labels.
   Standard_EXPORT Standard_Integer GetNotes(const XCAFDoc_AssemblyItemId& theItemId,
                                             TDF_LabelSequence&            theNoteLabels) const;
@@ -234,8 +234,8 @@ public:
   //! Gets all note labels of the labeled item.
   //! Notes linked to item's attributes aren't
   //! taken into account. The label sequence isn't cleared beforehand.
-  //! \param [in] theItemLabel   - item label.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[in]  theItemLabel   - item label.
+  //! \param[out]  theNoteLabels - sequence of labels.
   //! \return number of added labels.
   Standard_EXPORT Standard_Integer GetNotes(const TDF_Label&   theItemLabel,
                                             TDF_LabelSequence& theNoteLabels) const;
@@ -243,9 +243,9 @@ public:
   //! Gets all note labels of the assembly item's attribute.
   //! Notes linked to the item itself or to item's subshapes
   //! aren't taken into account. The label sequence isn't cleared beforehand.
-  //! \param [in] theItemId      - assembly item ID.
-  //! \param [in] theGUID        - assembly item's attribute GUID.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[in]  theItemId      - assembly item ID.
+  //! \param[in]  theGUID        - assembly item's attribute GUID.
+  //! \param[out]  theNoteLabels - sequence of labels.
   //! \return number of added labels.
   Standard_EXPORT Standard_Integer GetAttrNotes(const XCAFDoc_AssemblyItemId& theItemId,
                                                 const Standard_GUID&          theGUID,
@@ -254,9 +254,9 @@ public:
   //! Gets all note labels of the labeled item's attribute.
   //! Notes linked to the item itself or to item's subshapes
   //! aren't taken into account. The label sequence isn't cleared beforehand.
-  //! \param [in] theItemLabel   - item label.
-  //! \param [in] theGUID        - item's attribute GUID.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[in]  theItemLabel   - item label.
+  //! \param[in]  theGUID        - item's attribute GUID.
+  //! \param[out]  theNoteLabels - sequence of labels.
   //! \return number of added labels.
   Standard_EXPORT Standard_Integer GetAttrNotes(const TDF_Label&     theItemLabel,
                                                 const Standard_GUID& theGUID,
@@ -265,9 +265,9 @@ public:
   //! Gets all note labels of the annotated item.
   //! Notes linked to the item itself or to item's attributes
   //! taken into account. The label sequence isn't cleared beforehand.
-  //! \param [in] theItemId        - assembly item ID.
-  //! \param [in] theSubshapeIndex - assembly item's subshape index.
-  //! \param [out] theNoteLabels   - sequence of labels.
+  //! \param[in]  theItemId        - assembly item ID.
+  //! \param[in]  theSubshapeIndex - assembly item's subshape index.
+  //! \param[out]  theNoteLabels   - sequence of labels.
   //! \return number of added labels.
   Standard_EXPORT Standard_Integer GetSubshapeNotes(const XCAFDoc_AssemblyItemId& theItemId,
                                                     Standard_Integer              theSubshapeIndex,
@@ -279,50 +279,50 @@ public:
   //! @{
 
   //! Adds the given note to the assembly item.
-  //! \param [in] theNoteLabel - note label.
-  //! \param [in] theItemId    - assembly item ID.
+  //! \param[in]  theNoteLabel - note label.
+  //! \param[in]  theItemId    - assembly item ID.
   //! \return a handle to the assembly reference attribute.
   Standard_EXPORT Handle(XCAFDoc_AssemblyItemRef) AddNote(const TDF_Label&              theNoteLabel,
                                                           const XCAFDoc_AssemblyItemId& theItemId);
 
   //! Adds the given note to the labeled item.
-  //! \param [in] theNoteLabel - note label.
-  //! \param [in] theItemLabel - item label.
+  //! \param[in]  theNoteLabel - note label.
+  //! \param[in]  theItemLabel - item label.
   //! \return a handle to the assembly reference attribute.
   Standard_EXPORT Handle(XCAFDoc_AssemblyItemRef) AddNote(const TDF_Label& theNoteLabel,
                                                           const TDF_Label& theItemLabel);
 
   //! Adds the given note to the assembly item's attribute.
-  //! \param [in] theNoteLabel - note label.
-  //! \param [in] theItemId    - assembly item ID.
-  //! \param [in] theGUID      - assembly item's attribute GUID.
+  //! \param[in]  theNoteLabel - note label.
+  //! \param[in]  theItemId    - assembly item ID.
+  //! \param[in]  theGUID      - assembly item's attribute GUID.
   //! \return a handle to the assembly reference attribute.
   Standard_EXPORT Handle(XCAFDoc_AssemblyItemRef) AddNoteToAttr(const TDF_Label&              theNoteLabel,
                                                                 const XCAFDoc_AssemblyItemId& theItemId,
                                                                 const Standard_GUID&          theGUID);
 
   //! Adds the given note to the labeled item's attribute.
-  //! \param [in] theNoteLabel - note label.
-  //! \param [in] theItemLabel - item label.
-  //! \param [in] theGUID      - assembly item's attribute GUID.
+  //! \param[in]  theNoteLabel - note label.
+  //! \param[in]  theItemLabel - item label.
+  //! \param[in]  theGUID      - assembly item's attribute GUID.
   //! \return a handle to the assembly reference attribute.
   Standard_EXPORT Handle(XCAFDoc_AssemblyItemRef) AddNoteToAttr(const TDF_Label&     theNoteLabel,
                                                                 const TDF_Label&     theItemLabel,
                                                                 const Standard_GUID& theGUID);
 
   //! Adds the given note to the assembly item's subshape.
-  //! \param [in] theNoteLabel     - note label.
-  //! \param [in] theItemId        - assembly item ID.
-  //! \param [in] theSubshapeIndex - assembly item's subshape index.
+  //! \param[in]  theNoteLabel     - note label.
+  //! \param[in]  theItemId        - assembly item ID.
+  //! \param[in]  theSubshapeIndex - assembly item's subshape index.
   //! \return a handle to the assembly reference attribute.
   Standard_EXPORT Handle(XCAFDoc_AssemblyItemRef) AddNoteToSubshape(const TDF_Label&              theNoteLabel,
                                                                     const XCAFDoc_AssemblyItemId& theItemId,
                                                                     Standard_Integer              theSubshapeIndex);
 
   //! Adds the given note to the labeled item's subshape.
-  //! \param [in] theNoteLabel     - note label.
-  //! \param [in] theItemLabel     - item label.
-  //! \param [in] theSubshapeIndex - assembly item's subshape index.
+  //! \param[in]  theNoteLabel     - note label.
+  //! \param[in]  theItemLabel     - item label.
+  //! \param[in]  theSubshapeIndex - assembly item's subshape index.
   //! \return a handle to the assembly reference attribute.
   Standard_EXPORT Handle(XCAFDoc_AssemblyItemRef) AddNoteToSubshape(const TDF_Label& theNoteLabel,
                                                                     const TDF_Label& theItemLabel,
@@ -334,9 +334,9 @@ public:
   //! @{
 
   //! Removes the given note from the assembly item.
-  //! \param [in] theNoteLabel   - note label.
-  //! \param [in] theItemId      - assembly item ID.
-  //! \param [in] theDelIfOrphan - deletes the note from the notes hive 
+  //! \param[in]  theNoteLabel   - note label.
+  //! \param[in]  theItemId      - assembly item ID.
+  //! \param[in]  theDelIfOrphan - deletes the note from the notes hive 
   //!                              if there are no more assembly items
   //!                              linked with the note.
   //! \return true if the note is removed, otherwise - false.
@@ -345,9 +345,9 @@ public:
                                               Standard_Boolean              theDelIfOrphan = Standard_False);
 
   //! Removes the given note from the labeled item.
-  //! \param [in] theNoteLabel   - note label.
-  //! \param [in] theItemLabel   - item label.
-  //! \param [in] theDelIfOrphan - deletes the note from the notes hive 
+  //! \param[in]  theNoteLabel   - note label.
+  //! \param[in]  theItemLabel   - item label.
+  //! \param[in]  theDelIfOrphan - deletes the note from the notes hive 
   //!                              if there are no more labeled items
   //!                              linked with the note.
   //! \return true if the note is removed, otherwise - false.
@@ -356,10 +356,10 @@ public:
                                               Standard_Boolean theDelIfOrphan = Standard_False);
 
   //! Removes the given note from the assembly item's subshape.
-  //! \param [in] theNoteLabel     - note label.
-  //! \param [in] theItemId        - assembly item ID.
-  //! \param [in] theSubshapeIndex - assembly item's subshape index.
-  //! \param [in] theDelIfOrphan   - deletes the note from the notes hive 
+  //! \param[in]  theNoteLabel     - note label.
+  //! \param[in]  theItemId        - assembly item ID.
+  //! \param[in]  theSubshapeIndex - assembly item's subshape index.
+  //! \param[in]  theDelIfOrphan   - deletes the note from the notes hive 
   //!                                if there are no more assembly item's
   //!                                subshape linked with the note.
   //! \return true if the note is removed, otherwise - false.
@@ -369,10 +369,10 @@ public:
                                                       Standard_Boolean              theDelIfOrphan = Standard_False);
 
   //! Removes the given note from the labeled item's subshape.
-  //! \param [in] theNoteLabel     - note label.
-  //! \param [in] theItemLabel     - item label.
-  //! \param [in] theSubshapeIndex - labeled item's subshape index.
-  //! \param [in] theDelIfOrphan   - deletes the note from the notes hive 
+  //! \param[in]  theNoteLabel     - note label.
+  //! \param[in]  theItemLabel     - item label.
+  //! \param[in]  theSubshapeIndex - labeled item's subshape index.
+  //! \param[in]  theDelIfOrphan   - deletes the note from the notes hive 
   //!                                if there are no more assembly item's
   //!                                subshape linked with the note.
   //! \return true if the note is removed, otherwise - false.
@@ -382,10 +382,10 @@ public:
                                                       Standard_Boolean theDelIfOrphan = Standard_False);
 
   //! Removes a note from the assembly item's attribute.
-  //! \param [in] theNoteLabel   - note label.
-  //! \param [in] theItemId      - assembly item ID.
-  //! \param [in] theGUID        - assembly item's attribute GUID.
-  //! \param [in] theDelIfOrphan - deletes the note from the notes hive 
+  //! \param[in]  theNoteLabel   - note label.
+  //! \param[in]  theItemId      - assembly item ID.
+  //! \param[in]  theGUID        - assembly item's attribute GUID.
+  //! \param[in]  theDelIfOrphan - deletes the note from the notes hive 
   //!                              if there are no more assembly item's
   //!                              attribute linked with the note.
   //! \return true if the note is removed, otherwise - false.
@@ -395,10 +395,10 @@ public:
                                                   Standard_Boolean              theDelIfOrphan = Standard_False);
 
   //! Removes a note from the labeled item's attribute.
-  //! \param [in] theNoteLabel   - note label.
-  //! \param [in] theItemLabel   - item label.
-  //! \param [in] theGUID        - labeled item's attribute GUID.
-  //! \param [in] theDelIfOrphan - deletes the note from the notes hive 
+  //! \param[in]  theNoteLabel   - note label.
+  //! \param[in]  theItemLabel   - item label.
+  //! \param[in]  theGUID        - labeled item's attribute GUID.
+  //! \param[in]  theDelIfOrphan - deletes the note from the notes hive 
   //!                              if there are no more assembly item's
   //!                              attribute linked with the note.
   //! \return true if the note is removed, otherwise - false.
@@ -408,8 +408,8 @@ public:
                                                   Standard_Boolean     theDelIfOrphan = Standard_False);
 
   //! Removes all notes from the assembly item.
-  //! \param [in] theItemId      - assembly item ID.
-  //! \param [in] theDelIfOrphan - deletes removed notes from the notes
+  //! \param[in]  theItemId      - assembly item ID.
+  //! \param[in]  theDelIfOrphan - deletes removed notes from the notes
   //!                              hive if there are no more annotated items
   //!                              linked with the notes.
   //! \return true if the notes are removed, otherwise - false.
@@ -417,8 +417,8 @@ public:
                                                   Standard_Boolean              theDelIfOrphan = Standard_False);
 
   //! Removes all notes from the labeled item.
-  //! \param [in] theItemLabel   - item label.
-  //! \param [in] theDelIfOrphan - deletes removed notes from the notes
+  //! \param[in]  theItemLabel   - item label.
+  //! \param[in]  theDelIfOrphan - deletes removed notes from the notes
   //!                              hive if there are no more annotated items
   //!                              linked with the notes.
   //! \return true if the notes are removed, otherwise - false.
@@ -426,9 +426,9 @@ public:
                                                   Standard_Boolean theDelIfOrphan = Standard_False);
 
   //! Removes all notes from the assembly item's subshape.
-  //! \param [in] theItemId        - assembly item ID.
-  //! \param [in] theSubshapeIndex - assembly item's subshape index.
-  //! \param [in] theDelIfOrphan   - deletes removed notes from the notes
+  //! \param[in]  theItemId        - assembly item ID.
+  //! \param[in]  theSubshapeIndex - assembly item's subshape index.
+  //! \param[in]  theDelIfOrphan   - deletes removed notes from the notes
   //!                                hive if there are no more annotated items
   //!                                linked with the notes.
   //! \return true if the notes are removed, otherwise - false.
@@ -437,9 +437,9 @@ public:
                                                           Standard_Boolean              theDelIfOrphan = Standard_False);
 
   //! Removes all notes from the assembly item's attribute.
-  //! \param [in] theItemId      - assembly item ID.
-  //! \param [in] theGUID        - assembly item's attribute GUID.
-  //! \param [in] theDelIfOrphan - deletes removed notes from the notes
+  //! \param[in]  theItemId      - assembly item ID.
+  //! \param[in]  theGUID        - assembly item's attribute GUID.
+  //! \param[in]  theDelIfOrphan - deletes removed notes from the notes
   //!                              hive if there are no more annotated items
   //!                              linked with the notes.
   //! \return true if the notes are removed, otherwise - false.
@@ -448,9 +448,9 @@ public:
                                                       Standard_Boolean              theDelIfOrphan = Standard_False);
 
   //! Removes all notes from the labeled item's attribute.
-  //! \param [in] theItemLabel   - item label.
-  //! \param [in] theGUID        - labeled item's attribute GUID.
-  //! \param [in] theDelIfOrphan - deletes removed notes from the notes
+  //! \param[in]  theItemLabel   - item label.
+  //! \param[in]  theGUID        - labeled item's attribute GUID.
+  //! \param[in]  theDelIfOrphan - deletes removed notes from the notes
   //!                              hive if there are no more annotated items
   //!                              linked with the notes.
   //! \return true if the notes are removed, otherwise - false.
@@ -465,13 +465,13 @@ public:
 
   //! Deletes the given note.
   //! Removes all links with items annotated by the note.
-  //! \param [in] theNoteLabel - note label.
+  //! \param[in]  theNoteLabel - note label.
   //! \return true if the note is deleted, otherwise - false.
   Standard_EXPORT Standard_Boolean DeleteNote(const TDF_Label& theNoteLabel);
 
   //! Deletes the given notes.
   //! Removes all links with items annotated by the notes.
-  //! \param [in] theNoteLabels - note label sequence.
+  //! \param[in]  theNoteLabels - note label sequence.
   //! \return number of deleted notes.
   Standard_EXPORT Standard_Integer DeleteNotes(TDF_LabelSequence& theNoteLabels);
 
@@ -490,7 +490,7 @@ public:
 
   //! Returns note labels that aren't linked to annotated items.
   //! The label sequence isn't cleared beforehand.
-  //! \param [out] theNoteLabels - sequence of labels.
+  //! \param[out]  theNoteLabels - sequence of labels.
   Standard_EXPORT void GetOrphanNotes(TDF_LabelSequence& theNoteLabels) const;
   
   //! Deletes all notes that aren't linked to annotated items.

--- a/src/XCAFDoc/XCAFDoc_ShapeTool.hxx
+++ b/src/XCAFDoc/XCAFDoc_ShapeTool.hxx
@@ -424,14 +424,14 @@ public:
   Standard_EXPORT Standard_Boolean Expand (const TDF_Label& Shape);
 
   //! Method to get NamedData attribute assigned to the given shape label.
-  //! @param theLabel    [in] the shape Label
-  //! @param theToCreate [in] create and assign attribute if it doesn't exist
+  //! @param[in] theLabel     the shape Label
+  //! @param[in] theToCreate  create and assign attribute if it doesn't exist
   //! @return Handle to the NamedData attribute or Null if there is none
   Standard_EXPORT Handle(TDataStd_NamedData) GetNamedProperties (const TDF_Label& theLabel, const Standard_Boolean theToCreate = Standard_False) const;
 
   //! Method to get NamedData attribute assigned to a label of the given shape.
-  //! @param theShape    [in] input shape
-  //! @param theToCreate [in] create and assign attribute if it doesn't exist
+  //! @param[in] theShape     input shape
+  //! @param[in] theToCreate  create and assign attribute if it doesn't exist
   //! @return Handle to the NamedData attribute or Null if there is none
   Standard_EXPORT Handle(TDataStd_NamedData) GetNamedProperties(const TopoDS_Shape& theShape, const Standard_Boolean theToCreate = Standard_False) const;
   

--- a/src/XCAFDoc/XCAFDoc_VisMaterial.hxx
+++ b/src/XCAFDoc/XCAFDoc_VisMaterial.hxx
@@ -167,7 +167,7 @@ public: //! @name interface implementation
   virtual const Standard_GUID& ID() const Standard_OVERRIDE { return GetID(); }
 
   //! Restore attribute from specified state.
-  //! @param theWith [in] attribute state to restore (copy into this)
+  //! @param[in] theWith  attribute state to restore (copy into this)
   Standard_EXPORT virtual void Restore (const Handle(TDF_Attribute)& theWith) Standard_OVERRIDE;
 
   //! Create a new empty attribute.
@@ -175,7 +175,7 @@ public: //! @name interface implementation
 
   //! Paste this attribute into another one.
   //! @param theInto [in/out] target attribute to copy this into
-  //! @param theRelTable [in] relocation table
+  //! @param[in] theRelTable  relocation table
   Standard_EXPORT virtual void Paste (const Handle(TDF_Attribute)& theInto,
                                       const Handle(TDF_RelocationTable)& theRelTable) const Standard_OVERRIDE;
   

--- a/src/XCAFDoc/XCAFDoc_VisMaterialTool.hxx
+++ b/src/XCAFDoc/XCAFDoc_VisMaterialTool.hxx
@@ -82,8 +82,8 @@ public:
   Standard_EXPORT Standard_Boolean IsSetShapeMaterial (const TDF_Label& theLabel) const;
 
   //! Returns label with material assigned to shape label.
-  //! @param theShapeLabel [in] shape label
-  //! @param theMaterialLabel [out] material label
+  //! @param[in] theShapeLabel  shape label
+  //! @param[out] theMaterialLabel  material label
   //! @return FALSE if no material is assigned
   Standard_EXPORT static Standard_Boolean GetShapeMaterial (const TDF_Label& theShapeLabel, TDF_Label& theMaterialLabel);
 
@@ -91,8 +91,8 @@ public:
   Standard_EXPORT static Handle(XCAFDoc_VisMaterial) GetShapeMaterial (const TDF_Label& theShapeLabel);
 
   //! Sets a link with GUID XCAFDoc::VisMaterialRefGUID() from shape label to material label.
-  //! @param theShape [in] shape
-  //! @param theMaterialLabel [in] material label
+  //! @param[in] theShape  shape
+  //! @param[in] theMaterialLabel  material label
   //! @return FALSE if cannot find a label for shape
   Standard_EXPORT Standard_Boolean SetShapeMaterial (const TopoDS_Shape& theShape,
                                                      const TDF_Label& theMaterialLabel);
@@ -105,8 +105,8 @@ public:
   Standard_EXPORT Standard_Boolean IsSetShapeMaterial (const TopoDS_Shape& theShape);
 
   //! Returns label with material assigned to shape.
-  //! @param theShape [in] shape
-  //! @param theMaterialLabel [out] material label
+  //! @param[in] theShape  shape
+  //! @param[out] theMaterialLabel  material label
   //! @return FALSE if no material is assigned
   Standard_EXPORT Standard_Boolean GetShapeMaterial (const TopoDS_Shape& theShape, TDF_Label& theMaterialLabel);
 

--- a/src/Xw/Xw_Window.hxx
+++ b/src/Xw/Xw_Window.hxx
@@ -116,8 +116,8 @@ public:
   Standard_EXPORT virtual void InvalidateContent (const Handle(Aspect_DisplayConnection)& theDisp) Standard_OVERRIDE;
 
   //! Process a single window message.
-  //! @param theListener [in][out] listener to redirect message
-  //! @param theMsg [in][out] message to process
+  //! @param[in][out] theListener  listener to redirect message
+  //! @param[in][out] theMsg message to process
   //! @return TRUE if message has been processed
   Standard_EXPORT virtual bool ProcessMessage (Aspect_WindowInputListener& theListener,
                                                XEvent& theMsg);

--- a/src/gp/gp_TrsfNLerp.hxx
+++ b/src/gp/gp_TrsfNLerp.hxx
@@ -54,7 +54,7 @@ public:
   //! Compute interpolated value between two values.
   //! @param theT normalized interpolation coefficient within [0, 1] range,
   //!             with 0 pointing to first value and 1 to the second value.
-  //! @param theResult [out] interpolated value
+  //! @param[out] theResult  interpolated value
   void Interpolate (double theT, gp_Trsf& theResult) const
   {
     if (Abs (theT - 0.0) < Precision::Confusion())

--- a/tools/Convert/Convert_Tools.hxx
+++ b/tools/Convert/Convert_Tools.hxx
@@ -63,7 +63,7 @@ public:
 
   //! Converts stream to color if possible. It processes Quantity_Color, Quantity_ColorRGBA
   //! \param theStream source of presentation
-  //! \param theColor [out] converted color
+  //! \param[out] theColor  converted color
   //! \returns true if done
   Standard_EXPORT static Standard_Boolean ConvertStreamToColor (const Standard_SStream& theSStream,
                                                                 Quantity_Color& theColor);

--- a/tools/MessageModel/MessageModel_ItemAlert.hxx
+++ b/tools/MessageModel/MessageModel_ItemAlert.hxx
@@ -79,7 +79,7 @@ public:
                                           Standard_Integer& theLastPos) const Standard_OVERRIDE;
 
   //! Returns presentation of the attribute to be visualized in the view
-  //! \thePresentations [out] container of presentation handles to be visualized
+  //! \thePresentations[out]  container of presentation handles to be visualized
   virtual void Presentations (NCollection_List<Handle(Standard_Transient)>& thePresentations) Standard_OVERRIDE
   { TreeModel_ItemBase::Presentations (thePresentations); thePresentations.Append (myPresentation); }
 

--- a/tools/MessageModel/MessageModel_TreeModel.hxx
+++ b/tools/MessageModel/MessageModel_TreeModel.hxx
@@ -47,13 +47,13 @@ public:
 
   //!< Returns columns of the model for the metric
   //!< \param theMetricType metric
-  //!< \param theMetricColumns [out] container of metric columns
+  //!< \param[out] theMetricColumns  container of metric columns
   static Standard_EXPORT void GetMetricColumns (const Message_MetricType theMetricType, QList<int>& theMetricColumns);
 
   //!< Returns metric type for the column
-  //!< \param theColumnId [in] index of the tree column
-  //!< \param theMetricType [out] metric type if found
-  //!< \param thePosition [out] index of the metric column, 0 - is metric, 1 - is delta
+  //!< \param[in] theColumnId  index of the tree column
+  //!< \param[out] theMetricType  metric type if found
+  //!< \param[out] thePosition  index of the metric column, 0 - is metric, 1 - is delta
   //!< \return true if the column has metric parameters
   static Standard_EXPORT bool IsMetricColumn (const int theColumnId, Message_MetricType& theMetricType, int& thePosition);
 

--- a/tools/ShapeView/ShapeView_Tools.hxx
+++ b/tools/ShapeView/ShapeView_Tools.hxx
@@ -40,8 +40,8 @@ class ShapeView_Tools
 public:
 
   //! Checks whether it is possible to explode the shape. The search is recursive until all types are collected.
-  //! \param theShape [in] source shape object
-  //! \param theExplodeTypes [out] container of possible shape types to be exploded
+  //! \param[in] theShape  source shape object
+  //! \param[out] theExplodeTypes  container of possible shape types to be exploded
   //! \return true if explode is finished, all types are collected.
   Standard_EXPORT static Standard_Boolean IsPossibleToExplode(const TopoDS_Shape& theShape,
     NCollection_List<TopAbs_ShapeEnum>& theExplodeTypes);

--- a/tools/TInspector/TInspector_OpenFileDialog.hxx
+++ b/tools/TInspector/TInspector_OpenFileDialog.hxx
@@ -69,7 +69,7 @@ public:
   //! Returns preferences: previous opened documents.
   //! \param thePluginName name of the plugin
   //! \param theCommunicator source of preferences
-  //! \param theFileNames [out] container of recently opened file names
+  //! \param[out] theFileNames  container of recently opened file names
   Standard_EXPORT static void GetPluginRecentlyOpenedFiles (const TCollection_AsciiString& thePluginName,
                                                             TInspector_Communicator* theCommunicator,
                                                             QStringList& theFileNames);

--- a/tools/TreeModel/TreeModel_ItemBase.hxx
+++ b/tools/TreeModel/TreeModel_ItemBase.hxx
@@ -155,7 +155,7 @@ public:
     { (void)theRow, (void)theColumn; (void)theValue; }
 
   //! Returns presentation of the item to be visualized in the view
-  //! \thePresentations [out] container of presentation handles
+  //! \thePresentations[out]  container of presentation handles
   Standard_EXPORT virtual void Presentations (NCollection_List<Handle(Standard_Transient)>& thePresentations);
 protected:
 

--- a/tools/TreeModel/TreeModel_ItemProperties.hxx
+++ b/tools/TreeModel/TreeModel_ItemProperties.hxx
@@ -115,7 +115,7 @@ public:
                                 int theRole = Qt::DisplayRole);
 
   //! Returns presentation of the attribute to be visualized in the view
-  //! \thePresentations [out] container of presentation handles to be visualized
+  //! \thePresentations[out]  container of presentation handles to be visualized
   Standard_EXPORT void Presentations (NCollection_List<Handle(Standard_Transient)>& thePresentations);
 
   //! Returns flags for the item: ItemIsEnabled | Qt::ItemIsSelectable.

--- a/tools/TreeModel/TreeModel_ModelBase.hxx
+++ b/tools/TreeModel/TreeModel_ModelBase.hxx
@@ -177,7 +177,7 @@ public:
 
   //! Returns presentations of sub items
   //! \param theIndices a container of selected indices
-  //! \thePresentations [out] container of presentations
+  //! \thePresentations[out]  container of presentations
   Standard_EXPORT static void SubItemsPresentations (const QModelIndexList& theIndices,
                                                      NCollection_List<Handle(Standard_Transient)>& thePresentations);
 
@@ -198,7 +198,7 @@ protected:
 
   //! Returns presentations of sub items. Recursive method to get presentations of all children
   //! \param theItem an item to get own presentations and presentations of children
-  //! \thePresentations [out] container of presentations found
+  //! \thePresentations[out]  container of presentations found
   static void subItemsPresentations (const TreeModel_ItemBasePtr& theItem,
                                     NCollection_List<Handle(Standard_Transient)>& thePresentations);
 

--- a/tools/TreeModel/TreeModel_Tools.hxx
+++ b/tools/TreeModel/TreeModel_Tools.hxx
@@ -57,7 +57,7 @@ public:
   //! - visibility of columns,
   //! - columns width
   //! \param theTreeView a view instance
-  //! \param theItems [out] properties
+  //! \param[out] theItems  properties
   //! \param thePrefix preference item prefix
   Standard_EXPORT static void SaveState (QTreeView* theTreeView, QMap<QString, QString>& theItems,
                                          const QString& thePrefix = QString());

--- a/tools/VInspector/VInspector_ItemPresentableObject.hxx
+++ b/tools/VInspector/VInspector_ItemPresentableObject.hxx
@@ -60,7 +60,7 @@ public:
   Standard_EXPORT virtual void Reset() Standard_OVERRIDE;
 
   //! Returns presentation of the attribute to be visualized in the view
-  //! \thePresentations [out] container of presentation handles to be visualized
+  //! \thePresentations[out]  container of presentation handles to be visualized
   Standard_EXPORT virtual void Presentations (NCollection_List<Handle(Standard_Transient)>& thePresentations) Standard_OVERRIDE;
 
 protected:

--- a/tools/VInspector/VInspector_ViewModel.hxx
+++ b/tools/VInspector/VInspector_ViewModel.hxx
@@ -63,7 +63,7 @@ public:
   //! Returns tree view indices for the given pointers of presentable object
   //! \param thePointers a list of presentation pointers
   //! \param theParent an index of the parent item
-  //! \param [out] container of indices
+  //! \param[out]  container of indices
   Standard_EXPORT void FindPointers (const QStringList& thePointers,
                                      const QModelIndex& theParent,
                                      QModelIndexList& theFoundIndices);

--- a/tools/VInspector/VInspector_Window.hxx
+++ b/tools/VInspector/VInspector_Window.hxx
@@ -90,7 +90,7 @@ public:
   NCollection_List<Handle(AIS_InteractiveObject)> SelectedPresentations (QItemSelectionModel* theModel);
 
   //! Returns selected shapes
-  //! \param [out] container of shapes
+  //! \param[out]  container of shapes
   void SelectedShapes (NCollection_List<Handle(Standard_Transient)>& theSelPresentations);
 
 private:

--- a/tools/View/View_PreviewParameters.hxx
+++ b/tools/View/View_PreviewParameters.hxx
@@ -45,7 +45,7 @@ public:
   //! - visibility of columns,
   //! - columns width
   //! \param theTreeView a view instance
-  //! \param theItems [out] properties
+  //! \param[out] theItems  properties
   //! \param thePrefix preference item prefix
   static void SaveState (View_PreviewParameters* theParameters,
                          QMap<QString, QString>& theItems,

--- a/tools/View/View_ToolBar.hxx
+++ b/tools/View/View_ToolBar.hxx
@@ -76,7 +76,7 @@ public:
 
   //! Saves state of tool bar actions
   //! \param theToolBar a view instance
-  //! \param theItems [out] properties
+  //! \param[out] theItems  properties
   //! \param thePrefix preference item prefix
   Standard_EXPORT static void SaveState (View_ToolBar* theToolBar,
                                          QMap<QString, QString>& theItems,

--- a/tools/View/View_Widget.hxx
+++ b/tools/View/View_Widget.hxx
@@ -103,7 +103,7 @@ public:
 
   //! Saves state of widget actions
   //! \param theParameters a view instance
-  //! \param theItems [out] properties
+  //! \param[out] theItems  properties
   //! \param thePrefix preference item prefix
   Standard_EXPORT static void SaveState (View_Widget* theWidget,
                                          QMap<QString, QString>& theItems,

--- a/tools/View/View_Window.hxx
+++ b/tools/View/View_Window.hxx
@@ -80,7 +80,7 @@ public:
   //! - visibility of columns,
   //! - columns width
   //! \param theTreeView a view instance
-  //! \param theItems [out] properties
+  //! \param[out] theItems  properties
   //! \param thePrefix preference item prefix
   Standard_EXPORT static void SaveState (View_Window* theView, QMap<QString, QString>& theItems,
                                          const QString& thePrefix = QString());

--- a/tools/ViewControl/ViewControl_PropertyView.hxx
+++ b/tools/ViewControl/ViewControl_PropertyView.hxx
@@ -71,7 +71,7 @@ public:
   //! - visibility of columns,
   //! - columns width
   //! \param theTreeView a view instance
-  //! \param theItems [out] properties
+  //! \param[out] theItems  properties
   //! \param thePrefix preference item prefix
   Standard_EXPORT static void SaveState (ViewControl_PropertyView* theParameters,
                                          QMap<QString, QString>& theItems,

--- a/tools/ViewControl/ViewControl_Table.hxx
+++ b/tools/ViewControl/ViewControl_Table.hxx
@@ -72,7 +72,7 @@ public:
   QTableView* TableView() const { return myTableView; }
 
   //! Returns model indices of the selected cells in table view
-  //! \param theSelectedIndices [out] a container of indices: row to list of columns
+  //! \param[out] theSelectedIndices  a container of indices: row to list of columns
   Standard_EXPORT void SelectedIndices (QMap<int, QList<int>>& aSelectedIndices) const;
 
   //! Returns pointers from selected cells


### PR DESCRIPTION
Reorganized style for param to the next templates:
 - "@param theParameter description ..."
 - "@param[in] theParameter description ..."
 - "@param[out] theParameter description ..."
 - "@param[in][out] theParameter description ..."
 The replacement was with keeping spacing, no removing of extra spaces.
In some files '/' was used instead of '@', that was not updated yet.