### PR TITLE
Data Exchange - Update Readers with ShapeHealing parameters

### DIFF
--- a/src/DE/DE_ShapeFixParameters.hxx
+++ b/src/DE/DE_ShapeFixParameters.hxx
@@ -14,6 +14,7 @@
 #ifndef _DE_ShapeFixParameters_HeaderFile
 #define _DE_ShapeFixParameters_HeaderFile
 
+#include <Standard_Macro.hxx>
 #include <TopAbs_ShapeEnum.hxx>
 
 //! Struct for shape healing parameters storage
@@ -30,7 +31,7 @@ struct DE_ShapeFixParameters
   double           Tolerance3d                         = 1.e-6;
   double           MaxTolerance3d                      = 1.0;
   double           MinTolerance3d                      = 1.e-7;
-  TopAbs_ShapeEnum DetalizationLevel                   = TopAbs_ShapeEnum::TopAbs_FACE;
+  TopAbs_ShapeEnum DetalizationLevel                   = TopAbs_ShapeEnum::TopAbs_VERTEX;
   bool             NonManifold                         = false;
   FixMode          FixFreeShellMode                    = FixMode::FixOrNot;
   FixMode          FixFreeFaceMode                     = FixMode::FixOrNot;

--- a/src/DE/FILES
+++ b/src/DE/FILES
@@ -5,8 +5,8 @@ DE_ConfigurationNode.hxx
 DE_PluginHolder.hxx
 DE_Provider.cxx
 DE_Provider.hxx
-DE_ShapeFixConfigurationNode.cxx
 DE_ShapeFixConfigurationNode.hxx
 DE_ShapeFixParameters.hxx
+DE_ShapeFixParameters.cxx
 DE_Wrapper.cxx
 DE_Wrapper.hxx

