### PR TITLE
Visualization - NCollection_DataMap::Find() exception from AIS_Selection::Select()

### DIFF
--- a/src/AIS/AIS_Selection.cxx
+++ b/src/AIS/AIS_Selection.cxx
@@ -65,18 +65,16 @@ AIS_SelectStatus AIS_Selection::Select(const Handle(SelectMgr_EntityOwner)& theO
   const Standard_Boolean wasSelected = theOwner->IsSelected();
   const Standard_Boolean toSelect    = theOwner->Select(theSelScheme, isDetected);
 
-  if (toSelect && !wasSelected)
+  if (!wasSelected || !myResultMap.IsBound(theOwner))
   {
+    if (!toSelect)
+      return AIS_SS_NotDone;
+
     AIS_NListOfEntityOwner::Iterator aListIter;
     myresult.Append(theOwner, aListIter);
     myResultMap.Bind(theOwner, aListIter);
     theOwner->SetSelected(Standard_True);
     return AIS_SS_Added;
-  }
-
-  if (!toSelect && !wasSelected)
-  {
-    return AIS_SS_NotDone;
   }
 
   AIS_NListOfEntityOwner::Iterator aListIter = myResultMap.Find(theOwner);


### PR DESCRIPTION
Problem with NCollection_DataMap::Find() exception during multiple selection in OCC viewer.
Incorrect call is made from AIS_Selection::Select() method at line:
AIS_NListOfEntityOwner::Iterator aListIter = myResultMap.Find (theOwner);
Original issue: 0033742