### PR TITLE
0033664: Visualization - Selection does not work for simple shape

### DIFF
--- a/tests/v3d/bugs/bug33664_1
+++ b/tests/v3d/bugs/bug33664_1
@@ -1,0 +1,21 @@
+puts "============"
+puts "0033664: Visualization - Selection does not work for simple shape"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+vclear
+vinit View1
+
+restore [locate_data_file cylinder_surface.brep] b
+vdisplay -dispMode 1 b
+vfit
+vsensdis
+
+vselect 200 200
+if {[vnbselected] != "1"} {
+  puts "ERROR: wrong sensitive area"
+}
+
+vselect 0 0
+vdump $::imagedir/${::casename}_cylinder.png

--- a/tests/v3d/bugs/bug33664_2
+++ b/tests/v3d/bugs/bug33664_2
@@ -1,0 +1,36 @@
+puts "============"
+puts "0033664: Visualization - Selection does not work for simple shape"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+vclear
+vinit View1
+
+pcone c1 50 100 100
+ttranslate c1 100 0 100
+explode c1
+explode c1_1
+
+pcone c2 100 50 100
+ttranslate c2 -100 0 100
+explode c2
+explode c2_1
+
+pcone c3 0 100 100
+ttranslate c3 100 0 -100
+explode c3
+explode c3_1
+
+pcone c4 100 0 100
+ttranslate c4 -100 0 -100
+explode c4
+explode c4_1
+
+vdisplay c1_1_1 c2_1_1 c3_1_1 c4_1_1 -dispmode 1
+vsensdis
+
+vfront
+vfit
+
+vdump $::imagedir/${::casename}_cone.png


### PR DESCRIPTION
Original issue: https://tracker.dev.opencascade.org/view.php?id=33664
![image](https://github.com/user-attachments/assets/d7f37bb5-ae89-4a16-9602-9f83aa4d259d)

![image](https://github.com/user-attachments/assets/88b70ab1-9e4b-4a8d-b68e-e85a89dd993f)

Step to reproduce:
> Load the attached .brep and try to pick or select the arrow cylindrical body face. On my computer I can pick/select all faces except the cylindrical one.
> I have this problem on OCC 7.8.0 (I cannot select the good version in product version combo box).
Fixed direction calculation for Select3D_SensitiveCylinder created from Geom_CylindricalSurface