### PR TITLE
0033607: Visualization - Implementation of hardware occlusion queries

### DIFF
--- a/src/AIS/AIS_InteractiveContext.cxx
+++ b/src/AIS/AIS_InteractiveContext.cxx
@@ -414,6 +414,7 @@ void AIS_InteractiveContext::Display(const Handle(AIS_InteractiveObject)& theIOb
   {
     setObjectStatus(theIObj, PrsMgr_DisplayStatus_Displayed, theDispMode, theSelectionMode);
     theIObj->ViewAffinity()->SetVisible(true); // reset view affinity mask
+    theIObj->ViewOcclusionMask()->SetVisible(true); // reset view occlusion mask
     myMainVwr->StructureManager()->RegisterObject(theIObj, theIObj->ViewAffinity());
     myMainPM->Display(theIObj, theDispMode);
     if (theSelectionMode != -1)
@@ -492,6 +493,7 @@ void AIS_InteractiveContext::Load(const Handle(AIS_InteractiveObject)& theIObj,
                     aDispMode,
                     theSelMode != -1 ? theSelMode : aSelModeDef);
     theIObj->ViewAffinity()->SetVisible(true); // reset view affinity mask
+    theIObj->ViewOcclusionMask()->SetVisible (true); // reset view occlusion mask
     myMainVwr->StructureManager()->RegisterObject(theIObj, theIObj->ViewAffinity());
   }
 

--- a/src/Graphic3d/FILES
+++ b/src/Graphic3d/FILES
@@ -208,3 +208,4 @@ Graphic3d_Layer.cxx
 Graphic3d_Layer.hxx
 Graphic3d_ZLayerId.hxx
 Graphic3d_ZLayerSettings.hxx
+Graphic3d_ViewOcclusionMask.hxx

--- a/src/Graphic3d/Graphic3d_CStructure.hxx
+++ b/src/Graphic3d/Graphic3d_CStructure.hxx
@@ -22,6 +22,7 @@
 #include <Graphic3d_ViewAffinity.hxx>
 #include <Graphic3d_TransformPers.hxx>
 #include <Graphic3d_ZLayerId.hxx>
+#include <Graphic3d_ViewOcclusionMask.hxx>
 #include <TopLoc_Datum3D.hxx>
 #include <NCollection_IndexedMap.hxx>
 
@@ -173,6 +174,19 @@ public:
   //! The method is called during traverse of BVH tree.
   void MarkAsNotCulled() const { myIsCulled = Standard_False; }
 
+  //! Returns true if the structure occluded in specified view, otherwise
+  //! returns false.
+  Standard_Boolean IsOccluded(const Standard_Integer theViewId) const 
+  {
+    return (!OcclusionMask->IsVisible(theViewId));
+  }
+
+  //! Marks structure as Occluded by other structure in specified view,!
+  void SetOcclusionSate(const Standard_Integer theViewId, const bool theIsVisible) const 
+  {
+    OcclusionMask->SetVisible(theViewId, !theIsVisible);
+  }
+
   //! Returns whether check of object's bounding box clipping is enabled before drawing of object;
   //! TRUE by default.
   Standard_Boolean BndBoxClipCheck() const { return myBndBoxClipCheck; }
@@ -228,6 +242,7 @@ public:
 
 public:
   Handle(Graphic3d_ViewAffinity) ViewAffinity; //!< view affinity mask
+  Handle(Graphic3d_ViewOcclusionMask) OcclusionMask; //!< view occlusion mask
 
 protected:
   //! Create empty structure.

--- a/src/Graphic3d/Graphic3d_CView.cxx
+++ b/src/Graphic3d/Graphic3d_CView.cxx
@@ -533,6 +533,17 @@ void Graphic3d_CView::DisplayedStructures(Graphic3d_MapOfStructure& theStructure
 
 //=================================================================================================
 
+void Graphic3d_CView::OccludedStructures(Graphic3d_MapOfStructure& theStructures) const
+{
+  for (Graphic3d_MapOfStructure::Iterator aStructIter(myStructsDisplayed); aStructIter.More(); aStructIter.Next())
+  {
+    if (aStructIter.Value()->CStructure()->IsOccluded(this->myId))
+      theStructures.Add(aStructIter.Key());
+  }
+}
+
+//=================================================================================================
+
 Bnd_Box Graphic3d_CView::MinMaxValues(const Standard_Boolean theToIncludeAuxiliary) const
 {
   if (!IsDefined())

--- a/src/Graphic3d/Graphic3d_CView.hxx
+++ b/src/Graphic3d/Graphic3d_CView.hxx
@@ -154,6 +154,12 @@ public:
   //! Returns the set of structures displayed in this view.
   Standard_EXPORT void DisplayedStructures(Graphic3d_MapOfStructure& theStructures) const;
 
+  //! Returns number of occluded structures in the view
+  Standard_EXPORT void OccludedStructures(Graphic3d_MapOfStructure& theStructures) const;
+ 
+  //! Update occlusion test for displayed structures in the view
+  Standard_EXPORT virtual void UpdateOcclusion() = 0 ;
+
   //! Returns number of displayed structures in the view.
   virtual Standard_Integer NumberOfDisplayedStructures() const
   {

--- a/src/Graphic3d/Graphic3d_FrameStatsTimer.hxx
+++ b/src/Graphic3d/Graphic3d_FrameStatsTimer.hxx
@@ -22,11 +22,12 @@ enum Graphic3d_FrameStatsTimer
   Graphic3d_FrameStatsTimer_CpuCulling,
   Graphic3d_FrameStatsTimer_CpuPicking,
   Graphic3d_FrameStatsTimer_CpuDynamics,
+  Graphic3d_FrameStatsTimer_OcclusionCulling,
 };
 
 enum
 {
-  Graphic3d_FrameStatsTimer_NB = Graphic3d_FrameStatsTimer_CpuDynamics + 1
+  Graphic3d_FrameStatsTimer_NB = Graphic3d_FrameStatsTimer_OcclusionCulling + 1
 };
 
 #endif // _Graphic3d_FrameStatsTimer_HeaderFile

--- a/src/Graphic3d/Graphic3d_RenderingParams.cxx
+++ b/src/Graphic3d/Graphic3d_RenderingParams.cxx
@@ -64,6 +64,7 @@ void Graphic3d_RenderingParams::DumpJson(Standard_OStream& theOStream,
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, CameraApertureRadius)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, CameraFocalPlaneDist)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, FrustumCullingState)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, OcclusionQueryState)
 
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, ToneMappingMethod)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, Exposure)

