### PR TITLE
Foundation Classes - Move Map's algo part to external file

### DIFF
--- a/src/BRepMesh/BRepMesh_FaceChecker.cxx
+++ b/src/BRepMesh/BRepMesh_FaceChecker.cxx
@@ -309,7 +309,7 @@ void BRepMesh_FaceChecker::collectResult()
     const Handle(IMeshData::MapOfIEdgePtr)& aEdges = myWiresIntersectingEdges->Value(aWireIt);
     if (!aEdges.IsNull())
     {
-      myIntersectingEdges->Unite(*aEdges);
+      NCollection_MapAlgo::Unite(*myIntersectingEdges, *aEdges);
     }
   }
 }

--- a/src/BRepMesh/BRepMesh_ModelHealer.cxx
+++ b/src/BRepMesh/BRepMesh_ModelHealer.cxx
@@ -235,7 +235,7 @@ Standard_Boolean BRepMesh_ModelHealer::popEdgesToUpdate(
     Handle(IMeshData::MapOfIEdgePtr)& aIntersections = aFaceIt.ChangeValue();
     if (!aIntersections.IsNull())
     {
-      theEdgesToUpdate.Unite(*aIntersections);
+      NCollection_MapAlgo::Unite(theEdgesToUpdate, *aIntersections);
       aIntersections.Nullify();
     }
   }

--- a/src/BRepMesh/BRepMesh_NURBSRangeSplitter.cxx
+++ b/src/BRepMesh/BRepMesh_NURBSRangeSplitter.cxx
@@ -361,8 +361,8 @@ Handle(IMeshData::ListOfPnt2d) BRepMesh_NURBSRangeSplitter::GenerateSurfaceNodes
       aFixedParams[0], aFixedParams[1]).GetControlParametersToRemove(theParameters),
   };
 
