### PR TITLE
Visualization - AIS_Manipulator is unusable when attaching to objects with Graphic3d_TMF_ZoomPers

### DIFF
--- a/src/AIS/AIS_Manipulator.hxx
+++ b/src/AIS/AIS_Manipulator.hxx
@@ -416,6 +416,8 @@ protected:
   Standard_EXPORT Handle(Graphic3d_Group) getGroup(const Standard_Integer    theIndex,
                                                    const AIS_ManipulatorMode theMode) const;
 
+  Standard_EXPORT void attachToPoint(const gp_Pnt& thePoint);
+
   Standard_EXPORT void attachToBox(const Bnd_Box& theBox);
 
   Standard_EXPORT void adjustSize(const Bnd_Box& theBox);

--- a/src/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -12083,7 +12083,8 @@ static int VManipulator(Draw_Interpretor& theDi, Standard_Integer theArgsNb, con
   NCollection_Sequence<ManipAxisModeOnOff> aParts;
   gp_XYZ aLocation(RealLast(), RealLast(), RealLast()), aVDir, anXDir;
   //
-  bool                              toDetach = false;
+  bool                              toDetach    = false;
+  bool                              toAddObject = false;
   AIS_Manipulator::OptionsForAttach anAttachOptions;
   Handle(AIS_InteractiveObject)     anAttachObject;
   Handle(V3d_View)                  aViewAffinity;
@@ -12273,6 +12274,10 @@ static int VManipulator(Draw_Interpretor& theDi, Standard_Integer theArgsNb, con
       aTrsf.SetRotation(gp_Ax1(gp_Pnt(aRotPnt), gp_Dir(aRotAxis)), aTmpReal);
     }
     //
+    else if (anArg == "-addobject")
+    {
+      toAddObject = true;
+    }
     else if (anArg == "-detach")
     {
       toDetach = true;
@@ -12430,7 +12435,16 @@ static int VManipulator(Draw_Interpretor& theDi, Standard_Integer theArgsNb, con
 
   if (!anAttachObject.IsNull())
   {
-    aManipulator->Attach(anAttachObject, anAttachOptions);
+    if (toAddObject && aManipulator->IsAttached())
+    {
+      Handle(AIS_ManipulatorObjectSequence) anAttachObjects = aManipulator->Objects();
+      anAttachObjects->Append(anAttachObject);
+      aManipulator->Attach(anAttachObjects, anAttachOptions);
+    }
+    else
+    {
+      aManipulator->Attach(anAttachObject, anAttachOptions);
+    }
   }
   if (!aViewAffinity.IsNull())
   {
@@ -14490,6 +14504,7 @@ Options:
  '-enableModes    {0|1}'             enable modes when attaching
  '-view  {active | [name of view]}'  display manipulator only in defined view,
                                      by default it is displayed in all views of the current viewer
+ '-addObject                         allows attach manipulator to multiple objects (replace by default)
  '-detach'                           detach manipulator
  '-startTransform mouse_x mouse_y' - invoke start of transformation
  '-transform      mouse_x mouse_y' - invoke transformation

--- a/tests/v3d/bugs/bug32116
+++ b/tests/v3d/bugs/bug32116
@@ -1,0 +1,41 @@
+puts "============"
+puts "0032116: Visualization - AIS_Manipulator is unusable when attaching to objects with Graphic3d_TMF_ZoomPers"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+
+box b1 10 10 10 10 20 30
+box b2 50 50 50 10 20 30
+
+vinit View1
+vdisplay b1 -dispmode 1 -trsfPers zoom -trsfPersPos 0 0 0
+vdisplay b2 -dispmode 1 -trsfPers zoom -trsfPersPos 10 10 10
+vfit
+
+vmanipulator m -attach b1 -addObject
+vmanipulator m -attach b2 -addObject
+
+set mouse_pick {90 225}
+set mouse_drag {90 150}
+
+vmoveto {*}$mouse_pick
+vselect {*}$mouse_pick
+vmanipulator m -startTransform {*}$mouse_pick
+vmanipulator m -transform {*}$mouse_drag
+vmanipulator m -stopTransform
+vmoveto {*}$mouse_drag
+
+if { [vreadpixel {*}$mouse_drag -rgb -name] != "CYAN" } { puts "Error: wrong manipulator position" }
+if { [vreadpixel 115 170 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b1 tranformation" }
+if { [vreadpixel 400 10 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b2 tranformation" }
+
+vdump ${imagedir}/${casename}_1.png
+
+vmoveto 0 0
+vzoom 0.2
+
+if { [vreadpixel 210 170 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b1 tranformation" }
+if { [vreadpixel 310 120 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b2 tranformation" }
+
+vdump ${imagedir}/${casename}_2.png


### PR DESCRIPTION
Recalculation of manipulator position if attached object has zoom transform persistence as well as set its anchor point in Transformation.