### PR TITLE
Configuration - Re-Configuration time optimization

### DIFF
--- a/adm/cmake/doxygen.cmake
+++ b/adm/cmake/doxygen.cmake
@@ -56,7 +56,7 @@ else()
   endif()
 endif()
 
-# unset all redundant variables
-OCCT_CHECK_AND_UNSET (DOXYGEN_SKIP_DOT)
-OCCT_CHECK_AND_UNSET (DOXYGEN_EXECUTABLE)
-OCCT_CHECK_AND_UNSET (DOXYGEN_DOT_EXECUTABLE)
+# hide all redundant variables
+mark_as_advanced (DOXYGEN_SKIP_DOT)
+mark_as_advanced (DOXYGEN_EXECUTABLE)
+mark_as_advanced (DOXYGEN_DOT_EXECUTABLE)

--- a/adm/cmake/eigen.cmake
+++ b/adm/cmake/eigen.cmake
@@ -83,5 +83,5 @@ else()
   set (3RDPARTY_EIGEN_INCLUDE_DIR "" CACHE PATH "the path to Eigen header file" FORCE)
 endif()
 
-# unset all redundant variables
-OCCT_CHECK_AND_UNSET(Eigen3_DIR)
+# hide all redundant variables
+mark_as_advanced(Eigen3_DIR)

--- a/adm/cmake/ffmpeg.cmake
+++ b/adm/cmake/ffmpeg.cmake
@@ -247,7 +247,7 @@ foreach (LIBRARY_NAME ${CSF_FFmpeg})
   mark_as_advanced (3RDPARTY_FFMPEG_LIBRARY_${LIBRARY_NAME} 3RDPARTY_FFMPEG_DLL_${LIBRARY_NAME})
 endforeach()
 
-# unset all redundant variables
-OCCT_CHECK_AND_UNSET (FFMPEG_INCLUDE_DIRS)
-OCCT_CHECK_AND_UNSET (FFMPEG_LIBRARY_DIRS)
-OCCT_CHECK_AND_UNSET (FFMPEG_DIR)
+# hide all redundant variables
+mark_as_advanced (FFMPEG_INCLUDE_DIRS)
+mark_as_advanced (FFMPEG_LIBRARY_DIRS)
+mark_as_advanced (FFMPEG_DIR)

--- a/adm/cmake/freetype.cmake
+++ b/adm/cmake/freetype.cmake
@@ -389,10 +389,10 @@ endif()
   endif()
 #endif()
 
-# unset all redundant variables
-OCCT_CHECK_AND_UNSET(FREETYPE_INCLUDE_DIR_ft2build)
-OCCT_CHECK_AND_UNSET(FREETYPE_INCLUDE_DIR_freetype2)
-OCCT_CHECK_AND_UNSET(FREETYPE_LIBRARY_RELEASE)
+# hide all redundant variables
+mark_as_advanced(FREETYPE_INCLUDE_DIR_ft2build)
+mark_as_advanced(FREETYPE_INCLUDE_DIR_freetype2)
+mark_as_advanced(FREETYPE_LIBRARY_RELEASE)
 
 if (BUILD_SHARED_LIBS)
   mark_as_advanced (3RDPARTY_FREETYPE_LIBRARY 3RDPARTY_FREETYPE_DLL)

--- a/adm/cmake/rapidjson.cmake
+++ b/adm/cmake/rapidjson.cmake
@@ -90,5 +90,5 @@ else()
   set (3RDPARTY_RAPIDJSON_INCLUDE_DIR "" CACHE PATH "the path to RapidJSON header file" FORCE)
 endif()
 
-# unset all redundant variables
-OCCT_CHECK_AND_UNSET(RapidJSON_DIR)
+# hide all redundant variables
+mark_as_advanced(RapidJSON_DIR)

--- a/adm/cmake/tcl.cmake
+++ b/adm/cmake/tcl.cmake
@@ -273,13 +273,12 @@ if (TK_FOUND AND 3RDPARTY_TCL_DIR)
   endif()
 endif()
 
-# unset all redundant variables
-#TCL
-OCCT_CHECK_AND_UNSET (TCL_LIBRARY)
-OCCT_CHECK_AND_UNSET (TCL_INCLUDE_PATH)
-OCCT_CHECK_AND_UNSET (TCL_TCLSH)
+# hide all redundant variables
+# TCL
+mark_as_advanced (TCL_LIBRARY)
+mark_as_advanced (TCL_INCLUDE_PATH)
+mark_as_advanced (TCL_TCLSH)
 #TK
-OCCT_CHECK_AND_UNSET (TK_LIBRARY)
-OCCT_CHECK_AND_UNSET (TK_INCLUDE_PATH)
-OCCT_CHECK_AND_UNSET (TK_WISH)
-
+mark_as_advanced (TK_LIBRARY)
+mark_as_advanced (TK_INCLUDE_PATH)
+mark_as_advanced (TK_WISH)

--- a/adm/cmake/tk.cmake
+++ b/adm/cmake/tk.cmake
@@ -274,15 +274,15 @@ if (BUILD_SHARED_LIBS)
   mark_as_advanced (3RDPARTY_TK_LIBRARY 3RDPARTY_TK_DLL)
 endif()
 
-# unset all redundant variables
-#TCL
-OCCT_CHECK_AND_UNSET (TCL_LIBRARY)
-OCCT_CHECK_AND_UNSET (TCL_INCLUDE_PATH)
-OCCT_CHECK_AND_UNSET (TCL_TCLSH)
+# hide all redundant variables
+
+mark_as_advanced (TCL_LIBRARY)
+mark_as_advanced (TCL_INCLUDE_PATH)
+mark_as_advanced (TCL_TCLSH)
 #TK
-OCCT_CHECK_AND_UNSET (TK_LIBRARY)
-OCCT_CHECK_AND_UNSET (TK_INCLUDE_PATH)
-OCCT_CHECK_AND_UNSET (TK_WISH)
+mark_as_advanced (TK_LIBRARY)
+mark_as_advanced (TK_INCLUDE_PATH)
+mark_as_advanced (TK_WISH)
 
 if (NOT BUILD_SHARED_LIBS)
   OCCT_CHECK_AND_UNSET (3RDPARTY_TK_LIBRARY)

--- a/adm/cmake/vtk.cmake
+++ b/adm/cmake/vtk.cmake
@@ -341,6 +341,7 @@ if (NOT INSTALL_VTK)
   endif()
 endif()
 
-OCCT_CHECK_AND_UNSET (VTK_INCLUDE_DIRS)
-OCCT_CHECK_AND_UNSET (VTK_LIBRARY_DIRS)
-OCCT_CHECK_AND_UNSET (VTK_DIR)
+# hide some variables
+mark_as_advanced (VTK_INCLUDE_DIRS)
+mark_as_advanced (VTK_LIBRARY_DIRS)
+mark_as_advanced (VTK_DIR)


### PR DESCRIPTION
Refactor CMake files to hide redundant variables using mark_as_advanced.
The result - no re-find will be performed.
From 30s to 5s for second time reconfiguration stage.