--- a/src/Graphic3d/Graphic3d_RenderingParams.hxx
+++ b/src/Graphic3d/Graphic3d_RenderingParams.hxx
@@ -98,6 +98,14 @@ public:
     FrustumCulling_NoUpdate //!< culling is active, but the list of culled entities is not updated
   };
 
+  //! State of occlusion query
+  enum OcclusionQuery
+  {
+    OcclusionQuery_Off,     //!< occlusion query is disabled
+    OcclusionQuery_On,      //!< occlusion query is active
+    OcclusionQuery_NoUpdate //!< occlusion query is active, but the list of occluded entities is not updated
+  };
+
 public:
   //! Creates default rendering parameters.
   Graphic3d_RenderingParams()
@@ -144,6 +152,7 @@ public:
         CameraApertureRadius(0.0f),
         CameraFocalPlaneDist(1.0f),
         FrustumCullingState(FrustumCulling_On),
+        OcclusionQueryState(OcclusionQuery_Off),
         ToneMappingMethod(Graphic3d_ToneMappingMethod_Disabled),
         Exposure(0.f),
         WhitePoint(1.f),
@@ -258,6 +267,7 @@ public: //! @name Ray-Tracing/Path-Tracing parameters
   Standard_ShortReal                CameraApertureRadius;        //!< aperture radius of perspective camera used for depth-of-field, 0.0 by default (no DOF) (path tracing only)
   Standard_ShortReal                CameraFocalPlaneDist;        //!< focal  distance of perspective camera used for depth-of field, 1.0 by default (path tracing only)
   FrustumCulling                    FrustumCullingState;         //!< state of frustum culling optimization; FrustumCulling_On by default
+  OcclusionQuery                    OcclusionQueryState;         //!< state of occlusion query; OcclusionQuery_OFF by default
 
   Graphic3d_ToneMappingMethod       ToneMappingMethod;           //!< specifies tone mapping method for path tracing, Graphic3d_ToneMappingMethod_Disabled by default
   Standard_ShortReal                Exposure;                    //!< exposure value used for tone mapping (path tracing), 0.0 by default

--- a/src/Graphic3d/Graphic3d_ViewOcclusionMask.hxx
+++ b/src/Graphic3d/Graphic3d_ViewOcclusionMask.hxx
@@ -1,0 +1,25 @@
+// Created on: 2024-02-20
+// Created by: Hossam Ali
+// Copyright (c) 2024 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in
+// OCCT distribution for complete text of the license and disclaimer of any
+// warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _Graphic3d_ViewOcclusionMask_HeaderFile
+#define _Graphic3d_ViewOcclusionMask_HeaderFile
+
+#include <Graphic3d_ViewAffinity.hxx>
+
+//! define occlusion mask as alias for view affinity mask .
+typedef Graphic3d_ViewAffinity Graphic3d_ViewOcclusionMask;
+
+#endif //_Graphic3d_ViewOcclusionMask_HeaderFile

--- a/src/OpenGl/FILES
+++ b/src/OpenGl/FILES
@@ -153,3 +153,5 @@ OpenGl_TextBuilder.hxx
 OpenGl_TextBuilder.cxx
 OpenGl_HaltonSampler.hxx
 OpenGl_ShaderProgramDumpLevel.hxx
