### PR TITLE
Configuration - Inspector with SymLink error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -965,6 +965,10 @@ if (BUILD_Inspector)
   endforeach()
 
   # collect all the headers to <binary dir>/inc/inspector folder
+
+  # Ensure the include directory exists
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/${INSTALL_DIR_INCLUDE}/inspector")
+
   string(TIMESTAMP CURRENT_TIME "%H:%M:%S")
   message (STATUS "\nInfo: \(${CURRENT_TIME}\) Start collecting all OCCT tool header files into ${CMAKE_BINARY_DIR}/inc/inspector ...")
   COLLECT_AND_INSTALL_OCCT_HEADER_FILES ("${CMAKE_BINARY_DIR}" "${BUILD_TOOL_TOOLKITS}" "tools" "${INSTALL_DIR_INCLUDE}/inspector")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -343,6 +343,10 @@ foreach (OCCT_TOOL ${OCCT_TOOLS})
 endforeach()
 
 # collect all the headers to <binary dir>/inc/inspector folder
+
+# Ensure the include directory exists
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/${INSTALL_DIR_INCLUDE}/inspector")
+
 string(TIMESTAMP CURRENT_TIME "%H:%M:%S")
 message (STATUS "\nInfo: \(${CURRENT_TIME}\) Start collecting all OCCT tool header files into ${CMAKE_BINARY_DIR}/inc/inspector ...")
 COLLECT_AND_INSTALL_OCCT_HEADER_FILES ("${CMAKE_BINARY_DIR}" "${BUILD_TOOL_TOOLKITS}" "tools" "${INSTALL_DIR_INCLUDE}/inspector")


### PR DESCRIPTION
When configure Inspector with Symlink flag - configuration failed. Added force creating include folder to symlink creating.