### PR TITLE
Coding - Mutex update to avoid recursive mutex

### DIFF
--- a/src/BinLDrivers/BinLDrivers_DocumentSection.hxx
+++ b/src/BinLDrivers/BinLDrivers_DocumentSection.hxx
@@ -22,7 +22,6 @@
 #include <TCollection_AsciiString.hxx>
 #include <Standard_OStream.hxx>
 #include <Standard_IStream.hxx>
-#include <Message_ProgressIndicator.hxx>
 #include <TDocStd_FormatVersion.hxx>
 
 //! More or less independent part of the saved/restored document

--- a/src/Geom/Geom_BSplineSurface_1.cxx
+++ b/src/Geom/Geom_BSplineSurface_1.cxx
@@ -36,7 +36,6 @@
 #include <Standard_ConstructionError.hxx>
 #include <Standard_DimensionError.hxx>
 #include <Standard_DomainError.hxx>
-#include <Standard_Mutex.hxx>
 #include <Standard_NoSuchObject.hxx>
 #include <Standard_NotImplemented.hxx>
 #include <Standard_OutOfRange.hxx>

--- a/src/Message/Message_ProgressIndicator.hxx
+++ b/src/Message/Message_ProgressIndicator.hxx
@@ -16,7 +16,7 @@
 #ifndef _Message_ProgressIndicator_HeaderFile
 #define _Message_ProgressIndicator_HeaderFile
 
-#include <Standard_Mutex.hxx>
+#include <Standard_MemoryUtils.hxx>
 #include <Standard_Handle.hxx>
 
 DEFINE_STANDARD_HANDLE(Message_ProgressIndicator, Standard_Transient)
@@ -135,7 +135,7 @@ private:
 
 private:
   Standard_Real          myPosition;  //!< Total progress position ranged from 0 to 1
-  Standard_Mutex         myMutex;     //!< Protection of myPosition from concurrent increment
+  std::mutex             myMutex;     //!< Protection of myPosition from concurrent increment
   Message_ProgressScope* myRootScope; //!< The root progress scope
 
 private:
@@ -152,8 +152,8 @@ private:
 inline void Message_ProgressIndicator::Increment(const Standard_Real          theStep,
                                                  const Message_ProgressScope& theScope)
 {
-  // protect incrementation by mutex to avoid problems in multithreaded scenarios
-  Standard_Mutex::Sentry aSentry(myMutex);
+  // protect incrementing by mutex to avoid problems in multithreaded scenarios
+  std::lock_guard<std::mutex> aLock(myMutex);
 
   myPosition = Min(myPosition + theStep, 1.);
 

--- a/src/NCollection/NCollection_IncAllocator.hxx
+++ b/src/NCollection/NCollection_IncAllocator.hxx
@@ -18,9 +18,9 @@
 #include <NCollection_OccAllocator.hxx>
 #include <NCollection_Allocator.hxx>
 
+#include <memory>
+#include <mutex>
 #include <utility>
-
-class Standard_Mutex;
 
 /**
  *  Class NCollection_IncAllocator - incremental memory  allocator. This class
@@ -132,12 +132,12 @@ public:
   static constexpr size_t THE_MINIMUM_BLOCK_SIZE = 1024 * 2;
 
 private:
-  unsigned int    myBlockSize;                //!< Block size to incremental allocations
-  unsigned int    myBlockCount     = 0;       //!< Count of created blocks
-  Standard_Mutex* myMutex          = nullptr; //!< Thread-safety mutex
-  IBlock*         myAllocationHeap = nullptr; //!< Sorted list for allocations
-  IBlock*         myUsedHeap       = nullptr; //!< Sorted list for store empty blocks
-  IBlock*         myOrderedBlocks  = nullptr; //!< Ordered list for store growing size blocks
+  unsigned int                myBlockSize;                //!< Block size to incremental allocations
+  unsigned int                myBlockCount     = 0;       //!< Count of created blocks
+  std::unique_ptr<std::mutex> myMutex          = nullptr; //!< Thread-safety mutex
+  IBlock*                     myAllocationHeap = nullptr; //!< Sorted list for allocations
+  IBlock*                     myUsedHeap       = nullptr; //!< Sorted list for store empty blocks
+  IBlock* myOrderedBlocks = nullptr; //!< Ordered list for store growing size blocks
 
 public:
   // Declaration of CASCADE RTTI

--- a/src/RWGltf/RWGltf_CafReader.cxx
+++ b/src/RWGltf/RWGltf_CafReader.cxx
@@ -27,6 +27,8 @@
 #include <OSD_ThreadPool.hxx>
 #include <RWGltf_GltfLatePrimitiveArray.hxx>
 
+#include <memory>
+
 IMPLEMENT_STANDARD_RTTIEXT(RWGltf_CafReader, RWMesh_CafReader)
 
 //! Abstract base functor for parallel execution of glTF data loading.
@@ -61,7 +63,7 @@ public:
     }
     if (myThreadPool.HasThreads())
     {
-      Standard_Mutex::Sentry aLock(&myMutex);
+      std::lock_guard<std::mutex> aLock(myMutex);
       myProgress.Next();
     }
     else
@@ -78,7 +80,7 @@ protected:
 
 protected:
   NCollection_Vector<TopoDS_Face>* myFaceList;
-  mutable Standard_Mutex           myMutex;
+  mutable std::mutex               myMutex;
   mutable Message_ProgressScope    myProgress;
   const OSD_ThreadPool::Launcher&  myThreadPool;
 };

--- a/src/ShapeProcess/ShapeProcess_Context.cxx
+++ b/src/ShapeProcess/ShapeProcess_Context.cxx
@@ -19,15 +19,14 @@
 #include <ShapeProcess_Context.hxx>
 #include <Standard_ErrorHandler.hxx>
 #include <Standard_Failure.hxx>
-#include <Standard_Mutex.hxx>
 #include <Standard_Type.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <TCollection_HAsciiString.hxx>
 
+#include <memory>
+
 #include <sys/stat.h>
 IMPLEMENT_STANDARD_RTTIEXT(ShapeProcess_Context, Standard_Transient)
-
-static Standard_Mutex THE_SHAPE_PROCESS_MUTEX;
 
 //=================================================================================================
 
@@ -74,7 +73,9 @@ Handle(Resource_Manager) ShapeProcess_Context::LoadResourceManager(const Standar
 {
   // Mutex is needed because we are initializing and changing static variables here, so
   // without mutex it leads to race condition.
-  Standard_Mutex::Sentry aLock(&THE_SHAPE_PROCESS_MUTEX);
+  static std::mutex           THE_SHAPE_PROCESS_MUTEX;
+  std::lock_guard<std::mutex> lock(THE_SHAPE_PROCESS_MUTEX);
+
   // Optimisation of loading resource file: file is load only once
   // and reloaded only if file date has changed
   static Handle(Resource_Manager) sRC;

--- a/src/Standard/Standard_MemoryUtils.hxx
+++ b/src/Standard/Standard_MemoryUtils.hxx
@@ -18,9 +18,11 @@
 #include <NCollection_OccAllocator.hxx>
 
 #include <memory>
+#include <mutex>
 
 namespace opencascade
 {
+//! Makes shared pointer with OCCT allocator
 template <class T, class... Args>
 std::shared_ptr<T> make_shared(Args&&... theArgs)
 {
@@ -28,6 +30,7 @@ std::shared_ptr<T> make_shared(Args&&... theArgs)
                                                                     std::forward<Args>(theArgs)...);
 }
 
+//! Makes shared pointer with OCCT allocator
 template <class T, class... Args>
 std::shared_ptr<T> make_oshared(const Handle(NCollection_BaseAllocator)& theAlloc,
                                 Args&&... theArgs)
@@ -37,6 +40,7 @@ std::shared_ptr<T> make_oshared(const Handle(NCollection_BaseAllocator)& theAllo
     std::forward<Args>(theArgs)...);
 }
 
+//! Makes shared pointer with OCCT allocator
 template <class T, class... Args>
 std::shared_ptr<T> make_oshared(const NCollection_OccAllocator<T>& theAlloc, Args&&... theArgs)
 {
@@ -45,6 +49,7 @@ std::shared_ptr<T> make_oshared(const NCollection_OccAllocator<T>& theAlloc, Arg
     std::forward<Args>(theArgs)...);
 }
 
+//! Makes shared pointer with OCCT allocator
 template <class T, class... Args>
 std::shared_ptr<T> make_oshared(NCollection_OccAllocator<T>&& theAlloc, Args&&... theArgs)
 {
@@ -53,11 +58,59 @@ std::shared_ptr<T> make_oshared(NCollection_OccAllocator<T>&& theAlloc, Args&&..
     std::forward<Args>(theArgs)...);
 }
 
+//! Makes unique pointer
 template <typename T, class... Args>
 std::unique_ptr<T> make_unique(Args&&... theArgs)
 {
   return std::unique_ptr<T>(new T(std::forward<Args>(theArgs)...));
 }
+
+//! A scoped lock type for mutex pointers.
+//!
+//! A ptr_lock_guard controls mutex ownership within a scope, releasing
+//! ownership in the destructor. Unlike std::lock_guard, it works with mutex pointers
+//! and handles the case when the pointer is null.
+template <typename _Mutex>
+class lock_guard
+{
+public:
+  typedef _Mutex mutex_type;
+
+  //! Constructor locks the mutex if it's not null.
+  //! @param[in] theMutexPtr pointer to mutex
+  explicit lock_guard(mutex_type* theMutexPtr)
+      : myMutexPtr(theMutexPtr)
+  {
+    if (myMutexPtr)
+    {
+      myMutexPtr->lock();
+    }
+  }
+
+  //! Constructor with adopt_lock assumes the mutex is already locked.
+  //! @param[in] theMutexPtr pointer to mutex (assumed to be locked)
+  //! @param[in] adopt_lock parameter indicating the mutex is already locked
+  lock_guard(mutex_type* theMutexPtr, std::adopt_lock_t) noexcept
+      : myMutexPtr(theMutexPtr)
+  {
+  } // calling thread owns mutex
+
+  //! Destructor unlocks the mutex if it's not null.
+  ~lock_guard()
+  {
+    if (myMutexPtr)
+    {
+      myMutexPtr->unlock();
+    }
+  }
+
+  lock_guard(const ptr_lock_guard&)            = delete;
+  lock_guard& operator=(const ptr_lock_guard&) = delete;
+
+private:
+  mutex_type* myMutexPtr;
+};
+
 } // namespace opencascade
 
-#endif
+#endif // _Standard_MemoryUtils_HeaderFile

--- a/src/Standard/Standard_Type.cxx
+++ b/src/Standard/Standard_Type.cxx
@@ -17,7 +17,7 @@
 #include <NCollection_DataMap.hxx>
 #include <Standard_HashUtils.hxx>
 #include <Standard_Assert.hxx>
-#include <Standard_Mutex.hxx>
+#include <Standard_MemoryUtils.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(Standard_Type, Standard_Transient)
 
@@ -115,8 +115,8 @@ Standard_Type* Standard_Type::Register(const std::type_info&        theInfo,
 {
   // Access to registry is protected by mutex; it should not happen often because
   // instances are cached by Standard_Type::Instance() (one per binary module)
-  static Standard_Mutex  aMutex;
-  Standard_Mutex::Sentry aSentry(aMutex);
+  static std::mutex           aMutex;
+  std::lock_guard<std::mutex> aLock(aMutex);
 
   // return existing descriptor if already in the registry
   registry_type& aRegistry = GetRegistry();


### PR DESCRIPTION
Refactor mutex usage to std::mutex and lock_guard for improved thread safety.
Standard_Mutex is a recursive mutex.