--- a/src/DEIGES/DEIGES_ConfigurationNode.cxx
+++ b/src/DEIGES/DEIGES_ConfigurationNode.cxx
@@ -55,19 +55,20 @@ bool DEIGES_ConfigurationNode::Load(const Handle(DE_ConfigurationContext)& theRe
     THE_CONFIGURATION_SCOPE() + "." + GetFormat() + "." + GetVendor();
 
   InternalParameters.ReadBSplineContinuity =
-    (ReadMode_BSplineContinuity)theResource->IntegerVal("read.iges.bspline.continuity",
-                                                        InternalParameters.ReadBSplineContinuity,
-                                                        aScope);
+    (DEIGES_Parameters::ReadMode_BSplineContinuity)theResource->IntegerVal(
+      "read.iges.bspline.continuity",
+      InternalParameters.ReadBSplineContinuity,
+      aScope);
   InternalParameters.ReadPrecisionMode =
-    (ReadMode_Precision)theResource->IntegerVal("read.precision.mode",
-                                                InternalParameters.ReadPrecisionMode,
-                                                aScope);
+    (DEIGES_Parameters::ReadMode_Precision)
+      theResource->IntegerVal("read.precision.mode", InternalParameters.ReadPrecisionMode, aScope);
   InternalParameters.ReadPrecisionVal =
     theResource->RealVal("read.precision.val", InternalParameters.ReadPrecisionVal, aScope);
   InternalParameters.ReadMaxPrecisionMode =
-    (ReadMode_MaxPrecision)theResource->IntegerVal("read.maxprecision.mode",
-                                                   InternalParameters.ReadMaxPrecisionMode,
-                                                   aScope);
+    (DEIGES_Parameters::ReadMode_MaxPrecision)theResource->IntegerVal(
+      "read.maxprecision.mode",
+      InternalParameters.ReadMaxPrecisionMode,
+      aScope);
   InternalParameters.ReadMaxPrecisionVal =
     theResource->RealVal("read.maxprecision.val", InternalParameters.ReadMaxPrecisionVal, aScope);
   InternalParameters.ReadSameParamMode =
@@ -75,9 +76,10 @@ bool DEIGES_ConfigurationNode::Load(const Handle(DE_ConfigurationContext)& theRe
                             InternalParameters.ReadSameParamMode,
                             aScope);
   InternalParameters.ReadSurfaceCurveMode =
-    (ReadMode_SurfaceCurve)theResource->IntegerVal("read.surfacecurve.mode",
-                                                   InternalParameters.ReadSurfaceCurveMode,
-                                                   aScope);
+    (DEIGES_Parameters::ReadMode_SurfaceCurve)theResource->IntegerVal(
+      "read.surfacecurve.mode",
+      InternalParameters.ReadSurfaceCurveMode,
+      aScope);
   InternalParameters.EncodeRegAngle =
     theResource->RealVal("read.encoderegularity.angle", InternalParameters.EncodeRegAngle, aScope);
 
@@ -99,13 +101,14 @@ bool DEIGES_ConfigurationNode::Load(const Handle(DE_ConfigurationContext)& theRe
     theResource->BooleanVal("read.layer", InternalParameters.ReadLayer, aScope);
 
   InternalParameters.WriteBRepMode =
-    (WriteMode_BRep)theResource->IntegerVal("write.brep.mode",
-                                            InternalParameters.WriteBRepMode,
-                                            aScope);
+    (DEIGES_Parameters::WriteMode_BRep)theResource->IntegerVal("write.brep.mode",
+                                                               InternalParameters.WriteBRepMode,
+                                                               aScope);
   InternalParameters.WriteConvertSurfaceMode =
-    (WriteMode_ConvertSurface)theResource->IntegerVal("write.convertsurface.mode",
-                                                      InternalParameters.WriteConvertSurfaceMode,
-                                                      aScope);
+    (DEIGES_Parameters::WriteMode_ConvertSurface)theResource->IntegerVal(
+      "write.convertsurface.mode",
+      InternalParameters.WriteConvertSurfaceMode,
+      aScope);
   InternalParameters.WriteHeaderAuthor =
     theResource->StringVal("write.header.author", InternalParameters.WriteHeaderAuthor, aScope);
   InternalParameters.WriteHeaderCompany =
@@ -119,15 +122,15 @@ bool DEIGES_ConfigurationNode::Load(const Handle(DE_ConfigurationContext)& theRe
   InternalParameters.WriteSequence =
     theResource->StringVal("write.sequence", InternalParameters.WriteSequence, aScope);
   InternalParameters.WritePrecisionMode =
-    (WriteMode_PrecisionMode)theResource->IntegerVal("write.precision.mode",
-                                                     InternalParameters.WritePrecisionMode,
-                                                     aScope);
+    (DEIGES_Parameters::WriteMode_PrecisionMode)theResource->IntegerVal(
+      "write.precision.mode",
+      InternalParameters.WritePrecisionMode,
+      aScope);
   InternalParameters.WritePrecisionVal =
     theResource->RealVal("write.precision.val", InternalParameters.WritePrecisionVal, aScope);
   InternalParameters.WritePlaneMode =
-    (WriteMode_PlaneMode)theResource->IntegerVal("write.plane.mode",
-                                                 InternalParameters.WritePlaneMode,
-                                                 aScope);
+    (DEIGES_Parameters::WriteMode_PlaneMode)
+      theResource->IntegerVal("write.plane.mode", InternalParameters.WritePlaneMode, aScope);
   InternalParameters.WriteOffsetMode =
     theResource->BooleanVal("write.offset", InternalParameters.WriteOffsetMode, aScope);
   InternalParameters.WriteColor =

--- a/src/DEIGES/DEIGES_ConfigurationNode.hxx
+++ b/src/DEIGES/DEIGES_ConfigurationNode.hxx
@@ -14,6 +14,7 @@
 #ifndef _DEIGES_ConfigurationNode_HeaderFile
 #define _DEIGES_ConfigurationNode_HeaderFile
 
+#include <DEIGES_Parameters.hxx>
 #include <DE_ConfigurationNode.hxx>
 #include <UnitsMethods_LengthUnit.hxx>
 
@@ -84,101 +85,7 @@ public:
     Standard_OVERRIDE;
 
 public:
-  enum ReadMode_BSplineContinuity
-  {
-    ReadMode_BSplineContinuity_C0 = 0,
-    ReadMode_BSplineContinuity_C1,
-    ReadMode_BSplineContinuity_C2
-  };
-
-  enum ReadMode_Precision
-  {
-    ReadMode_Precision_File = 0,
-    ReadMode_Precision_User
-  };
-
-  enum ReadMode_MaxPrecision
-  {
-    ReadMode_MaxPrecision_Preferred = 0,
-    ReadMode_MaxPrecision_Forced
-  };
-
-  enum ReadMode_SurfaceCurve
-  {
-    ReadMode_SurfaceCurve_Default         = 0,
-    ReadMode_SurfaceCurve_2DUse_Preferred = 2,
-    ReadMode_SurfaceCurve_2DUse_Forced    = -2,
-    ReadMode_SurfaceCurve_3DUse_Preferred = 3,
-    ReadMode_SurfaceCurve_3DUse_Forced    = -3
-  };
-
-  enum WriteMode_BRep
-  {
-    WriteMode_BRep_Faces = 0,
-    WriteMode_BRep_BRep
-  };
-
-  enum WriteMode_ConvertSurface
-  {
-    WriteMode_ConvertSurface_Off = 0,
-    WriteMode_ConvertSurface_On
-  };
-
-  enum WriteMode_PrecisionMode
-  {
-    WriteMode_PrecisionMode_Least    = -1,
-    WriteMode_PrecisionMode_Average  = 0,
-    WriteMode_PrecisionMode_Greatest = 1,
-    WriteMode_PrecisionMode_Session  = 2
-  };
-
-  enum WriteMode_PlaneMode
-  {
-    WriteMode_PlaneMode_Plane = 0,
-    WriteMode_PlaneMode_BSpline
-  };
-
-  struct IGESCAFControl_InternalSection
-  {
-    // Common
-    // clang-format off
-    ReadMode_BSplineContinuity ReadBSplineContinuity = ReadMode_BSplineContinuity_C1; //<! Manages the continuity of BSpline curves
-    ReadMode_Precision ReadPrecisionMode = ReadMode_Precision_File; //<! Reads the precision mode value
-    double ReadPrecisionVal = 0.0001; //<! ReadMode_Precision for shape construction (if enabled user mode)
-    ReadMode_MaxPrecision ReadMaxPrecisionMode = ReadMode_MaxPrecision_Preferred; //<! Defines the mode of applying the maximum allowed tolerance
-    double ReadMaxPrecisionVal = 1; //<! Defines the maximum allowable tolerance
-    bool ReadSameParamMode = false; //<! Defines the using of BRepLib::SameParameter
-    ReadMode_SurfaceCurve ReadSurfaceCurveMode = ReadMode_SurfaceCurve_Default; //<! reference for the computation of curves in case of 2D/3D
-    double EncodeRegAngle = 0.57295779513; //<! Continuity which these two faces are connected with at that edge
-
-    //Read
-    bool ReadApproxd1 = false; //<! Flag to split bspline curves of degree 1
-    TCollection_AsciiString ReadResourceName = "IGES"; //<! Defines the name of the resource file to read
-    TCollection_AsciiString ReadSequence = "FromIGES"; //<! Defines the name of the sequence of operators to read
-    bool ReadFaultyEntities = false; //<! Parameter for reading failed entities
-    bool ReadOnlyVisible = false; //<! Parameter for reading invisible entities
-    bool ReadColor = true; //<! ColorMode is used to indicate read Colors or not
-    bool ReadName = true; //<! NameMode is used to indicate read Name or not
-    bool ReadLayer = true; //<! LayerMode is used to indicate read Layers or not
-
-    // Write
-    WriteMode_BRep WriteBRepMode = WriteMode_BRep_Faces; //<! Flag to define entities type to write
-    WriteMode_ConvertSurface WriteConvertSurfaceMode = WriteMode_ConvertSurface_Off; //<! Flag to convert surface to elementary
-    TCollection_AsciiString WriteHeaderAuthor; //<! Name of the author of the file
-    TCollection_AsciiString WriteHeaderCompany; //<! Name of the sending company
-    TCollection_AsciiString WriteHeaderProduct; //<! Name of the sending product
-    TCollection_AsciiString WriteHeaderReciever; //<! Name of the receiving company
-    TCollection_AsciiString WriteResourceName = "IGES"; //<! Defines the name of the resource file to write
-    TCollection_AsciiString WriteSequence = "ToIGES"; //<! Defines the name of the sequence of operators to write
-    WriteMode_PrecisionMode WritePrecisionMode = WriteMode_PrecisionMode_Average; //<! Specifies the mode of writing the resolution value into the IGES file
-    double WritePrecisionVal = 0.0001; //<! Resolution value for an IGES file when WriteMode_PrecisionMode is Greatest
-    WriteMode_PlaneMode WritePlaneMode = WriteMode_PlaneMode_Plane; //<! Flag to convert plane to the BSline
-    // clang-format on
-    bool WriteOffsetMode = false; //<! Writing offset curves like BSplines
-    bool WriteColor      = true;  //<! ColorMode is used to indicate write Colors or not
-    bool WriteName       = true;  //<! NameMode is used to indicate write Name or not
-    bool WriteLayer      = true;  //<! LayerMode is used to indicate write Layers or not
-  } InternalParameters;
+  DEIGES_Parameters InternalParameters;
 };
 
 #endif // _DEIGES_ConfigurationNode_HeaderFile

--- a/src/DEIGES/DEIGES_Parameters.cxx
+++ b/src/DEIGES/DEIGES_Parameters.cxx
@@ -1,0 +1,92 @@
+// Copyright (c) 2023 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Interface_Static.hxx>
+
+#include <DEIGES_Parameters.hxx>
+
+//=================================================================================================
+
+void DEIGES_Parameters::InitFromStatic()
+{
+  ReadBSplineContinuity = (ReadMode_BSplineContinuity)Interface_Static::IVal(
+    "read.iges.bspline.continuity");
+  ReadPrecisionMode =
+    (ReadMode_Precision)Interface_Static::IVal("read.precision.mode");
+  ReadPrecisionVal = Interface_Static::RVal("read.precision.val");
+  ReadMaxPrecisionMode =
+    (ReadMode_MaxPrecision)Interface_Static::IVal("read.maxprecision.mode");
+  ReadMaxPrecisionVal = Interface_Static::RVal("read.maxprecision.val");
+  ReadSameParamMode   = Interface_Static::IVal("read.stdsameparameter.mode") == 1;
+  ReadSurfaceCurveMode = (ReadMode_SurfaceCurve)Interface_Static::IVal("read.surfacecurve.mode");
+  EncodeRegAngle = Interface_Static::RVal("read.encoderegularity.angle");
+
+  ReadApproxd1       = Interface_Static::IVal("read.bspline.approxd1.mode") == 1;
+  ReadResourceName   = Interface_Static::CVal("read.resource.name");
+  ReadSequence       = Interface_Static::CVal("read.sequence");
+  ReadFaultyEntities = Interface_Static::IVal("read.fau_lty.entities") == 1;
+  ReadOnlyVisible    = Interface_Static::IVal("read.onlyvisible") == 1;
+  ReadColor          = Interface_Static::IVal("read.color") == 1;
+  ReadName           = Interface_Static::IVal("read.name") == 1;
+  ReadLayer          = Interface_Static::IVal("read.layer") == 1;
+
+  WriteBRepMode = (WriteMode_BRep)Interface_Static::IVal("write.brep.mode");
+  WriteConvertSurfaceMode = (WriteMode_ConvertSurface)Interface_Static::IVal(
+    "write.convertsurface.mode");
+  WriteHeaderAuthor   = Interface_Static::CVal("write.header.author");
+  WriteHeaderCompany  = Interface_Static::CVal("write.header.company");
+  WriteHeaderProduct  = Interface_Static::CVal("write.header.product");
+  WriteHeaderReciever = Interface_Static::CVal("write.header.receiver");
+  WriteResourceName   = Interface_Static::CVal("write.resource.name");
+  WriteSequence       = Interface_Static::CVal("write.sequence");
+  WritePrecisionMode =
+    (WriteMode_PrecisionMode)Interface_Static::IVal("write.precision.mode");
+  WritePrecisionVal = Interface_Static::RVal("write.precision.val");
+  WritePlaneMode =
+    (WriteMode_PlaneMode)Interface_Static::IVal("write.plane.mode");
+  WriteOffsetMode = Interface_Static::IVal("write.offset") == 1;
+  WriteColor      = Interface_Static::IVal("write.color") == 1;
+  WriteName       = Interface_Static::IVal("write.name") == 1;
+  WriteLayer      = Interface_Static::IVal("write.layer") == 1;
+}
+
+//=================================================================================================
+
+void DEIGES_Parameters::Reset()
+{
+  *this = DEIGES_Parameters();
+}
+
+//=================================================================================================
+
+DE_ShapeFixParameters DEIGES_Parameters::GetDefaultReadingParamsIGES()
+{
+  DE_ShapeFixParameters aShapeFixParameters;
+  aShapeFixParameters.DetalizationLevel   = TopAbs_EDGE;
+  aShapeFixParameters.CreateOpenSolidMode = DE_ShapeFixParameters::FixMode::Fix;
+  aShapeFixParameters.FixTailMode         = DE_ShapeFixParameters::FixMode::FixOrNot;
+  aShapeFixParameters.MaxTailAngle        = DE_ShapeFixParameters::FixMode::FixOrNot;
+  return aShapeFixParameters;
+}
+
+//=================================================================================================
+
+DE_ShapeFixParameters DEIGES_Parameters::GetDefaultWritingParamsIGES()
+{
+  DE_ShapeFixParameters aShapeFixParameters;
+  aShapeFixParameters.DetalizationLevel   = TopAbs_EDGE;
+  aShapeFixParameters.CreateOpenSolidMode = DE_ShapeFixParameters::FixMode::Fix;
+  aShapeFixParameters.FixTailMode         = DE_ShapeFixParameters::FixMode::FixOrNot;
+  aShapeFixParameters.MaxTailAngle        = DE_ShapeFixParameters::FixMode::FixOrNot;
+  return aShapeFixParameters;
+}

--- a/src/DEIGES/DEIGES_Parameters.hxx
+++ b/src/DEIGES/DEIGES_Parameters.hxx
@@ -1,0 +1,136 @@
+// Copyright (c) 2023 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _DEIGES_Parameters_HeaderFile
+#define _DEIGES_Parameters_HeaderFile
+
+#include <DE_ShapeFixParameters.hxx>
+#include <Resource_FormatType.hxx>
+#include <STEPControl_StepModelType.hxx>
+#include <TCollection_AsciiString.hxx>
+#include <UnitsMethods_LengthUnit.hxx>
+
+class DEIGES_Parameters
+{
+public:
+  enum ReadMode_BSplineContinuity
+  {
+    ReadMode_BSplineContinuity_C0 = 0,
+    ReadMode_BSplineContinuity_C1,
+    ReadMode_BSplineContinuity_C2
+  };
+
+  enum ReadMode_Precision
+  {
+    ReadMode_Precision_File = 0,
+    ReadMode_Precision_User
+  };
+
+  enum ReadMode_MaxPrecision
+  {
+    ReadMode_MaxPrecision_Preferred = 0,
+    ReadMode_MaxPrecision_Forced
+  };
+
+  enum ReadMode_SurfaceCurve
+  {
+    ReadMode_SurfaceCurve_Default         = 0,
+    ReadMode_SurfaceCurve_2DUse_Preferred = 2,
+    ReadMode_SurfaceCurve_2DUse_Forced    = -2,
+    ReadMode_SurfaceCurve_3DUse_Preferred = 3,
+    ReadMode_SurfaceCurve_3DUse_Forced    = -3
+  };
+
+  enum WriteMode_BRep
+  {
+    WriteMode_BRep_Faces = 0,
+    WriteMode_BRep_BRep
+  };
+
+  enum WriteMode_ConvertSurface
+  {
+    WriteMode_ConvertSurface_Off = 0,
+    WriteMode_ConvertSurface_On
+  };
+
+  enum WriteMode_PrecisionMode
+  {
+    WriteMode_PrecisionMode_Least    = -1,
+    WriteMode_PrecisionMode_Average  = 0,
+    WriteMode_PrecisionMode_Greatest = 1,
+    WriteMode_PrecisionMode_Session  = 2
+  };
+
+  enum WriteMode_PlaneMode
+  {
+    WriteMode_PlaneMode_Plane = 0,
+    WriteMode_PlaneMode_BSpline
+  };
+
+public:
+  DEIGES_Parameters() = default;
+
+  //! Initialize parameters
+  Standard_EXPORT void InitFromStatic();
+
+  //! Reset used parameters
+  Standard_EXPORT void Reset();
+
+  //! Returns default parameters for reading STEP files.
+  Standard_EXPORT static DE_ShapeFixParameters GetDefaultReadingParamsIGES();
+
+  //! Returns default parameters for writing STEP files.
+  Standard_EXPORT static DE_ShapeFixParameters GetDefaultWritingParamsIGES();
+
+public:
+  // Common
+  // clang-format off
+  ReadMode_BSplineContinuity ReadBSplineContinuity = ReadMode_BSplineContinuity_C1; //<! Manages the continuity of BSpline curves
+  ReadMode_Precision ReadPrecisionMode = ReadMode_Precision_File; //<! Reads the precision mode value
+  double ReadPrecisionVal = 0.0001; //<! ReadMode_Precision for shape construction (if enabled user mode)
+  ReadMode_MaxPrecision ReadMaxPrecisionMode = ReadMode_MaxPrecision_Preferred; //<! Defines the mode of applying the maximum allowed tolerance
+  double ReadMaxPrecisionVal = 1; //<! Defines the maximum allowable tolerance
+  bool ReadSameParamMode = false; //<! Defines the using of BRepLib::SameParameter
+  ReadMode_SurfaceCurve ReadSurfaceCurveMode = ReadMode_SurfaceCurve_Default; //<! reference for the computation of curves in case of 2D/3D
+  double EncodeRegAngle = 0.57295779513; //<! Continuity which these two faces are connected with at that edge
+
+  //Read
+  bool ReadApproxd1 = false; //<! Flag to split bspline curves of degree 1
+  TCollection_AsciiString ReadResourceName = "IGES"; //<! Defines the name of the resource file to read
+  TCollection_AsciiString ReadSequence = "FromIGES"; //<! Defines the name of the sequence of operators to read
+  bool ReadFaultyEntities = false; //<! Parameter for reading failed entities
+  bool ReadOnlyVisible = false; //<! Parameter for reading invisible entities
+  bool ReadColor = true; //<! ColorMode is used to indicate read Colors or not
+  bool ReadName = true; //<! NameMode is used to indicate read Name or not
+  bool ReadLayer = true; //<! LayerMode is used to indicate read Layers or not
+
+  // Write
+  WriteMode_BRep WriteBRepMode = WriteMode_BRep_Faces; //<! Flag to define entities type to write
+  WriteMode_ConvertSurface WriteConvertSurfaceMode = WriteMode_ConvertSurface_Off; //<! Flag to convert surface to elementary
+  TCollection_AsciiString WriteHeaderAuthor; //<! Name of the author of the file
+  TCollection_AsciiString WriteHeaderCompany; //<! Name of the sending company
+  TCollection_AsciiString WriteHeaderProduct; //<! Name of the sending product
+  TCollection_AsciiString WriteHeaderReciever; //<! Name of the receiving company
+  TCollection_AsciiString WriteResourceName = "IGES"; //<! Defines the name of the resource file to write
+  TCollection_AsciiString WriteSequence = "ToIGES"; //<! Defines the name of the sequence of operators to write
+  WriteMode_PrecisionMode WritePrecisionMode = WriteMode_PrecisionMode_Average; //<! Specifies the mode of writing the resolution value into the IGES file
+  double WritePrecisionVal = 0.0001; //<! Resolution value for an IGES file when WriteMode_PrecisionMode is Greatest
+  WriteMode_PlaneMode WritePlaneMode = WriteMode_PlaneMode_Plane; //<! Flag to convert plane to the BSline
+  bool WriteOffsetMode = false; //<! Writing offset curves like BSplines
+  bool WriteColor      = true;  //<! ColorMode is used to indicate write Colors or not
+  bool WriteName       = true;  //<! NameMode is used to indicate write Name or not
+  bool WriteLayer      = true;  //<! LayerMode is used to indicate write Layers or not
+  // clang-format on
+};
+
+#endif // _DESTEP_Parameters_HeaderFile

--- a/src/DEIGES/DEIGES_Provider.cxx
+++ b/src/DEIGES/DEIGES_Provider.cxx
@@ -66,19 +66,17 @@ void DEIGES_Provider::initStatic(const Handle(DE_ConfigurationNode)& theNode)
 
   // Get previous values
   myOldValues.ReadBSplineContinuity =
-    (DEIGES_ConfigurationNode::ReadMode_BSplineContinuity)Interface_Static::IVal(
+    (DEIGES_Parameters::ReadMode_BSplineContinuity)Interface_Static::IVal(
       "read.iges.bspline.continuity");
   myOldValues.ReadPrecisionMode =
-    (DEIGES_ConfigurationNode::ReadMode_Precision)Interface_Static::IVal("read.precision.mode");
+    (DEIGES_Parameters::ReadMode_Precision)Interface_Static::IVal("read.precision.mode");
   myOldValues.ReadPrecisionVal = Interface_Static::RVal("read.precision.val");
   myOldValues.ReadMaxPrecisionMode =
-    (DEIGES_ConfigurationNode::ReadMode_MaxPrecision)Interface_Static::IVal(
-      "read.maxprecision.mode");
+    (DEIGES_Parameters::ReadMode_MaxPrecision)Interface_Static::IVal("read.maxprecision.mode");
   myOldValues.ReadMaxPrecisionVal = Interface_Static::RVal("read.maxprecision.val");
   myOldValues.ReadSameParamMode   = Interface_Static::IVal("read.stdsameparameter.mode") == 1;
   myOldValues.ReadSurfaceCurveMode =
-    (DEIGES_ConfigurationNode::ReadMode_SurfaceCurve)Interface_Static::IVal(
-      "read.surfacecurve.mode");
+    (DEIGES_Parameters::ReadMode_SurfaceCurve)Interface_Static::IVal("read.surfacecurve.mode");
   myOldValues.EncodeRegAngle = Interface_Static::RVal("read.encoderegularity.angle") * 180.0 / M_PI;
 
   myOldValues.ReadApproxd1       = Interface_Static::IVal("read.iges.bspline.approxd1.mode") == 1;
@@ -88,9 +86,9 @@ void DEIGES_Provider::initStatic(const Handle(DE_ConfigurationNode)& theNode)
   myOldValues.ReadOnlyVisible    = Interface_Static::IVal("read.iges.onlyvisible") == 1;
 
   myOldValues.WriteBRepMode =
-    (DEIGES_ConfigurationNode::WriteMode_BRep)Interface_Static::IVal("write.iges.brep.mode");
+    (DEIGES_Parameters::WriteMode_BRep)Interface_Static::IVal("write.iges.brep.mode");
   myOldValues.WriteConvertSurfaceMode =
-    (DEIGES_ConfigurationNode::WriteMode_ConvertSurface)Interface_Static::IVal(
+    (DEIGES_Parameters::WriteMode_ConvertSurface)Interface_Static::IVal(
       "write.convertsurface.mode");
   myOldValues.WriteHeaderAuthor   = Interface_Static::CVal("write.iges.header.author");
   myOldValues.WriteHeaderCompany  = Interface_Static::CVal("write.iges.header.company");
@@ -99,11 +97,10 @@ void DEIGES_Provider::initStatic(const Handle(DE_ConfigurationNode)& theNode)
   myOldValues.WriteResourceName   = Interface_Static::CVal("write.iges.resource.name");
   myOldValues.WriteSequence       = Interface_Static::CVal("write.iges.sequence");
   myOldValues.WritePrecisionMode =
-    (DEIGES_ConfigurationNode::WriteMode_PrecisionMode)Interface_Static::IVal(
-      "write.precision.mode");
+    (DEIGES_Parameters::WriteMode_PrecisionMode)Interface_Static::IVal("write.precision.mode");
   myOldValues.WritePrecisionVal = Interface_Static::RVal("write.precision.val");
   myOldValues.WritePlaneMode =
-    (DEIGES_ConfigurationNode::WriteMode_PlaneMode)Interface_Static::IVal("write.iges.plane.mode");
+    (DEIGES_Parameters::WriteMode_PlaneMode)Interface_Static::IVal("write.iges.plane.mode");
   myOldValues.WriteOffsetMode = Interface_Static::IVal("write.iges.offset.mode") == 1;
 
   myOldLengthUnit = Interface_Static::IVal("xstep.cascade.unit");
@@ -120,8 +117,7 @@ void DEIGES_Provider::initStatic(const Handle(DE_ConfigurationNode)& theNode)
 
 //=================================================================================================
 
-void DEIGES_Provider::setStatic(
-  const DEIGES_ConfigurationNode::IGESCAFControl_InternalSection& theParameter)
+void DEIGES_Provider::setStatic(const DEIGES_Parameters& theParameter)
 {
   Interface_Static::SetIVal("read.iges.bspline.continuity", theParameter.ReadBSplineContinuity);
   Interface_Static::SetIVal("read.precision.mode", theParameter.ReadPrecisionMode);

--- a/src/DEIGES/DEIGES_Provider.hxx
+++ b/src/DEIGES/DEIGES_Provider.hxx
@@ -148,13 +148,13 @@ private:
   void initStatic(const Handle(DE_ConfigurationNode)& theNode);
 
   //! Initialize static variables
-  void setStatic(const DEIGES_ConfigurationNode::IGESCAFControl_InternalSection& theParameter);
+  void setStatic(const DEIGES_Parameters& theParameter);
 
   //! Reset used interface static variables
   void resetStatic();
 
-  DEIGES_ConfigurationNode::IGESCAFControl_InternalSection myOldValues;
-  int                                                      myOldLengthUnit = 1;
+  DEIGES_Parameters myOldValues;
+  int               myOldLengthUnit = 1;
 };
 
 #endif // _DEIGES_Provider_HeaderFile

--- a/src/DEIGES/FILES
+++ b/src/DEIGES/FILES
@@ -1,4 +1,6 @@
 DEIGES_ConfigurationNode.cxx
 DEIGES_ConfigurationNode.hxx
+DEIGES_Parameters.cxx
+DEIGES_Parameters.hxx
 DEIGES_Provider.cxx
 DEIGES_Provider.hxx

--- a/src/DESTEP/DESTEP_Parameters.cxx
+++ b/src/DESTEP/DESTEP_Parameters.cxx
@@ -95,3 +95,17 @@ void DESTEP_Parameters::Reset()
   DESTEP_Parameters aParameters;
   *this = aParameters;
 }
+
+//=================================================================================================
+
+DE_ShapeFixParameters DESTEP_Parameters::GetDefaultReadingParamsSTEP()
+{
+  return DE_ShapeFixParameters();
+}
+
+//=================================================================================================
+
+DE_ShapeFixParameters DESTEP_Parameters::GetDefaultWritingParamsSTEP()
+{
+  return DE_ShapeFixParameters();
+}

--- a/src/DESTEP/DESTEP_Parameters.hxx
+++ b/src/DESTEP/DESTEP_Parameters.hxx
@@ -14,6 +14,7 @@
 #ifndef _DESTEP_Parameters_HeaderFile
 #define _DESTEP_Parameters_HeaderFile
 
+#include <DE_ShapeFixParameters.hxx>
 #include <Resource_FormatType.hxx>
 #include <STEPControl_StepModelType.hxx>
 #include <TCollection_AsciiString.hxx>
@@ -120,6 +121,7 @@ public:
     WriteMode_VertexMode_SingleVertex
   };
 
+public:
   Standard_EXPORT DESTEP_Parameters();
 
   //! Initialize parameters
@@ -142,6 +144,12 @@ public:
         return "";
     }
   }
