### PR TITLE
Modeling - Resetting Plane YVector

### DIFF
--- a/src/GeomPlate/GeomPlate_BuildAveragePlane.cxx
+++ b/src/GeomPlate/GeomPlate_BuildAveragePlane.cxx
@@ -439,7 +439,7 @@ void GeomPlate_BuildAveragePlane::BasePlan(const gp_Vec& OZ)
       || ((Abs(n1) <= myTol) && (Abs(n3) <= myTol)))
   {
     myOX.SetCoord(V3(1), V3(2), V3(3));
-    myOY.SetCoord(0, 0, 0);
+    myOY = OZ ^ myOX;
   }
   else
   {


### PR DESCRIPTION
Fix calculation of myOY in GeomPlate_BuildAveragePlane to use cross product with OZ