### PR TITLE
Refactor mouse click handling logic for improved double-click detection

### DIFF
--- a/src/AIS/AIS_ViewController.cxx
+++ b/src/AIS/AIS_ViewController.cxx
@@ -695,8 +695,21 @@ bool AIS_ViewController::UpdateMouseButtons(const Graphic3d_Vec2i& thePoint,
     if (double(aDelta.cwiseAbs().maxComp()) < aTolClick)
     {
       ++myMouseClickCounter;
-      const bool isDoubleClick = myMouseClickCounter == 2 && myMouseClickTimer.IsStarted()
-                                 && myMouseClickTimer.ElapsedTime() <= myMouseDoubleClickInt;
+
+      const bool isCounterValid = myMouseClickCounter == 2;
+      const bool isTimerStarted = myMouseClickTimer.IsStarted();
+      const bool isTimerElapsed = myMouseClickTimer.ElapsedTime() > myMouseDoubleClickInt;
+
+      const bool isTimerValid = isTimerStarted && !isTimerElapsed;
+
+      const bool isDoubleClick = isCounterValid && isTimerValid;
+
+      if (!isTimerValid)
+      {
+        myMouseClickCounter = 1;
+      }
+
+      myMouseClickCounter %= 2;
 
       myMouseClickTimer.Stop();
       myMouseClickTimer.Reset();


### PR DESCRIPTION
Let's take this event timeline :
```
   A          B   C      
---o----------o---o------->
```

When event A occured, the timer is started, and the counter is raised to 1
When event B occured, later on, the timer is elapsed, and the counter have been raised to 2.
As the timer isn't valid anymore, the double click was not detected as true, and therefore the
counter isn't reset.
The timer, on the other hand, is reset as needed.
When event C occured, the counter is increased to 3, which will  deny us from detecting the
double click anymore.
Note : as we reset the counter to 0 in other function (in mouse update position, mainly) we
can work around this issue by sending mouse motion to the application.

We should be able to "detect" that the event B isn't a valid double click, and try to use it as
the "first" click of a futur double click.
To do this, we propose to check if the timer is valid, and if not, set the counter to one, meaning
it is suppose to be the first click.

Pull request to fix the problem explain in the following ticket :
https://github.com/Open-Cascade-SAS/OCCT/issues/356