+
+  //! Returns default parameters for reading STEP files.
+  Standard_EXPORT static DE_ShapeFixParameters GetDefaultReadingParamsSTEP();
+
+  //! Returns default parameters for writing STEP files.
+  Standard_EXPORT static DE_ShapeFixParameters GetDefaultWritingParamsSTEP();
 
 public:
   // Common

--- a/src/IGESCAFControl/IGESCAFControl_Reader.cxx
+++ b/src/IGESCAFControl/IGESCAFControl_Reader.cxx
@@ -39,7 +39,7 @@
 #include <XCAFDoc_LayerTool.hxx>
 #include <XCAFDoc_ShapeTool.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_TransferReader.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <UnitsMethods.hxx>
@@ -163,13 +163,12 @@ Standard_Boolean IGESCAFControl_Reader::Transfer (const Handle(TDocStd_Document)
   Standard_Real aScaleFactorMM = 1.;
   if (!XCAFDoc_DocumentTool::GetLengthUnit(doc, aScaleFactorMM, UnitsMethods_LengthUnit_Millimeter))
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+    XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
     aScaleFactorMM = UnitsMethods::GetCasCadeLengthUnit();
     // set length unit to the document
     XCAFDoc_DocumentTool::SetLengthUnit(doc, aScaleFactorMM, UnitsMethods_LengthUnit_Millimeter);
   }
   aModel->ChangeGlobalSection().SetCascadeUnit(aScaleFactorMM);
-
   TransferRoots(theProgress); // replaces the above
   num = NbShapes();
   if ( num <=0 ) return Standard_False;

--- a/src/IGESCAFControl/IGESCAFControl_Writer.cxx
+++ b/src/IGESCAFControl/IGESCAFControl_Writer.cxx
@@ -45,7 +45,7 @@
 #include <XCAFPrs.hxx>
 #include <XCAFPrs_Style.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <UnitsMethods.hxx>
 
@@ -589,7 +589,7 @@ void IGESCAFControl_Writer::prepareUnit(const TDF_Label& theLabel)
   }
   else
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+    XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
     Model()->ChangeGlobalSection().SetCascadeUnit(UnitsMethods::GetCasCadeLengthUnit());
   }
 }

--- a/src/IGESCAFControl/IGESCAFControl_Writer.hxx
+++ b/src/IGESCAFControl/IGESCAFControl_Writer.hxx
@@ -26,6 +26,7 @@
 #include <XCAFPrs_IndexedDataMapOfShapeStyle.hxx>
 #include <XCAFPrs_DataMapOfStyleTransient.hxx>
 #include <TopTools_MapOfShape.hxx>
+
 class XSControl_WorkSession;
 class TDocStd_Document;
 class TCollection_AsciiString;

--- a/src/IGESControl/IGESControl_ActorWrite.hxx
+++ b/src/IGESControl/IGESControl_ActorWrite.hxx
@@ -21,21 +21,18 @@
 #include <Standard_Type.hxx>
 
 #include <Transfer_ActorOfFinderProcess.hxx>
+
 class Transfer_Finder;
 class Transfer_Binder;
 class Transfer_FinderProcess;
-
-
 class IGESControl_ActorWrite;
+
 DEFINE_STANDARD_HANDLE(IGESControl_ActorWrite, Transfer_ActorOfFinderProcess)
 
 //! Actor to write Shape to IGES
 class IGESControl_ActorWrite : public Transfer_ActorOfFinderProcess
 {
-
 public:
-
-  
   Standard_EXPORT IGESControl_ActorWrite();
   
   //! Recognizes a ShapeMapper
@@ -50,21 +47,7 @@ public:
                     const Handle(Transfer_FinderProcess)& FP,
                     const Message_ProgressRange& theProgress = Message_ProgressRange()) Standard_OVERRIDE;
 
-
-
-
   DEFINE_STANDARD_RTTIEXT(IGESControl_ActorWrite,Transfer_ActorOfFinderProcess)
-
-protected:
-
-
-
-
-private:
-
-
-
-
 };
 
 

--- a/src/IGESControl/IGESControl_Reader.cxx
+++ b/src/IGESControl/IGESControl_Reader.cxx
@@ -15,6 +15,8 @@
 //abv 10.04.99 S4136: eliminate using BRepAPI::Precision()
 
 #include <BRepLib.hxx>
