### PR TITLE
Testing - Fix loading order of OCAF and XDE in bug tests

### DIFF
--- a/tests/bugs/moddata_3/bug31136_4
+++ b/tests/bugs/moddata_3/bug31136_4
@@ -3,7 +3,7 @@ puts "0031136: BinXCAF persistence loses normals from triangulation-only Faces"
 puts "=========="
 puts ""
 
-pload MODELING XDE OCAF VISUALIZATION
+pload MODELING OCAF XDE VISUALIZATION
 source $env(CSF_OCCTSamplesPath)/tcl/cad.tcl
 trinfo res
 wavefront res $imagedir/${test_image}

--- a/tests/bugs/moddata_3/bug31136_5
+++ b/tests/bugs/moddata_3/bug31136_5
@@ -3,7 +3,7 @@ puts "0031136: BinXCAF persistence loses normals from triangulation-only Faces"
 puts "=========="
 puts ""
 
-pload XDE OCAF
+pload OCAF XDE
 
 StoreTriangulation 1 -normals
 set res [StoreTriangulation -getnormals]

--- a/tests/bugs/xde/begin
+++ b/tests/bugs/xde/begin
@@ -1,3 +1,3 @@
-pload XDE
+pload OCAF XDE
 
 set subgroup xde


### PR DESCRIPTION
GNU compiler have some optimization leads to multiple definitions
  of static global objects.
In case of static linking there are no possible issues, but in case of plug-in
  application can have multiple definitions of single object.