+OpenGl_OcclusionQuery.hxx
+OpenGl_OcclusionQuery.cxx

--- a/src/OpenGl/OpenGl_LayerList.cxx
+++ b/src/OpenGl/OpenGl_LayerList.cxx
@@ -25,6 +25,7 @@
 #include <OpenGl_VertexBuffer.hxx>
 #include <OpenGl_View.hxx>
 #include <OpenGl_Workspace.hxx>
+#include <OpenGl_OcclusionQuery.hxx>
 
 namespace
 {
@@ -894,15 +895,74 @@ void OpenGl_LayerList::Render(const Handle(OpenGl_Workspace)& theWorkspace,
   theWorkspace->SetRenderFilter(aPrevFilter);
 }
 
-//=======================================================================
-// function : renderTransparent
-// purpose  : Render transparent objects using blending operator.
-//=======================================================================
+//=================================================================================================
+
+void OpenGl_LayerList::UpdateOcclusion(const Handle(OpenGl_Workspace) & theWorkspace)
+{  
+  const Handle(OpenGl_Context) &aCtx = theWorkspace->GetGlContext();
+  aCtx->core11fwd->glEnable(GL_DEPTH_TEST);
+  aCtx->core11fwd->glDepthFunc (GL_LESS);
+
+  // Remember global settings for glDepth mask and write mask
+  GLboolean aPrevColorMask[4];
+  GLboolean aPrevDepthMask;
+  aCtx->core11fwd->glGetBooleanv(GL_COLOR_WRITEMASK, aPrevColorMask);
+  aCtx->core11fwd->glGetBooleanv(GL_DEPTH_WRITEMASK, &aPrevDepthMask);
+
+  // Turn off writing to depth and color buffers 
+  aCtx->core11fwd->glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+
+  // Start record occlusion test computational cost  
+  const Handle(OpenGl_FrameStats) &aStats = theWorkspace->GetGlContext()->FrameStats();
+  OSD_Timer &aTimer = aStats->ActiveDataFrame().ChangeTimer( Graphic3d_FrameStatsTimer_OcclusionCulling);
+  aTimer.Start();
+
+  // Loop for all layers
+  for (NCollection_List<Handle(Graphic3d_Layer)>::Iterator aLayerIter(myLayers);
+       aLayerIter.More(); aLayerIter.Next()) {
+
+    const Handle(Graphic3d_Layer) &aLayer = aLayerIter.ChangeValue();
+
+    // Exclude frustum culled layer
+    if (aLayer->IsCulled())
+      continue;
+
+    aCtx->core11fwd->glClear(GL_COLOR_BUFFER_BIT| GL_DEPTH_BUFFER_BIT);
+
+    // Render priority list
+    const Standard_Integer aViewId = theWorkspace->View()->Identification();
+
+    for (Standard_Integer aPriorityIter = Graphic3d_DisplayPriority_Bottom; aPriorityIter <= Graphic3d_DisplayPriority_Topmost; ++aPriorityIter) 
+    {
+      const Graphic3d_IndexedMapOfStructure &aStructures = aLayer->Structures((Graphic3d_DisplayPriority)aPriorityIter);
+      for (OpenGl_Structure::StructIterator aStructIter(aStructures); aStructIter.More(); aStructIter.Next()) 
+      {
+        const OpenGl_Structure *aStruct = aStructIter.Value();  
+       
+        // Exclude view frustum culled structs
+        if (aStruct->IsCulled() || !aStruct->IsVisible(aViewId) ||aStruct->IsForHighlight)
+          continue;
+        
+        aStruct->UpdateOcclusion(theWorkspace);
+      }
+    }
+  }
+
+  // Back to prev settings 
+  aCtx->core11fwd->glDepthMask(aPrevDepthMask);
+  aCtx->core11fwd->glColorMask(aPrevColorMask[0], aPrevColorMask[1], aPrevColorMask[2], aPrevColorMask[3]);
+
+  aTimer.Stop();
+  aStats->ActiveDataFrame()[Graphic3d_FrameStatsTimer_CpuCulling] = aTimer.UserTimeCPU();
+}
+
+//=================================================================================================
+
 void OpenGl_LayerList::renderTransparent(const Handle(OpenGl_Workspace)&   theWorkspace,
-                                         OpenGl_LayerStack::iterator&      theLayerIter,
-                                         const OpenGl_GlobalLayerSettings& theGlobalSettings,
-                                         OpenGl_FrameBuffer*               theReadDrawFbo,
-                                         OpenGl_FrameBuffer*               theOitAccumFbo) const
+                                          OpenGl_LayerStack::iterator&      theLayerIter,
+                                          const OpenGl_GlobalLayerSettings& theGlobalSettings,
+                                          OpenGl_FrameBuffer*               theReadDrawFbo,
+                                          OpenGl_FrameBuffer*               theOitAccumFbo) const
 {
   // Check if current iterator has already reached the end of the stack.
   // This should happen if no additional layers has been added to

--- a/src/OpenGl/OpenGl_LayerList.hxx
+++ b/src/OpenGl/OpenGl_LayerList.hxx
@@ -109,6 +109,9 @@ public:
                               OpenGl_FrameBuffer*             theReadDrawFbo,
                               OpenGl_FrameBuffer*             theOitAccumFbo) const;
 