+#include <DEIGES_Parameters.hxx>
+#include <DE_ShapeFixParameters.hxx>
 #include <IFSelect_CheckCounter.hxx>
 #include <IFSelect_Functions.hxx>
 #include <IGESControl_Controller.hxx>
@@ -35,6 +37,7 @@
 #include <Transfer_Binder.hxx>
 #include <Transfer_IteratorOfProcessForTransient.hxx>
 #include <Transfer_TransientProcess.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_Controller.hxx>
 #include <XSControl_TransferReader.hxx>
 #include <XSControl_WorkSession.hxx>
@@ -82,8 +85,6 @@ Handle(IGESData_IGESModel) IGESControl_Reader::IGESModel () const
 {
   return Handle(IGESData_IGESModel)::DownCast(Model());
 }
-
-
 
 //=======================================================================
 //function : NbRootsForTransfer
@@ -313,4 +314,20 @@ void  IGESControl_Reader::PrintTransferInfo
     default: break;
     }
   }
+}
+
+//=================================================================================================
+
+DE_ShapeFixParameters IGESControl_Reader::GetDefaultParameters() const
+{
+  return DEIGES_Parameters::GetDefaultReadingParamsIGES();
+}
+
+//=================================================================================================
+
+ShapeProcess::OperationsFlags IGESControl_Reader::GetDefaultShapeProcessFlags() const
+{
+  ShapeProcess::OperationsFlags aFlags;
+  aFlags.set(ShapeProcess::Operation::FixShape);
+  return aFlags;
 }

--- a/src/IGESControl/IGESControl_Reader.hxx
+++ b/src/IGESControl/IGESControl_Reader.hxx
@@ -20,15 +20,12 @@
 #include <Standard.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
-
 #include <XSControl_Reader.hxx>
 #include <Standard_Integer.hxx>
 #include <IFSelect_PrintFail.hxx>
 #include <IFSelect_PrintCount.hxx>
-class XSControl_WorkSession;
+
 class IGESData_IGESModel;
-
-
 
 //! Reads IGES files, checks them and translates their contents into Open CASCADE models.
 //! The IGES data can be that of a whole model or that of a specific list of entities in the model.
@@ -68,9 +65,7 @@ class IGESData_IGESModel;
 class IGESControl_Reader  : public XSControl_Reader
 {
 public:
-
   DEFINE_STANDARD_ALLOC
-
   
   //! Creates a Reader from scratch
   Standard_EXPORT IGESControl_Reader();
@@ -96,29 +91,19 @@ public:
   //! Prints Statistics and check list for Transfer
   Standard_EXPORT void PrintTransferInfo (const IFSelect_PrintFail failwarn, const IFSelect_PrintCount mode) const;
 
-
-
-
 protected:
+  //! Returns default parameters for shape fixing.
+  //! @return default parameters for shape fixing.
+  Standard_EXPORT virtual DE_ShapeFixParameters GetDefaultParameters() const Standard_OVERRIDE;
 
-
-
-
+  //! Returns default flags for shape processing.
+  //! @return Default flags for shape processing.
+  Standard_EXPORT virtual ShapeProcess::OperationsFlags GetDefaultShapeProcessFlags() const Standard_OVERRIDE;
 
 private:
-
-
-
   Standard_Boolean theReadOnlyVisible;
-
-
 };
 
-
 #include <IGESControl_Reader.lxx>
-
-
-
-
 
 #endif // _IGESControl_Reader_HeaderFile

--- a/src/IGESControl/IGESControl_Writer.hxx
+++ b/src/IGESControl/IGESControl_Writer.hxx
@@ -17,16 +17,19 @@
 #ifndef _IGESControl_Writer_HeaderFile
 #define _IGESControl_Writer_HeaderFile
 
+#include <ShapeProcess.hxx>
 #include <Standard.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
-
 #include <IGESData_BasicEditor.hxx>
 #include <Standard_Integer.hxx>
 #include <Standard_CString.hxx>
 #include <Standard_OStream.hxx>
 #include <Message_ProgressRange.hxx>
 
+#include <unordered_map>
+
+struct DE_ShapeFixParameters;
 class Transfer_FinderProcess;
 class IGESData_IGESModel;
 class TopoDS_Shape;
@@ -47,9 +50,15 @@ class IGESData_IGESEntity;
 class IGESControl_Writer 
 {
 public:
-
   DEFINE_STANDARD_ALLOC
-  
+
+  using ParameterMap = std::unordered_map<std::string, std::string>;
+  // Flags defining operations to be performed on shapes. Since there is no std::optional in C++11,
+  // we use a pair. The first element is the flags, the second element is a boolean value that indicates
+  // whether the flags were set.
+  using ProcessingFlags = std::pair<ShapeProcess::OperationsFlags, bool>;
+
+public:
   //! Creates a writer object with the
   //! default unit (millimeters) and write mode (Face).
   //! IGESControl_Writer (const Standard_CString unit,
@@ -58,19 +67,21 @@ public:
   
   //! Creates a writer with given
   //! values for units and for write mode.
-  //! unit may be any unit that is accepted by the IGES standard.
+  //! theUnit may be any unit that is accepted by the IGES standard.
   //! By default, it is the millimeter.
-  //! modecr defines the write mode and may be:
+  //! theModecr defines the write mode and may be:
   //! - 0: Faces (default)
   //! - 1: BRep.
-  Standard_EXPORT IGESControl_Writer(const Standard_CString unit, const Standard_Integer modecr = 0);
+  Standard_EXPORT IGESControl_Writer(const Standard_CString theUnit,
+                                     const Standard_Integer theModecr = 0);
   
   //! Creates a writer object with the
-  //! prepared IGES model model in write mode.
-  //! modecr defines the write mode and may be:
+  //! prepared IGES model theModel in write mode.
+  //! theModecr defines the write mode and may be:
   //! - 0: Faces (default)
   //! - 1: BRep.
-  Standard_EXPORT IGESControl_Writer(const Handle(IGESData_IGESModel)& model, const Standard_Integer modecr = 0);
+  Standard_EXPORT IGESControl_Writer(const Handle(IGESData_IGESModel)& theModel,
+                                     const Standard_Integer            theModecr = 0);
   
   //! Returns the IGES model to be written in output.
   const Handle(IGESData_IGESModel) & Model() const
@@ -114,13 +125,49 @@ public:
   //! if the processor could not create the file).
   Standard_EXPORT Standard_Boolean Write (const Standard_CString file, const Standard_Boolean fnes = Standard_False);
 
- private:
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
+
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
+
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  inline const ParameterMap& GetParameters() const { return myShapeProcParams; }
+
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags);
+
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return The flags defining operations to be performed on shapes.
+  inline const ShapeProcess::OperationsFlags& GetShapeProcessFlags() const { return myShapeProcFlags.first; }
+
+  private:
+  //! If parameters haven't yet been provided, initializes them with default values
+  //! provided by GetDefaultParameters() method.
+  void InitializeMissingParameters();
+
+ private:
   Handle(Transfer_FinderProcess) myTP;
-  Handle(IGESData_IGESModel) myModel;
-  IGESData_BasicEditor myEditor;
-  Standard_Integer myWriteMode;
-  Standard_Boolean myIsComputed;
+  Handle(IGESData_IGESModel)     myModel;
+  IGESData_BasicEditor           myEditor;
+  Standard_Integer               myWriteMode;
+  Standard_Boolean               myIsComputed;
+  ParameterMap                   myShapeProcParams; //!< Parameters for shape processing.
+  ProcessingFlags                myShapeProcFlags;  //!< Flags defining operations to be performed on shapes.
 };
 
 #endif // _IGESControl_Writer_HeaderFile

--- a/src/IGESData/IGESData_GlobalSection.cxx
+++ b/src/IGESData/IGESData_GlobalSection.cxx
@@ -25,7 +25,7 @@
 #include <Quantity_Date.hxx>
 #include <TCollection_HAsciiString.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <UnitsMethods.hxx>
 
 #include <stdio.h>
@@ -116,7 +116,7 @@ void IGESData_GlobalSection::Init(const Handle(Interface_ParamSet)& params,
   //Message_Msg Msg48 ("XSTEP_48");
   //Message_Msg Msg49 ("XSTEP_49");
   //======================================
-  XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+  XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
   theSeparator = ',';       theEndMark = ';';
   theSendName.Nullify();    theFileName.Nullify();  theSystemId.Nullify();
   theInterfaceVersion.Nullify();

--- a/src/IGESToBRep/IGESToBRep_Actor.hxx
+++ b/src/IGESToBRep/IGESToBRep_Actor.hxx
@@ -24,6 +24,7 @@
 #include <Transfer_ActorOfTransientProcess.hxx>
 #include <Message_ProgressRange.hxx>
 
+struct DE_ShapeFixParameters;
 class Interface_InterfaceModel;
 class Standard_Transient;
 class Transfer_Binder;
@@ -39,10 +40,7 @@ DEFINE_STANDARD_HANDLE(IGESToBRep_Actor, Transfer_ActorOfTransientProcess)
 //! then returns the Binder which contains the Result
 class IGESToBRep_Actor : public Transfer_ActorOfTransientProcess
 {
-
 public:
-
-  
   Standard_EXPORT IGESToBRep_Actor();
   
   Standard_EXPORT void SetModel (const Handle(Interface_InterfaceModel)& model);
@@ -66,30 +64,12 @@ public:
   //! the file or from statics
   Standard_EXPORT Standard_Real UsedTolerance() const;
 
-
-
-
   DEFINE_STANDARD_RTTIEXT(IGESToBRep_Actor,Transfer_ActorOfTransientProcess)
 
-protected:
-
-
-
-
 private:
-
-
   Handle(Interface_InterfaceModel) themodel;
   Standard_Integer thecontinuity;
   Standard_Real theeps;
-
-
 };
-
-
-
-
-
-
 
 #endif // _IGESToBRep_Actor_HeaderFile

--- a/src/IGESToBRep/IGESToBRep_Reader.hxx
+++ b/src/IGESToBRep/IGESToBRep_Reader.hxx
@@ -17,15 +17,18 @@
 #ifndef _IGESToBRep_Reader_HeaderFile
 #define _IGESToBRep_Reader_HeaderFile
 
+#include <Message_ProgressRange.hxx>
+#include <ShapeProcess.hxx>
 #include <Standard.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
-
-#include <TopTools_SequenceOfShape.hxx>
 #include <Standard_Integer.hxx>
 #include <Standard_CString.hxx>
-#include <Message_ProgressRange.hxx>
+#include <TopTools_SequenceOfShape.hxx>
 
+#include <unordered_map>
+
+struct DE_ShapeFixParameters;
 class IGESData_IGESModel;
 class IGESToBRep_Actor;
 class Transfer_TransientProcess;
@@ -36,10 +39,15 @@ class TopoDS_Shape;
 class IGESToBRep_Reader 
 {
 public:
-
   DEFINE_STANDARD_ALLOC
 
-  
+  using ParameterMap = std::unordered_map<std::string, std::string>;
+  // Flags defining operations to be performed on shapes. Since there is no std::optional in C++11,
+  // we use a pair. The first element is the flags, the second element is a boolean value that indicates
+  // whether the flags were set.
+  using ProcessingFlags = std::pair<ShapeProcess::OperationsFlags, bool>;
+
+public:
   //! Creates a Reader
   Standard_EXPORT IGESToBRep_Reader();
   
@@ -108,32 +116,48 @@ public:
   //! - a compound containing the resulting shapes if there are several.
   Standard_EXPORT TopoDS_Shape OneShape() const;
 
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
 
-protected:
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  inline const ParameterMap& GetParameters() const { return myShapeProcParams; }
 
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags);
 
-
-
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return The flags defining operations to be performed on shapes.
+  inline const ShapeProcess::OperationsFlags& GetShapeProcessFlags() const { return myShapeProcFlags.first; }
 
 private:
+  //! If parameters haven't yet been provided, initializes them with default values.
+  void InitializeMissingParameters();
 
-
-
-  Handle(IGESData_IGESModel) theModel;
-  Standard_Boolean theDone;
-  TopTools_SequenceOfShape theShapes;
-  Handle(IGESToBRep_Actor) theActor;
+private:
+  Handle(IGESData_IGESModel)        theModel;
+  Standard_Boolean                  theDone;
+  TopTools_SequenceOfShape          theShapes;
+  Handle(IGESToBRep_Actor)          theActor;
   Handle(Transfer_TransientProcess) theProc;
-
-
+  ParameterMap                      myShapeProcParams; //!< Parameters for shape processing.
+  ProcessingFlags                   myShapeProcFlags;  //!< Flags defining operations to be performed on shapes.
 };