-  aParamsToRemove[0]->Subtract(*aFixedParams[0]);
-  aParamsToRemove[1]->Subtract(*aFixedParams[1]);
+  NCollection_MapAlgo::Subtract(*aParamsToRemove[0], *aFixedParams[0]);
+  NCollection_MapAlgo::Subtract(*aParamsToRemove[1], *aFixedParams[1]);
 
   // insert nodes of the regular grid
   Handle(IMeshData::ListOfPnt2d) aNodes = new IMeshData::ListOfPnt2d(

--- a/src/BRepOffset/BRepOffset_MakeOffset_1.cxx
+++ b/src/BRepOffset/BRepOffset_MakeOffset_1.cxx
@@ -3362,7 +3362,7 @@ Standard_Boolean BRepOffset_BuildOffsetFaces::CheckInvertedBlock (const TopoDS_S
       GetVerticesOnEdges (aCB1, myInvertedEdges, *pMVInverted1, *pMVAll1);
     }
     //
-    if (pMVInverted->HasIntersection (*pMVAll1))
+    if (NCollection_MapAlgo::HasIntersection(*pMVInverted, *pMVAll1))
     {
       return Standard_False;
     }
@@ -5886,8 +5886,8 @@ void BRepOffset_BuildOffsetFaces::IntersectFaces (TopTools_MapOfShape& theVertsT
           mapShapes(*aLFImi, TopAbs_EDGE, aMEVIm);
           mapShapes(*aLFImi, TopAbs_VERTEX, aMEVIm);
 
-          Standard_Boolean isIContainsE = aMEVIm.HasIntersection(anInsideEdges);
-          Standard_Boolean isIContainsV = aMEVIm.HasIntersection(anInsideVertices);
+          Standard_Boolean isIContainsE = NCollection_MapAlgo::HasIntersection(aMEVIm, anInsideEdges);
+          Standard_Boolean isIContainsV = NCollection_MapAlgo::HasIntersection(aMEVIm, anInsideVertices);
 
           for (j = i + 1; j <= aNb; ++j)
           {
@@ -5914,8 +5914,8 @@ void BRepOffset_BuildOffsetFaces::IntersectFaces (TopTools_MapOfShape& theVertsT
             mapShapes(*aLFImj, TopAbs_VERTEX, aMEVIm);
             // check images of both faces contain anInsideEdges and anInsideVertices
             // not process if false and true 
-            Standard_Boolean isJContainsE = aMEVIm.HasIntersection(anInsideEdges);
-            Standard_Boolean isJContainsV = aMEVIm.HasIntersection(anInsideVertices);
+            Standard_Boolean isJContainsE = NCollection_MapAlgo::HasIntersection(aMEVIm, anInsideEdges);
+            Standard_Boolean isJContainsV = NCollection_MapAlgo::HasIntersection(aMEVIm, anInsideVertices);
 
             // Check if one face is connected to inside edge then
             // the other must be also connected

--- a/src/NCollection/FILES
+++ b/src/NCollection/FILES
@@ -46,6 +46,7 @@ NCollection_List.hxx
 NCollection_ListNode.hxx
 NCollection_LocalArray.hxx
 NCollection_Map.hxx
+NCollection_MapAlgo.hxx
 NCollection_Mat3.hxx
 NCollection_Mat4.hxx
 NCollection_OccAllocator.hxx

--- a/src/NCollection/NCollection_Map.hxx
+++ b/src/NCollection/NCollection_Map.hxx
@@ -16,12 +16,13 @@
 #ifndef NCollection_Map_HeaderFile
 #define NCollection_Map_HeaderFile
 
+#include <NCollection_MapAlgo.hxx>
 #include <NCollection_DataMap.hxx>
-#include <NCollection_TListNode.hxx>
-#include <NCollection_StlIterator.hxx>
 #include <NCollection_DefaultHasher.hxx>
-
+#include <NCollection_StlIterator.hxx>
+#include <NCollection_TListNode.hxx>
 #include <Standard_NoSuchObject.hxx>
+
 #include <utility>
 
 /**
@@ -348,204 +349,80 @@ public:
   Standard_Integer Size(void) const
   { return Extent(); }
 
- public:
-  //!@name Boolean operations with maps as sets of keys
-  //!@{
+public:
 
-  //! @return true if two maps contains exactly the same keys
-  Standard_Boolean IsEqual (const NCollection_Map& theOther) const
+  //! Checks if two maps contain exactly the same keys.
+  //! This function compares the keys of this map and another map and returns true
+  //! if they contain exactly the same keys.
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean IsEqual(const NCollection_Map& theOther) const
   {
-    return Extent() == theOther.Extent()
-        && Contains (theOther);
+    return NCollection_MapAlgo::IsEqual<NCollection_Map>(*this, theOther);
   }
 
-  //! @return true if this map contains ALL keys of another map.
-  Standard_Boolean Contains (const NCollection_Map& theOther) const
+  //! Checks if this map contains all keys of another map.
+  //! This function checks if this map contains all keys of another map.
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean Contains(const NCollection_Map& theOther) const
   {
-    if (this == &theOther
-     || theOther.IsEmpty())
-    {
-      return Standard_True;
-    }
-    else if (Extent() < theOther.Extent())
-    {
-      return Standard_False;
-    }
-
-    for (Iterator anIter (theOther); anIter.More(); anIter.Next())
-    {
-      if (!Contains (anIter.Key()))
-      {
-        return Standard_False;
-      }
-    }
-
-    return Standard_True;
+    return NCollection_MapAlgo::Contains<NCollection_Map>(*this, theOther);
   }
 
   //! Sets this Map to be the result of union (aka addition, fuse, merge, boolean OR) operation between two given Maps
   //! The new Map contains the values that are contained either in the first map or in the second map or in both.
   //! All previous content of this Map is cleared.
   //! This map (result of the boolean operation) can also be passed as one of operands.
-  void Union (const NCollection_Map& theLeft,
-              const NCollection_Map& theRight)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  void Union(const NCollection_Map& theLeft, const NCollection_Map& theRight)
   {
-    if (&theLeft == &theRight)
-    {
-      Assign (theLeft);
-      return;
-    }
-
-    if (this != &theLeft
-     && this != &theRight)
-    {
-      Clear();
-    }
-
-    if (this != &theLeft)
-    {
-      for (Iterator anIter (theLeft); anIter.More(); anIter.Next())
-      {
-        Add (anIter.Key());
-      }
-    }
-    if (this != &theRight)
-    {
-      for (Iterator anIter (theRight); anIter.More(); anIter.Next())
-      {
-        Add (anIter.Key());
-      }
-    }
+    NCollection_MapAlgo::Union<NCollection_Map>(*this, theLeft, theRight);
   }
 
   //! Apply to this Map the boolean operation union (aka addition, fuse, merge, boolean OR) with another (given) Map.
   //! The result contains the values that were previously contained in this map or contained in the given (operand) map.
   //! This algorithm is similar to method Union().
   //! Returns True if contents of this map is changed.
-  Standard_Boolean Unite (const NCollection_Map& theOther)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean Unite(const NCollection_Map& theOther)
   {
-    if (this == &theOther)
-    {
-      return Standard_False;
-    }
-
-    const Standard_Integer anOldExtent = Extent();
-    Union (*this, theOther);
-    return anOldExtent != Extent();
+    return NCollection_MapAlgo::Unite<NCollection_Map>(*this, theOther);
   }
 
   //! Returns true if this and theMap have common elements.
-  Standard_Boolean HasIntersection (const NCollection_Map& theMap) const
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean HasIntersection(const NCollection_Map& theMap) const
   {
-    const NCollection_Map* aMap1 = this;
-    const NCollection_Map* aMap2 = &theMap;
-    if (theMap.Size() < Size())
-    {
-      aMap1 = &theMap;
-      aMap2 = this;
-    }
-
-    for (NCollection_Map::Iterator aIt(*aMap1); aIt.More(); aIt.Next())
-    {
-      if (aMap2->Contains(aIt.Value()))
-      {
-        return Standard_True;
-      }
-    }
-
-    return Standard_False;
+    return NCollection_MapAlgo::HasIntersection<NCollection_Map>(*this, theMap);
   }
 
   //! Sets this Map to be the result of intersection (aka multiplication, common, boolean AND) operation between two given Maps.
   //! The new Map contains only the values that are contained in both map operands.
   //! All previous content of this Map is cleared.
   //! This same map (result of the boolean operation) can also be used as one of operands.
-  void Intersection (const NCollection_Map& theLeft,
-                     const NCollection_Map& theRight)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  void Intersection(const NCollection_Map& theLeft, const NCollection_Map& theRight)
   {
-    if (&theLeft == &theRight)
-    {
-      Assign (theLeft);
-      return;
-    }
-
-    if (this == &theLeft)
-    {
-      NCollection_Map aCopy (1, this->myAllocator);
-      Exchange     (aCopy);
-      Intersection (aCopy, theRight);
-      return;
-    }
-    else if (this == &theRight)
-    {
-      NCollection_Map aCopy (1, this->myAllocator);
-      Exchange     (aCopy);
-      Intersection (theLeft, aCopy);
-      return;
-    }
-
-    Clear();
-    if (theLeft.Extent() < theRight.Extent())
-    {
-      for (Iterator anIter (theLeft); anIter.More(); anIter.Next())
-      {
-        if (theRight.Contains (anIter.Key()))
-        {
-          Add (anIter.Key());
-        }
-      }
-    }
-    else
-    {
-      for (Iterator anIter (theRight); anIter.More(); anIter.Next())
-      {
-        if (theLeft.Contains (anIter.Key()))
-        {
-          Add (anIter.Key());
-        }
-      }
-    }
+    NCollection_MapAlgo::Intersection<NCollection_Map>(*this, theLeft, theRight);
   }
 
   //! Apply to this Map the intersection operation (aka multiplication, common, boolean AND) with another (given) Map.
   //! The result contains only the values that are contained in both this and the given maps.
   //! This algorithm is similar to method Intersection().
   //! Returns True if contents of this map is changed.
-  Standard_Boolean Intersect (const NCollection_Map& theOther)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean Intersect(const NCollection_Map& theOther)
   {
-    if (this == &theOther
-     || IsEmpty())
-    {
-      return Standard_False;
-    }
-
-    const Standard_Integer anOldExtent = Extent();
-    Intersection (*this, theOther);
-    return anOldExtent != Extent();
+    return NCollection_MapAlgo::Intersect<NCollection_Map>(*this, theOther);
   }
 
   //! Sets this Map to be the result of subtraction (aka set-theoretic difference, relative complement,
   //! exclude, cut, boolean NOT) operation between two given Maps.
   //! The new Map contains only the values that are contained in the first map operands and not contained in the second one.
   //! All previous content of this Map is cleared.
-  void Subtraction (const NCollection_Map& theLeft,
-                    const NCollection_Map& theRight)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  void Subtraction(const NCollection_Map& theLeft, const NCollection_Map& theRight)
   {
-    if (this == &theLeft)
-    {
-      Subtract (theRight);
-      return;
-    }
-    else if (this == &theRight)
-    {
-      NCollection_Map aCopy (1, this->myAllocator);
-      Exchange    (aCopy);
-      Subtraction (theLeft, aCopy);
-      return;
-    }
-
-    Assign   (theLeft);
-    Subtract (theRight);
+    NCollection_MapAlgo::Subtraction<NCollection_Map>(*this, theLeft, theRight);
   }
 
   //! Apply to this Map the subtraction (aka set-theoretic difference, relative complement,
@@ -553,89 +430,29 @@ public:
   //! The result contains only the values that were previously contained in this map and not contained in this map.
   //! This algorithm is similar to method Subtract() with two operands.
   //! Returns True if contents of this map is changed.
-  Standard_Boolean Subtract (const NCollection_Map& theOther)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean Subtract(const NCollection_Map& theOther)
   {
-    if (this == &theOther)
-    {
-      if (IsEmpty())
-      {
-        return Standard_False;
-      }
-
-      Clear();
-      return Standard_True;
-    }
-
-    const Standard_Integer anOldExtent = Extent();
-    for (Iterator anIter (theOther); anIter.More(); anIter.Next())
-    {
-      Remove (anIter.Key());
-    }
-    return anOldExtent != Extent();
+    return NCollection_MapAlgo::Subtract<NCollection_Map>(*this, theOther);
   }
 
   //! Sets this Map to be the result of symmetric difference (aka exclusive disjunction, boolean XOR) operation between two given Maps.
   //! The new Map contains the values that are contained only in the first or the second operand maps but not in both.
   //! All previous content of this Map is cleared. This map (result of the boolean operation) can also be used as one of operands.
-  void Difference (const NCollection_Map& theLeft,
-                   const NCollection_Map& theRight)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  void Difference(const NCollection_Map& theLeft, const NCollection_Map& theRight)
   {
-    if (&theLeft == &theRight)
-    {
-      Clear();
-      return;
-    }
-    else if (this == &theLeft)
-    {
-      NCollection_Map aCopy (1, this->myAllocator);
-      Exchange   (aCopy);
-      Difference (aCopy, theRight);
-      return;
-    }
-    else if (this == &theRight)
-    {
-      NCollection_Map aCopy (1, this->myAllocator);
-      Exchange   (aCopy);
-      Difference (theLeft, aCopy);
-      return;
-    }
-
-    Clear();
-    for (Iterator anIter (theLeft); anIter.More(); anIter.Next())
-    {
-      if (!theRight.Contains (anIter.Key()))
-      {
-        Add (anIter.Key());
-      }
-    }
-    for (Iterator anIter (theRight); anIter.More(); anIter.Next())
-    {
-      if (!theLeft.Contains (anIter.Key()))
-      {
-        Add (anIter.Key());
-      }
-    }
+    NCollection_MapAlgo::Difference<NCollection_Map>(*this, theLeft, theRight);
   }
 
   //! Apply to this Map the symmetric difference (aka exclusive disjunction, boolean XOR) operation with another (given) Map.
   //! The result contains the values that are contained only in this or the operand map, but not in both.
   //! This algorithm is similar to method Difference().
   //! Returns True if contents of this map is changed.
-  Standard_Boolean Differ (const NCollection_Map& theOther)
+  Standard_DEPRECATED("This method will be removed right after 7.9. release. Use methods from NCollection_MapAlgo.hxx instead.")
+  Standard_Boolean Differ(const NCollection_Map& theOther)
   {
-    if (this == &theOther)
-    {
-      if (IsEmpty())
-      {
-        return Standard_False;
-      }
-      Clear();
-      return Standard_True;
-    }
-
-    const Standard_Integer anOldExtent = Extent();
-    Difference (*this, theOther);
-    return anOldExtent != Extent();
+    return NCollection_MapAlgo::Differ<NCollection_Map>(*this, theOther);
   }
 
 protected:

--- a/src/NCollection/NCollection_MapAlgo.hxx
+++ b/src/NCollection/NCollection_MapAlgo.hxx
@@ -1,0 +1,334 @@
+// Copyright (c) 2024 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef NCollection_MapAlgo_HeaderFile
+#define NCollection_MapAlgo_HeaderFile
+
+//! This namespace contains algorithms and utilities for managing NCollection_Map.
+//!
+//! The NCollection_MapAlgo namespace provides a set of template functions
+//! that facilitate the manipulation and management of NCollection_Map instances.
+//! These algorithms are designed to be efficient and easy to use, providing
+//! common operations such as union, intersection, subtraction, and symmetric difference
+//! on map collections.
+namespace NCollection_MapAlgo
+{
+  //! Sets this Map to be the result of union (aka addition, fuse, merge, boolean OR)
+  //! operation between two given Maps. The new Map contains the values that are
+  //! contained either in the first map or in the second map or in both.
+  //! All previous content of this Map is cleared. This map (result of the boolean
+  //! operation) can also be passed as one of operands.
+  template<class MapType>
+  void Union(MapType& theMap, const MapType& theLeftMap, const MapType& theRightMap)
+  {
+    if (&theLeftMap == &theRightMap)
+    {
+      theMap.Assign(theLeftMap);
+      return;
+    }
+
+    if (&theMap != &theLeftMap && &theMap != &theRightMap)
+    {
+      theMap.Clear();
+    }
+
+    if (&theMap != &theLeftMap)
+    {
+      for (typename MapType::Iterator anIter(theLeftMap); anIter.More(); anIter.Next())
+      {
+        theMap.Add(anIter.Key());
+      }
+    }
+    if (&theMap != &theRightMap)
+    {
+      for (typename MapType::Iterator anIter(theRightMap); anIter.More(); anIter.Next())
+      {
+        theMap.Add(anIter.Key());
+      }
+    }
+  }
+
+  //! Apply to this Map the boolean operation union (aka addition, fuse, merge, boolean OR)
+  //! with another (given) Map. The result contains the values that were previously
+  //! contained in this map or contained in the given (operand) map. This algorithm is
+  //! similar to method Union(). Returns True if contents of this map is changed.
+  template<class MapType>
+  bool Unite(MapType& theMap, const MapType& theOtherMap)
+  {
+    if (&theMap == &theOtherMap)
+    {
+      return false;
+    }
+
+    const int anOldExtent = theMap.Extent();
+    Union<MapType>(theMap, theMap, theOtherMap);
+    return anOldExtent != theMap.Extent();
+  }
+
+  //! Returns true if this and theMap have common elements.
+  template<class MapType>
+  bool HasIntersection(const MapType& theMap, const MapType& theOtherMap)
+  {
+    const MapType* aMap1 = &theMap;
+    const MapType* aMap2 = &theOtherMap;
+    if (theOtherMap.Size() < theMap.Size())
+    {
+      aMap1 = &theOtherMap;
+      aMap2 = &theMap;
+    }
+
+    for (typename MapType::Iterator aIt(*aMap1); aIt.More(); aIt.Next())
+    {
+      if (aMap2->Contains(aIt.Value()))
+      {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  //! Sets this Map to be the result of intersection (aka multiplication, common, boolean AND)
+  //! operation between two given Maps. The new Map contains only the values that are
+  //! contained in both map operands. All previous content of this Map is cleared.
+  //! This same map (result of the boolean operation) can also be used as one of operands.
+  template<class MapType>
+  void Intersection(MapType& theMap, const MapType& theLeftMap, const MapType& theRightMap)
+  {
+    if (&theLeftMap == &theRightMap)
+    {
+      theMap.Assign(theLeftMap);
+      return;
+    }
+
+    if (&theMap == &theLeftMap)
+    {
+      MapType aCopy(1, theMap.Allocator());
+      theMap.Exchange(aCopy);
+      Intersection<MapType>(theMap, aCopy, theRightMap);
+      return;
+    }
+    else if (&theMap == &theRightMap)
+    {
+      MapType aCopy(1, theMap.Allocator());
+      theMap.Exchange(aCopy);
+      Intersection<MapType>(theMap, theLeftMap, aCopy);
+      return;
+    }
+
+    theMap.Clear();
+    if (theLeftMap.Extent() < theRightMap.Extent())
+    {
+      for (typename MapType::Iterator anIter(theLeftMap); anIter.More(); anIter.Next())
+      {
+        if (theRightMap.Contains(anIter.Key()))
+        {
+          theMap.Add(anIter.Key());
+        }
+      }
+    }
+    else
+    {
+      for (typename MapType::Iterator anIter(theRightMap); anIter.More(); anIter.Next())
+      {
+        if (theLeftMap.Contains(anIter.Key()))
+        {
+          theMap.Add(anIter.Key());
+        }
+      }
+    }
+  }
+
+  //! Apply to this Map the intersection operation (aka multiplication, common, boolean AND)
+  //! with another (given) Map. The result contains only the values that are contained in
+  //! both this and the given maps. This algorithm is similar to method Intersection().
+  //! Returns True if contents of this map is changed.
+  template<class MapType>
+  bool Intersect(MapType& theMap, const MapType& theOtherMap)
+  {
+    if (&theMap == &theOtherMap || theMap.IsEmpty())
+    {
+      return false;
+    }
+
+    const int anOldExtent = theMap.Extent();
+    Intersection<MapType>(theMap, theMap, theOtherMap);
+    return anOldExtent != theMap.Extent();
+  }
+
+  //! Apply to this Map the subtraction (aka set-theoretic difference, relative complement,
+  //! exclude, cut, boolean NOT) operation with another (given) Map. The result contains
+  //! only the values that were previously contained in this map and not contained in this map.
+  //! This algorithm is similar to method Subtract() with two operands. Returns True if
+  //! contents of this map is changed.
+  template<class MapType>
+  bool Subtract(MapType& theMap, const MapType& theOtherMap)
+  {
+    if (&theMap == &theOtherMap)
+    {
+      if (theMap.IsEmpty())
+      {
+        return false;
+      }
+
+      theMap.Clear();
+      return true;
+    }
+
+    const int anOldExtent = theMap.Extent();
+    for (typename MapType::Iterator anIter(theOtherMap); anIter.More(); anIter.Next())
+    {
+      theMap.Remove(anIter.Key());
+    }
+    return anOldExtent != theMap.Extent();
+  }
+
+  //! Sets this Map to be the result of subtraction (aka set-theoretic difference, relative
+  //! complement, exclude, cut, boolean NOT) operation between two given Maps. The new Map
+  //! contains only the values that are contained in the first map operands and not contained
+  //! in the second one. All previous content of this Map is cleared.
+  template<class MapType>
+  void Subtraction(MapType& theMap, const MapType& theLeftMap, const MapType& theRightMap)
+  {
+    if (&theMap == &theLeftMap)
+    {
+      Subtract<MapType>(theMap, theRightMap);
+      return;
+    }
+    else if (&theMap == &theRightMap)
+    {
+      MapType aCopy(1, theMap.Allocator());
+      theMap.Exchange(aCopy);
+      Subtraction(theMap, theLeftMap, aCopy);
+      return;
+    }
+
+    theMap.Assign(theLeftMap);
+    Subtract<MapType>(theMap, theRightMap);
+  }
+
+  //! Sets this Map to be the result of symmetric difference (aka exclusive disjunction,
+  //! boolean XOR) operation between two given Maps. The new Map contains the values that
+  //! are contained only in the first or the second operand maps but not in both.
+  //! All previous content of this Map is cleared. This map (result of the boolean operation)
+  //! can also be used as one of operands.
+  template<class MapType>
+  void Difference(MapType& theMap, const MapType& theLeftMap, const MapType& theRightMap)
+  {
+    if (&theLeftMap == &theRightMap)
+    {
+      theMap.Clear();
+      return;
+    }
+    else if (&theMap == &theLeftMap)
+    {
+      MapType aCopy(1, theMap.Allocator());
+      theMap.Exchange(aCopy);
+      Difference<MapType>(theMap, aCopy, theRightMap);
+      return;
+    }
+    else if (&theMap == &theRightMap)
+    {
+      MapType aCopy(1, theMap.Allocator());
+      theMap.Exchange(aCopy);
+      Difference<MapType>(theMap, theLeftMap, aCopy);
+      return;
+    }
+
+    theMap.Clear();
+    for (typename MapType::Iterator anIter(theLeftMap); anIter.More(); anIter.Next())
+    {
+      if (!theRightMap.Contains(anIter.Key()))
+      {
+        theMap.Add(anIter.Key());
+      }
+    }
+    for (typename MapType::Iterator anIter(theRightMap); anIter.More(); anIter.Next())
+    {
+      if (!theLeftMap.Contains(anIter.Key()))
+      {
+        theMap.Add(anIter.Key());
+      }
+    }
+  }
+
+  //! Apply to this Map the symmetric difference (aka exclusive disjunction, boolean XOR)
+  //! operation with another (given) Map. The result contains the values that are contained
+  //! only in this or the operand map, but not in both. This algorithm is similar to method
+  //! Difference(). Returns True if contents of this map is changed.
+  template<class MapType>
+  bool Differ(MapType& theMap, const MapType& theOtherMap)
+  {
+    if (&theMap == &theOtherMap)
+    {
+      if (theMap.IsEmpty())
+      {
+        return false;
+      }
+      theMap.Clear();
+      return true;
+    }
+
+    const int anOldExtent = theMap.Extent();
+    Difference<MapType>(theMap, theMap, theOtherMap);
+    return anOldExtent != theMap.Extent();
+  }
+
+  //! Checks if this map contains all keys of another map.
+  //! This function checks if theMap contains all keys of theOtherMap. It first
+  //! checks if the two maps are the same instance or if theOtherMap is empty, in
+  //! which case it returns true. Then it compares the number of elements in both
+  //! maps. If theMap has fewer elements than theOtherMap, it returns false. Finally,
+  //! it iterates through all keys in theOtherMap and checks if each key is present
+  //! in theMap.
+  template<class MapType>
+  bool Contains(const MapType& theMap, const MapType& theOtherMap)
+  {
+    if (&theMap == &theOtherMap || theOtherMap.IsEmpty())
+    {
+      return true;
+    }
+    else if (theMap.Extent() < theOtherMap.Extent())
+    {
+      return false;
+    }
+
+    for (typename MapType::Iterator anIter(theOtherMap); anIter.More(); anIter.Next())
+    {
+      if (!theMap.Contains(anIter.Key()))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  //! Checks if two maps contain exactly the same keys.
+  //! This function compares the keys of two maps and returns true if they contain
+  //! exactly the same keys. It first checks if the two maps are the same instance,
+  //! in which case it returns true. Then it compares the number of elements in both
+  //! maps. If they are equal, it calls the Contains function to check if all keys
+  //! in theOtherMap are present in theMap.
+  template<class MapType>
+  bool IsEqual(const MapType& theMap, const MapType& theOtherMap)
+  {
+    if (&theMap == &theOtherMap)
+    {
+      return true;
+    }
+    return theMap.Extent() == theOtherMap.Extent() && Contains<MapType>(theMap, theOtherMap);
+  }
+}
+
+#endif // NCollection_MapAlgo_HeaderFile

--- a/src/QABugs/QABugs_19.cxx
+++ b/src/QABugs/QABugs_19.cxx
@@ -1424,12 +1424,12 @@ static Standard_Integer OCC24271 (Draw_Interpretor& di,
     aMapRight.Add (aKeyIter);
   }
 
-  QCOMPARE (aMapLeft .Contains (aMapRight), Standard_False);
-  QCOMPARE (aMapRight.Contains (aMapLeft),  Standard_False);
+  QCOMPARE (NCollection_MapAlgo::Contains (aMapLeft, aMapRight), Standard_False);
+  QCOMPARE (NCollection_MapAlgo::Contains (aMapRight, aMapLeft),  Standard_False);
 
   // validate Union operation
   NCollection_Map<Standard_Integer> aMapUnion;
-  aMapUnion.Union (aMapLeft, aMapRight);
+  NCollection_MapAlgo::Union(aMapUnion, aMapLeft, aMapRight);
   QCOMPARE (aMapUnion.Extent(), aRightUpper - aLeftLower + 1);
   for (Standard_Integer aKeyIter = aLeftLower; aKeyIter <= aRightUpper; ++aKeyIter)
   {
@@ -1438,18 +1438,18 @@ static Standard_Integer OCC24271 (Draw_Interpretor& di,
 
   // validate Intersection operation
   NCollection_Map<Standard_Integer> aMapSect;
-  aMapSect.Intersection (aMapLeft, aMapRight);
+  NCollection_MapAlgo::Intersection(aMapSect, aMapLeft, aMapRight);
   QCOMPARE (aMapSect.Extent(), aLeftUpper - aRightLower + 1);
   for (Standard_Integer aKeyIter = aRightLower; aKeyIter <= aLeftUpper; ++aKeyIter)
   {
     QCOMPARE (aMapSect.Contains (aKeyIter), Standard_True);
   }
-  QCOMPARE (aMapLeft .Contains (aMapSect), Standard_True);
-  QCOMPARE (aMapRight.Contains (aMapSect), Standard_True);
+  QCOMPARE (NCollection_MapAlgo::Contains (aMapLeft, aMapSect), Standard_True);
+  QCOMPARE (NCollection_MapAlgo::Contains (aMapRight, aMapSect), Standard_True);
 
   // validate Substruction operation
   NCollection_Map<Standard_Integer> aMapSubsLR;
-  aMapSubsLR.Subtraction (aMapLeft, aMapRight);
+  NCollection_MapAlgo::Subtraction(aMapSubsLR, aMapLeft, aMapRight);
   QCOMPARE (aMapSubsLR.Extent(), aRightLower - aLeftLower);
   for (Standard_Integer aKeyIter = aLeftLower; aKeyIter < aRightLower; ++aKeyIter)
   {
@@ -1457,7 +1457,7 @@ static Standard_Integer OCC24271 (Draw_Interpretor& di,
   }
 
   NCollection_Map<Standard_Integer> aMapSubsRL;
-  aMapSubsRL.Subtraction (aMapRight, aMapLeft);
+  NCollection_MapAlgo::Subtraction(aMapSubsRL, aMapRight, aMapLeft);
   QCOMPARE (aMapSubsRL.Extent(), aRightUpper - aLeftUpper);
   for (Standard_Integer aKeyIter = aLeftUpper + 1; aKeyIter < aRightUpper; ++aKeyIter)
   {
@@ -1466,7 +1466,7 @@ static Standard_Integer OCC24271 (Draw_Interpretor& di,
 
   // validate Difference operation
   NCollection_Map<Standard_Integer> aMapDiff;
-  aMapDiff.Difference (aMapLeft, aMapRight);
+  NCollection_MapAlgo::Difference(aMapDiff, aMapLeft, aMapRight);
   QCOMPARE (aMapDiff.Extent(), aRightLower - aLeftLower + aRightUpper - aLeftUpper);
   for (Standard_Integer aKeyIter = aLeftLower; aKeyIter < aRightLower; ++aKeyIter)
   {
@@ -1489,10 +1489,10 @@ static Standard_Integer OCC24271 (Draw_Interpretor& di,
   aMapSect.Add (43);
 
   NCollection_Map<Standard_Integer> aMapCopy (aMapSwap);
-  QCOMPARE (aMapCopy.IsEqual (aMapSwap), Standard_True);
+  QCOMPARE (NCollection_MapAlgo::IsEqual(aMapCopy, aMapSwap), Standard_True);
   aMapCopy.Remove (34);
   aMapCopy.Add    (43);
-  QCOMPARE (aMapCopy.IsEqual (aMapSwap), Standard_False);
+  QCOMPARE (NCollection_MapAlgo::IsEqual(aMapCopy, aMapSwap), Standard_False);
 
   return 0;
 }

--- a/src/QANCollection/QANCollection_Test.cxx
+++ b/src/QANCollection/QANCollection_Test.cxx
@@ -401,8 +401,8 @@ static void TestMap(QANCollection_MapFunc& theM, Draw_Interpretor& theDI)
     aM3.Add(2);
     aM3.Add(3);
 
-    if (!aM1.HasIntersection(aM2) || !aM2.HasIntersection(aM1) ||
-         aM1.HasIntersection(aM3) ||  aM3.HasIntersection(aM1))
+    if (!NCollection_MapAlgo::HasIntersection(aM1, aM2) || !NCollection_MapAlgo::HasIntersection(aM2, aM1) ||
+         NCollection_MapAlgo::HasIntersection(aM1, aM3) ||  NCollection_MapAlgo::HasIntersection(aM3, aM1))
     {
       theDI << "Error: method 'HasIntersection' failed.";
     }

--- a/src/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -2516,7 +2516,7 @@ Standard_Boolean ShapeUpgrade_UnifySameDomain::MergeEdges(TopTools_SequenceOfSha
       }
     }
   }
-  VerticesToAvoid.Unite(NonMergVrt);
+  NCollection_MapAlgo::Unite(VerticesToAvoid, NonMergVrt);
 
   // do loop while there are unused edges
   TopTools_MapOfShape aUsedEdges;

--- a/src/XCAFDoc/XCAFDoc_Editor.cxx
+++ b/src/XCAFDoc/XCAFDoc_Editor.cxx
@@ -672,7 +672,7 @@ bool XCAFDoc_Editor::FilterShapeTree(const Handle(XCAFDoc_ShapeTool)& theShapeTo
   for (TDF_LabelMap::Iterator aLabelIter (theLabelsToKeep); aLabelIter.More(); aLabelIter.Next())
   {
     GetParentShapeLabels (aLabelIter.Key(), aInternalLabels);
-    aLabelsToKeep.Unite(aInternalLabels);
+    NCollection_MapAlgo::Unite(aLabelsToKeep, aInternalLabels);
     aInternalLabels.Clear(false);
   }
   for(TDF_ChildIterator aLabelIter (theShapeTool->Label(), true); aLabelIter.More(); aLabelIter.Next())


### PR DESCRIPTION
Updated multiple classes to utilize the new NCollection_MapAlgo for union, intersection, and other set operations, improving code structure and maintainability.
Deprecated older methods in NCollection_Map in favor of the new algorithmic approaches.