### PR TITLE
Documentation - Fix various typos found in codebase

### DIFF
--- a/dox/user_guides/draw_test_harness/draw_test_harness.md
+++ b/dox/user_guides/draw_test_harness/draw_test_harness.md
@@ -1261,7 +1261,7 @@ clear
 
 **Example:** 
 ~~~~{.php}
-# erase eveerything with a name starting with c_ 
+# erase everything with a name starting with c_ 
 foreach var [directory c_*] {erase $var} 
 
 # clear 2d views 

--- a/src/AIS/AIS_InteractiveContext.cxx
+++ b/src/AIS/AIS_InteractiveContext.cxx
@@ -2605,7 +2605,7 @@ AIS_StatusOfDetection AIS_InteractiveContext::moveTo(const Handle(V3d_View)& the
   }
   else
   {
-    // previously detected object is unhilighted if it is not selected or hilighted
+    // previously detected object is unhighlighted if it is not selected or highlighted
     // with selection color if it is selected
     aStatus = AIS_SOD_Nothing;
     if (myAutoHilight && !myLastPicked.IsNull() && myLastPicked->HasSelectable())

--- a/src/AIS/AIS_InteractiveContext.hxx
+++ b/src/AIS/AIS_InteractiveContext.hxx
@@ -255,14 +255,14 @@ public: //! @name highlighting management
     return myStyles[Prs3d_TypeOfHighlight_Dynamic];
   }
 
-  //! Setup the style of dynamic highlighting corrsponding to Prs3d_TypeOfHighlight_Selected.
+  //! Setup the style of dynamic highlighting corresponding to Prs3d_TypeOfHighlight_Selected.
   //! This is just a short-cut to SetHighlightStyle(Prs3d_TypeOfHighlight_Dynamic,theStyle).
   void SetHighlightStyle(const Handle(Prs3d_Drawer)& theStyle)
   {
     myStyles[Prs3d_TypeOfHighlight_Dynamic] = theStyle;
   }
 
-  //! Returns current selection style settings corrsponding to Prs3d_TypeOfHighlight_Selected.
+  //! Returns current selection style settings corresponding to Prs3d_TypeOfHighlight_Selected.
   //! This is just a short-cut to HighlightStyle(Prs3d_TypeOfHighlight_Selected).
   const Handle(Prs3d_Drawer)& SelectionStyle() const
   {
@@ -299,7 +299,7 @@ public: //! @name highlighting management
                                         const Handle(Prs3d_Drawer)&          theStyle,
                                         const Standard_Boolean               theToUpdateViewer);
 
-  //! Removes hilighting from the Object.
+  //! Removes highlighting from the Object.
   Standard_EXPORT void Unhilight(const Handle(AIS_InteractiveObject)& theIObj,
                                  const Standard_Boolean               theToUpdateViewer);
 

--- a/src/D3DHostTest/D3DHostTest.hxx
+++ b/src/D3DHostTest/D3DHostTest.hxx
@@ -22,7 +22,7 @@ class D3DHostTest
 public:
   DEFINE_STANDARD_ALLOC
 
-  //! Adds Draw commands to the draw interpretor.
+  //! Adds Draw commands to the draw interpreter.
   Standard_EXPORT static void Commands(Draw_Interpretor& theDI);
 
   //! Plugin entry point function.

--- a/src/Draw/Draw.hxx
+++ b/src/Draw/Draw.hxx
@@ -32,7 +32,7 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! (Re)Load a Draw Harness plugin.
-  //! @param[in][out] theDI    Tcl interpretor to append loaded commands
+  //! @param[in][out] theDI    Tcl interpreter to append loaded commands
   //! @param[in] theKey  plugin code name to be resolved in resource file
   //! @param[in] theResourceFileName    description file name
   //! @param[in] theDefaultsDirectory   default folder for looking description file
@@ -58,7 +58,7 @@ public: //! @name Tcl variables management tools
   //! Sets a numeric variable.
   Standard_EXPORT static void Set(const Standard_CString Name, const Standard_Real val);
 
