### PR TITLE
Foundation Classes - Reorganize of OCCT RTTI

### DIFF
--- a/src/BOPTest/BOPTest.cxx
+++ b/src/BOPTest/BOPTest.cxx
@@ -92,7 +92,7 @@ void BOPTest::ReportAlerts(const Handle(Message_Report)& theReport)
   for (int iGravity = 0; iGravity < 2; iGravity++)
   {
     // report shapes for the same type of alert together
-    NCollection_Map<Handle(Standard_Transient)> aPassedTypes;
+    NCollection_Map<Handle(Standard_Type)> aPassedTypes;
     const Message_ListOfAlert& aList = theReport->GetAlerts (anAlertTypes[iGravity]);
     for (Message_ListOfAlert::Iterator aIt (aList); aIt.More(); aIt.Next())
     {

--- a/src/BinLDrivers/BinLDrivers_DocumentStorageDriver.hxx
+++ b/src/BinLDrivers/BinLDrivers_DocumentStorageDriver.hxx
@@ -120,8 +120,8 @@ private:
 
   BinObjMgt_Persistent myPAtt;
   TDF_LabelList myEmptyLabels;
-  TColStd_MapOfTransient myMapUnsupported;
-  TColStd_IndexedMapOfTransient myTypesMap;
+  NCollection_Map<Handle(Standard_Type)> myMapUnsupported;
+  NCollection_IndexedMap<Handle(Standard_Type)> myTypesMap;
   BinLDrivers_VectorOfDocumentSection mySections;
   TCollection_ExtendedString myFileName;
   //! Sizes of labels and some attributes that will be stored in the second pass

--- a/src/BinMDF/BinMDF_ADriverTable.cxx
+++ b/src/BinMDF/BinMDF_ADriverTable.cxx
@@ -90,12 +90,12 @@ const Handle(Standard_Type)& BinMDF_ADriverTable::AddDerivedDriver (Standard_CSt
 //=======================================================================
 
 void BinMDF_ADriverTable::AssignIds
-                (const TColStd_IndexedMapOfTransient& theTypes)
+                (const NCollection_IndexedMap<Handle(Standard_Type)>& theTypes)
 {
   myMapId.Clear();
   Standard_Integer i;
   for (i=1; i <= theTypes.Extent(); i++) {
-    Handle(Standard_Type) aType (Handle(Standard_Type)::DownCast (theTypes(i)));
+    const Handle(Standard_Type)& aType = theTypes(i);
     if (myMap.IsBound (aType)) {
       myMapId.Bind (aType, i);
     }
@@ -141,7 +141,8 @@ void BinMDF_ADriverTable::AssignIds
   {
     if (!myMapId.IsBound2 (aStrId.Value()))
     {
-      if (Handle(Standard_Type) anAdded = AddDerivedDriver (aStrId.Key().ToCString()))
+      Handle(Standard_Type) anAdded = AddDerivedDriver(aStrId.Key().ToCString());
+      if (!anAdded.IsNull())
       {
         myMapId.Bind (anAdded, aStrId.Value());
       }

--- a/src/BinMDF/BinMDF_ADriverTable.hxx
+++ b/src/BinMDF/BinMDF_ADriverTable.hxx
@@ -59,7 +59,7 @@ public:
   //! Assigns the IDs to the drivers of the given Types.
   //! It uses indices in the map as IDs.
   //! Useful in storage procedure.
-  Standard_EXPORT void AssignIds (const TColStd_IndexedMapOfTransient& theTypes);
+  Standard_EXPORT void AssignIds (const NCollection_IndexedMap<Handle(Standard_Type)>& theTypes);
   
   //! Assigns the IDs to the drivers of the given Type Names;
   //! It uses indices in the sequence as IDs.

--- a/src/BinObjMgt/BinObjMgt_Position.hxx
+++ b/src/BinObjMgt/BinObjMgt_Position.hxx
@@ -15,6 +15,7 @@
 #define _BinObjMgt_Position_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 class BinObjMgt_Position;
 DEFINE_STANDARD_HANDLE (BinObjMgt_Position, Standard_Transient)

--- a/src/BndLib/BndLib_Add2dCurve.cxx
+++ b/src/BndLib/BndLib_Add2dCurve.cxx
@@ -842,12 +842,9 @@ Standard_Boolean BndLib_Box2dCurve::IsTypeBase
   (const Handle(Geom2d_Curve)& aC2D,
    GeomAbs_CurveType& aTypeB)
 {
-  Standard_Boolean bRet; 
-  Handle(Standard_Type) aType;
+  Standard_Boolean bRet=Standard_True;
   //
-  bRet=Standard_True;
-  //
-  aType=aC2D->DynamicType();
+  const Handle(Standard_Type)& aType = aC2D->DynamicType();
   if (aType==STANDARD_TYPE(Geom2d_Line)) {
     aTypeB=GeomAbs_Line;
   }

--- a/src/CDF/CDF_MetaDataDriver.hxx
+++ b/src/CDF/CDF_MetaDataDriver.hxx
@@ -18,6 +18,7 @@
 #define _CDF_MetaDataDriver_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 class CDM_MetaData;
 class TCollection_ExtendedString;

--- a/src/Express/Express.hxx
+++ b/src/Express/Express.hxx
@@ -17,6 +17,7 @@
 #include <Standard_Boolean.hxx>
 #include <Standard_Type.hxx>
 #include <Standard_OStream.hxx>
+#include <Standard_Handle.hxx>
 
 class Express_Schema;
 class TCollection_AsciiString;

--- a/src/Express/Express_Field.hxx
+++ b/src/Express/Express_Field.hxx
@@ -15,6 +15,7 @@
 #define _Express_Field_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 class Express_Type;
 class TCollection_HAsciiString;

--- a/src/Express/Express_Type.hxx
+++ b/src/Express/Express_Type.hxx
@@ -15,6 +15,7 @@
 #define _Express_Type_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 class TCollection_AsciiString;
 

--- a/src/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
+++ b/src/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
@@ -215,7 +215,7 @@ void Geom2dAdaptor_Curve::load(const Handle(Geom2d_Curve)& C,
     myNestedEvaluator.Nullify();
     myBSplineCurve.Nullify();
 
-    Handle(Standard_Type) TheType = C->DynamicType();
+    const Handle(Standard_Type)& TheType = C->DynamicType();
     if ( TheType == STANDARD_TYPE(Geom2d_TrimmedCurve)) {
       Load(Handle(Geom2d_TrimmedCurve)::DownCast (C)->BasisCurve(),
 	   UFirst,ULast);

--- a/src/IFSelect/IFSelect_SignAncestor.cxx
+++ b/src/IFSelect/IFSelect_SignAncestor.cxx
@@ -32,9 +32,7 @@ Standard_Boolean IFSelect_SignAncestor::Matches(const Handle(Standard_Transient)
 						const TCollection_AsciiString& text,
 						const Standard_Boolean /*exact*/) const
 {
-  if (ent.IsNull()) return Standard_False;
-  DeclareAndCast(Standard_Type,atype,ent);
-  if (atype.IsNull()) atype = ent->DynamicType();
+  Handle(Standard_Type) atype = ent->DynamicType();
   return atype->SubType(text.ToCString());
 }
 						

--- a/src/IFSelect/IFSelect_SignType.cxx
+++ b/src/IFSelect/IFSelect_SignType.cxx
@@ -33,8 +33,7 @@ static Standard_CString nulsign = "";
    const Handle(Interface_InterfaceModel)& /*model*/) const
 {
   if (ent.IsNull()) return nulsign;
-  DeclareAndCast(Standard_Type,atype,ent);
-  if (atype.IsNull()) atype = ent->DynamicType();
+  Handle(Standard_Type) atype = ent->DynamicType();
   Standard_CString tn = atype->Name();
   if (!thenopk) return tn;
   for (int i = 0; tn[i] != '\0'; i ++) {

--- a/src/Interface/Interface_FileReaderTool.cxx
+++ b/src/Interface/Interface_FileReaderTool.cxx
@@ -250,7 +250,7 @@ Standard_Boolean Interface_FileReaderTool::RecognizeByLib(const Standard_Integer
   }
   if (CN <= 0 || proto.IsNull()) return Standard_False;
 //   Se recaler dans GeneralLib : Creation de l entite vide
-  Handle(Standard_Type) typrot = proto->DynamicType();
+  const Handle(Standard_Type)& typrot = proto->DynamicType();
   for (glib.Start(); glib.More(); glib.Next()) {
     proto = glib.Protocol();
     if (proto.IsNull()) continue;

--- a/src/Interface/Interface_GTool.hxx
+++ b/src/Interface/Interface_GTool.hxx
@@ -110,8 +110,8 @@ private:
   Handle(Interface_Protocol) theproto;
   Handle(Interface_SignType) thesign;
   Interface_GeneralLib thelib;
-  Interface_DataMapOfTransientInteger thentnum;
-  TColStd_IndexedDataMapOfTransientTransient thentmod;
+  NCollection_DataMap<Handle(Standard_Type),Standard_Integer> thentnum;
+  NCollection_IndexedDataMap<Handle(Standard_Type),Handle(Standard_Transient)> thentmod;
 
 
 };

--- a/src/Message/Message_Alert.hxx
+++ b/src/Message/Message_Alert.hxx
@@ -17,6 +17,7 @@
 #define _Message_Alert_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 DEFINE_STANDARD_HANDLE(Message_Alert, Standard_Transient)
 

--- a/src/Message/Message_Algorithm.cxx
+++ b/src/Message/Message_Algorithm.cxx
@@ -223,13 +223,9 @@ void Message_Algorithm::SendStatusMessages (const Message_ExecStatus& theStatus,
 
     // find message, prefixed by class type name, iterating by base classes if necessary
     TCollection_AsciiString aMsgName;
-    for (Handle(Standard_Type) aType = DynamicType(); ! aType.IsNull(); aType = aType->Parent())
-    {
+    Handle(Standard_Type) aType = DynamicType();
       aMsgName = aType->Name();
       aMsgName += aSuffix;
-      if (Message_MsgFile::HasMsg(aMsgName))
-        break;
-    }
 
     // create a message
     Message_Msg aMsg ( aMsgName );

--- a/src/OpenGl/OpenGl_Element.hxx
+++ b/src/OpenGl/OpenGl_Element.hxx
@@ -17,6 +17,7 @@
 #define OpenGl_Element_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Handle.hxx>
 
 class Graphic3d_FrameStatsDataTmp;
 class OpenGl_Workspace;

--- a/src/OpenGl/OpenGl_Resource.hxx
+++ b/src/OpenGl/OpenGl_Resource.hxx
@@ -17,6 +17,7 @@
 #define OpenGl_Resource_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 class OpenGl_Context;
 

--- a/src/STEPSelections/STEPSelections_SelectDerived.cxx
+++ b/src/STEPSelections/STEPSelections_SelectDerived.cxx
@@ -60,8 +60,7 @@ Standard_Boolean STEPSelections_SelectDerived::Matches(const Handle(Standard_Tra
     
   Standard_Boolean plex = module->IsComplex(CN);
     if (!plex) {
-      DeclareAndCast(Standard_Type,atype,ent);
-      if (atype.IsNull()) atype = ent->DynamicType();
+      Handle(Standard_Type) atype = ent->DynamicType();
       return atype->SubType(checker);
     } else {
       TColStd_SequenceOfAsciiString list;

--- a/src/SelectMgr/SelectMgr.hxx
+++ b/src/SelectMgr/SelectMgr.hxx
@@ -15,6 +15,7 @@
 #define _SelectMgr_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Handle.hxx>
 
 class Graphic3d_Structure;
 class Graphic3d_TransformPers;

--- a/src/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
+++ b/src/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
@@ -870,7 +870,7 @@ Standard_Boolean ShapeConstruct_ProjectCurveOnSurface::PerformByProjLib(Handle(G
   Handle(Geom_Curve) cIso;
   Standard_Real t1, t2;
   
-  Handle(Standard_Type) sType = mySurf->Surface()->DynamicType();
+  const Handle(Standard_Type)& sType = mySurf->Surface()->DynamicType();
   Standard_Boolean isAnalytic = Standard_True;
   if (sType == STANDARD_TYPE(Geom_BezierSurface) || sType == STANDARD_TYPE(Geom_BSplineSurface)) isAnalytic = Standard_False; 
   Standard_Real uf, ul, vf, vl;

--- a/src/Standard/Standard_ArrayStreamBuffer.cxx
+++ b/src/Standard/Standard_ArrayStreamBuffer.cxx
@@ -13,6 +13,8 @@
 
 #include <Standard_ArrayStreamBuffer.hxx>
 
+#include <cstring>
+
 // =======================================================================
 // function : Standard_ArrayStreamBuffer
 // purpose  :

--- a/src/Standard/Standard_DefineHandle.hxx
+++ b/src/Standard/Standard_DefineHandle.hxx
@@ -21,10 +21,10 @@
 //! Since OCCT 7.0, relevant macros are provided by Standard_Type.hxx and Standard_Handle.hxx.
 
 #include <Standard_Type.hxx>
+#include <Standard_Handle.hxx>
 
 class Standard_Transient;
 class Standard_Persistent;
-class Standard_Type;
 
 // Obsolete macros kept for compatibility
 #define IMPLEMENT_DOWNCAST(C1,BC)

--- a/src/Standard/Standard_Persistent.hxx
+++ b/src/Standard/Standard_Persistent.hxx
@@ -16,6 +16,7 @@
 #define _Standard_Persistent_HeaderFile
 
 #include <Standard_Type.hxx>
+#include <Standard_Transient.hxx>
 
 //! Root of "persistent" classes, a legacy support of
 //! object oriented databases, now outdated.

--- a/src/Standard/Standard_Transient.cxx
+++ b/src/Standard/Standard_Transient.cxx
@@ -18,9 +18,11 @@
 #include <Standard_CString.hxx>
 #include <Standard_ProgramError.hxx>
 
-const Handle(Standard_Type)& Standard_Transient::get_type_descriptor ()
+const Handle(Standard_Type)& Standard_Transient::get_type_descriptor()
 {
-  return opencascade::type_instance<Standard_Transient>::get();
+  static const opencascade::handle<Standard_Type> THE_TYPE_INSTANCE(new Standard_Type(typeid(Standard_Transient), get_type_name(),
+                                                                    sizeof(Standard_Transient), nullptr));
+  return THE_TYPE_INSTANCE;
 }
 
 //

--- a/src/Standard/Standard_Transient.hxx
+++ b/src/Standard/Standard_Transient.hxx
@@ -122,4 +122,6 @@ private:
 //! Definition of Handle_Standard_Transient as typedef for compatibility
 typedef opencascade::handle<Standard_Transient> Handle_Standard_Transient;
 
+#include <Standard_Handle.hxx>
+
 #endif 

--- a/src/Standard/Standard_Type.cxx
+++ b/src/Standard/Standard_Type.cxx
@@ -1,5 +1,5 @@
 // Copyright (c) 1998-1999 Matra Datavision
-// Copyright (c) 1999-2014 OPEN CASCADE SAS
+// Copyright (c) 1999-2024 OPEN CASCADE SAS
 //
 // This file is part of Open CASCADE Technology software library.
 //
@@ -12,40 +12,37 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-
 #include <Standard_Type.hxx>
-#include <Standard_Mutex.hxx>
-#include <Standard_Assert.hxx>
-
-#include <unordered_map>
-
-IMPLEMENT_STANDARD_RTTIEXT(Standard_Type,Standard_Transient)
 
 //============================================================================
-
-Standard_Type::Standard_Type (const std::type_info& theInfo,
-                              const char* theName,
-                              Standard_Size theSize,
-                              const Handle(Standard_Type)& theParent) :
-  myInfo(theInfo),
-  myName(theName),
-  mySize(theSize), 
-  myParent(theParent)
-{
-}
-
-//============================================================================
-
 Standard_Boolean Standard_Type::SubType (const Handle(Standard_Type)& theOther) const
 {
-  return ! theOther.IsNull() && (theOther == this || (! myParent.IsNull() && myParent->SubType (theOther)));
+  const Standard_Type* aTypeIter = this;
+  while (aTypeIter != nullptr)
+  {
+    if (*theOther == *aTypeIter)
+    {
+      return true;
+    }
+    aTypeIter = aTypeIter->Parent();
+  }
+  return false;
 }
 
 //============================================================================
 
 Standard_Boolean Standard_Type::SubType (const Standard_CString theName) const
 {
-  return theName != 0 && (IsEqual (myName, theName) || (! myParent.IsNull() && myParent->SubType (theName)));
+  const Standard_Type* aTypeIter = this;
+  while (aTypeIter != nullptr)
+  {
+    if (IsEqual(theName, aTypeIter->Name()))
+    {
+      return true;
+    }
+    aTypeIter = aTypeIter->Parent();
+  }
+  return false;
 }
 
 // ------------------------------------------------------------------
@@ -54,54 +51,4 @@ Standard_Boolean Standard_Type::SubType (const Standard_CString theName) const
 void Standard_Type::Print (Standard_OStream& AStream) const
 {
   AStream << std::hex << (Standard_Address)this << " : " << std::dec << myName ;
-}
-
-//============================================================================
-// Registry of types
-//============================================================================
-
-namespace {
-  // Map of string to type
-  typedef std::unordered_map<std::type_index, Standard_Type*> registry_type;
-
-  // Registry is made static in the function to ensure that it gets
-  // initialized by the time of first access
-  registry_type& GetRegistry() 
-  {
-    static registry_type theRegistry;
-    return theRegistry;
-  }
-
-  // To initialize theRegistry map as soon as possible to be destroyed the latest
-  Handle(Standard_Type) theType = STANDARD_TYPE(Standard_Transient);
-}
-
-Standard_Type* Standard_Type::Register (const std::type_info& theInfo, const char* theName,
-                                        Standard_Size theSize, const Handle(Standard_Type)& theParent)
-{
-  // Access to registry is protected by mutex; it should not happen often because
-  // instances are cached by Standard_Type::Instance() (one per binary module)
-  static Standard_Mutex theMutex;
-  Standard_Mutex::Sentry aSentry (theMutex);
-
-  // return existing descriptor if already in the registry
-  registry_type& aRegistry = GetRegistry();
-  Standard_Type* aType = 0;
-  auto anIter = aRegistry.find(theInfo);
-  if (anIter != aRegistry.end())
-    return anIter->second;
-
-  // else create a new descriptor
-  aType = new Standard_Type (theInfo, theName, theSize, theParent);
-
-  // then add it to registry and return (the reference to the handle stored in the registry)
-  aRegistry.emplace(theInfo, aType);
-  return aType;
-}
-
-Standard_Type::~Standard_Type ()
-{
-  // remove descriptor from the registry
-  registry_type& aRegistry = GetRegistry();
-  Standard_ASSERT(aRegistry.erase(myInfo) > 0, "Standard_Type::~Standard_Type() cannot find itself in registry",);
 }

--- a/src/Standard/Standard_Type.hxx
+++ b/src/Standard/Standard_Type.hxx
@@ -1,5 +1,5 @@
 // Copyright (c) 1991-1999 Matra Datavision
-// Copyright (c) 1999-2014 OPEN CASCADE SAS
+// Copyright (c) 1999-2024 OPEN CASCADE SAS
 //
 // This file is part of Open CASCADE Technology software library.
 //
@@ -16,71 +16,165 @@
 #define _Standard_Type_HeaderFile
 
 #include <Standard.hxx>
-#include <Standard_Handle.hxx>
-#include <Standard_Transient.hxx>
 #include <Standard_OStream.hxx>
+#include <Standard_Transient.hxx>
 
+#include <functional>
 #include <typeinfo>
 #include <typeindex>
 
-// Auxiliary tools to check at compile time that class declared as base in 
-// DEFINE_STANDARD_RTTI* macro is actually a base class.
-#if ! defined(OCCT_CHECK_BASE_CLASS)
-
-#if (defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || (__GNUC__ > 4)))
-
-// For GCC 4.7+, more strict check is possible -- ensuring that base class 
-// is direct base -- using non-standard C++ reflection functionality.
-
-#include <tr2/type_traits>
-#include <tuple>
-
-namespace opencascade 
+namespace opencascade
 {
-  template<typename T>
-  struct direct_base_class_as_tuple {};
-
-  template<typename ... Ts>
-  struct direct_base_class_as_tuple<std::tr2::__reflection_typelist<Ts...> >
-  {
-    typedef std::tuple<Ts...> type;
-  };
-
-  template <typename T, typename Tuple>
-  struct has_type;
-
-  template <typename T>
-  struct has_type<T, std::tuple<> > : std::false_type {};
-
-  template <typename T, typename U, typename... Ts>
-  struct has_type<T, std::tuple<U, Ts...> > : has_type<T, std::tuple<Ts...> > {};
-
-  template <typename T, typename... Ts>
-  struct has_type<T, std::tuple<T, Ts...> > : std::true_type {};
+  template <class T> class handle;
 }
 
-#define OCCT_CHECK_BASE_CLASS(Class,Base) \
-  using direct_base_classes = opencascade::direct_base_class_as_tuple<std::tr2::direct_bases<Class>::type>::type; \
-  static_assert(opencascade::has_type<Base, direct_base_classes>::type::value, "OCCT RTTI definition is incorrect: " #Base " is not direct base class of " #Class); \
-  static_assert(&get_type_name == &Class::get_type_name, "OCCT RTTI definition is misplaced: current class is not " #Class);
+class Standard_Transient;
 
-#elif (defined(_MSC_VER) && (_MSC_VER >= 1900))
+class Standard_Type
+{
+public:
 
-// VC14+ allow using address of member functions in static checks,
-// that allows checking for the current type being correctly named in the macro
-#define OCCT_CHECK_BASE_CLASS(Class,Base) \
-  static_assert(opencascade::is_base_but_not_same<Base, Class>::value, "OCCT RTTI definition is incorrect: " #Base " is not base class of " #Class); \
-  static_assert(&get_type_name == &Class::get_type_name, "OCCT RTTI definition is misplaced: current class is not " #Class);
+  Standard_Type(const std::type_info& theInfo,
+                const Standard_CString theName,
+                const Standard_Size theSize,
+                const Standard_Type* theParent) :
+    myInfo(theInfo),
+    myName(theName),
+    mySize(theSize),
+    myParent(theParent) {}
 
-#else
+  Standard_Type(const Standard_Type& theType) :
+    myInfo(theType.myInfo),
+    myName(theType.myName),
+    mySize(theType.mySize),
+    myParent(theType.myParent) {}
+
+  Standard_Type(Standard_Type&& theType) noexcept :
+    myInfo(theType.myInfo),
+    myName(theType.myName),
+    mySize(theType.mySize),
+    myParent(theType.myParent) {}
+
+  Standard_Type& operator=(const Standard_Type& theOther)
+  {
+    myInfo = theOther.myInfo;
+    myName = theOther.myName;
+    mySize = theOther.mySize;
+    myParent = theOther.myParent;
+    return *this;
+  }
+
+  //! Returns the system type name of the class (typeinfo.name)
+  Standard_CString SystemName() const { return myInfo.get().name(); }
+
+  //! Returns the hash code of the class (typeinfo.hash_code)
+  Standard_Size HashCode() const { return myInfo.get().hash_code(); }
+
+  //! Returns the given name of the class type (get_type_name)
+  Standard_CString Name() const { return myName; }
+
+  //! Returns the size of the class instance in bytes
+  Standard_Size Size() const { return mySize; }
+
+  //! Returns descriptor of the base class in the hierarchy. Can be null
+  const Standard_Type* Parent() const { return myParent; }
+
+  bool operator==(const Standard_Type& theType) const { return myInfo.get() == theType.myInfo.get(); }
+
+  bool operator==(const std::type_info& theInfo) const { return myInfo.get() == theInfo; }
+
+  //! Returns True if this type is the same as theOther, or inherits from theOther.
+  //! Note that multiple inheritance is not supported.
+  Standard_EXPORT Standard_Boolean SubType (const Handle(Standard_Type)& theOther) const;
+
+  //! Returns True if this type is the same as theOther, or inherits from theOther.
+  //! Note that multiple inheritance is not supported.
+  Standard_EXPORT Standard_Boolean SubType (const Standard_CString theOther) const;
+
+  //! Prints type (address of descriptor + name) to a stream
+  Standard_EXPORT void Print (Standard_OStream& theStream) const;
+
+  template<class T>
+  static const opencascade::handle<Standard_Type>& Instance()
+  {
+    return T::get_type_descriptor();
+  }
+
+private:
+  std::reference_wrapper<const std::type_info> myInfo; //!< STL Type descriptor of current class
+  Standard_CString myName; //!< Given name of the class
+  Standard_Size mySize;    //!< Size of the class instance, in bytes
+  const Standard_Type* myParent; //!< Type descriptor of parent class
+};
+
+namespace opencascade
+{
+  template <>
+  class handle<Standard_Type>
+  {
+  public:
+    //! STL-compliant typedef of contained type
+    typedef Standard_Type element_type;
+  public:
+    //! Empty constructor
+    handle() : myObject(nullptr) {}
+    //! Constructor from pointer to new object
+    handle (const Standard_Type* theType) : myObject(theType) {}
+    //! Copy constructor
+    handle (const handle& theHandle) : myObject(theHandle.myObject) {}
+    //! Assignment operator
+    handle& operator= (const handle& theHandle)
+    {
+      myObject = theHandle.myObject;
+      return *this;
+    }
+  
+    bool IsNull() const { return myObject == nullptr; }
+  
+    bool operator== (const handle& theHandle) const
+    {
+      return myObject == theHandle.myObject;
+    }
+  
+    bool operator!= (const handle& theHandle) const
+    {
+      return !(myObject == theHandle.myObject);
+    }
+
+    //! STL-like cast to pointer to referred object (note non-const).
+    //! @sa std::shared_ptr::get()
+    const Standard_Type* get() const { return myObject; }
+    //! Member access operator (note non-const)
+    const Standard_Type* operator-> () const { return myObject; }
+    //! Dereferencing operator (note non-const)
+    const Standard_Type& operator* () const { return *myObject; }
+  private:
+    const Standard_Type* myObject;
+  };
+}
+
+//! Operator printing type descriptor to stream
+inline Standard_OStream& operator << (Standard_OStream& theStream, const opencascade::handle<Standard_Type>& theType) 
+{
+  theStream << theType->Name();
+  return theStream;
+}
 
 // by default, check only the base class
 #define OCCT_CHECK_BASE_CLASS(Class,Base) \
   static_assert(opencascade::is_base_but_not_same<Base, Class>::value, "OCCT RTTI definition is incorrect: " #Base " is not base class of " #Class);
 
-#endif
-
-#endif /* ! defined(OCCT_CHECK_BASE_CLASS) */
+namespace std
+{
+  template <>
+  struct hash<Standard_Type>
+  {
+    size_t operator()(const Standard_Type& theType) const noexcept
+    {
+      return theType.HashCode();
+    }
+  };
+}
 
 //! Helper macro to get instance of a type descriptor for a class in a legacy way.
 #define STANDARD_TYPE(theType) theType::get_type_descriptor()
@@ -93,8 +187,13 @@ namespace opencascade
 #define DEFINE_STANDARD_RTTI_INLINE(Class,Base) \
 public: \
   typedef Base base_type; \
-  static const char* get_type_name () { return #Class; OCCT_CHECK_BASE_CLASS(Class,Base) } \
-  static const Handle(Standard_Type)& get_type_descriptor () { return Standard_Type::Instance<Class>(); } \
+  static const char* get_type_name() { return #Class; } \
+  static const Handle(Standard_Type)& get_type_descriptor() \
+  { \
+    static const Handle(Standard_Type) THE_TYPE_INSTANCE(new Standard_Type(typeid(Class), get_type_name(), \
+                                                         sizeof(Class), Base::get_type_descriptor().get())); \
+    return THE_TYPE_INSTANCE; \
+  } \
   virtual const Handle(Standard_Type)& DynamicType() const Standard_OVERRIDE { return get_type_descriptor (); }
 
 //! Helper macro to be included in definition of the classes inheriting
@@ -104,186 +203,18 @@ public: \
 #define DEFINE_STANDARD_RTTIEXT(Class,Base) \
 public: \
   typedef Base base_type; \
-  static const char* get_type_name () { return #Class; OCCT_CHECK_BASE_CLASS(Class,Base) } \
-  Standard_EXPORT static const Handle(Standard_Type)& get_type_descriptor (); \
+  static const char* get_type_name() { return #Class; } \
+  Standard_EXPORT static const Handle(Standard_Type)& get_type_descriptor(); \
   Standard_EXPORT virtual const Handle(Standard_Type)& DynamicType() const Standard_OVERRIDE;
 
 //! Defines implementation of type descriptor and DynamicType() function
 #define IMPLEMENT_STANDARD_RTTIEXT(Class,Base) \
-  const Handle(Standard_Type)& Class::get_type_descriptor () { return Standard_Type::Instance<Class>(); } \
-  const Handle(Standard_Type)& Class::DynamicType() const { return STANDARD_TYPE(Class); }
-
-// forward declaration of type_instance class
-namespace opencascade {
-  template <typename T>
-  class type_instance;
-}
-
-//! This class provides legacy interface (type descriptor) to run-time type
-//! information (RTTI) for OCCT classes inheriting from Standard_Transient.
-//!
-//! In addition to features provided by standard C++ RTTI (type_info), 
-//! Standard_Type allows passing descriptor as an object and using it for 
-//! analysis of the type:
-//! - get descriptor of a parent class
-//! - get user-defined name of the class
-//! - get size of the object
-//! 
-//! Use static template method Instance() to get descriptor for a given type.
-//! Objects supporting OCCT RTTI return their type descriptor by method DynamicType().
-//! 
-//! To be usable with OCCT type system, the class should provide:
-//! - typedef base_type to its base class in the hierarchy
-//! - method get_type_name() returning programmer-defined name of the class
-//!   (as a statically allocated constant C string or string literal)
-//!
-//! Note that user-defined name is used since typeid.name() is usually mangled in 
-//! compiler-dependent way.
-//! 
-//! Only single chain of inheritance is supported, with a root base class Standard_Transient.
-
-class Standard_Type : public Standard_Transient
-{
-public:
-
-  //! Returns the system type name of the class (typeinfo.name)
-  Standard_CString SystemName() const { return myInfo.name(); }
-  
-  //! Returns the given name of the class type (get_type_name)
-  Standard_CString Name() const { return myName; }
-  
-  //! Returns the size of the class instance in bytes
-  Standard_Size Size() const { return mySize; }
-
-  //! Returns descriptor of the base class in the hierarchy
-  const Handle(Standard_Type)& Parent () const { return myParent; }
-  
-  //! Returns True if this type is the same as theOther, or inherits from theOther.
-  //! Note that multiple inheritance is not supported.
-  Standard_EXPORT Standard_Boolean SubType (const Handle(Standard_Type)& theOther) const;
-
-  //! Returns True if this type is the same as theOther, or inherits from theOther.
-  //! Note that multiple inheritance is not supported.
-  Standard_EXPORT Standard_Boolean SubType (const Standard_CString theOther) const;
-
-  //! Prints type (address of descriptor + name) to a stream
-  Standard_EXPORT void Print (Standard_OStream& theStream) const;
-
-  //! Template function returning instance of the type descriptor for an argument class.
-  //!
-  //! For optimization, each type is registered only once (due to use of the static variable).
-  //!
-  //! See helper macro DEFINE_STANDARD_RTTI for defining these items in the class.
-  template <class T>
-  static const Handle(Standard_Type)& Instance()
-  {
-    return opencascade::type_instance<T>::get();
-  }
-
-  //! Register a type; returns either new or existing descriptor.
-  //!
-  //! @param theInfo object stores system name of the class
-  //! @param theName name of the class to be stored in Name field
-  //! @param theSize size of the class instance
-  //! @param theParent base class in the Transient hierarchy
-  //!
-  //! Note that this function is intended for use by opencascade::type_instance only. 
-  Standard_EXPORT static 
-    Standard_Type* Register (const std::type_info& theInfo, const char* theName,
-                             Standard_Size theSize, const Handle(Standard_Type)& theParent);
-
-  //! Destructor removes the type from the registry
-  Standard_EXPORT ~Standard_Type ();
-
-  // Define own RTTI
-  DEFINE_STANDARD_RTTIEXT(Standard_Type,Standard_Transient)
-
-private:
-
-  //! Constructor is private
-  Standard_Type (const std::type_info& theInfo, const char* theName,
-                 Standard_Size theSize, const Handle(Standard_Type)& theParent);
-
-private:
-  std::type_index myInfo;         //!< Object to store system name of the class
-  Standard_CString myName;        //!< Given name of the class
-  Standard_Size mySize;           //!< Size of the class instance, in bytes
-  Handle(Standard_Type) myParent; //!< Type descriptor of parent class
-};
-
-namespace opencascade {
-
-  //! Template class providing instantiation of type descriptors as singletons.
-  //! The descriptors are defined as static variables in function get(), which
-  //! is essential to ensure that they are initialized in correct sequence.
-  //!
-  //! For compilers that do not provide thread-safe initialization of static
-  //! variables (C++11 feature, N2660), additional global variable is
-  //! defined for each type to hold its type descriptor. These globals ensure
-  //! that all types get initialized during the library loading and thus no 
-  //! concurrency occurs when type system is accessed from multiple threads.
-  template <typename T>
-  class type_instance
-  {
-    static Handle(Standard_Type) myInstance;
-  public:
-    static const Handle(Standard_Type)& get ();
-  };
-
-  //! Specialization of type descriptor instance for void; returns null handle
-  template <>
-  class type_instance<void>
-  {
-  public:
-    static Handle(Standard_Type) get () { return 0; }
-  };
-
-  // Implementation of static function returning instance of the
-  // type descriptor
-  template <typename T>
-  const Handle(Standard_Type)& type_instance<T>::get ()
-  {
-#if (defined(_MSC_VER) && _MSC_VER < 1900) || \
-    (defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 3)) && \
-     ! defined(__clang__) && ! defined(__INTEL_COMPILER))
-    // ensure that myInstance is instantiated
-    (void)myInstance;
-#endif
-
-    // static variable inside function ensures that descriptors
-    // are initialized in correct sequence
-    static Handle(Standard_Type) anInstance =
-      Standard_Type::Register (typeid(T), T::get_type_name(), sizeof(T), 
-                               type_instance<typename T::base_type>::get());
-    return anInstance;
-  }
-
-  // Static class field is defined to ensure initialization of all type
-  // descriptors at load time of the library on compilers not supporting N2660:
-  // - VC++ below 14 (VS 2015)
-  // - GCC below 4.3
-  // Intel compiler reports itself as GCC on Linux and VC++ on Windows,
-  // and is claimed to support N2660 on Linux and on Windows "in VS2015 mode".
-  // CLang should support N2660 since version 2.9, but it is not clear how to 
-  // check its version reliably (on Linux it says it is GCC 4.2).
-#if (defined(_MSC_VER) && _MSC_VER < 1900) || \
-    (defined(__GNUC__) && (__GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 3)) && \
-     ! defined(__clang__) && ! defined(__INTEL_COMPILER))
-
-  template <typename T>
-  Handle(Standard_Type) type_instance<T>::myInstance (get());
-
-#endif
-}
-
-//! Operator printing type descriptor to stream
-inline Standard_OStream& operator << (Standard_OStream& theStream, const Handle(Standard_Type)& theType) 
-{
-  theType->Print (theStream);
-  return theStream;
-}
-
-//! Definition of Handle_Standard_Type as typedef for compatibility
-DEFINE_STANDARD_HANDLE(Standard_Type,Standard_Transient)
+  const Handle(Standard_Type)& Class::get_type_descriptor() \
+  { \
+    static const Handle(Standard_Type) THE_TYPE_INSTANCE(new Standard_Type(typeid(Class), get_type_name(), \
+                                                         sizeof(Class), Base::get_type_descriptor().get())); \
+    return THE_TYPE_INSTANCE; \
+  } \
+  const Handle(Standard_Type)& Class::DynamicType() const { return get_type_descriptor(); }
 
 #endif // _Standard_Type_HeaderFile

--- a/src/StepAP214/StepAP214_Protocol.cxx
+++ b/src/StepAP214/StepAP214_Protocol.cxx
@@ -756,7 +756,7 @@ static Standard_CString schemaAP242DIS = "AP242_MANAGED_MODEL_BASED_3D_ENGINEERI
 #include <StepVisual_TriangulatedSurfaceSet.hxx>
 
 static int THE_StepAP214_Protocol_init = 0;
-static Interface_DataMapOfTransientInteger types(819);
+static NCollection_DataMap<Handle(Standard_Type), Standard_Integer> types(819);
 
 //=======================================================================
 //function : StepAP214_Protocol

--- a/src/StepData/StepData_FileProtocol.cxx
+++ b/src/StepData/StepData_FileProtocol.cxx
@@ -31,7 +31,7 @@ static Standard_CString  thename = "";
     void StepData_FileProtocol::Add (const Handle(StepData_Protocol)& protocol)
 {
   if (protocol.IsNull()) return;
-  Handle(Standard_Type) ptype = protocol->DynamicType();
+  const Handle(Standard_Type)& ptype = protocol->DynamicType();
   Standard_Integer nb = thecomps.Length();
   for (Standard_Integer i = 1; i <= nb; i ++) {
     if (thecomps.Value(i)->IsInstance(ptype)) return;

--- a/src/StepData/StepData_PDescr.cxx
+++ b/src/StepData/StepData_PDescr.cxx
@@ -84,7 +84,7 @@ StepData_PDescr::StepData_PDescr  ()
       {  thekind = KindEntity;  thetype = atype;  thednam.Clear();  }
 
     void  StepData_PDescr::SetDescr (const Standard_CString dscnam)
-      {  thekind = KindEntity;  thetype.Nullify();
+      {  thekind = KindEntity;  thetype = Handle(Standard_Type)();
 	 thednam.Clear();  thednam.AssignCat(dscnam);  }
 
     void  StepData_PDescr::AddArity (const Standard_Integer arity)

--- a/src/StepFile/StepFile_Read.hxx
+++ b/src/StepFile/StepFile_Read.hxx
@@ -18,6 +18,7 @@
 #define StepFile_Read_HeaderFile
 
 #include <Standard_CString.hxx>
+#include <Standard_Handle.hxx>
 #include <Standard_Type.hxx>
 
 #include <iostream>

--- a/src/StepVisual/StepVisual_CoordinatesList.cxx
+++ b/src/StepVisual/StepVisual_CoordinatesList.cxx
@@ -14,7 +14,7 @@
 
 #include <StepVisual_CoordinatesList.hxx>
 #include <StepVisual_TessellatedItem.hxx>
-IMPLEMENT_STANDARD_RTTIEXT(StepVisual_CoordinatesList,StepGeom_TessellatedItem)
+IMPLEMENT_STANDARD_RTTIEXT(StepVisual_CoordinatesList, StepVisual_TessellatedItem)
 
 StepVisual_CoordinatesList::StepVisual_CoordinatesList ()  {}
 

--- a/src/StepVisual/StepVisual_TessellatedGeometricSet.cxx
+++ b/src/StepVisual/StepVisual_TessellatedGeometricSet.cxx
@@ -15,7 +15,7 @@
 #include <StepVisual_TessellatedGeometricSet.hxx>
 
 
-IMPLEMENT_STANDARD_RTTIEXT(StepVisual_TessellatedGeometricSet,StepGeom_TessellatedItem)
+IMPLEMENT_STANDARD_RTTIEXT(StepVisual_TessellatedGeometricSet, StepVisual_TessellatedItem)
 
 
 StepVisual_TessellatedGeometricSet::StepVisual_TessellatedGeometricSet ()  {}

--- a/src/TObj/TObj_Assistant.cxx
+++ b/src/TObj/TObj_Assistant.cxx
@@ -39,9 +39,9 @@ TColStd_SequenceOfTransient& TObj_Assistant::getModels()
 //purpose  : 
 //=======================================================================
 
-TColStd_IndexedMapOfTransient& TObj_Assistant::getTypes()
+NCollection_IndexedMap<Handle(Standard_Type)>& TObj_Assistant::getTypes()
 {
-  static TColStd_IndexedMapOfTransient sTypes;
+  static NCollection_IndexedMap<Handle(Standard_Type)> sTypes;
   return sTypes;
 }
 
@@ -119,7 +119,7 @@ Handle(Standard_Type) TObj_Assistant::FindType
   (const Standard_Integer theTypeIndex)
 {
   if(theTypeIndex > 0 && theTypeIndex <= getTypes().Extent())
-    return Handle(Standard_Type)::DownCast(getTypes().FindKey(theTypeIndex));
+    return getTypes().FindKey(theTypeIndex);
 
   return 0;
 }
@@ -166,12 +166,12 @@ DEFINE_STANDARD_HANDLE(TObj_Assistant_UnknownType,Standard_Transient)
 Standard_Integer TObj_Assistant::BindType
   (const Handle(Standard_Type)& theType)
 {
-  if(theType.IsNull())
-  {
-    Handle(Standard_Transient) anUnknownType;
-    anUnknownType = new TObj_Assistant_UnknownType;
-    return getTypes().Add(anUnknownType);
-  }
+  // if(!theType)
+  // {
+  //   Handle(Standard_Transient) anUnknownType;
+  //   anUnknownType = new TObj_Assistant_UnknownType;
+  //   return getTypes().Add(anUnknownType);
+  // }
 
   return getTypes().Add(theType);
 }

--- a/src/TObj/TObj_Assistant.hxx
+++ b/src/TObj/TObj_Assistant.hxx
@@ -103,7 +103,7 @@ private:
   static Standard_EXPORT TColStd_SequenceOfTransient&   getModels();
 
   //! Method for taking fields for map types
-  static Standard_EXPORT TColStd_IndexedMapOfTransient& getTypes();
+  static Standard_EXPORT NCollection_IndexedMap<Handle(Standard_Type)>& getTypes();
 
   //! Method for taking fields for the Current model
   static Standard_EXPORT Handle(TObj_Model)&            getCurrentModel();

--- a/src/TObj/TObj_Object.cxx
+++ b/src/TObj/TObj_Object.cxx
@@ -1220,7 +1220,7 @@ Standard_Boolean TObj_Object::copyData
                 (const Handle(TObj_Object)& theTargetObject)
 {
   Standard_Boolean IsDone = Standard_False;
-  if ( !theTargetObject->DynamicType()->SubType( DynamicType() ) )
+  if ( !theTargetObject->IsKind( DynamicType() ) )
     return IsDone;
   // init the copier by labels.
   TDF_Label aDataLabel = GetDataLabel();

--- a/src/Transfer/Transfer_TransferIterator.cxx
+++ b/src/Transfer/Transfer_TransferIterator.cxx
@@ -51,17 +51,13 @@ static Handle(Standard_Transient)   nultrans;  // pour retour const&(Null)
     void  Transfer_TransferIterator::SelectResult
   (const Handle(Standard_Type)& atype, const Standard_Boolean keep)
 {
-  Standard_Integer casetype = 0;
-  if (atype->SubType(STANDARD_TYPE(Standard_Transient)))  casetype = 2;
-
   for (Standard_Integer i = theitems->Length(); i > 0; i --) {
     Handle(Transfer_Binder) atr = theitems->Value(i);
     Handle(Standard_Type) btype = ResultType();
     Standard_Boolean matchtype;
     if      (!atr->HasResult()) matchtype = Standard_False;
     else if (atr->IsMultiple()) matchtype = Standard_False;
-    else if (casetype == 0) matchtype = (atype == btype);         // Type fixe
-    else                    matchtype = (btype->SubType(atype));  // Dynamique
+    else                        matchtype = (btype->SubType(atype));
     if (matchtype != keep) {
       theselect->SetValue(i,0);
       if (themaxi == i) themaxi = i-1;
@@ -154,8 +150,7 @@ static Handle(Standard_Transient)   nultrans;  // pour retour const&(Null)
     Standard_Boolean  Transfer_TransferIterator::HasTransientResult () const
 {
   Handle(Standard_Type) btype = ResultType();
-  if (btype.IsNull()) return Standard_False;
-  return btype->SubType(STANDARD_TYPE(Standard_Transient));
+  return !btype.IsNull();
 }
 
     const Handle(Standard_Transient)&

--- a/src/XCAFDoc/XCAFDoc_NotesTool.cxx
+++ b/src/XCAFDoc/XCAFDoc_NotesTool.cxx
@@ -36,7 +36,7 @@ namespace {
 
 }
 
-IMPLEMENT_DERIVED_ATTRIBUTE(XCAFDoc_NotesTool, XCAFDoc_NoteComment)
+IMPLEMENT_DERIVED_ATTRIBUTE(XCAFDoc_NotesTool, TDataStd_GenericEmpty)
 
 enum NotesTool_RootLabels
 {

--- a/src/XSControl/XSControl_Utils.cxx
+++ b/src/XSControl/XSControl_Utils.cxx
@@ -112,8 +112,7 @@ static const Standard_ExtString   voidext = { 0 };
   (const Handle(Standard_Transient)& item, const Standard_Boolean nopk) const
 {
   if (item.IsNull()) return "";
-  DeclareAndCast(Standard_Type,atype,item);
-  if (atype.IsNull()) atype = item->DynamicType();
+  Handle(Standard_Type) atype = item->DynamicType();
   Standard_CString tn = atype->Name();
   if (!nopk) return tn;
   for (int i = 0; tn[i] != '\0'; i ++) {


### PR DESCRIPTION
Implement functionality to avoid mutex operation and keeping unload data Making Standard_Type own specialized handle to avoid sharing and atomic operations

TODO:
Simplify the base type for type. Create extended type type. Simple will have ONLY reference to std::type_info and parent type. Extended will have a name and size of the object.