### PR TITLE
Typo fixes

### DIFF
--- a/adm/cmake/vtk.cmake
+++ b/adm/cmake/vtk.cmake
@@ -26,7 +26,7 @@ endif()
 # include occt macros. compiler_bitness, os_wiht_bit, compiler
 OCCT_INCLUDE_CMAKE_FILE ("adm/cmake/occt_macros")
 
-# specify VTK folder in connectin with 3RDPARTY_DIR
+# specify VTK folder in connection with 3RDPARTY_DIR
 if (3RDPARTY_DIR AND EXISTS "${3RDPARTY_DIR}")
   #CHECK_PATH_FOR_CONSISTENCY (3RDPARTY_DIR 3RDPARTY_VTK_DIR PATH "The directory containing VTK")
 

--- a/dox/user_guides/de_wrapper/de_wrapper.md
+++ b/dox/user_guides/de_wrapper/de_wrapper.md
@@ -197,7 +197,7 @@ All registered providers are set to the map with information about its vendor an
 
 @subsubsection occt_de_wrapper_3_3_1 Registering providers. Code sample
 
-It is nesessary to register only one ConfigurationNode for all needed formats.
+It is necessary to register only one ConfigurationNode for all needed formats.
 ~~~~{.cpp}
 Handle(DE_Wrapper) aSession = DE_Wrapper::GlobalWrapper();
 Handle(DE_ConfigurationNode) aNode = new DESTEP_ConfigurationNode();

--- a/dox/user_guides/mesh/mesh.md
+++ b/dox/user_guides/mesh/mesh.md
@@ -87,7 +87,7 @@ Note that if a given value of linear deflection is less than shape tolerance the
 
 The application should provide deflection parameters to compute a satisfactory mesh. Angular deflection is relatively simple and allows using a default value (12-20 degrees). Linear deflection has an absolute meaning and the application should provide the correct value for its models. Giving small values may result in a too huge mesh (consuming a lot of memory, which results in a  long computation time and slow rendering) while big values result in an ugly mesh.
 
-For an application working in dimensions known in advance it can be reasonable to use the absolute linear deflection for all models. This provides meshes according to metrics and precision used in the application (for example, it it is known that the model will be stored in meters, 0.004 m is enough for most tasks).
+For an application working in dimensions known in advance it can be reasonable to use the absolute linear deflection for all models. This provides meshes according to metrics and precision used in the application (for example, it is known that the model will be stored in meters, 0.004 m is enough for most tasks).
 
 However, an application that imports models created in other applications may not use the same deflection for all models. Note that actually this is an abnormal situation and this application is probably just a viewer for CAD models with  dimensions varying by an order of magnitude. This problem can be solved by introducing the concept of a relative linear deflection with some  LOD (level of detail). The level of detail is a scale factor for absolute deflection, which is applied to model dimensions.
 

--- a/src/BRepBuilderAPI/BRepBuilderAPI.hxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI.hxx
@@ -79,8 +79,8 @@ class Geom_Plane;
 //! the NotDone error. When Done is false on a command
 //! the error description can be asked to the command.
 //!
-//! In  theory  the  comands can be    called with any
-//! arguments, argument  checking  is performed by the
+//! In theory the commands can be called with any
+//! arguments, argument checking is performed by the
 //! command.
 class BRepBuilderAPI
 {

--- a/src/BRepBuilderAPI/BRepBuilderAPI_NurbsConvert.hxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI_NurbsConvert.hxx
@@ -28,7 +28,7 @@ class TopoDS_Shape;
 
 //! Conversion of the complete geometry of a shape
 //! (all 3D analytical representation of surfaces and curves)
-//! into NURBS geometry (execpt for Planes). For example,
+//! into NURBS geometry (except for Planes). For example,
 //! all curves supporting edges of the basis shape are converted
 //! into BSpline curves, and all surfaces supporting its faces are
 //! converted into BSpline surfaces.

--- a/src/BRepBuilderAPI/BRepBuilderAPI_Sewing.cxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI_Sewing.cxx
@@ -2332,7 +2332,7 @@ void BRepBuilderAPI_Sewing::Dump() const
   std::cout << " Number of Vertices          : " << myNbVertices << std::endl;
   std::cout << " Number of Nodes             : " << mapVertices.Extent() << std::endl;
   std::cout << " Number of Free Edges        : " << myFreeEdges.Extent() << std::endl;
-  std::cout << " Number of Contigous Edges   : " << myContigousEdges.Extent() << std::endl;
+  std::cout << " Number of Contiguous Edges  : " << myContigousEdges.Extent() << std::endl;
   std::cout << " Number of Multiple Edges    : " << myMultipleEdges.Extent() << std::endl;
   std::cout << " Number of Degenerated Edges : " << myDegenerated.Extent() << std::endl;
   std::cout << " ===========================================================" << std::endl;

--- a/src/BRepBuilderAPI/BRepBuilderAPI_Sewing.hxx
+++ b/src/BRepBuilderAPI/BRepBuilderAPI_Sewing.hxx
@@ -69,7 +69,7 @@ DEFINE_STANDARD_HANDLE(BRepBuilderAPI_Sewing, Standard_Transient)
 //! - set the cutting option as you need (default True)
 //! - define a tolerance
 //! - add shapes to be sewed -> Add
-//! - compute -> Perfom
+//! - compute -> Perform
 //! - output the resulted shapes
 //! - output free edges if necessary
 //! - output multiple edges if necessary
@@ -97,7 +97,7 @@ public:
                             const Standard_Boolean option3   = Standard_True,
                             const Standard_Boolean option4   = Standard_False);
 
-  //! Loades the context shape.
+  //! Loads the context shape.
   Standard_EXPORT void Load(const TopoDS_Shape& shape);
 
   //! Defines the shapes to be sewed or controlled
