### PR TITLE
Revert "0023638: Data Exchange - Reading IGES file produced invalid shape"

### DIFF
--- a/src/IGESData/IGESData_IGESModel.cxx
+++ b/src/IGESData/IGESData_IGESModel.cxx
@@ -23,7 +23,6 @@
 #include <Interface_Macros.hxx>
 #include <Interface_Static.hxx>
 #include <Message_Msg.hxx>
-#include <ShapeBuild_ReShape.hxx>
 #include <Standard_Transient.hxx>
 #include <Standard_Type.hxx>
 #include <TCollection_HAsciiString.hxx>
@@ -48,7 +47,6 @@ void IGESData_VerifyDate
 IGESData_IGESModel::IGESData_IGESModel ()
 {
   thestart = new TColStd_HSequenceOfHAsciiString();
-  myReShape = new ShapeBuild_ReShape();
 //  thecheckstx = new Interface_Check;
 //  thechecksem = new Interface_Check;
 }
@@ -64,7 +62,6 @@ void IGESData_IGESModel::ClearHeader ()
   IGESData_GlobalSection newheader;  // Un peu brutal, certes
   theheader = newheader;
   thestart = new TColStd_HSequenceOfHAsciiString();
-  myReShape = new ShapeBuild_ReShape();
 }
 
 

--- a/src/IGESData/IGESData_IGESModel.hxx
+++ b/src/IGESData/IGESData_IGESModel.hxx
@@ -22,7 +22,6 @@
 
 class IGESData_IGESEntity;
 class Interface_Check;
-class ShapeBuild_ReShape;
 class Standard_Transient;
 class TCollection_HAsciiString;
 
@@ -151,12 +150,6 @@ public:
   //! i.e. a string "Dnn" with nn = directory entry number (2*N-1)
   Standard_EXPORT Handle(TCollection_HAsciiString) StringLabel (const Handle(Standard_Transient)& ent) const Standard_OVERRIDE;
 
-  //! Gets ReShape used to store a model's shapes changes
-  const Handle(ShapeBuild_ReShape)& ReShape() const { return myReShape; }
-
-  //! Sets ReShape used to store a history of changes of the model's shapes
-  void SetReShape(const Handle(ShapeBuild_ReShape)& theReShape) { myReShape = theReShape; }
-
   DEFINE_STANDARD_RTTIEXT(IGESData_IGESModel,Interface_InterfaceModel)
 
 protected:
@@ -169,7 +162,6 @@ private:
 
   Handle(TColStd_HSequenceOfHAsciiString) thestart;
   IGESData_GlobalSection theheader;
-  Handle(ShapeBuild_ReShape) myReShape;
 
 };
 

--- a/src/IGESToBRep/IGESToBRep_Actor.cxx
+++ b/src/IGESToBRep/IGESToBRep_Actor.cxx
@@ -197,8 +197,8 @@ Handle(Transfer_Binder) IGESToBRep_Actor::Transfer
     shape = XSAlgo::AlgoContainer()->ProcessShape(shape, theeps, CAS.GetMaxTol(),
                                                   "read.iges.resource.name",
                                                   "read.iges.sequence",
-                                                  info, mymodel->ReShape(),
-                                                  aPS.Next(), false, TopAbs_EDGE);
+                                                  info, aPS.Next(),
+                                                  false, TopAbs_EDGE);
     XSAlgo::AlgoContainer()->MergeTransferInfo(TP, info, nbTPitems);
   }
 