+  //! Update occlusion test
+  Standard_EXPORT void UpdateOcclusion(const Handle(OpenGl_Workspace) & theWorkspace);
+
   //! Returns the set of OpenGL Z-layers.
   const NCollection_List<Handle(Graphic3d_Layer)>& Layers() const { return myLayers; }
 

--- a/src/OpenGl/OpenGl_OcclusionQuery.cxx
+++ b/src/OpenGl/OpenGl_OcclusionQuery.cxx
@@ -1,0 +1,110 @@
+// Created on: 2024-02-20
+// Created by: Hossam Ali
+// Copyright (c) 2024 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in
+// OCCT distribution for complete text of the license and disclaimer of any
+// warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <OpenGl_OcclusionQuery.hxx>
+
+#include <OpenGl_Context.hxx>
+#include <OpenGl_GlCore15.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(OpenGl_OcclusionQuery, OpenGl_Resource)
+
+// =======================================================================
+// function :
+// purpose  :
+// =======================================================================
+OpenGl_OcclusionQuery::OpenGl_OcclusionQuery(): myID(0), inUse(false), started(false)
+{
+}
+
+// =======================================================================
+// function :
+// purpose  :
+// =======================================================================
+OpenGl_OcclusionQuery::~OpenGl_OcclusionQuery() 
+{
+  Release(NULL);
+}
+// =======================================================================
+// function : Create()
+// purpose  :
+// =======================================================================
+void OpenGl_OcclusionQuery::Create(const Handle(OpenGl_Context) & theCtx,
+                                   GLenum theQueryType) {
+  theCtx->core15->glGenQueries(1, &myID);
+  myType = theQueryType;
+  inUse = false;
+  started = false;
+}
+// =======================================================================
+// function : Begin()
+// purpose  :
+// =======================================================================
+void OpenGl_OcclusionQuery::Begin(const Handle(OpenGl_Context) & theCtx) 
+{
+  inUse = true;
+  started = true;
+  theCtx->core15->glBeginQuery(myType, myID); 
+}
+ 
+// =======================================================================
+// function : End()
+// purpose  :
+// =======================================================================
+void OpenGl_OcclusionQuery::End(const Handle(OpenGl_Context) & theCtx) const
+{
+  theCtx->core15->glEndQuery(myType);
+}
+
+// =======================================================================
+// function : isResultsReady()
+// purpose  :
+// =======================================================================
+int OpenGl_OcclusionQuery::IsResultsReady(const Handle(OpenGl_Context) & theCtx) const
+{
+  // check if the query started before check for results
+  if(!started)
+    return false;
+
+  GLint aReady = 0;
+  theCtx->core15->glGetQueryObjectiv(myID, GL_QUERY_RESULT_AVAILABLE, &aReady);
+  return aReady;
+  }
+
+// =======================================================================
+// function : GetResults()
+// purpose  :
+// =======================================================================
+int OpenGl_OcclusionQuery::GetResults(const Handle(OpenGl_Context) & theCtx)
+{
+  inUse = false;
+  GLint aResult;
+  theCtx->core15->glGetQueryObjectiv(myID, GL_QUERY_RESULT, &aResult); 
+  return aResult;
+}
+
+// =======================================================================
+// function : Release()
+// purpose  : Destroy the query opengl resources 
+// =======================================================================
+void OpenGl_OcclusionQuery::Release(OpenGl_Context *theCtx) {
+  if (myID == 0)
+    return;
+  if (theCtx != NULL) {
+    theCtx->core15->glDeleteQueries(1, &myID);
+    myID = 0;
+    started = false;
+  }
+}