-
-
-
-
-
-
 
 #endif // _IGESToBRep_Reader_HeaderFile

--- a/src/STEPCAFControl/STEPCAFControl_Reader.cxx
+++ b/src/STEPCAFControl/STEPCAFControl_Reader.cxx
@@ -216,7 +216,7 @@
 #include <XCAFDimTolObjects_DatumObject.hxx>
 #include <XCAFView_Object.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_TransferReader.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <StepAP242_DraughtingModelItemAssociation.hxx>
@@ -568,7 +568,7 @@ void STEPCAFControl_Reader::prepareUnits(const Handle(StepData_StepModel)& theMo
   Standard_Real aScaleFactorMM = 1.;
   if (!XCAFDoc_DocumentTool::GetLengthUnit(theDoc, aScaleFactorMM, UnitsMethods_LengthUnit_Millimeter))
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+    XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
     aScaleFactorMM = UnitsMethods::GetCasCadeLengthUnit();
     // Sets length unit to the document
     XCAFDoc_DocumentTool::SetLengthUnit(theDoc, aScaleFactorMM, UnitsMethods_LengthUnit_Millimeter);
@@ -2368,7 +2368,7 @@ void readAnnotation(const Handle(XSControl_TransferReader)& theTR,
   // calculate units
   Handle(StepVisual_DraughtingModel) aDModel =
     Handle(StepVisual_DraughtingModel)::DownCast(aDMIA->UsedRepresentation());
-  XSAlgo::AlgoContainer()->PrepareForTransfer();
+  XSAlgo_ShapeProcessor::PrepareForTransfer();
   STEPControl_ActorRead anActor(aTP->Model());
   StepData_Factors aLocalFactors = theLocalFactors;
   anActor.PrepareUnits(aDModel, aTP, aLocalFactors);
@@ -2477,7 +2477,7 @@ void readConnectionPoints(const Handle(XSControl_TransferReader)& theTR,
   }
   if (!aSDR.IsNull())
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer();
+    XSAlgo_ShapeProcessor::PrepareForTransfer();
     STEPControl_ActorRead anActor(theTR->Model());
     StepData_Factors aLocalFactors = theLocalFactors;
     anActor.PrepareUnits(aSDR, aTP, aLocalFactors);
@@ -2915,7 +2915,7 @@ Standard_Boolean STEPCAFControl_Reader::setDatumToXCAF(const Handle(StepDimTol_D
               {
                 Handle(StepGeom_Axis2Placement3d) anAx
                   = Handle(StepGeom_Axis2Placement3d)::DownCast(aSRWP->ItemsValue(j));
-                XSAlgo::AlgoContainer()->PrepareForTransfer();
+                XSAlgo_ShapeProcessor::PrepareForTransfer();
                 STEPControl_ActorRead anActor(aTP->Model());
                 StepData_Factors aLocalFactors = theLocalFactors;
                 anActor.PrepareUnits(aSRWP, aTP, aLocalFactors);
@@ -4455,7 +4455,7 @@ Standard_Boolean STEPCAFControl_Reader::ReadGDTs(const Handle(XSControl_WorkSess
       StepData_Factors aLocalFactors = theLocalFactors;
       if (!aDMIA.IsNull())
       {
-        XSAlgo::AlgoContainer()->PrepareForTransfer();
+        XSAlgo_ShapeProcessor::PrepareForTransfer();
         STEPControl_ActorRead anActor(aModel);
         Handle(Transfer_TransientProcess) aTP = aTR->TransientProcess();
         anActor.PrepareUnits(aDMIA->UsedRepresentation(), aTP, aLocalFactors);
@@ -4811,7 +4811,7 @@ Standard_Boolean STEPCAFControl_Reader::ReadViews(const Handle(XSControl_WorkSes
     StepData_Factors aLocalFactors = theLocalFactors;
     if (!aDModel.IsNull())
     {
-      XSAlgo::AlgoContainer()->PrepareForTransfer();
+      XSAlgo_ShapeProcessor::PrepareForTransfer();
       STEPControl_ActorRead anActor(aTP->Model());
       anActor.PrepareUnits(aDModel, aTP, aLocalFactors);
     }
@@ -5366,6 +5366,49 @@ void STEPCAFControl_Reader::SetViewMode(const Standard_Boolean viewmode)
 Standard_Boolean STEPCAFControl_Reader::GetViewMode() const
 {
   return myViewMode;
+}
+
+//=============================================================================
+
+void STEPCAFControl_Reader::SetParameters(const ParameterMap& theParameters)
+{
+  myReader.SetParameters(theParameters);
+}
+
+//=============================================================================
+
+void STEPCAFControl_Reader::SetParameters(ParameterMap&& theParameters)
+{
+  myReader.SetParameters(std::move(theParameters));
+}
+
+//=============================================================================
+
+void STEPCAFControl_Reader::SetParameters(const DE_ShapeFixParameters& theParameters,
+                                          const ParameterMap&          theAdditionalParameters)
+{
+  myReader.SetParameters(theParameters, theAdditionalParameters);
+}
+
+//=============================================================================
+
+const STEPCAFControl_Reader::ParameterMap& STEPCAFControl_Reader::GetParameters() const
+{
+  return myReader.GetParameters();
+}
+
+//=============================================================================
+
+void STEPCAFControl_Reader::SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags)
+{
+  return myReader.SetShapeProcessFlags(theFlags);
+}
+
+//=============================================================================
+
+const STEPCAFControl_Reader::ProcessingFlags& STEPCAFControl_Reader::GetShapeProcessFlags() const
+{
+  return myReader.GetShapeProcessFlags();
 }
 
 //=======================================================================

--- a/src/STEPCAFControl/STEPCAFControl_Reader.hxx
+++ b/src/STEPCAFControl/STEPCAFControl_Reader.hxx
@@ -59,10 +59,12 @@ class Transfer_Binder;
 class STEPCAFControl_Reader 
 {
 public:
-
   DEFINE_STANDARD_ALLOC
 
-  
+  using ParameterMap = XSControl_Reader::ParameterMap;
+  using ProcessingFlags = XSControl_Reader::ProcessingFlags;
+
+public:
   //! Creates a reader with an empty
   //! STEP model and sets ColorMode, LayerMode, NameMode and
   //! PropsMode to Standard_True.
@@ -209,9 +211,38 @@ public:
 
   const XCAFDoc_DataMapOfShapeLabel& GetShapeLabelMap() const { return myMap; }
 
-protected:
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
-  
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
+
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
+
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  Standard_EXPORT const ParameterMap& GetParameters() const;
+
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags);
+
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return Pair of values defining operations to be performed on shapes and a boolean value
+  //!         that indicates whether the flags were set.
+  Standard_EXPORT const ProcessingFlags& GetShapeProcessFlags() const;
+
+protected:
   //! Translates STEP file already loaded into the reader
   //! into the document
   //! If num==0, translates all roots, else only root number num
@@ -319,7 +350,6 @@ protected:
   Standard_EXPORT virtual TCollection_ExtendedString convertName (const TCollection_AsciiString& theName) const;
 
 private:
-
   //! Internal method. Import all Datum attributes and set them to XCAF object. Set connection of Datum to GeomTolerance (theGDTL).
   Standard_Boolean setDatumToXCAF(const Handle(StepDimTol_Datum)& theDat,
     const TDF_Label theGDTL,
@@ -361,7 +391,6 @@ private:
                                   Handle(TDataStd_NamedData)& theAttr) const;
 
 private:
-
   STEPControl_Reader myReader;
   NCollection_DataMap<TCollection_AsciiString, Handle(STEPCAFControl_ExternFile)> myFiles;
   XCAFDoc_DataMapOfShapeLabel myMap;
@@ -375,7 +404,6 @@ private:
   Standard_Boolean myMatMode;
   Standard_Boolean myViewMode;
   NCollection_DataMap<Handle(Standard_Transient), TDF_Label> myGDTMap;
-
 };
 
 #endif // _STEPCAFControl_Reader_HeaderFile

--- a/src/STEPCAFControl/STEPCAFControl_Writer.cxx
+++ b/src/STEPCAFControl/STEPCAFControl_Writer.cxx
@@ -212,7 +212,7 @@
 #include <XCAFPrs_IndexedDataMapOfShapeStyle.hxx>
 #include <XCAFPrs_Style.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_TransferWriter.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <UnitsMethods.hxx>
@@ -361,7 +361,7 @@ void STEPCAFControl_Writer::prepareUnit(const TDF_Label& theLabel,
   }
   else
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+    XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
     theModel->SetLocalLengthUnit(UnitsMethods::GetCasCadeLengthUnit());
     theLocalFactors.SetCascadeUnit(UnitsMethods::GetCasCadeLengthUnit());
   }
@@ -561,6 +561,49 @@ Standard_Boolean STEPCAFControl_Writer::ExternFile(const Standard_CString theNam
     return Standard_False;
   theExtFile = myFiles.Find(theName);
   return Standard_True;
+}
+
+//=============================================================================
+
+void STEPCAFControl_Writer::SetParameters(const ParameterMap& theParameters)
+{
+  myWriter.SetParameters(theParameters);
+}
+
+//=============================================================================
+
+void STEPCAFControl_Writer::SetParameters(ParameterMap&& theParameters)
+{
+  myWriter.SetParameters(std::move(theParameters));
+}
+
+//=============================================================================
+
+void STEPCAFControl_Writer::SetParameters(const DE_ShapeFixParameters& theParameters,
+                                          const ParameterMap&          theAdditionalParameters)
+{
+  myWriter.SetParameters(theParameters, theAdditionalParameters);
+}
+
+//=============================================================================
+
+const STEPCAFControl_Writer::ParameterMap& STEPCAFControl_Writer::GetParameters() const
+{
+  return myWriter.GetParameters();
+}
+
+//=============================================================================
+
+void STEPCAFControl_Writer::SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags)
+{
+  myWriter.SetShapeProcessFlags(theFlags);
+}
+
+//=============================================================================
+
+const STEPCAFControl_Writer::ProcessingFlags& STEPCAFControl_Writer::GetShapeProcessFlags() const
+{
+  return myWriter.GetShapeProcessFlags();
 }
 
 //=======================================================================

--- a/src/STEPCAFControl/STEPCAFControl_Writer.hxx
+++ b/src/STEPCAFControl/STEPCAFControl_Writer.hxx
@@ -52,8 +52,10 @@ class STEPCAFControl_Writer
 public:
   DEFINE_STANDARD_ALLOC
 
-public:
+  using ParameterMap = STEPControl_Writer::ParameterMap;
+  using ProcessingFlags = STEPControl_Writer::ProcessingFlags;
 
+public:
   //! Creates a writer with an empty
   //! STEP model and sets ColorMode, LayerMode, NameMode and
   //! PropsMode to Standard_True.
@@ -212,8 +214,38 @@ public:
 
   Standard_Boolean GetMaterialMode() const { return myMatMode; }
 
-protected:
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
+
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
+
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  Standard_EXPORT const ParameterMap& GetParameters() const;
+
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags);
+
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return Pair of values defining operations to be performed on shapes and a boolean value
+  //!         that indicates whether the flags were set.
+  Standard_EXPORT const ProcessingFlags& GetShapeProcessFlags() const;
+
+protected:
   //! Transfers labels to a STEP model
   //! Returns True if translation is OK
   //! isExternFile setting from transferExternFiles method

--- a/src/STEPControl/STEPControl_ActorRead.hxx
+++ b/src/STEPControl/STEPControl_ActorRead.hxx
@@ -64,7 +64,6 @@ class STEPControl_ActorRead : public Transfer_ActorOfTransientProcess
 {
 
 public:
-
   Standard_EXPORT STEPControl_ActorRead(const Handle(Interface_InterfaceModel)& theModel);
 
   Standard_EXPORT virtual Standard_Boolean Recognize (const Handle(Standard_Transient)& start) Standard_OVERRIDE;
@@ -116,13 +115,9 @@ public:
                                                  const StepData_Factors& theLocalFactors = StepData_Factors());
 
 
-
-
   DEFINE_STANDARD_RTTIEXT(STEPControl_ActorRead,Transfer_ActorOfTransientProcess)
 
 protected:
-
-
   //! Transfers product definition entity
   //! theUseTrsf - special flag for using Axis2Placement from ShapeRepresentation for transform root shape
     Standard_EXPORT Handle(TransferBRep_ShapeBinder) TransferEntity (
@@ -204,11 +199,7 @@ protected:
                     const Handle(Transfer_TransientProcess)& TP,
                     const Message_ProgressRange& theProgress);
 
-
-
 private:
-
-
   Standard_EXPORT TopoDS_Shell closeIDEASShell (const TopoDS_Shell& shell, const TopTools_ListOfShape& closingShells);
 
   Standard_EXPORT void computeIDEASClosings (const TopoDS_Compound& comp, TopTools_IndexedDataMapOfShapeListOfShape& shellClosingMap);
@@ -221,18 +212,12 @@ private:
                                                   TopoDS_Compound& theCund,
                                                   Message_ProgressScope& thePS);
 
+private:
   StepToTopoDS_NMTool myNMTool;
   Standard_Real myPrecision;
   Standard_Real myMaxTol;
   Handle(StepRepr_Representation) mySRContext;
   Handle(Interface_InterfaceModel) myModel;
-
 };
-
-
-
-
-
-
 
 #endif // _STEPControl_ActorRead_HeaderFile

--- a/src/STEPControl/STEPControl_ActorWrite.hxx
+++ b/src/STEPControl/STEPControl_ActorWrite.hxx
@@ -43,8 +43,6 @@ class STEPControl_ActorWrite : public Transfer_ActorOfFinderProcess
 {
 
 public:
-
-  
   Standard_EXPORT STEPControl_ActorWrite();
   
   Standard_EXPORT virtual Standard_Boolean Recognize (const Handle(Transfer_Finder)& start) Standard_OVERRIDE;
@@ -98,19 +96,9 @@ public:
   Standard_EXPORT virtual Standard_Boolean IsAssembly (const Handle(StepData_StepModel)& theModel,
                                                        TopoDS_Shape& S) const;
 
-
-
-
   DEFINE_STANDARD_RTTIEXT(STEPControl_ActorWrite,Transfer_ActorOfFinderProcess)
 
-protected:
-
-
-
-
 private:
-
-  
   //! Non-manifold shapes are stored in NMSSR group
   //! (NON_MANIFOLD_SURFACE_SHAPE_REPRESENTATION).
   //! Use this method to get the corresponding NMSSR (or
@@ -128,8 +116,7 @@ private:
   Standard_Boolean separateShapeToSoloVertex(const TopoDS_Shape& theShape,
                                              TopTools_SequenceOfShape& theVertices);
 
-
-
+private:
   Standard_Integer mygroup;
   Standard_Real mytoler;
   STEPConstruct_ContextTool myContext;

--- a/src/STEPControl/STEPControl_Reader.cxx
+++ b/src/STEPControl/STEPControl_Reader.cxx
@@ -11,7 +11,7 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-
+#include <DE_ShapeFixParameters.hxx>
 #include <IFSelect_WorkLibrary.hxx>
 #include <Interface_EntityIterator.hxx>
 #include <Interface_Graph.hxx>
@@ -60,6 +60,7 @@
 #include <TColStd_MapOfAsciiString.hxx>
 #include <TColStd_SequenceOfAsciiString.hxx>
 #include <Transfer_TransientProcess.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_TransferReader.hxx>
 #include <XSControl_WorkSession.hxx>
 
@@ -83,7 +84,7 @@ STEPControl_Reader::STEPControl_Reader
 {
   STEPControl_Controller::Init();
   SetWS (WS,scratch);
-  SetNorm ("STEP");
+  SetNorm("STEP");
 }
 
 //=======================================================================
@@ -650,6 +651,23 @@ inline static TCollection_AsciiString getSiName(const Handle(StepBasic_SiUnit)& 
   };
   return aName;
 }
+
+//=================================================================================================
+
+DE_ShapeFixParameters STEPControl_Reader::GetDefaultParameters() const
+{
+  return DESTEP_Parameters::GetDefaultReadingParamsSTEP();
+}
+
+//=================================================================================================
+
+ShapeProcess::OperationsFlags STEPControl_Reader::GetDefaultShapeProcessFlags() const
+{
+  ShapeProcess::OperationsFlags aFlags;
+  aFlags.set(ShapeProcess::Operation::FixShape);
+  return aFlags;
+}
+
 
 //=======================================================================
 //function : findUnits

--- a/src/STEPControl/STEPControl_Reader.hxx
+++ b/src/STEPControl/STEPControl_Reader.hxx
@@ -126,22 +126,20 @@ public:
   //! Performs only if a model is not NULL
   Standard_EXPORT Standard_Real SystemLengthUnit() const;
 
-
 protected:
+  //! Returns default parameters for shape fixing.
+  //! This method is used by the base class to get default parameters for shape fixing.
+  //! @return default parameters for shape fixing.
+  Standard_EXPORT virtual DE_ShapeFixParameters GetDefaultParameters() const Standard_OVERRIDE;
 
-
-
+  //! Returns default flags for shape processing.
+  //! @return Default flags for shape processing.
+  Standard_EXPORT virtual ShapeProcess::OperationsFlags GetDefaultShapeProcessFlags() const Standard_OVERRIDE;
 
 
 private:
-
-  
   //! Returns  units for length , angle and solidangle for shape representations
   Standard_EXPORT Standard_Boolean findUnits (const Handle(StepRepr_RepresentationContext)& theReprContext, TColStd_Array1OfAsciiString& theNameUnits, TColStd_Array1OfReal& theFactorUnits);
-
-
-
-
 };
 
 

--- a/src/ShapeProcess/ShapeProcess.cxx
+++ b/src/ShapeProcess/ShapeProcess.cxx
@@ -218,6 +218,26 @@ Standard_Boolean ShapeProcess::Perform(const Handle(ShapeProcess_Context)& theCo
   return anIsAnySuccess;
 }
 
+//=================================================================================================
+
+std::pair<ShapeProcess::Operation, bool> ShapeProcess::ToOperationFlag(const char* theName)
+{
+  if (!theName)
+  {
+    return {Operation::First, false};
+  }
+
+  for (std::underlying_type<Operation>::type anOperation = Operation::First; anOperation <= Operation::Last; ++anOperation)
+  {
+    const char* anOperationName = toOperationName(static_cast<Operation>(anOperation));
+    if (anOperationName && !strcmp(theName, anOperationName))
+    {
+      return {static_cast<Operation>(anOperation), true};
+    }
+  }
+  return {Operation::First, false};
+}
+
 //=======================================================================
 //function : getOperators
 //purpose  :

--- a/src/ShapeProcess/ShapeProcess.hxx
+++ b/src/ShapeProcess/ShapeProcess.hxx
@@ -99,6 +99,11 @@ public:
                                                   const OperationsFlags&              theOperations,
                                                   const Message_ProgressRange&        theProgress = Message_ProgressRange());
 
+  //! Converts operation name to operation flag.
+  //! @param theName Operation name.
+  //! @return Operation flag and true if the operation name is valid, false otherwise.
+  Standard_EXPORT static std::pair<Operation, bool> ToOperationFlag(const char* theName);
+
 private:
   //! Returns operators to be performed according to the specified flags.
   //! @param theFlags Bitset of operations flags.

--- a/src/StepToTopoDS/StepToTopoDS_TranslateEdgeLoop.cxx
+++ b/src/StepToTopoDS/StepToTopoDS_TranslateEdgeLoop.cxx
@@ -74,7 +74,7 @@
 #include <TopoDS_Wire.hxx>
 #include <Transfer_TransientProcess.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 
 // ============================================================================
 // Method  : RemoveSinglePCurve
@@ -164,7 +164,7 @@ static void CheckPCurves (TopoDS_Wire& aWire, const TopoDS_Face& aFace,
 
 
     // advanced check
-    XSAlgo::AlgoContainer()->CheckPCurve (myEdge, aFace, preci, sbwd->IsSeam(i));
+    XSAlgo_ShapeProcessor::CheckPCurve(myEdge, aFace, preci, sbwd->IsSeam(i));
   }
 }
 