-  //! Returns main DRAW interpretor.
+  //! Returns main DRAW interpreter.
   Standard_EXPORT static Draw_Interpretor& GetInterpretor();
 
   //! Returns a variable value.

--- a/src/Draw/Draw_Interpretor.cxx
+++ b/src/Draw/Draw_Interpretor.cxx
@@ -311,7 +311,7 @@ void Draw_Interpretor::add(const Standard_CString          theCommandName,
                            Draw_Interpretor::CallBackData* theCallback,
                            const Standard_CString          theGroup)
 {
-  Standard_ASSERT_RAISE(myInterp != NULL, "Attempt to add command to Null interpretor");
+  Standard_ASSERT_RAISE(myInterp != NULL, "Attempt to add command to Null interpreter");
 
   Tcl_CreateCommand(myInterp, theCommandName, CommandCmd, (ClientData)theCallback, CommandDelete);
 

--- a/src/Draw/Draw_Interpretor.hxx
+++ b/src/Draw/Draw_Interpretor.hxx
@@ -28,7 +28,7 @@
 class TCollection_AsciiString;
 class TCollection_ExtendedString;
 
-//! Provides an encapsulation of the TCL interpretor to define Draw commands.
+//! Provides an encapsulation of the TCL interpreter to define Draw commands.
 class Draw_Interpretor
 {
 
@@ -56,7 +56,7 @@ public:
                                     Standard_Integer  theArgNb,
                                     const char**      theArgVec) = 0;
 
-    Draw_Interpretor* myDI; //!< pointer to Draw Interpretor
+    Draw_Interpretor* myDI; //!< pointer to Draw Interpreter
 
     // make sure allocation and de-allocation is done by the same memory allocator
     DEFINE_STANDARD_ALLOC
@@ -116,7 +116,7 @@ public:
   //! Empty constructor
   Standard_EXPORT Draw_Interpretor();
 
-  //! Initialize TCL interpretor
+  //! Initialize TCL interpreter
   Standard_EXPORT void Init();
 
   //! Creates a new command with name <theCommandName>, help string <theHelp> in group <theGroup>.

--- a/src/Draw/Draw_Printer.hxx
+++ b/src/Draw/Draw_Printer.hxx
@@ -28,7 +28,7 @@ class Draw_Printer : public Message_Printer
 {
   DEFINE_STANDARD_RTTIEXT(Draw_Printer, Message_Printer)
 public:
-  //! Creates a printer connected to the interpretor.
+  //! Creates a printer connected to the interpreter.
   Standard_EXPORT Draw_Printer(Draw_Interpretor& theTcl);
 
 protected:

--- a/src/Draw/Draw_VariableCommands.cxx
+++ b/src/Draw/Draw_VariableCommands.cxx
@@ -678,7 +678,7 @@ void Draw::Set(const Standard_CString name, const Handle(Draw_Drawable3D)& D)
 // MKV 29.03.05
 static char* tracevar(ClientData CD, Tcl_Interp*, const char* name, const char*, int)
 {
-  // protect if the map was destroyed before the interpretor
+  // protect if the map was destroyed before the interpreter
   if (Draw::Drawables().IsEmpty())
   {
     return NULL;

--- a/src/Draw/Draw_Window.cxx
+++ b/src/Draw/Draw_Window.cxx
@@ -1882,9 +1882,9 @@ static DWORD WINAPI tkLoop(const LPVOID theThreadParameter)
   ResetStdChannel(TCL_STDERR);
 
   #if (TCL_MAJOR_VERSION > 8) || ((TCL_MAJOR_VERSION == 8) && (TCL_MINOR_VERSION >= 5))
-  // Plain Tcl (8.6.4+) initializes interpretor channels automatically, but
+  // Plain Tcl (8.6.4+) initializes interpreter channels automatically, but
   // ActiveState Tcl (at least 8.6.4) does not seem to do that, so channels
-  // need to be set into interpretor explicitly
+  // need to be set into interpreter explicitly
   {
     Tcl_Channel aChannelIn  = Tcl_GetStdChannel(TCL_STDIN);
     Tcl_Channel aChannelOut = Tcl_GetStdChannel(TCL_STDOUT);

--- a/src/GeomLib/GeomLib.cxx
+++ b/src/GeomLib/GeomLib.cxx
@@ -941,7 +941,7 @@ void GeomLib::SameRange(const Standard_Real         Tolerance,
     }
   }
   else
-  { // On segmente le resultat
+  { // We segment the result
     Handle(Geom2d_TrimmedCurve) TC;
     Handle(Geom2d_Curve)        aCCheck = CurvePtr;
 
@@ -1148,8 +1148,8 @@ void GeomLib::BuildCurve3d(const Standard_Real       Tolerance,
   TColStd_Array1OfReal Param_de_decoupeC3(1, NbIntervalC3 + 1);
   Curve.Intervals(Param_de_decoupeC3, GeomAbs_C3);
 
-  // Note extension of the parameteric range
-  // Pour forcer le Trim au premier appel de l'evaluateur
+  // Note extension of the parametric range
+  // To force Trim on first evaluator call
   GeomLib_CurveOnSurfaceEvaluator ev(Curve, FirstParameter - 1., LastParameter + 1.);
 
   // Approximation avec decoupe preferentiel

--- a/src/GeomLib/GeomLib.hxx
+++ b/src/GeomLib/GeomLib.hxx
@@ -197,7 +197,7 @@ public:
   //! @param[in] Interval2  second interval to fuse
   //! @param[in] Confision  tolerance to compare intervals
   //! @param[in] IsAdjustToFirstInterval  flag to set method of fusion, if intervals are close
-  //!                               if false, intervals are fusing by half-division methdod
+  //!                               if false, intervals are fusing by half-division method
   //!                               if true, intervals are fusing by selecting value from Interval1
   //! @param[out] Fusion  output interval
   Standard_EXPORT static void FuseIntervals(

--- a/src/IntPatch/IntPatch_ALineToWLine.cxx
+++ b/src/IntPatch/IntPatch_ALineToWLine.cxx
@@ -704,7 +704,7 @@ void IntPatch_ALineToWLine::MakeWLine(const Handle(IntPatch_ALine)& theALine,
         }
         else
         {
-          // add point, set correxponding status: to be corrected later
+          // add point, set corresponding status: to be corrected later
           Standard_Boolean ToAdd = Standard_False;
           if (aLinOn2S->NbPoints() == 0)
           {

--- a/src/Interface/Interface_Protocol.hxx
+++ b/src/Interface/Interface_Protocol.hxx
@@ -108,7 +108,7 @@ public:
 
   //! Returns True if <ent> is an Unknown Entity for the Norm, i.e.
   //! same Type as them created by method UnknownEntity
-  //! (for an Entity out of the Norm, answer can be unpredicable)
+  //! (for an Entity out of the Norm, answer can be unpredictable)
   Standard_EXPORT virtual Standard_Boolean IsUnknownEntity(
     const Handle(Standard_Transient)& ent) const = 0;
 

--- a/src/Interface/Interface_ReportEntity.hxx
+++ b/src/Interface/Interface_ReportEntity.hxx
@@ -26,7 +26,7 @@ class Interface_Check;
 class Interface_ReportEntity;
 DEFINE_STANDARD_HANDLE(Interface_ReportEntity, Standard_Transient)
 
-//! A ReportEntity is produced to aknowledge and memorize the
+//! A ReportEntity is produced to acknowledge and memorize the
 //! binding between a Check and an Entity. The Check can bring
 //! Fails (+ Warnings if any), or only Warnings. If it is empty,
 //! the Report Entity is for an Unknown Entity.

--- a/src/ShapeBuild/ShapeBuild_Edge.cxx
+++ b/src/ShapeBuild/ShapeBuild_Edge.cxx
@@ -131,7 +131,7 @@ entity 132 edge 1
 
 //=================================================================================================
 
-// Added, cause invoke ShapeAnalysis leads to cyclic dependancy.
+// Added, cause invoke ShapeAnalysis leads to cyclic dependency.
 static Standard_Real AdjustByPeriod(const Standard_Real Val,
                                     const Standard_Real ToVal,
                                     const Standard_Real Period)

--- a/src/ShapeFix/ShapeFix_IntersectionTool.cxx
+++ b/src/ShapeFix/ShapeFix_IntersectionTool.cxx
@@ -102,7 +102,7 @@ Standard_Boolean ShapeFix_IntersectionTool::SplitEdge(const TopoDS_Edge&   edge,
   sae.PCurve(edge, face, c2d, a, b, Standard_True);
   if (Abs(a - param) < 0.01 * preci || Abs(b - param) < 0.01 * preci)
     return Standard_False;
-  // check distanse between edge and new vertex
+  // check distance between edge and new vertex
   gp_Pnt          P1;
   TopLoc_Location L;
   if (BRep_Tool::SameParameter(edge) && !BRep_Tool::Degenerated(edge))

--- a/src/TNaming/TNaming_Name.cxx
+++ b/src/TNaming/TNaming_Name.cxx
@@ -1327,7 +1327,7 @@ static Standard_Boolean Generated(const TDF_Label&                L,
                   {
                     a1NB = Standard_True;
                     break;
-                  } // lost only 1 neigbour
+                  } // lost only 1 neighbour
                 }
                 else if (aS.ShapeType() == TopAbs_FACE)
                 {
@@ -1341,7 +1341,7 @@ static Standard_Boolean Generated(const TDF_Label&                L,
                       {
                         a1NB = Standard_True;
                         break;
-                      } // lost only 1 neigbour
+                      } // lost only 1 neighbour
                     }
                   }
                 }

--- a/src/TPrsStd/TPrsStd_ConstraintTools.cxx
+++ b/src/TPrsStd/TPrsStd_ConstraintTools.cxx
@@ -467,7 +467,7 @@ void TPrsStd_ConstraintTools::ComputePerpendicular(const Handle(TDataXtd_Constra
   {
 #ifdef OCCT_DEBUG
     std::cout
-      << "TPrsStd_ConstraintTools::ComputePerpendicular: at leat two constraintes are needed"
+      << "TPrsStd_ConstraintTools::ComputePerpendicular: at least two constraints are needed"
       << std::endl;
 #endif
     NullifyAIS(anAIS);
@@ -535,7 +535,7 @@ void TPrsStd_ConstraintTools::ComputeParallel(const Handle(TDataXtd_Constraint)&
   if (nbgeom < 2)
   {
 #ifdef OCCT_DEBUG
-    std::cout << "TPrsStd_ConstraintTools::ComputeParallel: at least 2 constraintes are needed"
+    std::cout << "TPrsStd_ConstraintTools::ComputeParallel: at least 2 constraints are needed"
               << std::endl;
 #endif
     NullifyAIS(anAIS);
@@ -605,7 +605,7 @@ void TPrsStd_ConstraintTools::ComputeSymmetry(const Handle(TDataXtd_Constraint)&
   if (nbgeom < 3)
   {
 #ifdef OCCT_DEBUG
-    std::cout << "TPrsStd_ConstraintTools::ComputeSymmetry: at least 3 constraintes are needed"
+    std::cout << "TPrsStd_ConstraintTools::ComputeSymmetry: at least 3 constraints are needed"
               << std::endl;
 #endif
     NullifyAIS(anAIS);
@@ -753,7 +753,7 @@ void TPrsStd_ConstraintTools::ComputeTangent(const Handle(TDataXtd_Constraint)& 
   if (nbgeom < 2)
   {
 #ifdef OCCT_DEBUG
-    std::cout << "TPrsStd_ConstraintTools::ComputeTangent: at leat two constraintes are needed"
+    std::cout << "TPrsStd_ConstraintTools::ComputeTangent: at least two constraints are needed"
               << std::endl;
 #endif
     NullifyAIS(anAIS);
@@ -1172,7 +1172,7 @@ void TPrsStd_ConstraintTools::ComputeConcentric(const Handle(TDataXtd_Constraint
   if (nbgeom < 2)
   {
     throw Standard_ProgramError(
-      "TPrsStd_ConstraintTools::ComputeConcentric: at least 2 constraintes are needed");
+      "TPrsStd_ConstraintTools::ComputeConcentric: at least 2 constraints are needed");
   }
   if (!aConst->IsPlanar())
   {
@@ -2234,7 +2234,7 @@ void TPrsStd_ConstraintTools::ComputeCoincident(const Handle(TDataXtd_Constraint
   if (nbgeom < 2)
   {
 #ifdef OCCT_DEBUG
-    std::cout << "TPrsStd_ConstraintTools::ComputeCoincident: at leat two constraintes are needed"
+    std::cout << "TPrsStd_ConstraintTools::ComputeCoincident: at least two constraints are needed"
               << std::endl;
 #endif
     NullifyAIS(anAIS);
@@ -2305,7 +2305,7 @@ void TPrsStd_ConstraintTools::ComputeRound(const Handle(TDataXtd_Constraint)& aC
   if (nbgeom < 1)
   {
 #ifdef OCCT_DEBUG
-    std::cout << "TPrsStd_ConstraintTools::ComputeRound: at leat one geometry is needed"
+    std::cout << "TPrsStd_ConstraintTools::ComputeRound: at least one geometry is needed"
               << std::endl;
 #endif
     NullifyAIS(anAIS);

--- a/src/TPrsStd/TPrsStd_NamedShapeDriver.cxx
+++ b/src/TPrsStd/TPrsStd_NamedShapeDriver.cxx
@@ -29,8 +29,8 @@ IMPLEMENT_STANDARD_RTTIEXT(TPrsStd_NamedShapeDriver, TPrsStd_Driver)
 
 #undef OPTIM_UPDATE // If this variable is defined there will be done
 
-//                      more otimized update of AIS_Shape. If an object was
-//                      erased in the viewer and it's location was changed
+//                      more optimized update of AIS_Shape. If an object was
+//                      erased in the viewer and its location was changed
 //                      but topological data wasn't then when displayed only
 //                      the object's presentation will be moved to new location
 //                      without recompute. The shape in AIS_Shape will

--- a/src/TransferBRep/TransferBRep_ShapeMapper.hxx
+++ b/src/TransferBRep/TransferBRep_ShapeMapper.hxx
@@ -42,7 +42,7 @@ public:
   //! Returns the contained value
   Standard_EXPORT const TopoDS_Shape& Value() const;
 
-  //! Specific testof equality : defined as False if <other> has
+  //! Specific test of equality : defined as False if <other> has
   //! not the same true Type, else contents are compared (by
   //! C++ operator ==)
   Standard_EXPORT Standard_Boolean

--- a/src/XCAFDoc/XCAFDoc_ClippingPlaneTool.hxx
+++ b/src/XCAFDoc/XCAFDoc_ClippingPlaneTool.hxx
@@ -110,7 +110,7 @@ public:
   Standard_EXPORT Standard_Boolean GetCapping(const TDF_Label& theClippingPlaneL) const;
 
   //! Get capping value for given clipping plane label
-  //! Return true if Label is valid abd capping is exist.
+  //! Return true if Label is valid and capping exists.
   Standard_EXPORT Standard_Boolean GetCapping(const TDF_Label&  theClippingPlaneL,
                                               Standard_Boolean& theCapping) const;
 

--- a/src/XSDRAW/XSDRAW.cxx
+++ b/src/XSDRAW/XSDRAW.cxx
@@ -157,7 +157,7 @@ void XSDRAW::LoadDraw(Draw_Interpretor& theCommands)
   LoadSession();
 
   // skl: we make remove commands "x" and "exit" in order to this commands are
-  //      performed not in IFSelect_SessionPilot but in standard Tcl interpretor
+  //      performed not in IFSelect_SessionPilot but in standard Tcl interpreter
   XSDRAW::RemoveCommand("x");
   XSDRAW::RemoveCommand("exit");
 

--- a/tests/bugs/moddata_3/bug24896
+++ b/tests/bugs/moddata_3/bug24896
@@ -16,7 +16,7 @@ regexp {([-0-9.+eE]+)$} [dump d_val] full dist
 regexp { +Vertex +: +Min +[-0-9.+eE]+ +Max +([-0-9.+eE]+)} [ maxtolerance d ] full toler
 set good_dist 0
 if { [expr abs( ${dist} - ${good_dist} )] > ${toler} } {
-    puts "Faulty : the distanse is ${dist}. It is bad value"
+    puts "Faulty : the distance is ${dist}. It is bad value"
 }
 
 # 2

--- a/tests/bugs/moddata_3/bug25223
+++ b/tests/bugs/moddata_3/bug25223
@@ -81,7 +81,7 @@ regexp {([-0-9.+eE]+)$} [dump d_val] full dist
 regexp { +Vertex +: +Min +[-0-9.+eE]+ +Max +([-0-9.+eE]+)} [ maxtolerance d ] full toler
 set good_dist 3.99072821948773e-08
 if { [expr abs( ${dist} - ${good_dist} )] > ${toler} } {
-    puts "Error : the distanse is ${dist}. It is bad value"
+    puts "Error : the distance is ${dist}. It is bad value"
 }
 
 smallview

--- a/tests/bugs/moddata_3/bug28866
+++ b/tests/bugs/moddata_3/bug28866
@@ -21,8 +21,8 @@ foreach pnt ${pnts} {
  set log [projponf f $pnt -min -t]
  regexp {proj dist = ([-0-9.+eE]+)} ${log} full distmax
  if { ${distmax} > ${CMP_TOL} } {
-    puts "Error: Wrong distanse ($pnt)"
+    puts "Error: Wrong distance ($pnt)"
  } else {
-    puts "OK: Good distanse ($pnt)"
+    puts "OK: Good distance ($pnt)"
  }
 }

--- a/tools/ViewControl/ViewControl_ColorSelector.cxx
+++ b/tools/ViewControl/ViewControl_ColorSelector.cxx
@@ -71,7 +71,7 @@ public:
   //! Returns item information(short) for display role.
   //! \param theIndex a model index
   //! \param theRole a view role
-  //! \return value intepreted depending on the given role
+  //! \return value interpreted depending on the given role
   Standard_EXPORT virtual QVariant Data(const int theRow,
                                         const int theColumn,
                                         int       theRole = Qt::DisplayRole) const Standard_OVERRIDE


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.fr" -L aadd,abnd,abord,acces,acount,adn,afile,aline,alo,alocation,alog,als,anc,ane,anid,anormal,anout,ans,anumber,aother,aparent,apoints,aprogram,asender,asign,asnd,ba,bbuild,bloc,bord,bu,caf,cas,childrens,childs,classe,clen,commun,cylindre,discret,don,dout,dum,ede,enew,entite,entites,extrem,fo,fonction,geometrie,guid,hilight,hilights,hist,identic,ii,indx,inout,invalide,ist,iterm,llength,lod,maked,mape,mke,modeling,methode,mye,myu,nam,nd,nin,normale,normales,ons,parametre,parametres,periode,pinter,pres,projet,remplace,reste,resul,secont,serie,siz,shs,slin,som,somme,syntaxe,sur,te,thei,theis,ther,theres,thes,thev,thex,thet,tol,transfert,unhilight,unhilights,va,vas,verifie,vertexes,weight`