### PR TITLE
Foundation Classes - Standard_Type destructor static_assert

### DIFF
--- a/src/Standard/Standard_Type.cxx
+++ b/src/Standard/Standard_Type.cxx
@@ -148,5 +148,5 @@ Standard_Type::~Standard_Type ()
 {
   // remove descriptor from the registry
   registry_type& aRegistry = GetRegistry();
-  Standard_ASSERT(!aRegistry.UnBind(mySystemName), "Standard_Type::~Standard_Type() cannot find itself in registry",);
+  Standard_ASSERT(aRegistry.UnBind(mySystemName), "Standard_Type::~Standard_Type() cannot find itself in registry",);
 }


### PR DESCRIPTION
Fix assertion logic in Standard_Type destructor for registry unbinding
Report: https://dev.opencascade.org/content/crash-cleanup-after-reading-step-file
Regression after: https://github.com/Open-Cascade-SAS/OCCT/pull/236