@@ -146,7 +146,7 @@ public:
 
   //! Gives the original edge (free boundary) which becomes the
   //! the section. Remember that sections constitute  common edges.
-  //! This imformation is important for control because with
+  //! This information is important for control because with
   //! original edge we can find the surface to which the section
   //! is attached.
   Standard_EXPORT const TopoDS_Edge& SectionToBoundary(const TopoDS_Edge& section) const;

--- a/src/BRepFill/BRepFill_DraftLaw.cxx
+++ b/src/BRepFill/BRepFill_DraftLaw.cxx
@@ -69,4 +69,3 @@ void BRepFill_DraftLaw::CleanLaw(const Standard_Real TolAngular)
     }
   }
 }
-Cacul une tranformation

--- a/src/BRepFill/BRepFill_DraftLaw.cxx
+++ b/src/BRepFill/BRepFill_DraftLaw.cxx
@@ -27,7 +27,7 @@ IMPLEMENT_STANDARD_RTTIEXT(BRepFill_DraftLaw, BRepFill_Edge3DLaw)
 
 //=======================================================================
 // function : ToG0
-// purpose  : Cacul une tranformation T tq T.M2 = M1
+// purpose  : Calculate a transformation T tq T.M2 = M1
 //=======================================================================
 static void ToG0(const gp_Mat& M1, const gp_Mat& M2, gp_Mat& T)
 {
@@ -69,3 +69,4 @@ void BRepFill_DraftLaw::CleanLaw(const Standard_Real TolAngular)
     }
   }
 }
+Cacul une tranformation

--- a/src/BSplCLib/BSplCLib.hxx
+++ b/src/BSplCLib/BSplCLib.hxx
@@ -1321,10 +1321,10 @@ public:
   //! result of the  poles are divided by the
   //! result of   the   interpolation of  the
   //! weights. Otherwise if HomogenousFlag == 1
-  //! the Poles and Weigths are treated homogeneously
+  //! the Poles and Weights are treated homogeneously
   //! that is that those are interpolated as they
   //! are and result is returned without division
