### PR TITLE
Coding - Moving to use IsKind by type

### DIFF
--- a/src/AIS/AIS_InteractiveContext.cxx
+++ b/src/AIS/AIS_InteractiveContext.cxx
@@ -2171,7 +2171,7 @@ void AIS_InteractiveContext::RebuildSelectionStructs()
 void AIS_InteractiveContext::Disconnect (const Handle(AIS_InteractiveObject)& theAssembly,
                                          const Handle(AIS_InteractiveObject)& theObjToDisconnect)
 {
-  if (theAssembly->IsInstance ("AIS_MultipleConnectedInteractive"))
+  if (theAssembly->IsInstance (STANDARD_TYPE(AIS_MultipleConnectedInteractive)))
   {
     Handle(AIS_MultipleConnectedInteractive) theObj (Handle(AIS_MultipleConnectedInteractive)::DownCast (theAssembly));
     theObj->Disconnect (theObjToDisconnect);
@@ -2185,7 +2185,7 @@ void AIS_InteractiveContext::Disconnect (const Handle(AIS_InteractiveObject)& th
     const Handle(SelectMgr_SelectableObject)& anObj = theObjToDisconnect; // to avoid ambiguity
     mgrSelector->Remove (anObj);
   }
-  else if (theAssembly->IsInstance ("AIS_ConnectedInteractive") && theObjToDisconnect.IsNull())
+  else if (theAssembly->IsInstance (STANDARD_TYPE(AIS_ConnectedInteractive)) && theObjToDisconnect.IsNull())
   {
     Handle(AIS_ConnectedInteractive) theObj (Handle(AIS_ConnectedInteractive)::DownCast (theAssembly));
     theObj->Disconnect();

--- a/src/MeshVS/MeshVS_Mesh.cxx
+++ b/src/MeshVS/MeshVS_Mesh.cxx
@@ -1192,18 +1192,26 @@ void MeshVS_Mesh::ClearSelected ()
 //=======================================================================
 Handle (MeshVS_PrsBuilder) MeshVS_Mesh::FindBuilder ( const Standard_CString theTypeName ) const
 {
-  Standard_Integer len = myBuilders.Length();
-  Handle(MeshVS_PrsBuilder) aBuilder;
-  Standard_Boolean IsExist = Standard_False;
-
-  for ( Standard_Integer i=1; i<=len && !IsExist; i++)
-    if ( myBuilders.Value (i)->IsKind ( theTypeName ) )
+  for (const Handle(MeshVS_PrsBuilder)& aBuilder : myBuilders)
+  {
+    if (aBuilder->IsKind(theTypeName))
     {
-      aBuilder = myBuilders.Value (i);
-      IsExist = Standard_True;
+      return aBuilder;
     }
+  }
+  return nullptr;
+}
 
-  return aBuilder;
+Handle(MeshVS_PrsBuilder) MeshVS_Mesh::FindBuilder (const Handle(Standard_Type)& theType) const
+{
+  for (const Handle(MeshVS_PrsBuilder)& aBuilder : myBuilders)
+  {
+    if (aBuilder->IsKind(theType))
+    {
+      return aBuilder;
+    }
+  }
+  return nullptr;
 }
 
 //=======================================================================

--- a/src/MeshVS/MeshVS_Mesh.hxx
+++ b/src/MeshVS/MeshVS_Mesh.hxx
@@ -108,7 +108,13 @@ public:
   Standard_EXPORT void RemoveBuilderById (const Standard_Integer Id);
   
   //! Finds builder by its type the string represents
+  Standard_DEPRECATED("This method will be removed right after 7.9 release. \
+Use FindBuilder(const Handle(Standard_Type)&) instead \
+or directly iterate under sequence of builders.")
   Standard_EXPORT Handle(MeshVS_PrsBuilder) FindBuilder (const Standard_CString TypeString) const;
+
+  //! Finds builder by its type the type represents
+  Standard_EXPORT Handle(MeshVS_PrsBuilder) FindBuilder (const Handle(Standard_Type)& TypeString) const;
   
   //! Returns map of owners.
   Standard_EXPORT const MeshVS_DataMapOfIntegerOwner& GetOwnerMaps (const Standard_Boolean IsElement);

--- a/src/XSDRAWIGES/XSDRAWIGES.cxx
+++ b/src/XSDRAWIGES/XSDRAWIGES.cxx
@@ -18,10 +18,10 @@
 #include <DDocStd.hxx>
 #include <DDocStd_DrawDocument.hxx>
 #include <Draw.hxx>
+#include <DrawTrSurf.hxx>
 #include <Draw_Interpretor.hxx>
 #include <Draw_PluginMacro.hxx>
 #include <Draw_ProgressIndicator.hxx>
-#include <DrawTrSurf.hxx>
 #include <IGESCAFControl_Reader.hxx>
 #include <IGESCAFControl_Writer.hxx>
 #include <IGESControl_Controller.hxx>
@@ -29,7 +29,10 @@
 #include <IGESControl_Writer.hxx>
 #include <IGESData_IGESEntity.hxx>
 #include <IGESData_IGESModel.hxx>
+#include <IGESGeom_BoundedSurface.hxx>
+#include <IGESGeom_TrimmedSurface.hxx>
 #include <IGESSelect_Activator.hxx>
+#include <IGESSolid_Face.hxx>
 #include <Interface_Macros.hxx>
 #include <Interface_Static.hxx>
 #include <Message.hxx>
@@ -621,13 +624,13 @@ static Standard_Integer XSDRAWIGES_tplosttrim(Draw_Interpretor& theDI,
   Handle(XSControl_WorkSession) aWorkSession = XSDRAW::Session();
   const Handle(Transfer_TransientProcess)& anTransientProcess = aWorkSession->TransferReader()->TransientProcess();
   TColStd_Array1OfAsciiString aTypeStrings(1, 3);
-  TColStd_Array1OfAsciiString aKindStrings(1, 3);
+  NCollection_Array1<Handle(Standard_Type>) aKindTypes(1, 3);
   aTypeStrings.SetValue(1, "xst-type(CurveOnSurface)");
   aTypeStrings.SetValue(2, "xst-type(Boundary)");
   aTypeStrings.SetValue(3, "xst-type(Loop)");
-  aKindStrings.SetValue(1, "IGESGeom_TrimmedSurface");
-  aKindStrings.SetValue(2, "IGESGeom_BoundedSurface");
-  aKindStrings.SetValue(3, "IGESSolid_Face");
+  aKindTypes.SetValue(1, STANDARD_TYPE(IGESGeom_TrimmedSurface));
+  aKindTypes.SetValue(2, STANDARD_TYPE(IGESGeom_BoundedSurface));
+  aKindTypes.SetValue(3, STANDARD_TYPE(IGESSolid_Face));
   if (anTransientProcess.IsNull())
   {
     theDI << "No Transfer Read\n";
@@ -639,6 +642,10 @@ static Standard_Integer XSDRAWIGES_tplosttrim(Draw_Interpretor& theDI,
   if (theNbArgs > 1)
   {
     TCollection_AsciiString anArg(theArgVec[1]);
+    TColStd_Array1OfAsciiString aKindStrings(1, 3);
+    aKindStrings.SetValue(1, "IGESGeom_TrimmedSurface");
+    aKindStrings.SetValue(2, "IGESGeom_BoundedSurface");
+    aKindStrings.SetValue(3, "IGESSolid_Face");
     for (anIndex = 1; anIndex <= 3; anIndex++)
     {
       if (aKindStrings.Value(anIndex).Location(anArg, 1, aKindStrings.Value(anIndex).Length()) != 0)
@@ -683,7 +690,7 @@ static Standard_Integer XSDRAWIGES_tplosttrim(Draw_Interpretor& theDI,
         {
           for (Standard_Integer i = 1; i <= aNumSharingEntities; i++)
           {
-            if (aSharingEntities->Value(i)->IsKind(aKindStrings.Value(anIndex).ToCString()))
+            if (aSharingEntities->Value(i)->IsKind(aKindTypes.Value(anIndex)))
             {
               if (aFaceMap.Add(aSharingEntities->Value(i)))
               {

--- a/src/XSDRAWSTL/XSDRAWSTL.cxx
+++ b/src/XSDRAWSTL/XSDRAWSTL.cxx
@@ -765,11 +765,11 @@ static Standard_Integer meshcolors(Draw_Interpretor& theDI,
 
         for (Standard_Integer aCount = 0; aCount < aMesh->GetBuildersCount(); aCount++)
         {
-          aTempBuilder = aMesh->FindBuilder("MeshVS_ElementalColorPrsBuilder");
+          aTempBuilder = aMesh->FindBuilder(STANDARD_TYPE(MeshVS_ElementalColorPrsBuilder));
           if (!aTempBuilder.IsNull())
             aMesh->RemoveBuilderById(aTempBuilder->GetId());
 
-          aTempBuilder = aMesh->FindBuilder("MeshVS_NodalColorPrsBuilder");
+          aTempBuilder = aMesh->FindBuilder(STANDARD_TYPE(MeshVS_NodalColorPrsBuilder));
           if (!aTempBuilder.IsNull())
             aMesh->RemoveBuilderById(aTempBuilder->GetId());
         }
@@ -980,7 +980,7 @@ static Standard_Integer meshvectors(Draw_Interpretor& theDI,
 
   Handle(MeshVS_PrsBuilder) aTempBuilder;
 
-  aTempBuilder = aMesh->FindBuilder("MeshVS_VectorPrsBuilder");
+  aTempBuilder = aMesh->FindBuilder(STANDARD_TYPE(MeshVS_VectorPrsBuilder));
   if (!aTempBuilder.IsNull())
     aMesh->RemoveBuilderById(aTempBuilder->GetId());
 


### PR DESCRIPTION
Refactor AIS_InteractiveContext and MeshVS_Mesh to use STANDARD_TYPE for type checks;
deprecate old FindBuilder method