### PR TITLE
Visualization - AIS_Shape bounding box re-computation is not working properly

### DIFF
--- a/src/AIS/AIS_Shape.cxx
+++ b/src/AIS/AIS_Shape.cxx
@@ -735,6 +735,8 @@ const Bnd_Box& AIS_Shape::BoundingBox()
 
   if (myCompBB)
   {
+    // Clear the bounding box to re-compute it.
+    myBB.SetVoid();
     BRepBndLib::Add(myshape, myBB, false);
     myCompBB = Standard_False;
   }

--- a/tests/v3d/bugs/bug_gh421
+++ b/tests/v3d/bugs/bug_gh421
@@ -1,0 +1,20 @@
+puts "============"
+puts "Visualization - Bounding box is not decreasing for mode 2 #421"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+vclear
+
+box b 100 200 300
+vinit View1
+vdisplay b -dispMode 2
+# OK
+box b 10 200 300
+vdisplay b -dispMode 2
+
+vfit
+
+checkcolor 243 2 0 0 0
+
+vdump $::imagedir/${::casename}.png


### PR DESCRIPTION
Fixed issue with bounding box cleaning algorithm that was causing the bounding box to be only increased.
Now the bounding box is increased and decreased to fit the shape.