### PR TITLE
Coding - Bump version to 8.0.0.dev

### DIFF
--- a/adm/cmake/version.cmake
+++ b/adm/cmake/version.cmake
@@ -16,7 +16,7 @@
 #  For development version git commit hash can be added to the version string
 #======================================================================
 
-set (OCC_VERSION_MAJOR 7 )
-set (OCC_VERSION_MINOR 9 )
+set (OCC_VERSION_MAJOR 8 )
+set (OCC_VERSION_MINOR 0 )
 set (OCC_VERSION_MAINTENANCE 0 )
-set (OCC_VERSION_DEVELOPMENT )
+set (OCC_VERSION_DEVELOPMENT "dev" )


### PR DESCRIPTION
New maintaining schema will be applied:
 maintenance stable release on top of minor (3 times per year).
   with binary compatible changes
   name - 7.9.1, 7.9.2, 7.9.3
 development fully-tested release based on master (every 5+- weeks)
    no binary compatible changes
    the latest features available the same as in master
    name - 8.0.0.rc1, 8.0.0.rc2, 8.0.0.rc3,...
the weekly branch IR still will be weekly and usually type of release will be "dev"
  of the next minor release. In current case "8.0.0".