--- a/src/Transfer/Transfer_ActorOfFinderProcess.cxx
+++ b/src/Transfer/Transfer_ActorOfFinderProcess.cxx
@@ -20,13 +20,20 @@
 #include <Transfer_ProcessForFinder.hxx>
 #include <Transfer_SimpleBinderOfTransient.hxx>
 #include <Transfer_TransientMapper.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(Transfer_ActorOfFinderProcess,Transfer_ActorOfProcessForFinder)
 
+//=============================================================================
+
 Transfer_ActorOfFinderProcess::Transfer_ActorOfFinderProcess ()    {  themodetrans = 0;  }
+
+//=============================================================================
 
 Standard_Integer& Transfer_ActorOfFinderProcess::ModeTrans ()
 {  return themodetrans;  }
+
+//=============================================================================
 
 Handle(Transfer_Binder)  Transfer_ActorOfFinderProcess::Transfer
   (const Handle(Transfer_Finder)& fnd,
@@ -40,6 +47,8 @@ Handle(Transfer_Binder)  Transfer_ActorOfFinderProcess::Transfer
   return TransientResult (res);
 }
 
+//=============================================================================
+
 Handle(Transfer_Binder)  Transfer_ActorOfFinderProcess::Transferring
   (const Handle(Transfer_Finder)& ent,
    const Handle(Transfer_ProcessForFinder)& TP,
@@ -48,6 +57,8 @@ Handle(Transfer_Binder)  Transfer_ActorOfFinderProcess::Transferring
   return Transfer(ent,Handle(Transfer_FinderProcess)::DownCast(TP), theProgress);
 }
 
+//=============================================================================
+
 Handle(Standard_Transient)  Transfer_ActorOfFinderProcess::TransferTransient
   (const Handle(Standard_Transient)& /*ent*/,
    const Handle(Transfer_FinderProcess)&,
@@ -55,4 +66,42 @@ Handle(Standard_Transient)  Transfer_ActorOfFinderProcess::TransferTransient
 {
   Handle(Standard_Transient) nulres;
   return nulres;
+}
+
+//=============================================================================
+
+void Transfer_ActorOfFinderProcess::SetParameters(const ParameterMap& theParameters)
+{
+  myShapeProcParams = theParameters;
+}
+
+//=============================================================================
+
+void Transfer_ActorOfFinderProcess::SetParameters(ParameterMap&& theParameters)
+{
+  myShapeProcParams = std::move(theParameters);
+}
+
+//=============================================================================
+
+void Transfer_ActorOfFinderProcess::SetParameters(const DE_ShapeFixParameters& theParameters,
+                                                  const ParameterMap&          theAdditionalParameters)
+{
+  myShapeProcParams.clear();
+  XSAlgo_ShapeProcessor::FillParameterMap(theParameters, true, myShapeProcParams);
+  for (const auto& aParam : theAdditionalParameters)
+  {
+    if (myShapeProcParams.find(aParam.first) == myShapeProcParams.end())
+    {
+      myShapeProcParams[aParam.first] = aParam.second;
+    }
+  }
+}
+
+//=============================================================================
+
+void Transfer_ActorOfFinderProcess::SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags)
+{
+  myShapeProcFlags.first = theFlags;
+  myShapeProcFlags.second = true;
 }

--- a/src/Transfer/Transfer_ActorOfFinderProcess.hxx
+++ b/src/Transfer/Transfer_ActorOfFinderProcess.hxx
@@ -18,8 +18,12 @@
 #define _Transfer_ActorOfFinderProcess_HeaderFile
 
 #include <Standard.hxx>
-
+#include <ShapeProcess.hxx>
 #include <Transfer_ActorOfProcessForFinder.hxx>