--- a/src/OpenGl/OpenGl_OcclusionQuery.hxx
+++ b/src/OpenGl/OpenGl_OcclusionQuery.hxx
@@ -1,0 +1,72 @@
+// Created on: 2024-02-20
+// Created by: Hossam Ali
+// Copyright (c) 2024 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in
+// OCCT distribution for complete text of the license and disclaimer of any
+// warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef OpenGl_OcclusionQuery_HeaderFile
+#define OpenGl_OcclusionQuery_HeaderFile
+
+#include <OpenGl_Resource.hxx>
+#include <OpenGl_GlCore15.hxx>
+
+class OpenGl_Context;
+
+DEFINE_STANDARD_HANDLE(OpenGl_OcclusionQuery, OpenGl_Resource)
+
+//! Implementation of OpenGl view.
+class OpenGl_OcclusionQuery : public OpenGl_Resource {
+public:
+  DEFINE_STANDARD_RTTIEXT(OpenGl_OcclusionQuery, OpenGl_Resource)
+
+  //! Constructor.
+  Standard_EXPORT OpenGl_OcclusionQuery();
+
+  //! Default destructor.
+  Standard_EXPORT virtual ~OpenGl_OcclusionQuery();
+  
+  //! Create the occlusion test Gl resources.
+  Standard_EXPORT virtual void Create(const Handle(OpenGl_Context)& theCtx, GLenum theType);
+
+  //! Begins occlusion query.
+  Standard_EXPORT virtual void Begin(const Handle(OpenGl_Context) & theCtx);
+
+  //! Ends occlusion query
+  Standard_EXPORT virtual void End(const Handle(OpenGl_Context) & theCtx) const;
+
+  //! Check if the query results ready for retrive or not.
+  Standard_EXPORT virtual int IsResultsReady(const Handle(OpenGl_Context) & theCtx) const;
+
+  //! Return the query results based on query type.
+  Standard_EXPORT virtual int GetResults(const Handle(OpenGl_Context) & theCtx);
+
+  //! Return is the query in use or not
+  Standard_EXPORT bool IsInUse() { return inUse; }
+
+  //! Return Query ID
+  Standard_EXPORT unsigned int GetID() const {return myID;}; 
+
+  //! Destroys query object.
+  Standard_EXPORT virtual void Release (OpenGl_Context * theCtx) Standard_OVERRIDE;
+
+  //! Returns estimated GPU memory usage - not implemented.
+  virtual Standard_Size EstimatedDataSize() const Standard_OVERRIDE { return 0; }
+
+private:
+  GLuint   myID;                     //!< OpenGL query ID.
+  GLenum   myType;                   //!< OpenGL query Type.
+  bool     inUse;                    //!< store bool answer is the query still inprogress or finished.
+  bool     started;                  //!< bool answer is the query stated before or this the first time.
+};
+
+#endif // _OpenGl_OcclusionQuery_Header

