### PR TITLE
Visualization - dynamic highlight results are not cleared by AIS_InteractiveContext::Redisplay()

### DIFF
--- a/src/AIS/AIS_InteractiveContext.cxx
+++ b/src/AIS/AIS_InteractiveContext.cxx
@@ -961,9 +961,19 @@ void AIS_InteractiveContext::RecomputeSelectionOnly(const Handle(AIS_Interactive
     mgrSelector->Deactivate(theIO, aModesIter.Value());
   }
 
-  mgrSelector->RecomputeSelection(theIO);
-
   const Handle(AIS_GlobalStatus)* aStatus = myObjects.Seek(theIO);
+  if (aStatus != NULL)
+  {
+    if (!myLastPicked.IsNull() && myLastPicked->IsSameSelectable(theIO))
+    {
+      clearDynamicHighlight();
+      myLastPicked.Nullify();
+    }
+
+    unselectOwners(theIO);
+  }
+
+  mgrSelector->RecomputeSelection(theIO);
   if (aStatus == NULL || theIO->DisplayStatus() != PrsMgr_DisplayStatus_Displayed)
   {
     return;

--- a/src/AIS/AIS_InteractiveContext.hxx
+++ b/src/AIS/AIS_InteractiveContext.hxx
@@ -163,6 +163,7 @@ public: //! @name object display management
   Standard_EXPORT void RemoveAll(const Standard_Boolean theToUpdateViewer);
 
   //! Recomputes the seen parts presentation of the Object.
+  //! The object will be also unhighlighted and removed from selection.
   //! If theAllModes equals true, all presentations are present in the object even if unseen.
   Standard_EXPORT void Redisplay(const Handle(AIS_InteractiveObject)& theIObj,
                                  const Standard_Boolean               theToUpdateViewer,
@@ -175,13 +176,14 @@ public: //! @name object display management
                                  const Standard_Boolean      theToUpdateViewer);
 
   //! Recomputes the displayed presentations, flags the others.
-  //! Doesn't update presentations.
+  //! Doesn't update selections.
   Standard_EXPORT void RecomputePrsOnly(const Handle(AIS_InteractiveObject)& theIObj,
                                         const Standard_Boolean               theToUpdateViewer,
                                         const Standard_Boolean theAllModes = Standard_False);
 
   //! Recomputes the active selections, flags the others.
   //! Doesn't update presentations.
+  //! The object will be also unhighlighted and removed from selection.
   Standard_EXPORT void RecomputeSelectionOnly(const Handle(AIS_InteractiveObject)& anIObj);
 
   //! Updates displayed interactive object by checking and recomputing its flagged as "to be

--- a/src/ViewerTest/ViewerTest.cxx
+++ b/src/ViewerTest/ViewerTest.cxx
@@ -5193,6 +5193,8 @@ static int VDisplay2(Draw_Interpretor& theDI, Standard_Integer theArgNb, const c
     }
   }
 
+  // invalidate picking cache
+  ViewerTest::CurrentEventManager()->ResetPreviousMoveTo();
   return 0;
 }
 

--- a/tests/v3d/bugs/bug32829
+++ b/tests/v3d/bugs/bug32829
@@ -1,0 +1,60 @@
+puts "============"
+puts "0032829: Visualization - dynamic highlight results are not cleared by AIS_InteractiveContext::Redisplay()"
+puts "============"
+puts ""
+
+pload MODELING OCAF XDE VISUALIZATION
+
+# Create a green cube and add it in the document
+XNewDoc aDoc
+set aCubeLab [XNewShape aDoc]
+set aCubeName "CubeEntityInstance"
+SetName   aDoc $aCubeLab $aCubeName
+XSetColor aDoc $aCubeLab GREEN
+box aCube 0.1 0.1 0.1
+XAddComponent aDoc $aCubeLab aCube
+
+# Create a purple cylinder with a location and add it in the document
+set aCylLab [XNewShape aDoc]
+set aCylName "CylinderEntityInstance"
+SetName   aDoc $aCylLab $aCylName
+XSetColor aDoc $aCylLab PURPLE
+pcylinder  aCyl 0.015 0.05
+ttranslate aCyl 0.3 0.1 0.13
+XAddComponent aDoc $aCylLab aCyl
+XUpdateAssemblies aDoc
+
+# Update/display the document then fit the view
+vinit View1
+vselprops localSelHighlight -dispMode -1
+XDisplay aDoc -dispMode 1 -docPrefix 0
+vfit
+
+# Parenting configuration : cube is the parent of cylinder
+vparent $aCubeName -ignoreVisu
+vchild  $aCubeName -add $aCylName
+
+# Check if the set location works (cube moving with cylinder)
+vlocation $aCylName  -setLocation 0. 0. -0.2
+vlocation $aCubeName -setLocation 0. 0.  0.1
+
+# Face selection mode
+vselmode -set FACE 1
+
+# Check if the face selection mode works with the cylinder
+vmoveto 370 270
+#vselect 370 270
+
+# Display the cylinder (if bug1 has been executed)
+vdisplay $aCylName
+
+# Select the top face of the cylinder
+vselect 370 270
+#vselect 370 271; # will be OK if not the same pixel
+
+# Move the cylinder but the selected face is not updated
+vlocation $aCylName -setLocation 0. 0. 0.
+
+if { [vreadpixel 370 270 -rgb -name] != "BLACK" } { puts "Error: highlight presentation was not cleared." }
+
+vdump ${imagedir}/${casename}.png


### PR DESCRIPTION
AIS_InteractiveContext::RecomputeSelectionOnly() now removes old Owners of recomputed object from selection results.
vdisplay command now resets AIS_ViewController::ResetPreviousMoveTo() cache.