+
+#include <unordered_map>
+
+struct DE_ShapeFixParameters;
 class Transfer_Binder;
 class Transfer_Finder;
 class Transfer_ProcessForFinder;
@@ -36,10 +40,14 @@ DEFINE_STANDARD_HANDLE(Transfer_ActorOfFinderProcess, Transfer_ActorOfProcessFor
 //! a user. To be interpreted for each norm
 class Transfer_ActorOfFinderProcess : public Transfer_ActorOfProcessForFinder
 {
+public:
+  using ParameterMap = std::unordered_map<std::string, std::string>;
+  // Flags defining operations to be performed on shapes. Since there is no std::optional in C++11,
+  // we use a pair. The first element is the flags, the second element is a boolean value that indicates
+  // whether the flags were set.
+  using ProcessingFlags = std::pair<ShapeProcess::OperationsFlags, bool>;
 
 public:
-
-  
   Standard_EXPORT Transfer_ActorOfFinderProcess();
   
   //! Returns the Transfer Mode, modifiable
@@ -60,22 +68,45 @@ public:
                     const Handle(Transfer_FinderProcess)& TP,
                     const Message_ProgressRange& theProgress = Message_ProgressRange());
 
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
+
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  inline const ParameterMap& GetParameters() const { return myShapeProcParams; }
+
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags);
+
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return Pair of values defining operations to be performed on shapes and a boolean value
+  //!         that indicates whether the flags were set.
+  inline const ProcessingFlags& GetShapeProcessFlags() const { return myShapeProcFlags; }
 
   DEFINE_STANDARD_RTTIEXT(Transfer_ActorOfFinderProcess,Transfer_ActorOfProcessForFinder)
 
 protected:
-
-
   Standard_Integer themodetrans;
 
-
 private:
-
-
-
-
+  ParameterMap    myShapeProcParams; //!< Parameters for shape processing.
+  ProcessingFlags myShapeProcFlags;  //!< Flags defining operations to be performed on shapes.
 };
 
 

--- a/src/Transfer/Transfer_ActorOfTransientProcess.cxx
+++ b/src/Transfer/Transfer_ActorOfTransientProcess.cxx
@@ -17,10 +17,14 @@
 #include <Transfer_ProcessForTransient.hxx>
 #include <Transfer_SimpleBinderOfTransient.hxx>
 #include <Transfer_TransientProcess.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(Transfer_ActorOfTransientProcess,Transfer_ActorOfProcessForTransient)
 
-Transfer_ActorOfTransientProcess::Transfer_ActorOfTransientProcess ()    {  }
+Transfer_ActorOfTransientProcess::Transfer_ActorOfTransientProcess()
+{}
+
+//=============================================================================
 
 Handle(Transfer_Binder)  Transfer_ActorOfTransientProcess::Transfer
   (const Handle(Standard_Transient)& start,
@@ -32,6 +36,8 @@ Handle(Transfer_Binder)  Transfer_ActorOfTransientProcess::Transfer
   return TransientResult (res);
 }
 
+//=============================================================================
+
 Handle(Transfer_Binder)  Transfer_ActorOfTransientProcess::Transferring
   (const Handle(Standard_Transient)& ent,
    const Handle(Transfer_ProcessForTransient)& TP,
@@ -40,6 +46,8 @@ Handle(Transfer_Binder)  Transfer_ActorOfTransientProcess::Transferring
   return Transfer(ent,Handle(Transfer_TransientProcess)::DownCast(TP), theProgress);
 }
 
+//=============================================================================
+
 Handle(Standard_Transient)  Transfer_ActorOfTransientProcess::TransferTransient
   (const Handle(Standard_Transient)& /*ent*/,
    const Handle(Transfer_TransientProcess)& /*TP*/,
@@ -47,4 +55,42 @@ Handle(Standard_Transient)  Transfer_ActorOfTransientProcess::TransferTransient
 {
   Handle(Standard_Transient) nulres;
   return nulres;
+}
+
+//=============================================================================
+
+void Transfer_ActorOfTransientProcess::SetParameters(const ParameterMap& theParameters)
+{
+  myShapeProcParams = theParameters;
+}
+
+//=============================================================================
+
+void Transfer_ActorOfTransientProcess::SetParameters(ParameterMap&& theParameters)
+{
+  myShapeProcParams = std::move(theParameters);
+}
+
+//=============================================================================
+
+void Transfer_ActorOfTransientProcess::SetParameters(const DE_ShapeFixParameters& theParameters,
+                                                     const ParameterMap&          theAdditionalParameters)
+{
+  myShapeProcParams.clear();
+  XSAlgo_ShapeProcessor::FillParameterMap(theParameters, true, myShapeProcParams);
+  for (const auto& aParam : theAdditionalParameters)
+  {
+    if (myShapeProcParams.find(aParam.first) == myShapeProcParams.end())
+    {
+      myShapeProcParams[aParam.first] = aParam.second;
+    }
+  }
+}
+
+//=============================================================================
+
+void Transfer_ActorOfTransientProcess::SetProcessingFlags(const ShapeProcess::OperationsFlags& theFlags)
+{
+  myShapeProcFlags.first = theFlags;
+  myShapeProcFlags.second = true;
 }

--- a/src/Transfer/Transfer_ActorOfTransientProcess.hxx
+++ b/src/Transfer/Transfer_ActorOfTransientProcess.hxx
@@ -17,9 +17,13 @@
 #ifndef _Transfer_ActorOfTransientProcess_HeaderFile
 #define _Transfer_ActorOfTransientProcess_HeaderFile
 
+#include <ShapeProcess.hxx>
 #include <Standard.hxx>
-
 #include <Transfer_ActorOfProcessForTransient.hxx>
+
+#include <unordered_map>
+
+struct DE_ShapeFixParameters;
 class Transfer_Binder;
 class Standard_Transient;
 class Transfer_ProcessForTransient;
@@ -31,10 +35,14 @@ DEFINE_STANDARD_HANDLE(Transfer_ActorOfTransientProcess, Transfer_ActorOfProcess
 //! The original class was renamed. Compatibility only
 class Transfer_ActorOfTransientProcess : public Transfer_ActorOfProcessForTransient
 {
+public:
+  using ParameterMap = std::unordered_map<std::string, std::string>;
+  // Flags defining operations to be performed on shapes. Since there is no std::optional in C++11,
+  // we use a pair. The first element is the flags, the second element is a boolean value that indicates
+  // whether the flags were set.
+  using ProcessingFlags = std::pair<ShapeProcess::OperationsFlags, bool>;
 
 public:
-
-  
   Standard_EXPORT Transfer_ActorOfTransientProcess();
   
   Standard_EXPORT virtual Handle(Transfer_Binder) Transferring
@@ -52,27 +60,42 @@ public:
                           const Handle(Transfer_TransientProcess)& TP,
                           const Message_ProgressRange& theProgress = Message_ProgressRange());
 
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
+
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  inline const ParameterMap& GetParameters() const { return myShapeProcParams; }
+
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetProcessingFlags(const ShapeProcess::OperationsFlags& theFlags);
+
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return Pair: the flags defining operations to be performed on shapes and a boolean value that indicates
+  //!         whether the flags were set.
+  inline const ProcessingFlags& GetProcessingFlags() const { return myShapeProcFlags; }
 
   DEFINE_STANDARD_RTTIEXT(Transfer_ActorOfTransientProcess,Transfer_ActorOfProcessForTransient)
 
-protected:
-
-
-
-
 private:
-
-
-
-
+  ParameterMap    myShapeProcParams; //!< Parameters for shape processing.
+  ProcessingFlags myShapeProcFlags;  //!< Flags defining operations to be performed on shapes.
 };
-
-
-
-
-
-
 
 #endif // _Transfer_ActorOfTransientProcess_HeaderFile

--- a/src/Transfer/Transfer_ProcessForTransient_0.cxx
+++ b/src/Transfer/Transfer_ProcessForTransient_0.cxx
@@ -922,9 +922,18 @@ Handle(Transfer_Binder) Transfer_ProcessForTransient::TransferProduct
   Message_ProgressScope aScope(theProgress, NULL, 1, true);
   while (!actor.IsNull())
   {
-    if (actor->Recognize(start)) binder = actor->Transferring(start, this, aScope.Next());
-    else binder.Nullify();
-    if (!binder.IsNull()) break;
+    if (actor->Recognize(start))
+    {
+      binder = actor->Transferring(start, this, aScope.Next());
+    }
+    else
+    {
+      binder.Nullify();
+    }
+    if (!binder.IsNull())
+    {
+      break;
+    }
     actor = actor->Next();
   }
   if (aScope.UserBreak())

--- a/src/XDEDRAW/XDEDRAW_Shapes.cxx
+++ b/src/XDEDRAW/XDEDRAW_Shapes.cxx
@@ -35,7 +35,7 @@
 #include <XCAFDoc_ShapeTool.hxx>
 #include <XDEDRAW_Shapes.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <UnitsMethods.hxx>
 
 #include <stdio.h>
@@ -62,7 +62,7 @@ static Standard_Integer addShape (Draw_Interpretor& di, Standard_Integer argc, c
   Standard_Real aLengthUnit = 1.;
   if (!XCAFDoc_DocumentTool::GetLengthUnit(Doc, aLengthUnit))
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+    XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
     aLengthUnit = UnitsMethods::GetCasCadeLengthUnit(UnitsMethods_LengthUnit_Meter);
     XCAFDoc_DocumentTool::SetLengthUnit(Doc, aLengthUnit);
   }

--- a/src/XSAlgo/XSAlgo_ShapeProcessor.hxx
+++ b/src/XSAlgo/XSAlgo_ShapeProcessor.hxx
@@ -35,6 +35,7 @@ class XSAlgo_ShapeProcessor
 public:
   using OperationsFlags = ShapeProcess::OperationsFlags;
   using ParameterMap    = std::unordered_map<std::string, std::string>;
+  using ProcessingData  = std::pair<ParameterMap, OperationsFlags>;
 
 public:
   //! Constructor.
@@ -84,10 +85,49 @@ public:
                                                       const Standard_Real    thePrecision,
                                                       const Standard_Boolean theIsSeam);
 
+  //! Reads the parameter map from and operation flags from the file specified in static interface.
+  //! @param theFileResourceName Name of the parameter in interface static that contains the name
+  //!        of the file. For example, parameter "read.iges.resource.name" may contain string "IGES".
+  //! @param theScopeResourceName Name of the parameter in interface static that contains the name
+  //!        of the scope. For example, parameter "read.iges.sequence" may contain string "FromIGES".
+  //! @return Read parameter map.
+  Standard_EXPORT static ProcessingData ReadProcessingData(const std::string& theFileResourceName,
+                                                           const std::string& theScopeResourceName);
+
   //! Fill the parameter map with the values from the specified parameters.
   //! @param theParameters Parameters to be used in the processing.
+  //! @param theIsForce Flag indicating whether parameter should be replaced if it already exists in the map.
   //! @param theMap Map to fill.
-  Standard_EXPORT static void FillParameterMap(const DE_ShapeFixParameters& theParameters, ParameterMap& theMap);
+  Standard_EXPORT static void FillParameterMap(const DE_ShapeFixParameters& theParameters,
+                                               const bool                   theIsReplace,
+                                               ParameterMap&                theMap);
+
+  //! Set the parameter in the map.
+  //! @param theKey Key of the parameter.
+  //! @param theValue Value of the parameter.
+  //! @param theIsReplace Flag indicating whether parameter should be replaced if it already exists in the map.
+  //! @param theMap Map to set the parameter in.
+  Standard_EXPORT static void SetParameter(const char*                    theKey,
+                                           DE_ShapeFixParameters::FixMode theValue,
+                                           const bool                     theIsReplace,
+                                           ParameterMap&                  theMap);
+
+  //! Set the parameter in the map.
+  //! @param theKey Key of the parameter.
+  //! @param theValue Value of the parameter.
+  //! @param theIsReplace Flag indicating whether parameter should be replaced if it already exists in the map.
+  //! @param theMap Map to set the parameter in.
+  Standard_EXPORT static void SetParameter(const char* theKey, double theValue, const bool theIsReplace, ParameterMap& theMap);
+
+  //! Set the parameter in the map.
+  //! @param theKey Key of the parameter.
+  //! @param theValue Value of the parameter.
+  //! @param theIsReplace Flag indicating whether parameter should be replaced if it already exists in the map.
+  //! @param theMap Map to set the parameter in.
+  Standard_EXPORT static void SetParameter(const char*   theKey,
+                                           std::string&& theValue,
+                                           const bool    theIsReplace,
+                                           ParameterMap& theMap);
 
   //! The function is designed to set the length unit for the application before performing a
   //! transfer operation. It ensures that the length unit is correctly configured based on the

