### PR TITLE
Modeling - SIGSEGV BRepAdaptor_Curve2d and UnifySameDomain

### DIFF
--- a/src/BRepAdaptor/BRepAdaptor_Curve2d.cxx
+++ b/src/BRepAdaptor/BRepAdaptor_Curve2d.cxx
@@ -57,9 +57,12 @@ void BRepAdaptor_Curve2d::Initialize(const TopoDS_Edge& E, const TopoDS_Face& F)
 {
   myEdge = E;
   myFace = F;
-  Standard_Real              pf, pl;
-  const Handle(Geom2d_Curve) PC = BRep_Tool::CurveOnSurface(E, F, pf, pl);
-  Geom2dAdaptor_Curve::Load(PC, pf, pl);
+  Standard_Real              aFirs, aLast;
+  const Handle(Geom2d_Curve) aPCurve = BRep_Tool::CurveOnSurface(E, F, aFirs, aLast);
+  if (!aPCurve.IsNull())
+  {
+    Geom2dAdaptor_Curve::Load(aPCurve, aFirs, aLast);
+  }
 }
 
 //=================================================================================================

--- a/src/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -435,9 +435,17 @@ static Standard_Boolean FindCoordBounds(const TopTools_SequenceOfShape&         
   theNumberOfIntervals = aPairSeq.Length();
 
   if (aPairSeq.Length() == 2)
+  {
     theMinCoord = aPairSeq(2).first - thePeriod;
-  else
+  }
+  else if (aPairSeq.Length() > 0)
+  {
     theMinCoord = aPairSeq(1).first;
+  }
+  else
+  {
+    return Standard_False;
+  }
 
   theMaxCoord = aPairSeq(1).second;
   return Standard_True;


### PR DESCRIPTION
SIGSEGV with MakeVertexInsideFace.
Fixed exceptions with loading null curve and using out of range index.
By K.Leontev. [bos #37951]