--- a/src/OpenGl/OpenGl_Structure.cxx
+++ b/src/OpenGl/OpenGl_Structure.cxx
@@ -108,7 +108,8 @@ OpenGl_Structure::OpenGl_Structure(const Handle(Graphic3d_StructureManager)& the
       myInstancedStructure(NULL),
       myIsRaytracable(Standard_False),
       myModificationState(0),
-      myIsMirrored(Standard_False)
+      myIsMirrored(Standard_False),
+      myQuery(new OpenGl_OcclusionQuery())
 {
   updateLayerTransformation();
 }
@@ -629,6 +630,41 @@ void OpenGl_Structure::Render(const Handle(OpenGl_Workspace)& theWorkspace) cons
 
 //=================================================================================================
 
+void OpenGl_Structure::RenderOccluder(const Handle(OpenGl_Workspace)& theWorkspace) const 
+{
+  const Handle(OpenGl_Context) &aCtx = theWorkspace->GetGlContext();
+  aCtx->ApplyModelViewMatrix();
+  renderBoundingBox(theWorkspace);
+}
+
+//=================================================================================================
+
+void OpenGl_Structure::UpdateOcclusion(const Handle(OpenGl_Workspace)& theWorkspace) const
+{
+  const Handle(OpenGl_Context) &aCtx = theWorkspace->GetGlContext();
+  if (myQuery->GetID()==0)
+      myQuery->Create(aCtx, GL_SAMPLES_PASSED);
+
+  if(myQuery->IsResultsReady(aCtx))
+  {
+    int aResult = myQuery->GetResults(aCtx);
+    const Standard_Integer aViewId = theWorkspace->View()->Identification();
+    if (aResult)
+      SetOcclusionSate(aViewId, Standard_False);
+    else
+      SetOcclusionSate(aViewId, Standard_True);
+  }
+
+  if(!myQuery->IsInUse())
+  {
+    myQuery->Begin(aCtx);
+    RenderOccluder(theWorkspace);
+    myQuery->End(aCtx);
+  }
+}
+
+//=================================================================================================
+
 void OpenGl_Structure::Release(const Handle(OpenGl_Context)& theGlCtx)
 {
   // Release groups
@@ -644,6 +680,8 @@ void OpenGl_Structure::ReleaseGlResources(const Handle(OpenGl_Context)& theGlCtx
   {
     aGroupIter.ChangeValue()->Release(theGlCtx);
   }
+
+  myQuery->Release(theGlCtx.get());
 }
 
 //=================================================================================================

--- a/src/OpenGl/OpenGl_Structure.hxx
+++ b/src/OpenGl/OpenGl_Structure.hxx
@@ -21,6 +21,7 @@
 #include <OpenGl_GraphicDriver.hxx>
 #include <OpenGl_Group.hxx>
 #include <OpenGl_Workspace.hxx>
+#include <OpenGl_OcclusionQuery.hxx>
 
 #include <NCollection_List.hxx>
 
@@ -98,6 +99,12 @@ public:
   //! Renders the structure.
   Standard_EXPORT virtual void Render(const Handle(OpenGl_Workspace)& theWorkspace) const;
 
+  //! Renders occluder presentation of the structure 
+  Standard_EXPORT void RenderOccluder(const Handle(OpenGl_Workspace)& theWorkspace) const;
+
+  //! Performs occlusion test for the structure
+  Standard_EXPORT void UpdateOcclusion(const Handle(OpenGl_Workspace)& theWorkspace) const;
+  
   //! Releases structure resources.
   Standard_EXPORT virtual void Release(const Handle(OpenGl_Context)& theGlCtx);
 
@@ -184,6 +191,8 @@ protected:
   mutable Standard_Size      myModificationState;
 
   Standard_Boolean           myIsMirrored; //!< Used to tell OpenGl to interpret polygons in clockwise order.
+
+  Handle(OpenGl_OcclusionQuery)      myQuery; //! test the occlusion status of the structure;
   // clang-format on
 };
 

--- a/src/OpenGl/OpenGl_View.cxx
+++ b/src/OpenGl/OpenGl_View.cxx
@@ -2501,6 +2501,10 @@ void OpenGl_View::render(Graphic3d_Camera::Projection theProjection,
   {
     myAccumFrames        = 0;
     myWorldViewProjState = aWVPState;
+
+    // Invalidiate occlusion test if camera has changed.
+    if (myRenderParams.OcclusionQueryState == Graphic3d_RenderingParams::OcclusionQuery_On)
+      myRenderParams.OcclusionQueryState = Graphic3d_RenderingParams::OcclusionQuery_NoUpdate;
   }
 
   myLocalOrigin.SetCoord(0.0, 0.0, 0.0);
@@ -2629,6 +2633,16 @@ void OpenGl_View::InvalidateBVHData(const Graphic3d_ZLayerId theLayerId)
 
 //=================================================================================================
 
+void OpenGl_View::UpdateOcclusion()
+{
+  myZLayers.UpdateOcclusion(myWorkspace);
+ 
+  // re-validate occlusion results  
+  myRenderParams.OcclusionQueryState = Graphic3d_RenderingParams::OcclusionQuery_On;
+}
+
+//=================================================================================================
+
 void OpenGl_View::renderStructs(Graphic3d_Camera::Projection theProjection,
                                 OpenGl_FrameBuffer*          theReadDrawFbo,
                                 OpenGl_FrameBuffer*          theOitAccumFbo,
@@ -2644,6 +2658,10 @@ void OpenGl_View::renderStructs(Graphic3d_Camera::Projection theProjection,
   {
     return;
   }
+
+  // Update occlusion here after update culling to ensure the frusrum culling updated
+  if (myRenderParams.OcclusionQueryState == Graphic3d_RenderingParams::OcclusionQuery_NoUpdate)
+    UpdateOcclusion();
 
   Handle(OpenGl_Context) aCtx       = myWorkspace->GetGlContext();
   Standard_Boolean       toRenderGL = theToDrawImmediate

--- a/src/OpenGl/OpenGl_View.hxx
+++ b/src/OpenGl/OpenGl_View.hxx
@@ -204,6 +204,9 @@ public:
   //! Returns additional buffers for depth peeling OIT.
   const Handle(OpenGl_DepthPeeling)& DepthPeelingFbos() const { return myDepthPeelingFbos; }
 
+  //! Perform occlusion test for the set of structures presented in the view  
+  Standard_EXPORT virtual void UpdateOcclusion()  Standard_OVERRIDE;
+
 public:
   //! Returns gradient background fill colors.
   Standard_EXPORT virtual Aspect_GradientBackground GradientBackground() const Standard_OVERRIDE;
@@ -437,7 +440,7 @@ protected: //! @name Rendering of GL graphics (with prepared drawing buffer).
                                              OpenGl_FrameBuffer*          theReadDrawFbo,
                                              OpenGl_FrameBuffer*          theOitAccumFbo,
                                              const Standard_Boolean       theToDrawImmediate);
-
+  
   //! Renders trihedron.
   void renderTrihedron(const Handle(OpenGl_Workspace)& theWorkspace);
 

--- a/src/PrsMgr/PrsMgr_PresentableObject.cxx
+++ b/src/PrsMgr/PrsMgr_PresentableObject.cxx
@@ -42,6 +42,7 @@ const gp_Trsf& PrsMgr_PresentableObject::getIdentityTrsf()
 PrsMgr_PresentableObject::PrsMgr_PresentableObject(const PrsMgr_TypeOfPresentation3d theType)
     : myParent(NULL),
       myViewAffinity(new Graphic3d_ViewAffinity()),
+      myViewOcclusionMask(new Graphic3d_ViewOcclusionMask()),
       myDrawer(new Prs3d_Drawer()),
       myTypeOfPresentation3d(theType),
       myDisplayStatus(PrsMgr_DisplayStatus_None),

--- a/src/PrsMgr/PrsMgr_PresentableObject.hxx
+++ b/src/PrsMgr/PrsMgr_PresentableObject.hxx
@@ -19,6 +19,7 @@
 
 #include <Aspect_TypeOfFacingModel.hxx>
 #include <gp_GTrsf.hxx>
+#include <Graphic3d_ViewOcclusionMask.hxx>
 #include <Graphic3d_ClipPlane.hxx>
 #include <Prs3d_Drawer.hxx>
 #include <PrsMgr_ListOfPresentableObjects.hxx>
@@ -76,6 +77,9 @@ public:
 
   //! Return view affinity mask.
   const Handle(Graphic3d_ViewAffinity)& ViewAffinity() const { return myViewAffinity; }
+  
+  //! Return view occlusion mask.
+  const Handle(Graphic3d_ViewOcclusionMask)& ViewOcclusionMask() const { return myViewOcclusionMask; }
 
   //! Returns true if the Interactive Object has display mode setting overriding global setting
   //! (within Interactive Context).
@@ -601,6 +605,7 @@ protected:
   PrsMgr_PresentableObject*              myParent;                  //!< pointer to the parent object
   PrsMgr_Presentations                   myPresentations;           //!< list of presentations
   Handle(Graphic3d_ViewAffinity)         myViewAffinity;            //!< view affinity mask
+  Handle(Graphic3d_ViewOcclusionMask)    myViewOcclusionMask;       //!< view occlusion mask
   Handle(Graphic3d_SequenceOfHClipPlane) myClipPlanes;              //!< sequence of object-specific clipping planes
   Handle(Prs3d_Drawer)                   myDrawer;                  //!< main presentation attributes
   Handle(Prs3d_Drawer)                   myHilightDrawer;           //!< (optional) custom presentation attributes for highlighting selected object

--- a/src/PrsMgr/PrsMgr_PresentationManager.cxx
+++ b/src/PrsMgr/PrsMgr_PresentationManager.cxx
@@ -381,6 +381,7 @@ void PrsMgr_PresentationManager::displayImmediate(const Handle(V3d_Viewer)& theV
       {
         aShadowPrs->CStructure()->ViewAffinity = new Graphic3d_ViewAffinity();
         aShadowPrs->CStructure()->ViewAffinity->SetVisible(Standard_False);
+        aShadowPrs->CStructure()->OcclusionMask = new Graphic3d_ViewOcclusionMask();
         aShadowPrs->Display();
       }
 
@@ -503,7 +504,11 @@ Handle(PrsMgr_Presentation) PrsMgr_PresentationManager::Presentation(
   thePrsObj->Presentations().Append(aPrs);
   thePrsObj->Fill(this, aPrs, theMode);
 
-  // set layer index accordingly to object's presentations
+  // Update object occlusion state by passing occlusion state handle to
+  // underlying graphic structures
+  aPrs->CStructure()->OcclusionMask = thePrsObj->ViewOcclusionMask();
+
+  // Set layer index accordingly to object's presentations
   aPrs->SetUpdateStatus(Standard_False);
   return aPrs;
 }

--- a/src/V3d/V3d_Trihedron.cxx
+++ b/src/V3d/V3d_Trihedron.cxx
@@ -238,6 +238,7 @@ void V3d_Trihedron::Display(const V3d_View& theView)
     myStructure->CStructure()->ViewAffinity = new Graphic3d_ViewAffinity();
     myStructure->CStructure()->ViewAffinity->SetVisible(Standard_False);
     myStructure->CStructure()->ViewAffinity->SetVisible(theView.View()->Identification(), true);
+    myStructure->CStructure()->OcclusionMask = new Graphic3d_ViewOcclusionMask();
     myToCompute = Standard_True;
   }
   if (myToCompute)

--- a/src/V3d/V3d_Viewer.cxx
+++ b/src/V3d/V3d_Viewer.cxx
@@ -799,6 +799,7 @@ void V3d_Viewer::ShowGridEcho(const Handle(V3d_View)& theView, const Graphic3d_V
   myGridEchoStructure->CStructure()->ViewAffinity->SetVisible(Standard_False);
   myGridEchoStructure->CStructure()->ViewAffinity->SetVisible(theView->View()->Identification(),
                                                               true);
+  myGridEchoStructure->CStructure()->OcclusionMask = new Graphic3d_ViewOcclusionMask();
   myGridEchoStructure->Display();
 }
 

--- a/src/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -13639,13 +13639,75 @@ static int VChangeMouseGesture(Draw_Interpretor&,
 
 //=================================================================================================
 
+static Standard_Integer VNbOccluded(Draw_Interpretor & theDi,
+                                  Standard_Integer theArgNb,
+                                  const char **theArgVec) {
+  NCollection_List<TCollection_AsciiString> aViewList;
+  if (theArgNb > 1)
+  {
+    TCollection_AsciiString anArg (theArgVec[1]);
+    anArg.UpperCase();
+    if (anArg.IsEqual ("ALL")
+     || anArg.IsEqual ("*"))
+    {
+      for (ViewerTest_ViewerCommandsViewMap::Iterator anIter (ViewerTest_myViews);
+           anIter.More(); anIter.Next())
+      {
+        aViewList.Append (anIter.Key1());
+      }
+      if (aViewList.IsEmpty())
+      {
+        std::cout << "No views available\n";
+        return 0;
+      }
+    }
+    else
+    {
+      ViewerTest_Names aViewName (theArgVec[1]);
+      if (!ViewerTest_myViews.IsBound1 (aViewName.GetViewName()))
+      {
+        Message::SendFail() << "Error: the view with name '" << theArgVec[1] << "' does not exist";
+        return 1;
+      }
+      aViewList.Append (aViewName.GetViewName());
+    }
+  }
+  else
+  {
+    // query from the active view
+    if (ViewerTest::CurrentView().IsNull())
+    {
+      Message::SendFail ("Error: no active view");
+      return 1;
+    }
+    aViewList.Append (ViewerTest_myViews.Find2 (ViewerTest::CurrentView()));
+  }
+
+  for (NCollection_List<TCollection_AsciiString>::Iterator anIter(aViewList);
+       anIter.More(); anIter.Next()) {
+    Handle(V3d_View) aView = ViewerTest_myViews.Find1(anIter.Value());
+    aView->ChangeRenderingParams().OcclusionQueryState = Graphic3d_RenderingParams::OcclusionQuery_NoUpdate;
+    aView->Redraw();
+    aView->Redraw();
+    aView->View()->UpdateOcclusion();
+    Graphic3d_MapOfStructure aOcculdedStructs;
+    aView->View()->OccludedStructures(aOcculdedStructs);
+
+    theDi << aOcculdedStructs.Extent() << "\n";
+  }
+
+  return 0;
+}
+
+//=================================================================================================
+
 static void ViewerTest_ExitProc(ClientData)
 {
   NCollection_List<TCollection_AsciiString> aViewList;
   for (NCollection_DoubleMap<TCollection_AsciiString, Handle(V3d_View)>::Iterator anIter(
-         ViewerTest_myViews);
-       anIter.More();
-       anIter.Next())
+        ViewerTest_myViews);
+      anIter.More();
+      anIter.Next())
   {
     aViewList.Append(anIter.Key1());
   }
@@ -14668,4 +14730,9 @@ Changes the gesture for the mouse button.
  -button  the mouse button;
  -gesture the new gesture for the button.
 )" /* [vchangemousegesture] */);
+
+  addCmd("vnboccluded", VNbOccluded, /* [vnboccluded] */ R"(
+vnboccluded  ALL - print nb of occluded objects for all created views
+vnboccluded [view_id] print nb of occluded objects for specified view_id  . 
+)" /* [vnboccluded] */);
 }

--- a/tests/v3d/occlusion/boxes
+++ b/tests/v3d/occlusion/boxes
@@ -1,0 +1,33 @@
+puts "=============================================================================================="
+puts "CR33607: Visualization - Test occlusion query on two boxes using two orthographic projections"
+puts "=============================================================================================="
+
+pload MODELING VISUALIZATION
+vclear
+vclose ALL
+
+box b 10 10 10
+box c 12 0 0 10 10 10
+
+# check normal right view angle 
+vinit name=View1
+vsetdispmode 1
+vdisplay c b
+vright
+vfit
+vzoom 0.5
+
+#run occlusion query test for each view 
+if {[vnboccluded View1] != "1"} {
+    puts "ERROR: occluded objects in view 1 expected to be 1"
+  }
+
+# check front view angle
+vclear
+vdisplay c b
+vfront
+vfit
+
+if {[vnboccluded View1] != "0"} {
+    puts "ERROR: occluded objects in view 2 expected to be 0"
+  }


### PR DESCRIPTION
Hardware occlusion queries provide a mechanism to determine whether any pixels would be drawn. For instance, it can be used as a visibility filter any pixels would be drawn. for instance, it can be used as a visibility filter

Graphic3d_ViewOcclusionMask : Provides a way to access occlusion test results for every graphical presentation per each defined view of the viewer

OpenGl_OcclusionQuery: Provides an OpenGL implementation for occlusion queries

Graphic3d_RenderingParams:  provides way to enable or disable occlusion query

AIS_InteractiveContext : resets the view occlusion mask for newly loaded objects

Each view invalidates its occlusion query results if the camera has changed.

vnboccluded: Adds a new DRAW command to return the number of occluded objects in the view