### PR TITLE
Foundation Classes - Host resolving by itself

### DIFF
--- a/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx
@@ -140,7 +140,12 @@ TCollection_AsciiString OSD_Host::InternetAddress()
   TCollection_AsciiString result, host;
 
   host = HostName();
-  memcpy(&internet_address, gethostbyname(host.ToCString()), sizeof(struct hostent));
+  const auto* aHostByName = gethostbyname(host.ToCString());
+  if (aHostByName == nullptr)
+  {
+    aHostByName = gethostbyname("localhost");
+  }
+  memcpy(&internet_address, aHostByName, sizeof(struct hostent));
 
   // Gets each bytes into integers
   a = (unsigned char)internet_address.h_addr_list[0][0];

--- a/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx
@@ -139,7 +139,7 @@ TCollection_AsciiString OSD_Host::InternetAddress()
   char                    buffer[16];
   TCollection_AsciiString result, host;
 
-  host = HostName();
+  host                    = HostName();
   const auto* aHostByName = gethostbyname(host.ToCString());
   if (aHostByName == nullptr)
   {


### PR DESCRIPTION
Fixed issue  when gethostbyname returns a nullptr, because the host can't resolve itself