--- a/src/XSControl/XSControl_Reader.hxx
+++ b/src/XSControl/XSControl_Reader.hxx
@@ -17,10 +17,11 @@
 #ifndef _XSControl_Reader_HeaderFile
 #define _XSControl_Reader_HeaderFile
 
+#include <DE_ShapeFixParameters.hxx>
+#include <ShapeProcess.hxx>
 #include <Standard.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
-
 #include <TColStd_SequenceOfTransient.hxx>
 #include <TopTools_SequenceOfShape.hxx>
 #include <Standard_CString.hxx>
@@ -30,11 +31,13 @@
 #include <IFSelect_PrintCount.hxx>
 #include <Message_ProgressRange.hxx>
 
+#include <unordered_map>
+
 class XSControl_WorkSession;
 class Interface_InterfaceModel;
 class Standard_Transient;
+class Transfer_ActorOfTransientProcess;
 class TopoDS_Shape;
-
 
 //! A groundwork to convert a shape to data which complies
 //! with a particular norm. This data can be that of a whole
@@ -70,9 +73,13 @@ class TopoDS_Shape;
 class XSControl_Reader 
 {
 public:
-
   DEFINE_STANDARD_ALLOC
 
+  using ParameterMap = std::unordered_map<std::string, std::string>;
+  // Flags defining operations to be performed on shapes. Since there is no std::optional in C++11,
+  // we use a pair. The first element is the flags, the second element is a boolean value that indicates
+  // whether the flags were set.
+  using ProcessingFlags = std::pair<ShapeProcess::OperationsFlags, bool>;
   
   //! Creates a Reader from scratch (creates an empty WorkSession)
   //! A WorkSession or a Controller must be provided before running
@@ -260,28 +267,68 @@ public:
   //! Gives statistics about Transfer
   Standard_EXPORT void GetStatsTransfer (const Handle(TColStd_HSequenceOfTransient)& list, Standard_Integer& nbMapped, Standard_Integer& nbWithResult, Standard_Integer& nbWithFail) const;
 
+  //! Sets parameters for shape processing.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(const ParameterMap& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters are moved from the input map.
+  //! @param theParameters the parameters for shape processing.
+  Standard_EXPORT void SetParameters(ParameterMap&& theParameters);
 
+  //! Sets parameters for shape processing.
+  //! Parameters from @p theParameters are copied to the internal map.
+  //! Parameters from @p theAdditionalParameters are copied to the internal map
+  //! if they are not present in @p theParameters.
+  //! @param theParameters the parameters for shape processing.
+  //! @param theAdditionalParameters the additional parameters for shape processing.
+  Standard_EXPORT void SetParameters(const DE_ShapeFixParameters& theParameters,
+                                     const ParameterMap&          theAdditionalParameters = {});
+
+  //! Returns parameters for shape processing that was set by SetParameters() method.
+  //! @return the parameters for shape processing. Empty map if no parameters were set.
+  Standard_EXPORT const ParameterMap& GetParameters() const;
+
+  //! Sets flags defining operations to be performed on shapes.
+  //! @param theFlags The flags defining operations to be performed on shapes.
+  Standard_EXPORT void SetShapeProcessFlags(const ShapeProcess::OperationsFlags& theFlags);
+
+  //! Returns flags defining operations to be performed on shapes.
+  //! @return Pair of values defining operations to be performed on shapes and a boolean value
+  //!         that indicates whether the flags were set.
+  Standard_EXPORT const ProcessingFlags& GetShapeProcessFlags() const;
 
 protected:
-
-  
   //! Returns a sequence of produced shapes
   Standard_EXPORT TopTools_SequenceOfShape& Shapes();
 
+  //! Returns default parameters for shape fixing.
+  //! This method should be implemented in the derived classes to return default parameters for shape fixing.
+  //! @return Default parameters for shape fixing.
+  virtual DE_ShapeFixParameters GetDefaultParameters() const { return DE_ShapeFixParameters(); }
 
+  //! Returns default flags for shape processing.
+  //! This method should be implemented in the derived classes to return default flags for shape processing.
+  //! @return Default flags for shape processing.
+  virtual ShapeProcess::OperationsFlags GetDefaultShapeProcessFlags() const { return ShapeProcess::OperationsFlags(); }
+
+private:
+  //! Returns the Actor for the Transfer of an Entity.
+  //! This Actor is used by the Reader to perform the Transfer.
+  //! @return the Actor for the Transfer of an Entity. May be nullptr.
+  Handle(Transfer_ActorOfTransientProcess) GetActor() const;
+
+  //! If parameters haven't yet been provided, initializes them with default values
+  //! provided by GetDefaultParameters() method.
+  void InitializeMissingParameters();
+
+protected:
   Standard_Boolean therootsta;
   TColStd_SequenceOfTransient theroots;
 
-
 private:
-
-
-
   Handle(XSControl_WorkSession) thesession;
   TopTools_SequenceOfShape theshapes;
-
-
 };
 
 

--- a/src/XSDRAWIGES/XSDRAWIGES.cxx
+++ b/src/XSDRAWIGES/XSDRAWIGES.cxx
@@ -46,7 +46,7 @@
 #include <Transfer_IteratorOfProcessForTransient.hxx>
 #include <Transfer_TransientProcess.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_TransferReader.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <XSDRAW.hxx>
@@ -216,12 +216,16 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
       modepri = Draw::Atoi(str);
     }
 
+    XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+      XSAlgo_ShapeProcessor::ReadProcessingData("read.iges.resource.name", "read.iges.sequence");
+    Reader.SetParameters(std::move(aProcessingData.first));
+    Reader.SetShapeProcessFlags(aProcessingData.second);
+
     if (modepri == 0)
     {  //fin
       theDI << "Bye and good luck! \n";
       break;
     }
-
     else if (modepri <= 2)
     {  // 1 : Visible Roots, 2 : All Roots
       theDI << "All Geometry Transfer\n";
@@ -489,6 +493,12 @@ static Standard_Integer testread(Draw_Interpretor& theDI,
     case IFSelect_RetFail: { theDI << "error during read\n";  return 1; }
     default: { theDI << "failure\n";   return 1; }
   }
+
+  XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+    XSAlgo_ShapeProcessor::ReadProcessingData("read.iges.resource.name", "read.iges.sequence");
+  Reader.SetParameters(std::move(aProcessingData.first));
+  Reader.SetShapeProcessFlags(aProcessingData.second);
+
   Reader.TransferRoots();
   TopoDS_Shape shape = Reader.OneShape();
   DBRep::Set(theArgVec[2], shape);
@@ -519,6 +529,11 @@ static Standard_Integer brepiges(Draw_Interpretor& theDI,
   Handle(Draw_ProgressIndicator) aProgress = new Draw_ProgressIndicator(theDI, 1);
   Message_ProgressScope aRootProgress(aProgress->Start(), "Translating", 100);
   aProgress->Show(aRootProgress);
+
+  XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+    XSAlgo_ShapeProcessor::ReadProcessingData("write.iges.resource.name", "write.iges.sequence");
+  anIgesWriter.SetParameters(std::move(aProcessingData.first));
+  anIgesWriter.SetShapeProcessFlags(aProcessingData.second);
 
   Message_ProgressScope aStepProgress(aRootProgress.Next(90), NULL, theNbArgs);
   for (Standard_Integer i = 1; i < theNbArgs && aStepProgress.More(); i++)
@@ -577,6 +592,10 @@ static Standard_Integer testwrite(Draw_Interpretor& theDI,
     return 1;
   }
   IGESControl_Writer Writer;
+  XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+    XSAlgo_ShapeProcessor::ReadProcessingData("write.iges.resource.name", "write.iges.sequence");
+  Writer.SetParameters(std::move(aProcessingData.first));
+  Writer.SetShapeProcessFlags(aProcessingData.second);
   Standard_CString filename = theArgVec[1];
   TopoDS_Shape shape = DBRep::Get(theArgVec[2]);
   Standard_Boolean ok = Writer.AddShape(shape);
@@ -810,6 +829,10 @@ static Standard_Integer etest(Draw_Interpretor& theDI,
   IGESControl_Reader aReader;
   aReader.ReadFile(theArgVec[1]);
   aReader.SetReadVisible(Standard_True);
+  XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+    XSAlgo_ShapeProcessor::ReadProcessingData("read.iges.resource.name", "read.iges.sequence");
+  aReader.SetParameters(std::move(aProcessingData.first));
+  aReader.SetShapeProcessFlags(aProcessingData.second);
   aReader.TransferRoots();
   TopoDS_Shape shape = aReader.OneShape();
   DBRep::Set(theArgVec[2], shape);
@@ -882,6 +905,11 @@ static Standard_Integer ReadIges(Draw_Interpretor& theDI,
     return 1;
   }
 
+  XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+    XSAlgo_ShapeProcessor::ReadProcessingData("read.iges.resource.name", "read.iges.sequence");
+  aReader.SetParameters(std::move(aProcessingData.first));
+  aReader.SetShapeProcessFlags(aProcessingData.second);
+
   Handle(TDocStd_Document) aDocument;
   if (!DDocStd::GetDocument(theArgVec[1], aDocument, Standard_False))
   {
@@ -943,6 +971,10 @@ static Standard_Integer WriteIges(Draw_Interpretor& theDI, Standard_Integer theN
       case 'l': aWriter.SetLayerMode(mode); break;
       }
   }
+  XSAlgo_ShapeProcessor::ProcessingData aProcessingData =
+    XSAlgo_ShapeProcessor::ReadProcessingData("write.iges.resource.name", "write.iges.sequence");
+  aWriter.SetParameters(std::move(aProcessingData.first));
+  aWriter.SetShapeProcessFlags(aProcessingData.second);
   aWriter.Transfer(aDocument, aRootScope.Next());
 
   if (isModified)

--- a/src/XSDRAWVRML/XSDRAWVRML.cxx
+++ b/src/XSDRAWVRML/XSDRAWVRML.cxx
@@ -32,7 +32,7 @@
 #include <VrmlData_Scene.hxx>
 #include <XCAFDoc_DocumentTool.hxx>
 #include <XSAlgo.hxx>
-#include <XSAlgo_AlgoContainer.hxx>
+#include <XSAlgo_ShapeProcessor.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <XSDRAW.hxx>
 
@@ -165,7 +165,7 @@ static Standard_Integer ReadVrml(Draw_Interpretor& theDI,
   Standard_Real aScaleFactor = 1.;
   if (!XCAFDoc_DocumentTool::GetLengthUnit(aDoc, aScaleFactor))
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer();
+    XSAlgo_ShapeProcessor::PrepareForTransfer();
     aScaleFactor = UnitsMethods::GetCasCadeLengthUnit();
   }
 
@@ -227,7 +227,7 @@ static Standard_Integer WriteVrml(Draw_Interpretor& di, Standard_Integer argc, c
   Standard_Real aScaleFactorM = 1.;
   if (!XCAFDoc_DocumentTool::GetLengthUnit(aDoc, aScaleFactorM))
   {
-    XSAlgo::AlgoContainer()->PrepareForTransfer(); // update unit info
+    XSAlgo_ShapeProcessor::PrepareForTransfer(); // update unit info
     aScaleFactorM = UnitsMethods::GetCasCadeLengthUnit(UnitsMethods_LengthUnit_Meter);
   }
   if (!writer.WriteDoc(aDoc, argv[2], aScaleFactorM))


### PR DESCRIPTION
All instances of using XSAlgo_AlgoContainer are replaced with XSAlgo_ShapeProcessor.

Parameters for XSAlgo_ShapeProcessor operations are now can be passes via the updated interface of respective classes.