### PR TITLE
Modeling - Removing surface after transformation

### DIFF
--- a/src/BRepTools/BRepTools_TrsfModification.cxx
+++ b/src/BRepTools/BRepTools_TrsfModification.cxx
@@ -280,10 +280,6 @@ Standard_Boolean BRepTools_TrsfModification::NewCurve(const TopoDS_Edge&  E,
 {
   Standard_Real f, l;
   C = BRep_Tool::Curve(E, L, f, l);
-  if (C.IsNull())
-  {
-    return Standard_False;
-  }
 
   Tol = BRep_Tool::Tolerance(E);
   Tol *= Abs(myTrsf.ScaleFactor());

--- a/src/BRepTools/BRepTools_TrsfModification.hxx
+++ b/src/BRepTools/BRepTools_TrsfModification.hxx
@@ -89,13 +89,10 @@ public:
                                                              Handle(Poly_PolygonOnTriangulation)& P)
     Standard_OVERRIDE;
 
-  //! Returns true if the edge E has been modified.
-  //! If the edge has been modified:
+  //! Always returns true indicating that the edge E is always modified.
   //! - C is the new geometric support of the edge,
   //! - L is the new location, and
   //! - Tol is the new tolerance.
-  //! If the edge has not been modified, this function
-  //! returns false, and the values of C, L and Tol are not significant.
   Standard_EXPORT Standard_Boolean NewCurve(const TopoDS_Edge&  E,
                                             Handle(Geom_Curve)& C,
                                             TopLoc_Location&    L,

--- a/tests/bugs/modalg_8/bug33591
+++ b/tests/bugs/modalg_8/bug33591
@@ -1,0 +1,18 @@
+puts "========================"
+puts "0033591: Modeling Algorithms - Regression: old surface is not removed after translation or rotation with geometry copying"
+puts "========================"
+puts ""
+
+pload MODELING
+psphere Sphere_1 80
+trotate Sphere_1  0 0 0  0 1 0  90 -copy
+ttranslate Sphere_1 0 0 200 -copy
+
+catch {dump Sphere_1} dumpOutput
+if {[regexp {Dump of ([0-9]+) surfaces} $dumpOutput match num]} {
+  set numSurfaces $num
+}
+
+if {$numSurfaces != 1} {
+  puts "Error: The number of surfaces must be 1"
+}


### PR DESCRIPTION
Old surface is not removed after translation or rotation with geometry copying
Removed unnecessary condition that was added by an earlier fix.
Added a test case.
Original issue: 0033591