### PR TITLE
Coding - Deprecate Handle_* type usage

### DIFF
--- a/dox/user_guides/draw_test_harness/draw_test_harness.md
+++ b/dox/user_guides/draw_test_harness/draw_test_harness.md
@@ -825,7 +825,7 @@ DBRep::Set(char*,B);
 #### In DrawTrSurf package:
  
 ~~~~{.php}
-Handle_Geom_Geometry Get(Standard_CString& Name) ; 
+Handle(Geom_Geometry) Get(Standard_CString& Name) ; 
 ~~~~
 
 #### In DBRep package:

--- a/dox/user_guides/modeling_algos/modeling_algos.md
+++ b/dox/user_guides/modeling_algos/modeling_algos.md
@@ -137,7 +137,7 @@ This class is used to  interpolate a BSplineCurve passing through an array of po
 This class may be  instantiated as follows: 
 ~~~~{.cpp}
 Geom2dAPI_Interpolate 
-(const  Handle_TColgp_HArray1OfPnt2d& Points, 
+(const  Handle(TColgp_HArray1OfPnt2d)& Points, 
 const  Standard_Boolean PeriodicFlag, 
 const Standard_Real  Tolerance); 
 
@@ -165,7 +165,7 @@ Geom2dAPI_Interpolate(Points,
 This class may be  instantiated as follows: 
 ~~~~{.cpp}
 GeomAPI_Interpolate 
-(const  Handle_TColgp_HArray1OfPnt& Points, 
+(const  Handle(TColgp_HArray1OfPnt)& Points, 
 const  Standard_Boolean PeriodicFlag, 
 const Standard_Real  Tolerance); 
 

--- a/src/BRepTest/BRepTest_BasicCommands.cxx
+++ b/src/BRepTest/BRepTest_BasicCommands.cxx
@@ -878,7 +878,7 @@ static Standard_Integer gbounding(Draw_Interpretor& di,Standard_Integer n,const 
     Standard_Boolean Is3d = Standard_True;
     Handle(Geom_Curve) C;
     Handle(Geom_Surface) S;
-    Handle_Geom2d_Curve C2d;
+    Handle(Geom2d_Curve) C2d;
     S = DrawTrSurf::GetSurface(a[1]);
     if (!S.IsNull())
     {

--- a/src/PrsMgr/PrsMgr_Presentation3d.hxx
+++ b/src/PrsMgr/PrsMgr_Presentation3d.hxx
@@ -21,6 +21,7 @@
 
 Standard_DEPRECATED("Deprecated alias to PrsMgr_Presentation3d")
 typedef PrsMgr_Presentation PrsMgr_Presentation3d;
+Standard_DEPRECATED("This typedef will be removed right after 7.9 release. Use Handle(T) directly instead.")
 typedef Handle_PrsMgr_Presentation Handle_PrsMgr_Presentation3d;
 
 #endif // _PrsMgr_Presentation3d_HeaderFile

--- a/src/PrsMgr/PrsMgr_PresentationManager3d.hxx
+++ b/src/PrsMgr/PrsMgr_PresentationManager3d.hxx
@@ -21,7 +21,9 @@
 
 Standard_DEPRECATED("Deprecated alias to PrsMgr_PresentationManager")
 typedef PrsMgr_PresentationManager PrsMgr_PresentationManager3d;
-Standard_DEPRECATED("Deprecated alias to PrsMgr_PresentationManager")
+#include <Standard_WarningsDisable.hxx>
+Standard_DEPRECATED("This typedef will be removed right after 7.9 release. Use Handle(T) directly instead.")
 typedef Handle_PrsMgr_PresentationManager Handle_PrsMgr_PresentationManager3d;
+#include <Standard_WarningsRestore.hxx>
 
 #endif // _PrsMgr_PresentationManager3d_HeaderFile

--- a/src/QANCollection/QANCollection_Handle.cxx
+++ b/src/QANCollection/QANCollection_Handle.cxx
@@ -148,7 +148,7 @@ static Standard_Integer QAHandleOps (Draw_Interpretor& theDI,
   // check operations with Handle_* classes
   Handle(Geom_Line) hLine = aLine;
   CHECK(theDI, ! hLine.IsNull(), "hhandle for non-null");
-
+#include <Standard_WarningsDisable.hxx>
   const Handle_Geom_Line& chLine = aLine; // cast to self const ref
   const Handle_Geom_Curve& chCurve = aLine; // cast to base const ref
   const Handle_Geom_Line& hhLine = hLine; // cast to self const ref
@@ -203,7 +203,7 @@ static Standard_Integer QAHandleOps (Draw_Interpretor& theDI,
 #else
   CHECK(theDI, hTmpRefBase.get() != aCurve2.get(),  "local reference to temporary handle object (Handle_ to base type)");
 #endif
-
+#include <Standard_WarningsRestore.hxx>
   Handle(Geom_Surface) aSurf;
   (void)aSurf;
 

--- a/src/Standard/Standard_Handle.hxx
+++ b/src/Standard/Standard_Handle.hxx
@@ -415,7 +415,7 @@ namespace std
 //! For compatibility with previous versions of OCCT, define Handle_Class alias for opencascade::handle<Class>.
 #if (defined(_MSC_VER) && _MSC_VER >= 1800) 
 //! For Visual Studio 2013+, define Handle_Class as non-template class to allow exporting this type in C++/CLI.
-#define DEFINE_STANDARD_HANDLECLASS(C1,C2,BC) class C1; class Handle_##C1 : public Handle(C1) \
+#define DEFINE_STANDARD_HANDLECLASS(C1,C2,BC) class C1; class Standard_DEPRECATED("This class will be removed right after 7.9 release. Use Handle(T) directly instead.") Handle_##C1 : public Handle(C1) \
 { \
 public: \
   Handle_##C1() {} \
@@ -428,7 +428,7 @@ public: \
 };
 #else
 //! For other compilers, use simple typedef
-#define DEFINE_STANDARD_HANDLECLASS(C1,C2,BC) class C1; typedef Handle(C1) Handle_##C1;
+#define DEFINE_STANDARD_HANDLECLASS(C1,C2,BC) class C1; Standard_DEPRECATED("This typedef will be removed right after 7.9 release. Use Handle(T) directly instead.") typedef Handle(C1) Handle_##C1;
 #endif
 
 #define DEFINE_STANDARD_HANDLE(C1,C2) DEFINE_STANDARD_HANDLECLASS(C1,C2,Standard_Transient)

--- a/src/Standard/Standard_Transient.hxx
+++ b/src/Standard/Standard_Transient.hxx
@@ -120,6 +120,8 @@ private:
 };
 
 //! Definition of Handle_Standard_Transient as typedef for compatibility
+
+Standard_DEPRECATED("This typedef will be removed right after 7.9 release. Use Handle(T) directly instead.")
 typedef opencascade::handle<Standard_Transient> Handle_Standard_Transient;
 
 #endif 

--- a/src/Standard/Standard_WarningsDisable.hxx
+++ b/src/Standard/Standard_WarningsDisable.hxx
@@ -32,6 +32,7 @@
   #pragma clang diagnostic ignored "-Wall"
   #pragma clang diagnostic ignored "-Wextra"
   #pragma clang diagnostic ignored "-Wshorten-64-to-32"
+  #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #elif defined(_MSC_VER)
   #pragma warning(push, 0)
 #elif defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6))

--- a/src/TPrsStd/TPrsStd_AISPresentation.cxx
+++ b/src/TPrsStd/TPrsStd_AISPresentation.cxx
@@ -1010,7 +1010,7 @@ Handle(AIS_InteractiveContext) TPrsStd_AISPresentation::getAISContext() const
   if ( TPrsStd_AISViewer::Find(Label(), aViewer) )
     return aViewer->GetInteractiveContext();
 
-  return Handle_AIS_InteractiveContext();
+  return Handle(AIS_InteractiveContext)();
 }
 
 //=======================================================================

--- a/src/V3d/V3d_Light.hxx
+++ b/src/V3d/V3d_Light.hxx
@@ -20,6 +20,9 @@
 #include <Graphic3d_CLight.hxx>
 
 typedef Graphic3d_CLight V3d_Light;
+#include <Standard_WarningsDisable.hxx>
+Standard_DEPRECATED("This typedef will be removed right after 7.9 release. Use Handle(T) directly instead.")
 typedef Handle_Graphic3d_CLight Handle_V3d_Light;
+#include <Standard_WarningsRestore.hxx>
 
 #endif // _V3d_Light_HeaderFile


### PR DESCRIPTION
Handle_* require special processing in Windows
  and it is already not needed for VS15+
In 7.9 dev will be reorginized to use typedef even for MSVC.
In 8.0 will be fully removed.