--- a/src/XSAlgo/XSAlgo_AlgoContainer.cxx
+++ b/src/XSAlgo/XSAlgo_AlgoContainer.cxx
@@ -90,10 +90,9 @@ TopoDS_Shape XSAlgo_AlgoContainer::ProcessShape(const TopoDS_Shape& theShape,
                                                 const Standard_CString thePrscfile,
                                                 const Standard_CString thePseq,
                                                 Handle(Standard_Transient)& theInfo,
-                                                const Handle(ShapeBuild_ReShape)& theReShape,
                                                 const Message_ProgressRange& theProgress,
                                                 const Standard_Boolean theNonManifold,
-                                                const TopAbs_ShapeEnum theDetalisationLevel) const
+                                                const TopAbs_ShapeEnum theDetailingLevel) const
 {
   if (theShape.IsNull())
   {
@@ -110,7 +109,7 @@ TopoDS_Shape XSAlgo_AlgoContainer::ProcessShape(const TopoDS_Shape& theShape,
       // If resource file wasn't found, use static values instead
       Interface_Static::FillMap(aContext->ResourceManager()->GetMap());
     }
-    aContext->SetDetalisation(theDetalisationLevel);
+    aContext->SetDetalisation(theDetailingLevel);
   }
   aContext->SetNonManifold(theNonManifold);
   theInfo = aContext;
@@ -147,7 +146,6 @@ TopoDS_Shape XSAlgo_AlgoContainer::ProcessShape(const TopoDS_Shape& theShape,
         aSfs->SetMaxTolerance(theMaxTol);
         aSfs->FixFaceTool()->FixWireTool()->FixSameParameterMode() = Standard_False;
         aSfs->FixSolidTool()->CreateOpenSolidMode() = Standard_False;
-        aSfs->SetContext(theReShape);
         aSfs->Perform(theProgress);
 
         TopoDS_Shape aShape = aSfs->Shape();
@@ -182,26 +180,6 @@ TopoDS_Shape XSAlgo_AlgoContainer::ProcessShape(const TopoDS_Shape& theShape,
     return theShape; // return original shape
 
   return aContext->Result();
-}
-
-//=======================================================================
-//function : ProcessShape
-//purpose  :
-//=======================================================================
-TopoDS_Shape XSAlgo_AlgoContainer::ProcessShape(const TopoDS_Shape& theShape,
-                                                const Standard_Real thePrec,
-                                                const Standard_Real theMaxTol,
-                                                const Standard_CString thePrscfile,
-                                                const Standard_CString thePseq,
-                                                Handle(Standard_Transient)& theInfo,
-                                                const Message_ProgressRange& theProgress,
-                                                const Standard_Boolean theNonManifold,
-                                                const TopAbs_ShapeEnum theDetalisationLevel) const
-{
-  Handle(ShapeBuild_ReShape) aReShape = new ShapeBuild_ReShape();
-  return ProcessShape(theShape, thePrec, theMaxTol, thePrscfile,
-                      thePseq, theInfo, aReShape, theProgress, 
-                      theNonManifold, theDetalisationLevel);
 }
 
 //=======================================================================

--- a/src/XSAlgo/XSAlgo_AlgoContainer.hxx
+++ b/src/XSAlgo/XSAlgo_AlgoContainer.hxx
@@ -24,7 +24,6 @@
 #include <Standard_Transient.hxx>
 #include <TopAbs_ShapeEnum.hxx>
 
-class ShapeBuild_ReShape;
 class XSAlgo_ToolContainer;
 class TopoDS_Shape;
 class TopoDS_Edge;
@@ -64,6 +63,7 @@ public:
   //! @param[out] theInfo information to be recorded in the translation map
   //! @param[in] theProgress progress indicator
   //! @param[in] theNonManifold flag to proceed with non-manifold topology
+  //! @param[in] theDetailingLevel the lowest shape type to be processed, lower shapes are ignored
   //! @return the processed shape
   Standard_EXPORT virtual TopoDS_Shape ProcessShape (const TopoDS_Shape&          theShape,
                                                      const Standard_Real          thePrec,
@@ -73,30 +73,8 @@ public:
                                                      Handle(Standard_Transient)&  theInfo,
                                                      const Message_ProgressRange& theProgress = Message_ProgressRange(),
                                                      const Standard_Boolean       theNonManifold = Standard_False,
-                                                     const TopAbs_ShapeEnum theDetalisationLevel = TopAbs_VERTEX) const;
+                                                     const TopAbs_ShapeEnum       theDetailingLevel = TopAbs_VERTEX) const;
 
-  //! Does shape processing with specified tolerances
-  //! @param[in] theShape shape to process
-  //! @param[in] thePrec basic precision and tolerance
-  //! @param[in] theMaxTol maximum allowed tolerance
-  //! @param[in] thePrscfile name of the resource file
-  //! @param[in] thePseq name of the sequence of operators defined in the resource file for Shape Processing
-  //! @param[out] theInfo information to be recorded in the translation map
-  //! @param[in] theReShape tool to record the modifications of input shape
-  //! @param[in] theProgress progress indicator
-  //! @param[in] theNonManifold flag to proceed with non-manifold topology
-  //! @return the processed shape
-  Standard_EXPORT virtual TopoDS_Shape ProcessShape(const TopoDS_Shape&               theShape,
-                                                    const Standard_Real               thePrec,
-                                                    const Standard_Real               theMaxTol,
-                                                    const Standard_CString            thePrscfile,
-                                                    const Standard_CString            thePseq,
-                                                    Handle(Standard_Transient)&       theInfo,
-                                                    const Handle(ShapeBuild_ReShape)& theReShape,
-                                                    const Message_ProgressRange&      theProgress = Message_ProgressRange(),
-                                                    const Standard_Boolean            theNonManifold = Standard_False,
-                                                    const TopAbs_ShapeEnum theDetalisationLevel = TopAbs_VERTEX) const;
-  
   //! Checks quality of pcurve of the edge on the given face,
   //! and corrects it if necessary.
   Standard_EXPORT virtual Standard_Boolean CheckPCurve (const TopoDS_Edge& edge, const TopoDS_Face& face, const Standard_Real preci, const Standard_Boolean isSeam) const;

--- a/tests/bugs/iges/bug23638
+++ b/tests/bugs/iges/bug23638
@@ -1,4 +1,4 @@
-puts "TODO OCC23638 ALL: Faulty shapes in variables faulty_1 to faulty_1"
+puts "TODO OCC23638 ALL: Faulty shapes in variables faulty_1 to faulty_"
 
 puts "============"
 puts "CR23638"
@@ -7,6 +7,8 @@ puts ""
 #######################################################################
 # Reading IGES file produced invalid shape
 #######################################################################
+
+param read.surfacecurve.mode -3
 
 igesread [locate_data_file bug23638_cadbad.igs] result *
 


### PR DESCRIPTION
This reverts commit c479c4f6d89ed7c5e33dd35a5e110f13776b7cab.
The problem related with no changes on the ShapeHealing stage.
ReShape do not propagated well for all scenarios.
The test case update is not relevant.