### PR TITLE
Modeling - Bounding BSpline periodic tolerance issue

### DIFF
--- a/src/FoundationClasses/TKMath/ElCLib/ElCLib.cxx
+++ b/src/FoundationClasses/TKMath/ElCLib/ElCLib.cxx
@@ -109,12 +109,17 @@ void ElCLib::AdjustPeriodic(const Standard_Real UFirst,
     return;
   }
 
-  U1 -= Floor((U1 - UFirst) / period) * period;
-  if (ULast - U1 < Preci)
-    U1 -= period;
-  U2 -= Floor((U2 - U1) / period) * period;
-  if (U2 - U1 < Preci)
-    U2 += period;
+  // Adjust U1 to be in [UFirst, ULast]
+  U1 = UFirst + fmod(U1 - UFirst, period);
+  if (U1 < UFirst) U1 += period;
+
+  // Handle the case where U1 is very close to ULast
+  if (ULast - U1 <= Preci)
+    U1 = UFirst;  // or other appropriate handling
+    
+  // Adjust U2 to be in [U1, U1 + period]
+  U2 = U1 + fmod(U2 - U1, period);
+  if (U2 < U1) U2 += period;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKGeomBase/BndLib/BndLib_Add3dCurve.cxx
+++ b/src/ModelingData/TKGeomBase/BndLib/BndLib_Add3dCurve.cxx
@@ -197,11 +197,12 @@ void BndLib_Add3dCurve::Add(const Adaptor3d_Curve& C,
         Handle(Geom_Geometry)     G = Bs->Copy();
         Handle(Geom_BSplineCurve) Bsaux(Handle(Geom_BSplineCurve)::DownCast(G));
         Standard_Real             u1 = U1, u2 = U2;
+        Standard_Real aSegmentTol = 2. * Precision::PConfusion();
         //// modified by jgv, 24.10.01 for BUC61031 ////
         if (Bsaux->IsPeriodic())
           ElCLib::AdjustPeriodic(Bsaux->FirstParameter(),
                                  Bsaux->LastParameter(),
-                                 Precision::PConfusion(),
+                                 aSegmentTol,
                                  u1,
                                  u2);
         else
@@ -215,7 +216,6 @@ void BndLib_Add3dCurve::Add(const Adaptor3d_Curve& C,
             u2 = Bsaux->LastParameter();
           //  modified by NIZHNY-EAP Fri Dec  3 14:29:18 1999 ___END___
         }
-        Standard_Real aSegmentTol = 2. * Precision::PConfusion();
         if (Abs(u2 - u1) < aSegmentTol)
           aSegmentTol = Abs(u2 - u1) * 0.01;
         Bsaux->Segment(u1, u2, aSegmentTol);

--- a/tests/bugs/modalg_8/bug_gh466
+++ b/tests/bugs/modalg_8/bug_gh466
@@ -1,0 +1,10 @@
+puts "========================================================================="
+puts "GH466: BRepBndLib::AddClose crashes"
+puts "========================================================================="
+puts ""
+
+pload QAcommands
+
+restore [locate_data_file bug_gh466.brep] result
+
+OCC566 result


### PR DESCRIPTION
Refactor ElCLib::AdjustPeriodic to improve handling of periodic adjustments and segment tolerance in BndLib_Add3dCurve
Previously the calculation was not synchronize between segmenting and adjusting.