### PR TITLE
Coding, Emscripten - fix runtime crashes on WASM64 (-sMEMORY64=1)

### DIFF
--- a/src/DRAWEXE/DRAWEXE.cxx
+++ b/src/DRAWEXE/DRAWEXE.cxx
@@ -125,17 +125,18 @@ private:
 
 //! Print message to Module.printMessage callback.
 EM_JS(void, occJSPrintMessage, (const char* theStr, int theGravity), {
+  const aStr = Number(theStr); // bigintToI53Checked(theStr);
   if (Module.printMessage != undefined && Module.printMessage != null)
   {
-    Module.printMessage(UTF8ToString(theStr), theGravity);
+    Module.printMessage(UTF8ToString(aStr), theGravity);
   }
   else if (Module.print != undefined && Module.print != null)
   {
-    Module.print(UTF8ToString(theStr));
+    Module.print(UTF8ToString(aStr));
   }
   else
   {
-    // console.info (UTF8ToString(theStr));
+    // console.info (UTF8ToString(aStr));
   }
 });
 

--- a/src/Message/Message_PrinterSystemLog.cxx
+++ b/src/Message/Message_PrinterSystemLog.cxx
@@ -63,16 +63,28 @@ static android_LogPriority getAndroidLogPriority(const Message_Gravity theGravit
   #include <emscripten/emscripten.h>
 
 //! Print message to console.debug().
-EM_JS(void, occJSConsoleDebug, (const char* theStr), { console.debug(UTF8ToString(theStr)); });
+EM_JS(void, occJSConsoleDebug, (const char* theStr), {
+  const aStr = Number(theStr); // bigintToI53Checked(theStr);
+  console.debug(UTF8ToString(aStr));
+});
 
 //! Print message to console.info().
-EM_JS(void, occJSConsoleInfo, (const char* theStr), { console.info(UTF8ToString(theStr)); });
+EM_JS(void, occJSConsoleInfo, (const char* theStr), {
+  const aStr = Number(theStr); // bigintToI53Checked(theStr);
+  console.info(UTF8ToString(aStr));
+});
 
 //! Print message to console.warn().
-EM_JS(void, occJSConsoleWarn, (const char* theStr), { console.warn(UTF8ToString(theStr)); });
+EM_JS(void, occJSConsoleWarn, (const char* theStr), {
+  const aStr = Number(theStr); // bigintToI53Checked(theStr);
+  console.warn(UTF8ToString(aStr));
+});
 
 //! Print message to console.error().
-EM_JS(void, occJSConsoleError, (const char* theStr), { console.error(UTF8ToString(theStr)); });
+EM_JS(void, occJSConsoleError, (const char* theStr), {
+  const aStr = Number(theStr); // bigintToI53Checked(theStr);
+  console.error(UTF8ToString(aStr));
+});
 #else
   #include <syslog.h>
 

--- a/src/OSD/OSD_MemInfo.cxx
+++ b/src/OSD/OSD_MemInfo.cxx
@@ -37,7 +37,7 @@
   #include <emscripten.h>
 
 //! Return WebAssembly heap size in bytes.
-EM_JS(size_t, OSD_MemInfo_getModuleHeapLength, (), { return Module.HEAP8.length; });
+EM_JS(double, OSD_MemInfo_getModuleHeapLength, (), { return Module.HEAP8.length; });
 #endif
 
 // =======================================================================
@@ -168,7 +168,7 @@ void OSD_MemInfo::Update()
   }
   if (IsActive(MemVirtual))
   {
-    myCounters[MemVirtual] = OSD_MemInfo_getModuleHeapLength();
+    myCounters[MemVirtual] = (size_t)OSD_MemInfo_getModuleHeapLength();
   }
   #elif (defined(__linux__) || defined(__linux))
   if (IsActive(MemHeapUsage))

--- a/src/OpenGl/OpenGl_Context.cxx
+++ b/src/OpenGl/OpenGl_Context.cxx
@@ -3137,7 +3137,7 @@ bool OpenGl_Context::GetBufferSubData(unsigned int theTarget,
   }
 #ifdef __EMSCRIPTEN__
   EM_ASM_(
-    { Module.ctx.getBufferSubData($0, $1, HEAPU8.subarray($2, $2 + $3)); },
+    { Module.ctx.getBufferSubData($0, Number($1), HEAPU8.subarray(Number($2), Number($2 + $3))); },
     theTarget,
     theOffset,
     theData,

--- a/src/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -134,13 +134,19 @@ typedef Aspect_NeutralWindow ViewerTest_Window;
 #endif
 
 #if defined(__EMSCRIPTEN__)
+  #if defined(_LP64)
+EM_JS(char*, occJSNumberToPtr, (double thePtr), { return BigInt(thePtr); });
+  #else
+EM_JS(char*, occJSNumberToPtr, (double thePtr), { return thePtr; });
+  #endif
+
 //! Return DOM id of default WebGL canvas from Module.canvas.
 EM_JS(char*, occJSModuleCanvasId, (), {
   const aCanvasId = Module.canvas.id;
   const aNbBytes  = lengthBytesUTF8(aCanvasId) + 1;
   const aStrPtr   = Module._malloc(aNbBytes);
   stringToUTF8(aCanvasId, aStrPtr, aNbBytes);
-  return aStrPtr;
+  return occJSNumberToPtr(aStrPtr);
 });
 
 //! Return DOM id of default WebGL canvas from Module.canvas.


### PR DESCRIPTION
by explicitly casting between BigInt and Number within EM_JS() blocks.