-  //! by the interpolated weigths.
+  //! by the interpolated weights.
   Standard_EXPORT static Standard_Integer SolveBandedSystem(const math_Matrix&     Matrix,
                                                             const Standard_Integer UpperBandWidth,
                                                             const Standard_Integer LowerBandWidth,
@@ -1348,10 +1348,10 @@ public:
   //! result of the  poles are divided by the
   //! result of   the   interpolation of  the
   //! weights. Otherwise if HomogenousFlag == 1
-  //! the Poles and Weigths are treated homogeneously
+  //! the Poles and Weights are treated homogeneously
   //! that is that those are interpolated as they
   //! are and result is returned without division
-  //! by the interpolated weigths.
+  //! by the interpolated weights.
   Standard_EXPORT static Standard_Integer SolveBandedSystem(const math_Matrix&     Matrix,
                                                             const Standard_Integer UpperBandWidth,
                                                             const Standard_Integer LowerBandWidth,

--- a/src/BSplCLib/BSplCLib_CurveComputation.gxx
+++ b/src/BSplCLib/BSplCLib_CurveComputation.gxx
@@ -618,7 +618,7 @@ BSplCLib::SolveBandedSystem(const math_Matrix&  Matrix,
 //function : Solves a LU factored Matrix 
 //purpose  : if HomogeneousFlag is 1 then the input and the output
 //           will be homogeneous that is no division or multiplication
-//           by weigths will happen. On the contrary if HomogeneousFlag
+//           by weights will happen. On the contrary if HomogeneousFlag
 //           is 0 then the poles will be multiplied first by the weights
 //           and after interpolation they will be divided by the weights
 //=======================================================================

--- a/src/Cocoa/Cocoa_Window.hxx
+++ b/src/Cocoa/Cocoa_Window.hxx
@@ -79,7 +79,7 @@ public:
   Standard_EXPORT Cocoa_Window(NSView* theViewNS);
 #endif
 
-  //! Destroys the Window and all resourses attached to it
+  //! Destroys the Window and all resources attached to it
   Standard_EXPORT ~Cocoa_Window();
 
   //! Opens the window <me>

--- a/src/Express/Express_Entity.hxx
+++ b/src/Express/Express_Entity.hxx
@@ -53,7 +53,7 @@ public:
   Standard_EXPORT Standard_Integer
     NbFields(const Standard_Boolean theInherited = Standard_False) const;
 
-  //! Sets abstruct flag for entity;
+  //! Sets abstract flag for entity;
   Standard_EXPORT void SetAbstractFlag(const Standard_Boolean theIsAbstract);
 
   //! Returns abstract flag.

--- a/src/Express/Express_Item.hxx
+++ b/src/Express/Express_Item.hxx
@@ -106,13 +106,13 @@ public:
   //! Set flag for presence of method Check in the class
   Standard_EXPORT void SetCheckFlag(const Standard_Boolean theCheckFlag);
 
-  //! Get flag resposible for  presence of method Check in the class
+  //! Get flag responsible for presence of method Check in the class
   Standard_EXPORT Standard_Boolean CheckFlag() const;
 
   //! Set flag for presence of method FillShared in the class
   Standard_EXPORT void SetFillSharedFlag(const Standard_Boolean theFillSharedFlag);
 
-  //! Get flag resposible for  presence of method FillShared in the class
+  //! Get flag responsible for presence of method FillShared in the class
   Standard_EXPORT Standard_Boolean FillSharedFlag() const;
 
   //! Set start entity index

--- a/src/Express/Express_Schema.cxx
+++ b/src/Express/Express_Schema.cxx
@@ -109,7 +109,7 @@ Handle(Express_Item) Express_Schema::Item(const Handle(TCollection_HAsciiString)
 
 //=======================================================================
 // function : nameToCasCade
-// purpose  : auxilary for Prepare()
+// purpose  : auxiliary for Prepare()
 //           Convert STEP-style name (lowercase, with underscores)
 //           to CASCADE-style name (each word starts with uppercase, no intervals)
 //=======================================================================
@@ -135,7 +135,7 @@ static void nameToCasCade(const Handle(TCollection_HAsciiString)& theName)
 
 //=======================================================================
 // function : nameToCasCade
-// purpose  : auxilary for Prepare()
+// purpose  : auxiliary for Prepare()
 //           Convert names for Type object
 //=======================================================================
 static void nameToCasCade(const Handle(Express_Type)& theType)

--- a/src/Geom2dConvert/Geom2dConvert.cxx
+++ b/src/Geom2dConvert/Geom2dConvert.cxx
@@ -567,7 +567,7 @@ static Handle(Geom2d_BSplineCurve) MultNumandDenom(const Handle(Geom2d_BSplineCu
 
 //=======================================================================
 // function : Pretreatment
-// purpose  : Put the two first and two last weigths at one if they are
+// purpose  : Put the two first and two last weights at one if they are
 //           equal
 //=======================================================================
 
@@ -594,7 +594,7 @@ static void Pretreatment(TColGeom2d_Array1OfBSplineCurve& tab)
 //=======================================================================
 // function : NeedToBeTreated
 // purpose  : Say if the BSpline is rational and if the two first and two
-//           last weigths are different
+//           last weights are different
 //=======================================================================
 
 static Standard_Boolean NeedToBeTreated(const Handle(Geom2d_BSplineCurve)& BS)

--- a/src/GeomConvert/GeomConvert.cxx
+++ b/src/GeomConvert/GeomConvert.cxx
@@ -580,7 +580,7 @@ static Handle(Geom_BSplineCurve) MultNumandDenom(const Handle(Geom2d_BSplineCurv
 
 //=======================================================================
 // function : Pretreatment
-// purpose  : Put the two first and two last weigths at one if they are
+// purpose  : Put the two first and two last weights at one if they are
 //           equal
 //=======================================================================
 
@@ -607,7 +607,7 @@ static void Pretreatment(TColGeom_Array1OfBSplineCurve& tab)
 //=======================================================================
 // function : NeedToBeTreated
 // purpose  : Say if the BSpline is rational and if the two first and two
-//           last weigths are different
+//           last weights are different
 //=======================================================================
 
 static Standard_Boolean NeedToBeTreated(const Handle(Geom_BSplineCurve)& BS)

--- a/src/IGESDimen/IGESDimen_ToolGeneralNote.cxx
+++ b/src/IGESDimen/IGESDimen_ToolGeneralNote.cxx
@@ -277,7 +277,7 @@ void IGESDimen_ToolGeneralNote::OwnCopy(const Handle(IGESDimen_GeneralNote)& ano
     {
       Standard_Integer fontCode = another->FontCode(i);
       fontCodes->SetValue(i, fontCode);
-      ////          fontEntities->SetValue(i, NULL);    par defaut
+      ////          fontEntities->SetValue(i, NULL);    by default
     }
 
     Standard_Real slantAngle = another->SlantAngle(i);

--- a/src/IntCurveSurface/IntCurveSurface_Inter.gxx
+++ b/src/IntCurveSurface/IntCurveSurface_Inter.gxx
@@ -379,7 +379,7 @@ void IntCurveSurface_Inter::Perform(const TheCurve&   curve,
 {
   // Protection from double type overflow.
   // This may happen inside square magnitude computation based on normal,
-  // which was computed on bound parameteres (bug26525).
+  // which was computed on bound parameters (bug26525).
   Standard_Real UU1 = U1, UU2 = U2, VV1 = V1, VV2 = V2;
   if (U1 < -1.0e50)
     UU1 = -1.0e50;

--- a/src/PLib/PLib_HermitJacobi.hxx
+++ b/src/PLib/PLib_HermitJacobi.hxx
@@ -33,7 +33,7 @@ DEFINE_STANDARD_HANDLE(PLib_HermitJacobi, PLib_Base)
 //! This class provides method  to work with Jacobi Polynomials
 //! relatively to an order of constraint
 //! q = myWorkDegree-2*(myNivConstr+1)
-//! Jk(t) for k=0,q compose the Jacobi Polynomial base relatively to the weigth W(t)
+//! Jk(t) for k=0,q compose the Jacobi Polynomial base relatively to the weight W(t)
 //! iorder is the integer  value for the constraints:
 //! iorder = 0 <=> ConstraintOrder = GeomAbs_C0
 //! iorder = 1 <=> ConstraintOrder = GeomAbs_C1

--- a/src/PLib/PLib_JacobiPolynomial.hxx
+++ b/src/PLib/PLib_JacobiPolynomial.hxx
@@ -33,7 +33,7 @@ DEFINE_STANDARD_HANDLE(PLib_JacobiPolynomial, PLib_Base)
 //! This class provides method  to work with Jacobi  Polynomials
 //! relatively to   an order of constraint
 //! q  = myWorkDegree-2*(myNivConstr+1)
-//! Jk(t)  for k=0,q compose  the   Jacobi Polynomial  base relatively  to  the weigth W(t)
+//! Jk(t)  for k=0,q compose  the   Jacobi Polynomial  base relatively  to  the weight W(t)
 //! iorder is the integer  value for the constraints:
 //! iorder = 0 <=> ConstraintOrder  = GeomAbs_C0
 //! iorder = 1 <=>  ConstraintOrder = GeomAbs_C1
@@ -80,7 +80,7 @@ public:
   Standard_EXPORT void Points(const Standard_Integer NbGaussPoints,
                               TColStd_Array1OfReal&  TabPoints) const;
 
-  //! returns the Jacobi weigths for Gauss integration only for
+  //! returns the Jacobi weights for Gauss integration only for
   //! the positive    values of the  Legendre roots   in the order they
   //! are given by the method Points
   //! NbGaussPoints   is the number of points chosen   for  the integral

--- a/src/QABugs/QABugs_20.cxx
+++ b/src/QABugs/QABugs_20.cxx
@@ -5002,7 +5002,7 @@ static Standard_Integer OCC33657_4(Draw_Interpretor& theDI,
   aReader.TransferRoots();
   TopoDS_Shape aSourceShape = aReader.OneShape();
 
-  // Analyzer to compare the shape with the the same shape after write-read sequence.
+  // Analyzer to compare the shape with the same shape after write-read sequence.
   ShapeAnalysis_ShapeContents aSourceAnalyzer;
   aSourceAnalyzer.Perform(aSourceShape);
 

--- a/src/RWGltf/RWGltf_GltfOStreamWriter.hxx
+++ b/src/RWGltf/RWGltf_GltfOStreamWriter.hxx
@@ -14,7 +14,7 @@
 #ifndef _RWGltf_GltfOStreamWriter_HeaderFile
 #define _RWGltf_GltfOStreamWriter_HeaderFile
 
-// disable warnings, occures in rapidjson
+// disable warnings, occurs in rapidjson
 #include <Standard_WarningsDisable.hxx>
 #include <rapidjson/prettywriter.h>
 #include <rapidjson/ostreamwrapper.h>

--- a/src/STEPCAFControl/STEPCAFControl_GDTProperty.cxx
+++ b/src/STEPCAFControl/STEPCAFControl_GDTProperty.cxx
@@ -70,13 +70,13 @@ Handle(StepVisual_CoordinatesList) GenerateCoordinateList(
 //           0, if theTriangulation has no normals.
 //           1, if all normals contained in theTriangulation are equal.
 //             Note that Poly_Triangulation supports only 2 options:
-//             either no normals or a normal assosciated with each node.
+//             either no normals or a normal associated with each node.
 //             So when source complex_triangulated_surface_set has just
 //             one normal, it will be just associated with every node in
 //             Poly_Triangulation. Return value of one indicates that
 //             that's what probably happen during reading.
 //           theTriangulation->NbNodes(), if each vertex has a unique
-//             node ossociated with it.
+//             node associated with it.
 //=======================================================================
 Standard_Integer CountNormals(const Handle(Poly_Triangulation)& theTriangulation)
 {

--- a/src/STEPCAFControl/STEPCAFControl_Reader.cxx
+++ b/src/STEPCAFControl/STEPCAFControl_Reader.cxx
@@ -6143,7 +6143,7 @@ Standard_Boolean STEPCAFControl_Reader::ReadMetadata(const Handle(XSControl_Work
       const std::vector<TDF_Label> aLabels =
         collectShapeLabels(theWS, aTransientProcess, aPropertyDefinition);
 
-      // Fill all atributes for each shape label.
+      // Fill all attributes for each shape label.
       for (const auto& aLabel : aLabels)
       {
         Handle(TDataStd_NamedData) anAttribute = getNamedData(aLabel);

--- a/src/STEPCAFControl/STEPCAFControl_Writer.hxx
+++ b/src/STEPCAFControl/STEPCAFControl_Writer.hxx
@@ -129,15 +129,15 @@ public:
              const Standard_CString          theIsMulti  = 0,
              const Message_ProgressRange&    theProgress = Message_ProgressRange());
 
-  //! Mehod to writing sequence of root assemblies or part of the file specified by use by one label
+  //! Method to writing sequence of root assemblies or part of the file specified by use by one label
   Standard_EXPORT Standard_Boolean
     Transfer(const TDF_LabelSequence&        theLabelSeq,
              const STEPControl_StepModelType theMode     = STEPControl_AsIs,
              const Standard_CString          theIsMulti  = 0,
              const Message_ProgressRange&    theProgress = Message_ProgressRange());
 
-  //! Mehod to writing sequence of root assemblies or part of the file specified by use by one label
-  //! This method uses if need to set parameters avoiding
+  //! Method to writing sequence of root assemblies or part of the file specified by use by one label
+  //! This method is utilized if there's a need to set parameters avoiding
   //! initialization from Interface_Static
   Standard_EXPORT Standard_Boolean
     Transfer(const TDF_LabelSequence&        theLabelSeq,
@@ -159,7 +159,7 @@ public:
             const Message_ProgressRange&    theProgress = Message_ProgressRange());
 
   //! Transfers a document and writes it to a STEP file
-  //! This method uses if need to set parameters avoiding
+  //! This method is utilized if there's a need to set parameters avoiding
   //! initialization from Interface_Static
   //! Returns True if translation is OK
   Standard_EXPORT Standard_Boolean

--- a/src/STEPCAFControl/STEPCAFControl_Writer.hxx
+++ b/src/STEPCAFControl/STEPCAFControl_Writer.hxx
@@ -129,14 +129,16 @@ public:
              const Standard_CString          theIsMulti  = 0,
              const Message_ProgressRange&    theProgress = Message_ProgressRange());
 
-  //! Method to writing sequence of root assemblies or part of the file specified by use by one label
+  //! Method to writing sequence of root assemblies
+  //! or part of the file specified by use by one label
   Standard_EXPORT Standard_Boolean
     Transfer(const TDF_LabelSequence&        theLabelSeq,
              const STEPControl_StepModelType theMode     = STEPControl_AsIs,
              const Standard_CString          theIsMulti  = 0,
              const Message_ProgressRange&    theProgress = Message_ProgressRange());
 
-  //! Method to writing sequence of root assemblies or part of the file specified by use by one label
+  //! Method to writing sequence of root assemblies
+  //! or part of the file specified by use by one label.
   //! This method is utilized if there's a need to set parameters avoiding
   //! initialization from Interface_Static
   Standard_EXPORT Standard_Boolean

--- a/src/SWDRAW/SWDRAW_ShapeAnalysis.cxx
+++ b/src/SWDRAW/SWDRAW_ShapeAnalysis.cxx
@@ -1296,9 +1296,9 @@ static Standard_Integer getanasurf(Draw_Interpretor& di, Standard_Integer n, con
   {
     di << "Usage: \n";
     di << "getanasurf res shape [target [tol [sample]]] \n";
-    di << "target is reqired type of surface and can be: pln, cyl, con sph \n";
+    di << "target is required type of surface and can be: pln, cyl, con sph \n";
     di << "sample is surface of required type, which parameters are used as starting \n";
-    di << "point for seaching parametrs of surface by Least Square method when input shape \n";
+    di << "point for searching parameters of surface by Least Square method when input shape \n";
     di << "is edge or wire \n";
     return 1;
   }
@@ -1331,7 +1331,7 @@ static Standard_Integer getanasurf(Draw_Interpretor& di, Standard_Integer n, con
   if (n > 4)
     tol = Draw::Atof(a[4]);
 
-  // get sample  target for edge and wire
+  // get sample target for edge and wire
   GeomAdaptor_Surface aSampleSurf;
   if (n > 5 && (sh.ShapeType() == TopAbs_EDGE || sh.ShapeType() == TopAbs_WIRE))
   {
@@ -1410,7 +1410,7 @@ Standard_Integer getanacurve(Draw_Interpretor& di, Standard_Integer n, const cha
   {
     di << "Usage: \n";
     di << "getanacurve res shape [target [tol]] \n";
-    di << "target is reqired type of curve and can be: lin, cir, ell  \n";
+    di << "target is required type of curve and can be: lin, cir, ell  \n";
     return 1;
   }
   TopoDS_Shape sh = DBRep::Get(a[2]);
@@ -1419,7 +1419,7 @@ Standard_Integer getanacurve(Draw_Interpretor& di, Standard_Integer n, const cha
   TopAbs_ShapeEnum aShType = sh.ShapeType();
   if (!(aShType == TopAbs_WIRE || aShType == TopAbs_EDGE))
   {
-    di << "Wrong shape type, shape can be wire or or edge \n";
+    di << "Wrong shape type, shape can be wire or an edge \n";
     return 1;
   }
 

--- a/src/ShapeAnalysis/ShapeAnalysis_Edge.hxx
+++ b/src/ShapeAnalysis/ShapeAnalysis_Edge.hxx
@@ -56,7 +56,7 @@ public:
   //! Tells if the edge has a 3d curve
   Standard_EXPORT Standard_Boolean HasCurve3d(const TopoDS_Edge& edge) const;
 
-  //! Returns the 3d curve and bounding parameteres for the edge
+  //! Returns the 3d curve and bounding parameters for the edge
   //! Returns False if no 3d curve.
   //! If <orient> is True (default), takes orientation into account:
   //! if the edge is reversed, cf and cl are toggled
@@ -86,7 +86,7 @@ public:
                                           Standard_Real&         cl,
                                           const Standard_Boolean orient = Standard_True) const;
 
-  //! Returns the pcurve and bounding parameteres for the edge
+  //! Returns the pcurve and bounding parameters for the edge
   //! lying on the surface.
   //! Returns False if the edge has no pcurve on this surface.
   //! If <orient> is True (default), takes orientation into account:

--- a/src/ShapeBuild/ShapeBuild_ReShape.cxx
+++ b/src/ShapeBuild/ShapeBuild_ReShape.cxx
@@ -11,7 +11,7 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-//    abv 28.04.99 S4137: ading method Apply for work on all types of shapes
+//    abv 28.04.99 S4137: adding method Apply for work on all types of shapes
 
 #include <BRep_Builder.hxx>
 #include <BRep_Tool.hxx>
@@ -220,7 +220,7 @@ TopoDS_Shape ShapeBuild_ReShape::Apply(const TopoDS_Shape& shape, const TopAbs_S
     }
     locStatus |= ShapeExtend::EncodeStatus(ShapeExtend_DONE3);
     if (st == TopAbs_COMPOUND || newsh.ShapeType() == sh.ShapeType())
-    { // fix for SAMTECH bug OCC322 about abcense internal vertices after sewing.
+    { // fix for SAMTECH bug OCC322 about absence internal vertices after sewing.
       B.Add(result, newsh);
       continue;
     }

--- a/src/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
+++ b/src/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
@@ -1513,7 +1513,7 @@ Standard_Boolean ShapeConstruct_ProjectCurveOnSurface::ApproxPCurve(const Standa
   // regular part of surface (interior), one part along degenerated boundary
   // and one along seam.
   // Since it cannot be adjusted later by arranging pcurves (curve is single),
-  // to fix it it is nesessary to have a possibility of adjusting seam
+  // to fix it it's necessary to have a possibility of adjusting seam
   // part of such curve either to left or right boundary of surface.
   // Test is performed only if flag AdjustOverDegen is not -1.
   // If AdjustOverDegen is True, seam part of curve is adjusted to

--- a/src/ShapeExtend/ShapeExtend_ComplexCurve.hxx
+++ b/src/ShapeExtend/ShapeExtend_ComplexCurve.hxx
@@ -43,7 +43,7 @@ public:
   Standard_EXPORT virtual const Handle(Geom_Curve)& Curve(const Standard_Integer index) const = 0;
 
   //! Returns number of the curve for the given parameter U
-  //! and local paramete r UOut for the found curve
+  //! and local parameter UOut for the found curve
   Standard_EXPORT virtual Standard_Integer LocateParameter(const Standard_Real U,
                                                            Standard_Real&      UOut) const = 0;
 

--- a/src/ShapeExtend/ShapeExtend_CompositeSurface.hxx
+++ b/src/ShapeExtend/ShapeExtend_CompositeSurface.hxx
@@ -104,7 +104,7 @@ public:
 
   //! Initializes by a grid of surfaces with given global
   //! parametrisation defined by UJoints and VJoints arrays,
-  //! each having langth equal to number of patches in corresponding
+  //! each having length equal to number of patches in corresponding
   //! direction + 1. Global joint values should be sorted in
   //! increasing order.
   //! All the Surfaces of the grid must have geometrical

--- a/src/ShapeProcess/ShapeProcess.hxx
+++ b/src/ShapeProcess/ShapeProcess.hxx
@@ -39,7 +39,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Describes all available operations.
-  //! C++11 enum class is not used to allow implicit conversion to undelying type.
+  //! C++11 enum class is not used to allow implicit conversion to underlying type.
   enum Operation : uint8_t
   {
     First       = 0, // First operation index.

--- a/src/Sweep/Sweep_NumShapeTool.cxx
+++ b/src/Sweep/Sweep_NumShapeTool.cxx
@@ -128,7 +128,7 @@ Sweep_NumShape Sweep_NumShapeTool::FirstVertex() const
       return Sweep_NumShape(1, TopAbs_VERTEX, myNumShape.Closed(), Standard_False, Standard_False);
     }
     else
-      throw Standard_ConstructionError("inifinite Shape");
+      throw Standard_ConstructionError("infinite Shape");
   }
   return myNumShape;
 }
@@ -148,7 +148,7 @@ Sweep_NumShape Sweep_NumShapeTool::LastVertex() const
                             Standard_False);
     }
     else
-      throw Standard_ConstructionError("inifinite Shape");
+      throw Standard_ConstructionError("infinite Shape");
   }
   return myNumShape;
 }

--- a/src/TDF/TDF_ComparisonTool.hxx
+++ b/src/TDF/TDF_ComparisonTool.hxx
@@ -73,7 +73,7 @@ public:
     const Handle(TDF_DataSet)&         aDiffDataSet,
     const Standard_Integer             anOption = 2);
 
-  //! Substracts from <aRefDataSet> all the items bound
+  //! Subtracts from <aRefDataSet> all the items bound
   //! into <aRelocationTable>. The result is put into
   //! <aDiffDataSet>. Returns True if the difference
   //! contains at least one item. (An item is a target

--- a/src/TDF/TDF_RelocationTable.cxx
+++ b/src/TDF/TDF_RelocationTable.cxx
@@ -170,7 +170,7 @@ Standard_Boolean TDF_RelocationTable::HasTransientRelocation(
 
 //=======================================================================
 // function : Clear
-// purpose  : Clears the relocation dictonnary.
+// purpose  : Clears the relocation dictionary.
 //=======================================================================
 
 void TDF_RelocationTable::Clear()

--- a/src/TObj/TObj_Object.hxx
+++ b/src/TObj/TObj_Object.hxx
@@ -358,7 +358,7 @@ public:
   /**
    * Public methods to check modifications of the object since last commit
    */
-  //! Returns true if object attributes or or his children were modified in the current open
+  //! Returns true if object attributes or its children were modified in the current open
   //! transaction
   Standard_EXPORT Standard_Boolean HasModifications() const;
 

--- a/src/XDEDRAW/XDEDRAW_Layers.cxx
+++ b/src/XDEDRAW/XDEDRAW_Layers.cxx
@@ -575,7 +575,7 @@ void XDEDRAW_Layers::InitCommands(Draw_Interpretor& di)
 
   di.Add("XSetLayer",
          "DocName {Shape|Label} StringLayer [shapeInOneLayer(0/1)] \t: Set reference between Shape "
-         "and Layer (add layer if nesessary). shapeInOneLayer 0 is default",
+         "and Layer (add layer if necessary). shapeInOneLayer 0 is default",
          __FILE__,
          setLayer,
          g);

--- a/tests/boolean/bcommon_simple/E8
+++ b/tests/boolean/bcommon_simple/E8
@@ -17,7 +17,7 @@ mkplane fa wa
 prism ba fa 0 0 4
 
 # prism from bottom
-# chenge of wire construction order
+# change of wire construction order
 
 vertex v5 2 0 0
 vertex v6 3 0 0

--- a/tests/bugs/caf/bug31918_2
+++ b/tests/bugs/caf/bug31918_2
@@ -67,7 +67,7 @@ set half_time2 [lindex [time {
 } 20] 0]
 puts "Second half of document open time $half_time2 mcs"
 
-# Check that open of two halfs of the document separately is not too much slower than open of the whole
+# Check that opening of two halves of the document separately is not too much slower than opening of the whole
 if { [expr ($half_time1 + $half_time2) * 0.9] > $whole_time } {
   puts "Error : loading of half of the document content is too slow relatively to the whole document load"
 }

--- a/tests/bugs/fclasses/bug24137
+++ b/tests/bugs/fclasses/bug24137
@@ -18,5 +18,5 @@ regexp {([-0-9.+eE]+)$} [dump d_val] full dist
 set good_dist 0
 set toler 2.0e-06
 if { [expr abs( ${dist} - ${good_dist} )] > ${toler} } {
-    puts "Faulty : the distanse is ${dist}. It is bad value"
+    puts "Faulty : the distance is ${dist}. It is bad value"
 }

--- a/tests/bugs/modalg_2/bug238_1
+++ b/tests/bugs/modalg_2/bug238_1
@@ -20,7 +20,7 @@ regexp {([-0-9.+eE]+)$} [dump $di_val] full dis
 if { [expr $dis > 1.e-5] } {
     puts "Faulty : Result shape is WRONG !!!" 
 } else {
-    puts " Result shape is COMPLITE"
+    puts " Result shape is COMPLETE"
 }
 
 checknbshapes result -vertex 14 -edge 7

--- a/tests/bugs/modalg_2/bug238_2
+++ b/tests/bugs/modalg_2/bug238_2
@@ -20,7 +20,7 @@ regexp {([-0-9.+eE]+)$} [dump $di_val] full dis
 if { [expr $dis > 1.e-5] } {
     puts "Faulty : Result shape is WRONG !!!" 
 } else {
-    puts " Result shape is COMPLITE"
+    puts " Result shape is COMPLETE"
 }
 
 checknbshapes result -vertex 14 -edge 7

--- a/tests/bugs/modalg_6/bug27240_1
+++ b/tests/bugs/modalg_6/bug27240_1
@@ -9,11 +9,11 @@ puts ""
 restore [locate_data_file bug27240_vent2-trim.brep] b
 explode b
 
-# workaround - increate the tolerance value of the vertex to fill the gap between section curves
+# workaround - increase the tolerance value of the vertex to fill the gap between section curves
 explode b_1 v
 settolerance b_1_1 0.005
 
-# workaround - increate the tolerance value of the edge to fill the gap between section curves
+# workaround - increase the tolerance value of the edge to fill the gap between section curves
 explode b_2 e
 settolerance b_2_5 0.0005
 

--- a/tests/bugs/modalg_8/bug33179
+++ b/tests/bugs/modalg_8/bug33179
@@ -1,5 +1,5 @@
 puts "================================"
-puts "0033179: Modeling Algorithms - Crash in in ShapeFix_Shape with the attached object, when healing for fixing SameParameterFlag"
+puts "0033179: Modeling Algorithms - Crash in ShapeFix_Shape with the attached object, when healing for fixing SameParameterFlag"
 puts "================================"
 
 restore [locate_data_file bug33179.brep] s

--- a/tests/bugs/modalg_8/bug33515
+++ b/tests/bugs/modalg_8/bug33515
@@ -1,5 +1,5 @@
 puts "================================"
-puts "	0033515: Modeling Algorithm - BRepExtrema_DistShapeShape poduces wrong result"
+puts "	0033515: Modeling Algorithm - BRepExtrema_DistShapeShape produces wrong result"
 puts "================================"
 
 restore [locate_data_file bug33515_w1.brep] w1

--- a/tests/bugs/step/bug33657_1
+++ b/tests/bugs/step/bug33657_1
@@ -1,4 +1,4 @@
 # Check performance of STEPCAFControl_Reader/Writer constructors in multithreading environment.
-# If no crash occures, its fine.
+# If no crash occurs, its fine.
 pload QAcommands
 OCC33657_1

--- a/tests/bugs/step/bug33657_2
+++ b/tests/bugs/step/bug33657_2
@@ -1,4 +1,4 @@
 # Check performance of STEPControl_Reader in multithreading environment.
-# If no crash occures, its fine.
+# If no crash occurs, its fine.
 pload QAcommands
 OCC33657_2 [locate_data_file bug21802_as1-oc-214.stp]

--- a/tests/bugs/step/bug33657_3
+++ b/tests/bugs/step/bug33657_3
@@ -1,4 +1,4 @@
 # Check performance of STEPControl_Writer in multithreading environment.
-# If no crash occures, its fine.
+# If no crash occurs, its fine.
 pload QAcommands
 OCC33657_1

--- a/tests/bugs/xde/bug816_1
+++ b/tests/bugs/xde/bug816_1
@@ -12,11 +12,11 @@ set file ${imagedir}/OCC816.stp
 restore [locate_data_file OCC816-apple.rle] result
 
 if [ catch { brepiges result $file } res ] {
-   puts "Faulty OCC816 : brepiges not complite"
+   puts "Faulty OCC816 : brepiges not complete"
 }
 
 if [ catch { igesbrep $file a *} res ] {
-   puts "Faulty OCC816 : igesbrep not complite"
+   puts "Faulty OCC816 : igesbrep not complete"
 }
 
 checkview -display result -2d -path ${imagedir}/${test_image}.png

--- a/tests/bugs/xde/bug816_2
+++ b/tests/bugs/xde/bug816_2
@@ -12,11 +12,11 @@ set file ${imagedir}/OCC816.stp
 restore [locate_data_file OCC816-lemon.rle] result
 
 if [ catch { brepiges result $file } res ] {
-   puts "Faulty OCC816 : brepiges not complite"
+   puts "Faulty OCC816 : brepiges not complete"
 }
 
 if [ catch { igesbrep $file a *} res ] {
-   puts "Faulty OCC816 : igesbrep not complite"
+   puts "Faulty OCC816 : igesbrep not complete"
 }
 
 checkview -display result -2d -path ${imagedir}/${test_image}.png

--- a/tests/caf/progress/A1
+++ b/tests/caf/progress/A1
@@ -8,7 +8,7 @@
 
 puts "caf009-A1"
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # Create binary document

--- a/tests/caf/progress/A2
+++ b/tests/caf/progress/A2
@@ -8,7 +8,7 @@
 
 puts "caf009-A2"
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t
 
 # Create binary document

--- a/tests/caf/progress/B1
+++ b/tests/caf/progress/B1
@@ -10,7 +10,7 @@ puts "caf009-B1"
 
 set bDoc [CreateBinDoc]
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # Open binary document

--- a/tests/caf/progress/B2
+++ b/tests/caf/progress/B2
@@ -10,7 +10,7 @@ puts "caf009-B2"
 
 set xDoc [CreateXmlDoc]
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # Open xml document

--- a/tests/caf/progress/C1
+++ b/tests/caf/progress/C1
@@ -21,7 +21,7 @@ Open ${bDoc} Doc
 box b 1 1 1
 SetShape Doc 0:2 b
  
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t
 
 # Save

--- a/tests/caf/progress/C2
+++ b/tests/caf/progress/C2
@@ -21,7 +21,7 @@ Open ${xDoc} Doc
 box b 1 1 1
 SetShape Doc 0:2 b
 
-# Configurate XProgress
+# Configure XProgress
 XProgress +t
 
 # Save

--- a/tests/de/iges_1/A2
+++ b/tests/de/iges_1/A2
@@ -1,7 +1,7 @@
 # !!!! This file is generated automatically, do not edit manually! See end script
 set filename buc40130.igs
 
-# set min as local lenght unit
+# set min as local length unit
 set lengthunit_start "min"
 
 set ref_data {

--- a/tests/de/iges_1/B4
+++ b/tests/de/iges_1/B4
@@ -4,7 +4,7 @@ puts "TODO CR23096 ALL: LABELS : Faulty"
 
 set filename t500core.igs
 
-# set min as local lenght unit
+# set min as local length unit
 set lengthunit_start "min"
 
 set ref_data {

--- a/tests/de/iges_1/M9
+++ b/tests/de/iges_1/M9
@@ -1,7 +1,7 @@
 # !!!! This file is generated automatically, do not edit manually! See end script
 set filename ardi1.igs
 
-# set in as local lenght unit
+# set in as local length unit
 set lengthunit_start "in"
 
 set ref_data {

--- a/tests/de/iges_2/H1
+++ b/tests/de/iges_2/H1
@@ -1,7 +1,7 @@
 # !!!! This file is generated automatically, do not edit manually! See end script
 set filename waaier_para.igs
 
-# set min as local lenght unit
+# set min as local length unit
 set lengthunit_start "min"
 
 set ref_data {

--- a/tests/de/step_2/A3
+++ b/tests/de/step_2/A3
@@ -4,7 +4,7 @@ puts "TODO CR23096 ALL: TOLERANCE : Faulty"
 
 set filename tr9_r0501-ug.stp
 
-# set in as local lenght unit
+# set in as local length unit
 set lengthunit_start "in"
 
 set ref_data {

--- a/tests/lowalgos/progress/A1
+++ b/tests/lowalgos/progress/A1
@@ -16,7 +16,7 @@ trotate e3 0 0 0 0 0 1 90
 tcopy e3 e4 
 ttranslate e4 2 0 0 
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # create the surface 

--- a/tests/lowalgos/progress/A2
+++ b/tests/lowalgos/progress/A2
@@ -12,7 +12,7 @@ mkedge e3 c2
 tcopy e3 e4 
 ttranslate e4 2 0 0 
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # create the surface 

--- a/tests/lowalgos/progress/A3
+++ b/tests/lowalgos/progress/A3
@@ -23,7 +23,7 @@ for {set j 0} {$j < 301} {incr j; incr i} {
   lappend points p$i
 }
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # create the surface 

--- a/tests/lowalgos/progress/A4
+++ b/tests/lowalgos/progress/A4
@@ -10,7 +10,7 @@ for {set i 0} {$i < $n} {incr i} {
   lappend l p$i
 }
 
-# Configurate XProgress 
+# Configure XProgress 
 XProgress +t 
 
 # create the surface 

--- a/tests/v3d/bugs/bug32116
+++ b/tests/v3d/bugs/bug32116
@@ -27,15 +27,15 @@ vmanipulator m -stopTransform
 vmoveto {*}$mouse_drag
 
 if { [vreadpixel {*}$mouse_drag -rgb -name] != "CYAN" } { puts "Error: wrong manipulator position" }
-if { [vreadpixel 115 170 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b1 tranformation" }
-if { [vreadpixel 400 10 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b2 tranformation" }
+if { [vreadpixel 115 170 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b1 transformation" }
+if { [vreadpixel 400 10 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b2 transformation" }
 
 vdump ${imagedir}/${casename}_1.png
 
 vmoveto 0 0
 vzoom 0.2
 
-if { [vreadpixel 210 170 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b1 tranformation" }
-if { [vreadpixel 310 120 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b2 tranformation" }
+if { [vreadpixel 210 170 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b1 transformation" }
+if { [vreadpixel 310 120 -rgb -name] != "DARKGOLDENROD" } { puts "Error: wrong b2 transformation" }
 
 vdump ${imagedir}/${casename}_2.png


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.fr" -L aadd,abnd,abord,acount,adn,afile,aline,alo,alocation,alog,als,anc,ane,anid,anormal,anout,ans,anumber,aother,aparent,apoints,aprogram,asender,asign,asnd,ba,bbuild,bloc,bord,bu,caf,cas,childrens,childs,classe,clen,commun,cylindre,don,dout,dum,ede,entites,fo,fonction,guid,hist,identic,ii,inout,invalide,ist,iterm,llength,lod,mape,modeling,methode,mye,myu,nam,nd,nin,normale,normales,ons,parametre,parametres,periode,pres,reste,resul,secont,serie,shs,slin,somme,syntaxe,sur,te,thei,theis,ther,theres,thes,thev,thex,tol,transfert,va,vas,verifie,vertexes,weight`

@dpasukhi same as #28