### PR TITLE
Application Framework - Invalid document after partial read of XBF

### DIFF
--- a/src/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.hxx
+++ b/src/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.hxx
@@ -127,7 +127,7 @@ private:
   TColStd_MapOfInteger myMapUnsupported;
   BinLDrivers_VectorOfDocumentSection mySections;
   NCollection_Map<Standard_Integer> myUnresolvedLinks;
-
+  NCollection_Map<Standard_Integer> myResolvedLinks;
 
 };
 


### PR DESCRIPTION
Resolve missed refereces until all are resolved to produce expected
  result without exceptions.
XCAFDoc_ShapeTool::GetShape() throws Standard_NullObject exception after
  partial read of XBF document

XCAFDoc_ShapeTool::GetShape() throws Standard_NullObject exception when XBF document is read partially using functionality of PCDM_ReaderFilter.

The problem is that XBF driver resolves N+1 level of referenced items only while XCAFDoc_ShapeTool::GetShape() requires to follow the deeper chain of references.