### PR TITLE
Data Exchange  - Add kinematic support to XCAF document structure

### DIFF
--- a/src/DataExchange/TKXCAF/PACKAGES.cmake
+++ b/src/DataExchange/TKXCAF/PACKAGES.cmake
@@ -4,6 +4,7 @@ set(OCCT_TKXCAF_LIST_OF_PACKAGES
   XCAFDimTolObjects
   XCAFNoteObjects
   XCAFDoc
+  XCAFKinObjects
   XCAFPrs
   XCAFView
 )

--- a/src/DataExchange/TKXCAF/XCAFDoc/FILES.cmake
+++ b/src/DataExchange/TKXCAF/XCAFDoc/FILES.cmake
@@ -46,6 +46,8 @@ set(OCCT_XCAFDoc_FILES
   XCAFDoc_GraphNode.cxx
   XCAFDoc_GraphNode.hxx
   XCAFDoc_GraphNodeSequence.hxx
+  XCAFDoc_KinematicTool.cxx
+  XCAFDoc_KinematicTool.hxx
   XCAFDoc_LayerTool.cxx
   XCAFDoc_LayerTool.hxx
   XCAFDoc_LengthUnit.cxx

--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc.cxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc.cxx
@@ -248,6 +248,38 @@ const Standard_GUID& XCAFDoc::LockGUID()
 
 //=================================================================================================
 
+const Standard_GUID& XCAFDoc::KinematicRefShapeGUID()
+{
+  static const Standard_GUID ID("CD65A782-448C-4935-8499-2210D970C175");
+  return ID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFDoc::KinematicRefLink1GUID()
+{
+  static const Standard_GUID ID("35FF1462-E684-465F-B0B9-5CAD14B5018F");
+  return ID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFDoc::KinematicRefLink2GUID()
+{
+  static const Standard_GUID ID("6AA96F91-7436-46F9-A955-4B3CCC42592B");
+  return ID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFDoc::KinematicRefJointGUID()
+{
+  static const Standard_GUID ID("596B048C-A965-4514-A059-464560BFAE4E");
+  return ID;
+}
+
+//=================================================================================================
+
 TCollection_AsciiString XCAFDoc::AttributeInfo(const Handle(TDF_Attribute)& theAtt)
 {
   TCollection_AsciiString anInfo;

--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc.hxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc.hxx
@@ -108,6 +108,18 @@ public:
   Standard_EXPORT static const Standard_GUID& ViewRefNoteGUID();
   Standard_EXPORT static const Standard_GUID& ViewRefAnnotationGUID();
 
+  //! Return GUIDs for GraphNode representing specified types of Kinematics
+  Standard_EXPORT static const Standard_GUID& KinematicRefShapeGUID();
+
+  //! Return GUIDs for TreeNode representing specified types of Kinematics
+  Standard_EXPORT static const Standard_GUID& KinematicRefLink1GUID();
+
+  //! Return GUIDs for TreeNode representing specified types of Kinematics
+  Standard_EXPORT static const Standard_GUID& KinematicRefLink2GUID();
+
+  //! Return GUIDs for TreeNode representing specified types of Kinematics
+  Standard_EXPORT static const Standard_GUID& KinematicRefJointGUID();
+
   //! Returns GUID for UAttribute identifying lock flag
   Standard_EXPORT static const Standard_GUID& LockGUID();
 

--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_KinematicTool.cxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_KinematicTool.cxx
@@ -1,0 +1,746 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFDoc_KinematicTool.hxx>
+
+#include <XCAFDoc.hxx>
+#include <XCAFKinObjects_KinematicPair.hxx>
+#include <XCAFKinObjects_KinematicPairValue.hxx>
+#include <Standard_GUID.hxx>
+#include <Standard_Type.hxx>
+#include <TDataStd_Name.hxx>
+#include <TDataStd_TreeNode.hxx>
+#include <TDataStd_UAttribute.hxx>
+#include <TDF_Attribute.hxx>
+#include <TDF_ChildIDIterator.hxx>
+#include <TDF_Label.hxx>
+#include <TDataStd_Integer.hxx>
+#include <XCAFDoc.hxx>
+#include <XCAFDoc_DocumentTool.hxx>
+#include <XCAFDoc_GraphNode.hxx>
+#include <XCAFDoc_ShapeTool.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFDoc_KinematicTool, TDF_Attribute)
+
+//=================================================================================================
+
+XCAFDoc_KinematicTool::XCAFDoc_KinematicTool() {}
+
+//=================================================================================================
+
+Handle(XCAFDoc_KinematicTool) XCAFDoc_KinematicTool::Set(const TDF_Label& theLabel)
+{
+  Handle(XCAFDoc_KinematicTool) anAttr;
+  if (!theLabel.FindAttribute(XCAFDoc_KinematicTool::GetID(), anAttr))
+  {
+    anAttr = new XCAFDoc_KinematicTool();
+    theLabel.AddAttribute(anAttr);
+  }
+  return anAttr;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFDoc_KinematicTool::GetID()
+{
+  static Standard_GUID KinematicToolID("322D8F8D-8E93-4F6A-A98B-CCC2EBBCC34D");
+  return KinematicToolID;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::BaseLabel() const
+{
+  return Label();
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddMechanism()
+{
+  TDF_TagSource           aTag;
+  TDF_Label               aMechanismL = aTag.NewChild(Label());
+  TCollection_AsciiString aName       = "Mechanism ";
+  aName.AssignCat(TCollection_AsciiString(Label().NbChildren()));
+  TDataStd_Name::Set(aMechanismL, aName);
+  TDF_Label aRootOfLinks = aMechanismL.FindChild(1);
+  TDataStd_Name::Set(aRootOfLinks, "Links");
+  TDF_Label aRootOfJoints = aMechanismL.FindChild(2);
+  TDataStd_Name::Set(aRootOfJoints, "Joints");
+  return aMechanismL;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::IsMechanism(const TDF_Label& theLabel) const
+{
+  if (!Label().IsEqual(theLabel.Father()))
+    return Standard_False;
+
+  return (theLabel.NbChildren() == 2 || theLabel.NbChildren() == 3);
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::RemoveMechanism(const TDF_Label& theLabel)
+{
+  if (!IsMechanism(theLabel))
+    return;
+
+  for (TDF_ChildIterator aLinkIt(getRootOfLinks(theLabel)); aLinkIt.More(); aLinkIt.Next())
+  {
+    RemoveLink(aLinkIt.Value());
+  }
+  for (TDF_ChildIterator aJointIt(getRootOfJoints(theLabel)); aJointIt.More(); aJointIt.Next())
+  {
+    RemoveJoint(aJointIt.Value());
+  }
+  if (!getRootOfStates(theLabel).IsNull())
+  {
+    for (TDF_ChildIterator aStateIt(getRootOfStates(theLabel)); aStateIt.More(); aStateIt.Next())
+    {
+      RemoveState(aStateIt.Value());
+    }
+  }
+
+  theLabel.ForgetAllAttributes();
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddLink(const TDF_Label&       theMechanism,
+                                         const Standard_Boolean isBase)
+{
+  if (!IsMechanism(theMechanism))
+    return TDF_Label();
+  TDF_TagSource aTag;
+  TDF_Label     aLink = aTag.NewChild(getRootOfLinks(theMechanism));
+  if (isBase)
+  {
+    SetBaseLink(aLink);
+  }
+  else
+  {
+    TCollection_AsciiString aName = "Link ";
+    aName.AssignCat(TCollection_AsciiString(aLink.Tag()));
+    TDataStd_Name::Set(aLink, aName);
+  }
+  return aLink;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddLink(const TDF_Label&         theMechanism,
+                                         const TDF_LabelSequence& theShapes,
+                                         const Standard_Boolean   isBase)
+{
+  TDF_Label aNewLink = AddLink(theMechanism, isBase);
+  if (aNewLink.IsNull() || theShapes.Length() == 0)
+    return aNewLink;
+
+  SetLink(aNewLink, theShapes);
+  return aNewLink;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddLink(const TDF_Label&       theMechanism,
+                                         const TDF_Label&       theShape,
+                                         const Standard_Boolean isBase)
+{
+  TDF_LabelSequence anAuxSequence;
+  anAuxSequence.Append(theShape);
+  return AddLink(theMechanism, anAuxSequence, isBase);
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::SetLink(const TDF_Label&         theLink,
+                                                const TDF_LabelSequence& theShapes)
+{
+  if (theShapes.Length() == 0)
+    return Standard_False;
+
+  Handle(XCAFDoc_GraphNode) aLinkGNode;
+  Handle(XCAFDoc_GraphNode) aShapesGNode;
+
+  // Clear link from old references to shapes
+  if (theLink.FindAttribute(XCAFDoc::KinematicRefShapeGUID(), aLinkGNode))
+  {
+    while (aLinkGNode->NbFathers() > 0)
+    {
+      aShapesGNode = aLinkGNode->GetFather(1);
+      aShapesGNode->UnSetChild(aLinkGNode);
+      if (aShapesGNode->NbChildren() == 0)
+      {
+        aShapesGNode->ForgetAttribute(XCAFDoc::KinematicRefShapeGUID());
+      }
+    }
+    theLink.ForgetAttribute(XCAFDoc::KinematicRefShapeGUID());
+  }
+
+  // Create new references
+  aLinkGNode = new XCAFDoc_GraphNode;
+  aLinkGNode = XCAFDoc_GraphNode::Set(theLink);
+  aLinkGNode->SetGraphID(XCAFDoc::KinematicRefShapeGUID());
+
+  for (Standard_Integer i = theShapes.Lower(); i <= theShapes.Upper(); i++)
+  {
+    if (!theShapes.Value(i).FindAttribute(XCAFDoc::KinematicRefShapeGUID(), aShapesGNode))
+    {
+      aShapesGNode = new XCAFDoc_GraphNode;
+      aShapesGNode = XCAFDoc_GraphNode::Set(theShapes.Value(i));
+      aShapesGNode->SetGraphID(XCAFDoc::KinematicRefShapeGUID());
+    }
+    aShapesGNode->SetChild(aLinkGNode);
+    aLinkGNode->SetFather(aShapesGNode);
+  }
+
+  return Standard_True;
+}
+
+//=================================================================================================
+
+Standard_EXPORT Standard_Boolean XCAFDoc_KinematicTool::SetBaseLink(const TDF_Label& theLink)
+{
+  TDF_Label aMechanism = theLink.Father().Father();
+  if (!IsMechanism(aMechanism))
+    return Standard_False;
+  TDF_LabelSequence aLinks = GetLinks(aMechanism);
+  for (TDF_LabelSequence::Iterator anIt(aLinks); anIt.More(); anIt.Next())
+  {
+    Handle(TDataStd_Integer) aBase;
+    if (anIt.Value().FindAttribute(TDataStd_Integer::GetID(), aBase))
+    {
+      anIt.Value().ForgetAttribute(aBase);
+      Handle(TDataStd_Name) aLinkName;
+      if (anIt.Value().FindAttribute(TDataStd_Name::GetID(), aLinkName)
+          && !aLinkName->Get().IsDifferent("Base"))
+      {
+        TCollection_AsciiString aName = "Link ";
+        aName.AssignCat(TCollection_AsciiString(anIt.Value().Tag()));
+        TDataStd_Name::Set(anIt.Value(), aName);
+      }
+    }
+  }
+  Handle(TDataStd_Name) aLinkName;
+  if (!theLink.FindAttribute(TDataStd_Name::GetID(), aLinkName)
+      || (!aLinkName.IsNull()
+          && !aLinkName->Get().IsDifferent(TCollection_AsciiString("Link ") + theLink.Tag())))
+  {
+    TDataStd_Name::Set(theLink, "Base");
+  }
+  TDataStd_Integer::Set(theLink, 1);
+
+  return Standard_True;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::SetLink(const TDF_Label& theLink, const TDF_Label& theShape)
+{
+  TDF_LabelSequence anAuxSequence;
+  anAuxSequence.Append(theShape);
+  return SetLink(theLink, anAuxSequence);
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::IsLink(const TDF_Label& theLink) const
+{
+  Handle(XCAFDoc_GraphNode) aLinkGNode;
+  return theLink.FindAttribute(XCAFDoc::KinematicRefShapeGUID(), aLinkGNode);
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::RemoveLink(const TDF_Label& theLink)
+{
+  if (!IsLink(theLink))
+    return;
+
+  Handle(XCAFDoc_GraphNode) aLinkGNode;
+  Handle(XCAFDoc_GraphNode) aShapesGNode;
+
+  // Remove all referenced joints
+  TDF_LabelSequence aRefJoints = GetJointsOfLink(theLink);
+  for (TDF_LabelSequence::Iterator anIt(aRefJoints); anIt.More(); anIt.Next())
+  {
+    RemoveJoint(anIt.Value());
+  }
+
+  // Clear link from old references to shapes
+  if (theLink.FindAttribute(XCAFDoc::KinematicRefShapeGUID(), aLinkGNode))
+  {
+    while (aLinkGNode->NbFathers() > 0)
+    {
+      aShapesGNode = aLinkGNode->GetFather(1);
+      aShapesGNode->UnSetChild(aLinkGNode);
+      if (aShapesGNode->NbChildren() == 0)
+      {
+        aShapesGNode->ForgetAttribute(XCAFDoc::KinematicRefShapeGUID());
+      }
+    }
+  }
+  theLink.ForgetAllAttributes();
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddJoint(const TDF_Label& theMechanism)
+{
+  if (!IsMechanism(theMechanism))
+    return TDF_Label();
+
+  TDF_TagSource                        aTag;
+  TDF_Label                            aJoint = aTag.NewChild(getRootOfJoints(theMechanism));
+  Handle(XCAFKinObjects_KinematicPair) aPair  = XCAFKinObjects_KinematicPair::Set(aJoint);
+  TCollection_AsciiString              aName  = "Joint ";
+  aName.AssignCat(TCollection_AsciiString(aJoint.Tag()));
+  TDataStd_Name::Set(aJoint, aName);
+  return aJoint;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddJoint(const TDF_Label& theMechanism,
+                                          const TDF_Label& theLink1,
+                                          const TDF_Label& theLink2)
+{
+  TDF_Label aNewJoint = AddJoint(theMechanism);
+  if (aNewJoint.IsNull())
+    return TDF_Label();
+
+  SetJoint(aNewJoint, theLink1, theLink2);
+  return aNewJoint;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::IsJoint(const TDF_Label& theJoint) const
+{
+  Handle(TDataStd_TreeNode) anAuxAttr;
+  return (theJoint.FindAttribute(XCAFDoc::KinematicRefLink1GUID(), anAuxAttr)
+          && theJoint.FindAttribute(XCAFDoc::KinematicRefLink2GUID(), anAuxAttr));
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::SetJoint(const TDF_Label& theJoint,
+                                                 const TDF_Label& theLink1,
+                                                 const TDF_Label& theLink2)
+{
+  if (!IsLink(theLink1) || !IsLink(theLink2))
+    return Standard_False;
+
+  Handle(TDataStd_TreeNode) aJointNode, aLinkNode;
+  // Add reference to first link
+  aJointNode = TDataStd_TreeNode::Set(theJoint, XCAFDoc::KinematicRefLink1GUID());
+  aLinkNode  = TDataStd_TreeNode::Set(theLink1, XCAFDoc::KinematicRefLink1GUID());
+  aJointNode->Remove(); // fix against bug in TreeNode::Append()
+  aLinkNode->Append(aJointNode);
+
+  // Add reference to second link
+  aJointNode = TDataStd_TreeNode::Set(theJoint, XCAFDoc::KinematicRefLink2GUID());
+  aLinkNode  = TDataStd_TreeNode::Set(theLink2, XCAFDoc::KinematicRefLink2GUID());
+  aJointNode->Remove(); // fix against bug in TreeNode::Append()
+  aLinkNode->Append(aJointNode);
+
+  return Standard_True;
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::RemoveJoint(const TDF_Label& theJoint)
+{
+  if (!IsJoint(theJoint))
+    return;
+
+  Handle(TDataStd_TreeNode) aNode;
+  theJoint.FindAttribute(XCAFDoc::KinematicRefLink1GUID(), aNode);
+  aNode->Remove();
+  theJoint.FindAttribute(XCAFDoc::KinematicRefLink2GUID(), aNode);
+  aNode->Remove();
+
+  theJoint.ForgetAllAttributes();
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetMechanisms() const
+{
+  TDF_LabelSequence aMechArray;
+  for (TDF_ChildIterator anIt(Label()); anIt.More(); anIt.Next())
+  {
+    TDF_Label aMechanism = anIt.Value();
+    if (IsMechanism(aMechanism))
+    {
+      aMechArray.Append(aMechanism);
+    }
+  }
+
+  return aMechArray;
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetLinks(const TDF_Label& theMechanism) const
+{
+  TDF_LabelSequence aLinkArray;
+  if (!IsMechanism(theMechanism))
+    return aLinkArray;
+
+  for (TDF_ChildIterator anIt(getRootOfLinks(theMechanism)); anIt.More(); anIt.Next())
+  {
+    TDF_Label aLink = anIt.Value();
+    if (IsLink(aLink))
+    {
+      aLinkArray.Append(aLink);
+    }
+  }
+
+  return aLinkArray;
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetJoints(const TDF_Label& theMechanism) const
+{
+  TDF_LabelSequence aJointArray;
+  if (!IsMechanism(theMechanism))
+    return aJointArray;
+
+  for (TDF_ChildIterator anIt(getRootOfJoints(theMechanism)); anIt.More(); anIt.Next())
+  {
+    TDF_Label aJoint = anIt.Value();
+    if (IsJoint(aJoint))
+    {
+      aJointArray.Append(aJoint);
+    }
+  }
+
+  return aJointArray;
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::GetLinksOfJoint(const TDF_Label& theJoint,
+                                            TDF_Label&       theLink1,
+                                            TDF_Label&       theLink2) const
+{
+  if (!IsJoint(theJoint))
+    return;
+
+  Handle(TDataStd_TreeNode) aNode;
+
+  if (theJoint.FindAttribute(XCAFDoc::KinematicRefLink1GUID(), aNode))
+    theLink1 = aNode->Father()->Label();
+
+  if (theJoint.FindAttribute(XCAFDoc::KinematicRefLink2GUID(), aNode))
+    theLink2 = aNode->Father()->Label();
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetJointsOfLink(const TDF_Label&       theLink,
+                                                         const Standard_Boolean toFirst,
+                                                         const Standard_Boolean toSecond) const
+{
+  TDF_LabelSequence aJointsArray;
+  if (!IsLink(theLink))
+    return aJointsArray;
+
+  Handle(TDataStd_TreeNode) aNode, aChildNode;
+
+  if (toFirst && theLink.FindAttribute(XCAFDoc::KinematicRefLink1GUID(), aNode))
+  {
+    aChildNode = aNode->First();
+    while (!aChildNode.IsNull())
+    {
+      aJointsArray.Append(aChildNode->Label());
+      aChildNode = aChildNode->Next();
+    }
+  }
+
+  if (toSecond && theLink.FindAttribute(XCAFDoc::KinematicRefLink2GUID(), aNode))
+  {
+    aChildNode = aNode->First();
+    while (!aChildNode.IsNull())
+    {
+      aJointsArray.Append(aChildNode->Label());
+      aChildNode = aChildNode->Next();
+    }
+  }
+
+  return aJointsArray;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddState(const TDF_Label& theMechanism)
+{
+  if (!IsMechanism(theMechanism))
+    return TDF_Label();
+
+  TDF_Label aRootOfState = getRootOfStates(theMechanism);
+  if (aRootOfState.IsNull())
+  {
+    aRootOfState = theMechanism.FindChild(3);
+    TDataStd_Name::Set(aRootOfState, "States");
+  }
+  TDF_TagSource           aTag;
+  TDF_Label               aState = aTag.NewChild(aRootOfState);
+  TCollection_AsciiString aName  = "State ";
+  aName.AssignCat(TCollection_AsciiString(aState.Tag()));
+  TDataStd_Name::Set(aState, aName);
+  return aState;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::IsState(const TDF_Label& theState) const
+{
+  return IsMechanism(theState.Father().Father()) && theState.Father().Tag() == 3;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::AddValue(const TDF_Label& theState)
+{
+  if (!IsState(theState))
+    return TDF_Label();
+
+  return theState.NewChild();
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFDoc_KinematicTool::IsValue(const TDF_Label& theValue) const
+{
+  return XCAFKinObjects_KinematicPairValue::IsValidLabel(theValue);
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::RemoveValue(const TDF_Label& theValue)
+{
+  if (!IsValue(theValue))
+    return;
+
+  Handle(TDataStd_TreeNode) aNode;
+  theValue.FindAttribute(XCAFDoc::KinematicRefJointGUID(), aNode);
+  aNode->Remove();
+
+  theValue.ForgetAllAttributes();
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_KinematicPair) XCAFDoc_KinematicTool::GetKinematicPair(
+  const TDF_Label& theLabel)
+{
+  if (!XCAFKinObjects_KinematicPair::IsValidLabel(theLabel))
+    return NULL;
+  return XCAFKinObjects_KinematicPair::Set(theLabel);
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_KinematicPairValue) XCAFDoc_KinematicTool::GetKinematicPairValue(
+  const TDF_Label& theLabel)
+{
+  if (!XCAFKinObjects_KinematicPairValue::IsValidLabel(theLabel))
+    return NULL;
+  return XCAFKinObjects_KinematicPairValue::Set(theLabel);
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetStates(const TDF_Label& theMechanism) const
+{
+  TDF_LabelSequence aStatesArray;
+  if (!IsMechanism(theMechanism))
+    return aStatesArray;
+
+  TDF_Label aRootOfState = getRootOfStates(theMechanism);
+  if (aRootOfState.IsNull())
+    return aStatesArray;
+
+  for (TDF_ChildIterator anIt(aRootOfState); anIt.More(); anIt.Next())
+  {
+    TDF_Label aState = anIt.Value();
+    if (!GetValuesOfState(aState).IsEmpty())
+      aStatesArray.Append(aState);
+  }
+  return aStatesArray;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::GetStateOfValue(const TDF_Label& theValue) const
+{
+  if (!IsValue(theValue))
+    return TDF_Label();
+  return theValue.Father();
+}
+
+//=================================================================================================
+
+Standard_EXPORT TDF_LabelSequence
+  XCAFDoc_KinematicTool::GetValuesOfState(const TDF_Label& theState) const
+{
+  TDF_LabelSequence aValueArray;
+  if (!IsState(theState))
+    return aValueArray;
+
+  for (TDF_ChildIterator anIt(theState); anIt.More(); anIt.Next())
+  {
+    TDF_Label aValue = anIt.Value();
+    if (IsValue(aValue))
+    {
+      aValueArray.Append(aValue);
+    }
+  }
+
+  return aValueArray;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::GetJointOfValue(const TDF_Label& theValue) const
+{
+  TDF_Label aJoint;
+  if (!IsValue(theValue))
+    return aJoint;
+
+  Handle(TDataStd_TreeNode) aNode, aChildNode;
+
+  if (theValue.FindAttribute(XCAFDoc::KinematicRefJointGUID(), aNode))
+  {
+    aJoint = aNode->Father()->Label();
+  }
+  return aJoint;
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetValuesOfJoint(const TDF_Label& theJoint) const
+{
+  TDF_LabelSequence aValuesArray;
+  if (!IsJoint(theJoint))
+    return aValuesArray;
+
+  Handle(TDataStd_TreeNode) aNode, aChildNode;
+
+  if (theJoint.FindAttribute(XCAFDoc::KinematicRefJointGUID(), aNode))
+  {
+    aChildNode = aNode->First();
+    while (!aChildNode.IsNull())
+    {
+      if (IsValue(aChildNode->Label()))
+      {
+        aValuesArray.Append(aChildNode->Label());
+      }
+      aChildNode = aChildNode->Next();
+    }
+  }
+  return aValuesArray;
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::RemoveState(const TDF_Label& theState)
+{
+  if (!IsState(theState))
+    return;
+  Handle(TDataStd_TreeNode) aNode;
+  TDF_LabelSequence         aSeqOfValues = GetValuesOfState(theState);
+  for (Standard_Integer anInd = 1; anInd <= aSeqOfValues.Length(); ++anInd)
+  {
+    RemoveValue(aSeqOfValues.Value(anInd));
+  }
+  theState.ForgetAllAttributes();
+}
+
+//=================================================================================================
+
+TDF_LabelSequence XCAFDoc_KinematicTool::GetRefShapes(const TDF_Label& theLink) const
+{
+  Handle(XCAFDoc_GraphNode) aGNode;
+  TDF_LabelSequence         aShapeArray;
+  if (theLink.FindAttribute(XCAFDoc::KinematicRefShapeGUID(), aGNode) && aGNode->NbFathers() > 0)
+  {
+    for (Standard_Integer i = 1; i <= aGNode->NbFathers(); i++)
+    {
+      aShapeArray.Append(aGNode->GetFather(i)->Label());
+    }
+  }
+  return aShapeArray;
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::getRootOfLinks(const TDF_Label& theMechanism) const
+{
+  return theMechanism.FindChild(1, Standard_False);
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::getRootOfJoints(const TDF_Label& theMechanism) const
+{
+  return theMechanism.FindChild(2, Standard_False);
+}
+
+//=================================================================================================
+
+TDF_Label XCAFDoc_KinematicTool::getRootOfStates(const TDF_Label& theMechanism) const
+{
+  return theMechanism.FindChild(3, Standard_False);
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFDoc_KinematicTool::ID() const
+{
+  return GetID();
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::Restore(const Handle(TDF_Attribute)& /*theWith*/) {}
+
+//=================================================================================================
+
+Handle(TDF_Attribute) XCAFDoc_KinematicTool::NewEmpty() const
+{
+  return new XCAFDoc_KinematicTool;
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::Paste(const Handle(TDF_Attribute)& /*into*/,
+                                  const Handle(TDF_RelocationTable)& /*theRT*/) const
+{
+}
+
+//=================================================================================================
+
+void XCAFDoc_KinematicTool::DumpJson(Standard_OStream& theOStream, Standard_Integer theDepth) const
+{
+  OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
+
+  OCCT_DUMP_BASE_CLASS(theOStream, theDepth, TDF_Attribute)
+}

--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_KinematicTool.hxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_KinematicTool.hxx
@@ -1,0 +1,321 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_KinematicTool_HeaderFile
+#define _XCAFKinObjects_KinematicTool_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_Type.hxx>
+
+#include <TDF_Attribute.hxx>
+#include <Standard_Boolean.hxx>
+#include <TDF_LabelSequence.hxx>
+#include <Standard_Integer.hxx>
+
+class XCAFKinObjects_KinematicPair;
+class XCAFKinObjects_KinematicPairValue;
+class XCAFDoc_ShapeTool;
+class TDF_Label;
+class Standard_GUID;
+class TDF_Attribute;
+
+class XCAFDoc_KinematicTool;
+DEFINE_STANDARD_HANDLE(XCAFDoc_KinematicTool, TDF_Attribute)
+
+//! Provides tools to store and retrieve Kinematics in and from TDocStd_Document.
+//! Kinematic data storage consists of several mechanisms, each mechanism has
+//! its own sets of links and joints. The tool manages the hierarchy of kinematic
+//! elements (mechanisms, links, joints, states, values) and their relationships.
+//!
+//! The document structure is organized as follows:
+//! - Each mechanism has a label under the base label
+//! - Under each mechanism label, there are child labels for links (1), joints (2),
+//!   and optionally states (3)
+//! - Links represent rigid bodies that can be moved by joints
+//! - Joints define the connection between two links and constrain their relative movement
+//! - States represent specific configurations of the kinematic system
+//! - Values define parameters for joints in various states
+class XCAFDoc_KinematicTool : public TDF_Attribute
+{
+
+public:
+  //! Default constructor.
+  Standard_EXPORT XCAFDoc_KinematicTool();
+
+  //! Creates (if not exist) KinematicTool on the specified label.
+  //! @param theLabel Label where KinematicTool should be created
+  //! @return Handle to the created or found KinematicTool
+  Standard_EXPORT static Handle(XCAFDoc_KinematicTool) Set(const TDF_Label& theLabel);
+
+  //! Returns the GUID for KinematicTool attribute.
+  //! @return Standard_GUID identifying KinematicTool
+  Standard_EXPORT static const Standard_GUID& GetID();
+
+  //! Returns the base label under which kinematic data is stored.
+  //! @return TDF_Label that serves as the root for all kinematic data
+  Standard_EXPORT TDF_Label BaseLabel() const;
+
+  //! Creates a new mechanism as a child under the base label.
+  //! Creates child labels for links (1) and joints (2).
+  //! @return TDF_Label of the newly created mechanism
+  Standard_EXPORT TDF_Label AddMechanism();
+
+  //! Checks if the given label represents a mechanism.
+  //! A valid mechanism has child labels for links (1) and joints (2),
+  //! and optionally for states (3).
+  //! @param theLabel Label to check
+  //! @return true if the label represents a mechanism, false otherwise
+  Standard_EXPORT Standard_Boolean IsMechanism(const TDF_Label& theLabel) const;
+
+  //! Removes the given mechanism with all underlying information.
+  //! Removes all links, joints, states and their associated data.
+  //! @param theLabel Label of the mechanism to remove
+  Standard_EXPORT void RemoveMechanism(const TDF_Label& theLabel);
+
+  //! Adds a new empty label for a link under the specified mechanism.
+  //! @param theMechanism Parent mechanism
+  //! @param isBase Whether the link is the base link of the mechanism
+  //! @return TDF_Label of the newly created link
+  Standard_EXPORT TDF_Label AddLink(const TDF_Label&       theMechanism,
+                                    const Standard_Boolean isBase = Standard_False);
+
+  //! Adds a new label with a link and associates it with the given shapes.
+  //! @param theMechanism Parent mechanism
+  //! @param theShapes Sequence of labels pointing to shapes that make up the link
+  //! @param isBase Whether the link is the base link of the mechanism
+  //! @return TDF_Label of the newly created link
+  Standard_EXPORT TDF_Label AddLink(const TDF_Label&         theMechanism,
+                                    const TDF_LabelSequence& theShapes,
+                                    const Standard_Boolean   isBase = Standard_False);
+
+  //! Adds a new label with a link and associates it with a single shape.
+  //! @param theMechanism Parent mechanism
+  //! @param theShape Label pointing to the shape for the link
+  //! @param isBase Whether the link is the base link of the mechanism
+  //! @return TDF_Label of the newly created link
+  Standard_EXPORT TDF_Label AddLink(const TDF_Label&       theMechanism,
+                                    const TDF_Label&       theShape,
+                                    const Standard_Boolean isBase = Standard_False);
+
+  //! Checks if the given label represents a link.
+  //! @param theLink Label to check
+  //! @return true if the label represents a link, false otherwise
+  Standard_EXPORT Standard_Boolean IsLink(const TDF_Label& theLink) const;
+
+  //! Sets shapes references for a link.
+  //! Removes any existing shape references before setting the new ones.
+  //! @param theLink Link to set shapes for
+  //! @param theShapes Sequence of labels pointing to shapes for the link
+  //! @return true if successful, false otherwise
+  Standard_EXPORT Standard_Boolean SetLink(const TDF_Label&         theLink,
+                                           const TDF_LabelSequence& theShapes);
+
+  //! Sets the given link as the base link for its parent mechanism.
+  //! Only one base link is allowed per mechanism.
+  //! @param theLink Link to set as base
+  //! @return true if successful, false otherwise
+  Standard_EXPORT Standard_Boolean SetBaseLink(const TDF_Label& theLink);
+
+  //! Sets a single shape reference for a link.
+  //! @param theLink Link to set shape for
+  //! @param theShape Label pointing to the shape for the link
+  //! @return true if successful, false otherwise
+  Standard_EXPORT Standard_Boolean SetLink(const TDF_Label& theLink, const TDF_Label& theShape);
+
+  //! Removes the given link and its references.
+  //! Also removes all joints connected to this link.
+  //! @param theLink Link to remove
+  Standard_EXPORT void RemoveLink(const TDF_Label& theLink);
+
+  //! Adds a new empty label for a joint under the specified mechanism.
+  //! @param theMechanism Parent mechanism
+  //! @return TDF_Label of the newly created joint
+  Standard_EXPORT TDF_Label AddJoint(const TDF_Label& theMechanism);
+
+  //! Adds a new label with a joint connecting the two given links.
+  //! @param theMechanism Parent mechanism
+  //! @param theLink1 First link to connect
+  //! @param theLink2 Second link to connect
+  //! @return TDF_Label of the newly created joint
+  Standard_EXPORT TDF_Label AddJoint(const TDF_Label& theMechanism,
+                                     const TDF_Label& theLink1,
+                                     const TDF_Label& theLink2);
+
+  //! Checks if the given label represents a joint.
+  //! @param theJoint Label to check
+  //! @return true if the label represents a joint, false otherwise
+  Standard_EXPORT Standard_Boolean IsJoint(const TDF_Label& theJoint) const;
+
+  //! Sets references to links for a joint.
+  //! @param theJoint Joint to set links for
+  //! @param theLink1 First link of the joint
+  //! @param theLink2 Second link of the joint
+  //! @return true if successful, false otherwise
+  Standard_EXPORT Standard_Boolean SetJoint(const TDF_Label& theJoint,
+                                            const TDF_Label& theLink1,
+                                            const TDF_Label& theLink2);
+
+  //! Removes the given joint and its references.
+  //! @param theJoint Joint to remove
+  Standard_EXPORT void RemoveJoint(const TDF_Label& theJoint);
+
+  //! Checks if the given label represents a value.
+  //! @param theValue Label to check
+  //! @return true if the label represents a value, false otherwise
+  Standard_EXPORT Standard_Boolean IsValue(const TDF_Label& theValue) const;
+
+  //! Adds a new empty label for a state under the specified mechanism.
+  //! @param theMechanism Parent mechanism
+  //! @return TDF_Label of the newly created state
+  Standard_EXPORT TDF_Label AddState(const TDF_Label& theMechanism);
+
+  //! Checks if the given label represents a state.
+  //! @param theState Label to check
+  //! @return true if the label represents a state, false otherwise
+  Standard_EXPORT Standard_Boolean IsState(const TDF_Label& theState) const;
+
+  //! Adds a new empty label for a value under the specified state.
+  //! @param theState Parent state
+  //! @return TDF_Label of the newly created value
+  Standard_EXPORT TDF_Label AddValue(const TDF_Label& theState);
+
+  //! Removes the given value and its references.
+  //! @param theValue Value to remove
+  Standard_EXPORT void RemoveValue(const TDF_Label& theValue);
+
+  //! Gets XCAFKinObjects_KinematicPair attribute from the given label.
+  //! If such attribute is missing (first attempt after document import), sets the attribute.
+  //! @param theLabel Label to check and get attribute from
+  //! @return Handle to the kinematic pair attribute or NULL if label is invalid
+  Standard_EXPORT Handle(XCAFKinObjects_KinematicPair) GetKinematicPair(const TDF_Label& theLabel);
+
+  //! Gets XCAFKinObjects_KinematicPairValue attribute from the given label.
+  //! If such attribute is missing (first attempt after document import), sets the attribute.
+  //! @param theLabel Label to check and get attribute from
+  //! @return Handle to the kinematic pair value attribute or NULL if label is invalid
+  Standard_EXPORT Handle(XCAFKinObjects_KinematicPairValue) GetKinematicPairValue(
+    const TDF_Label& theLabel);
+
+  //! Retrieves all states labels of the given mechanism.
+  //! @param theMechanism Parent mechanism
+  //! @return Sequence of state labels
+  Standard_EXPORT TDF_LabelSequence GetStates(const TDF_Label& theMechanism) const;
+
+  //! Retrieves all value labels of the given state.
+  //! @param theState Parent state
+  //! @return Sequence of value labels
+  Standard_EXPORT TDF_LabelSequence GetValuesOfState(const TDF_Label& theState) const;
+
+  //! Gets reference to state of the given value.
+  //! @param theValue Value to get state for
+  //! @return Label of the parent state
+  Standard_EXPORT TDF_Label GetStateOfValue(const TDF_Label& theValue) const;
+
+  //! Gets reference to joint of the given value.
+  //! @param theValue Value to get joint for
+  //! @return Label of the referenced joint
+  Standard_EXPORT TDF_Label GetJointOfValue(const TDF_Label& theValue) const;
+
+  //! Gets references to values of the given joint.
+  //! @param theJoint Joint to get values for
+  //! @return Sequence of value labels
+  Standard_EXPORT TDF_LabelSequence GetValuesOfJoint(const TDF_Label& theJoint) const;
+
+  //! Removes the given state and all its values.
+  //! @param theState State to remove
+  Standard_EXPORT void RemoveState(const TDF_Label& theState);
+
+  //! Retrieves all mechanisms labels.
+  //! @return Sequence of mechanism labels
+  Standard_EXPORT TDF_LabelSequence GetMechanisms() const;
+
+  //! Retrieves all link labels of the given mechanism.
+  //! @param theMechanism Parent mechanism
+  //! @return Sequence of link labels
+  Standard_EXPORT TDF_LabelSequence GetLinks(const TDF_Label& theMechanism) const;
+
+  //! Retrieves all joint labels of the given mechanism.
+  //! @param theMechanism Parent mechanism
+  //! @return Sequence of joint labels
+  Standard_EXPORT TDF_LabelSequence GetJoints(const TDF_Label& theMechanism) const;
+
+  //! Gets references to links of the given joint.
+  //! @param theJoint Joint to get links for
+  //! @param theLink1 [out] First link of the joint
+  //! @param theLink2 [out] Second link of the joint
+  Standard_EXPORT void GetLinksOfJoint(const TDF_Label& theJoint,
+                                       TDF_Label&       theLink1,
+                                       TDF_Label&       theLink2) const;
+
+  //! Gets references to joints of the given link.
+  //! @param theLink Link to get joints for
+  //! @param toFirst Whether to include joints where the link is the first link
+  //! @param toSecond Whether to include joints where the link is the second link
+  //! @return Sequence of joint labels
+  Standard_EXPORT TDF_LabelSequence
+    GetJointsOfLink(const TDF_Label&       theLink,
+                    const Standard_Boolean toFirst  = Standard_True,
+                    const Standard_Boolean toSecond = Standard_True) const;
+
+public:
+  //! Gets reference shapes of the given link.
+  //! @param theLink Link to get shapes for
+  //! @return Sequence of shape labels
+  Standard_EXPORT TDF_LabelSequence GetRefShapes(const TDF_Label& theLink) const;
+
+  //! Returns the GUID identifying this attribute.
+  //! @return Standard_GUID of this attribute
+  Standard_EXPORT const Standard_GUID& ID() const Standard_OVERRIDE;
+
+  //! Restores the attribute from another attribute.
+  //! @param with Attribute to restore from
+  Standard_EXPORT void Restore(const Handle(TDF_Attribute)& with) Standard_OVERRIDE;
+
+  //! Creates a new empty attribute.
+  //! @return Handle to the new attribute
+  Standard_EXPORT Handle(TDF_Attribute) NewEmpty() const Standard_OVERRIDE;
+
+  //! Pastes the attribute into another attribute.
+  //! @param into Target attribute to paste into
+  //! @param theRT Relocation table
+  Standard_EXPORT void Paste(const Handle(TDF_Attribute)&       into,
+                             const Handle(TDF_RelocationTable)& theRT) const Standard_OVERRIDE;
+
+  //! Dumps the content of me into the stream.
+  //! @param theOStream Stream to output data to
+  //! @param theDepth Depth of the dumped information
+  Standard_EXPORT virtual void DumpJson(Standard_OStream& theOStream,
+                                        Standard_Integer  theDepth = -1) const Standard_OVERRIDE;
+
+private:
+  //! Gets the root label for links of the given mechanism.
+  //! @param theMechanism Mechanism to get links root for
+  //! @return Label of links root (child 1)
+  Standard_EXPORT TDF_Label getRootOfLinks(const TDF_Label& theMechanism) const;
+
+  //! Gets the root label for joints of the given mechanism.
+  //! @param theMechanism Mechanism to get joints root for
+  //! @return Label of joints root (child 2)
+  Standard_EXPORT TDF_Label getRootOfJoints(const TDF_Label& theMechanism) const;
+
+  //! Gets the root label for states of the given mechanism.
+  //! @param theMechanism Mechanism to get states root for
+  //! @return Label of states root (child 3) or null if not exist
+  Standard_EXPORT TDF_Label getRootOfStates(const TDF_Label& theMechanism) const;
+
+  DEFINE_STANDARD_RTTIEXT(XCAFDoc_KinematicTool, TDF_Attribute)
+};
+
+#endif // _XCAFKinObjects_KinematicTool_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/FILES.cmake
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/FILES.cmake
@@ -1,0 +1,20 @@
+# Source files for XCAFKinObjects package
+set(OCCT_XCAFKinObjects_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+set(OCCT_XCAFKinObjects_FILES
+  XCAFKinObjects_HighOrderPairObject.cxx
+  XCAFKinObjects_HighOrderPairObject.hxx
+  XCAFKinObjects_KinematicPair.cxx
+  XCAFKinObjects_KinematicPair.hxx
+  XCAFKinObjects_KinematicPairValue.cxx
+  XCAFKinObjects_KinematicPairValue.hxx
+  XCAFKinObjects_LowOrderPairObject.cxx
+  XCAFKinObjects_LowOrderPairObject.hxx
+  XCAFKinObjects_LowOrderPairObjectWithCoupling.cxx
+  XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx
+  XCAFKinObjects_PairObject.cxx
+  XCAFKinObjects_PairObject.hxx
+  XCAFKinObjects_PairType.hxx
+  XCAFKinObjects_PairValueObject.cxx
+  XCAFKinObjects_PairValueObject.hxx
+)

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_HighOrderPairObject.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_HighOrderPairObject.cxx
@@ -1,0 +1,422 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFKinObjects_HighOrderPairObject.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_Surface.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_HighOrderPairObject, XCAFKinObjects_PairObject)
+
+//=================================================================================================
+
+XCAFKinObjects_HighOrderPairObject::XCAFKinObjects_HighOrderPairObject()
+{
+  myLimits   = nullptr;
+  myIsRanged = Standard_False;
+}
+
+//=================================================================================================
+
+XCAFKinObjects_HighOrderPairObject::XCAFKinObjects_HighOrderPairObject(
+  const Handle(XCAFKinObjects_HighOrderPairObject)& theObj)
+{
+  SetName(theObj->Name());
+  SetType(theObj->Type());
+  SetFirstTransformation(theObj->FirstTransformation());
+  SetSecondTransformation(theObj->SecondTransformation());
+  myOrientation = theObj->myOrientation;
+  myLimits      = theObj->myLimits;
+  myGeom        = theObj->myGeom;
+  myIsRanged    = theObj->HasLimits();
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetType(const XCAFKinObjects_PairType theType)
+{
+  XCAFKinObjects_PairObject::SetType(theType);
+  switch (theType)
+  {
+    case XCAFKinObjects_PairType_PointOnSurface: {
+      myLimits = new TColStd_HArray1OfReal(1, 6);
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 1);
+      break;
+    }
+    case XCAFKinObjects_PairType_SlidingSurface: {
+      myLimits = new TColStd_HArray1OfReal(1, 2);
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 2);
+      break;
+    }
+    case XCAFKinObjects_PairType_RollingSurface: {
+      myLimits = new TColStd_HArray1OfReal(1, 2);
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 2);
+      break;
+    }
+    case XCAFKinObjects_PairType_PointOnPlanarCurve: {
+      myLimits = new TColStd_HArray1OfReal(1, 6);
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 1);
+      break;
+    }
+    case XCAFKinObjects_PairType_SlidingCurve: {
+      myLimits = nullptr;
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 2);
+      break;
+    }
+    case XCAFKinObjects_PairType_RollingCurve: {
+      myLimits = nullptr;
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 2);
+      break;
+    }
+    case XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve: {
+      myLimits = nullptr;
+      myGeom   = NCollection_Array1<Handle(Geom_Geometry)>(1, 1);
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetAllLimits(
+  const Handle(TColStd_HArray1OfReal)& theLimits)
+{
+  Standard_Integer aNbLimits = 0;
+  switch (Type())
+  {
+    case XCAFKinObjects_PairType_PointOnSurface: {
+      aNbLimits = 6;
+      break;
+    }
+    case XCAFKinObjects_PairType_SlidingSurface: {
+      aNbLimits = 2;
+      break;
+    }
+    case XCAFKinObjects_PairType_RollingSurface: {
+      aNbLimits = 2;
+      break;
+    }
+    case XCAFKinObjects_PairType_PointOnPlanarCurve: {
+      aNbLimits = 6;
+      break;
+    }
+    default:
+      break;
+  }
+
+  if (theLimits->Length() == aNbLimits)
+  {
+    myLimits   = theLimits;
+    myIsRanged = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_HighOrderPairObject::HasLimits() const
+{
+  return myIsRanged;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetRotationLowLimit(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+  {
+    myLimits->ChangeValue(1) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::RotationLowLimit()
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+    return myLimits->Value(1);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetRotationUpperLimit(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+  {
+    myLimits->ChangeValue(2) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::RotationUpperLimit()
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+    return myLimits->Value(2);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetLowLimitYaw(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+  {
+    myLimits->ChangeValue(1) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::LowLimitYaw()
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return myLimits->Value(1);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetUpperLimitYaw(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+  {
+    myLimits->ChangeValue(2) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::UpperLimitYaw()
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return myLimits->Value(2);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetLowLimitRoll(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+  {
+    myLimits->ChangeValue(3) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::LowLimitRoll()
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return myLimits->Value(3);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetUpperLimitRoll(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+  {
+    myLimits->ChangeValue(4) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::UpperLimitRoll()
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return myLimits->Value(4);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetLowLimitPitch(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+  {
+    myLimits->ChangeValue(5) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::LowLimitPitch()
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return myLimits->Value(5);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetUpperLimitPitch(const Standard_Real theLimit)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+  {
+    myLimits->ChangeValue(6) = theLimit;
+    myIsRanged               = Standard_True;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_HighOrderPairObject::UpperLimitPitch()
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return myLimits->Value(6);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetCurve(const Handle(Geom_Curve)& theCurve)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+    myGeom.ChangeFirst() = theCurve;
+}
+
+//=================================================================================================
+
+Handle(Geom_Curve) XCAFKinObjects_HighOrderPairObject::Curve() const
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+      || Type() == XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+    return Handle(Geom_Curve)::DownCast(myGeom.First());
+  return nullptr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetFirstCurve(const Handle(Geom_Curve)& theCurve)
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingCurve
+      || Type() == XCAFKinObjects_PairType_RollingCurve)
+    myGeom.ChangeFirst() = theCurve;
+}
+
+//=================================================================================================
+
+Handle(Geom_Curve) XCAFKinObjects_HighOrderPairObject::FirstCurve() const
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingCurve
+      || Type() == XCAFKinObjects_PairType_RollingCurve)
+    return Handle(Geom_Curve)::DownCast(myGeom.First());
+  return nullptr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetSecondCurve(const Handle(Geom_Curve)& theCurve)
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingCurve
+      || Type() == XCAFKinObjects_PairType_RollingCurve)
+    myGeom.ChangeLast() = theCurve;
+}
+
+//=================================================================================================
+
+Handle(Geom_Curve) XCAFKinObjects_HighOrderPairObject::SecondCurve() const
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingCurve
+      || Type() == XCAFKinObjects_PairType_RollingCurve)
+    return Handle(Geom_Curve)::DownCast(myGeom.Last());
+  return nullptr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetSurface(const Handle(Geom_Surface)& theSurface)
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnSurface)
+    myGeom.ChangeFirst() = theSurface;
+}
+
+//=================================================================================================
+
+Handle(Geom_Surface) XCAFKinObjects_HighOrderPairObject::Surface() const
+{
+  if (Type() == XCAFKinObjects_PairType_PointOnSurface)
+    return Handle(Geom_Surface)::DownCast(myGeom.First());
+  return nullptr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetFirstSurface(const Handle(Geom_Surface)& theSurface)
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+    myGeom.ChangeFirst() = theSurface;
+}
+
+//=================================================================================================
+
+Handle(Geom_Surface) XCAFKinObjects_HighOrderPairObject::FirstSurface() const
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+    return Handle(Geom_Surface)::DownCast(myGeom.First());
+  return nullptr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_HighOrderPairObject::SetSecondSurface(const Handle(Geom_Surface)& theSurface)
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+    myGeom.ChangeLast() = theSurface;
+}
+
+//=================================================================================================
+
+Handle(Geom_Surface) XCAFKinObjects_HighOrderPairObject::SecondSurface() const
+{
+  if (Type() == XCAFKinObjects_PairType_SlidingSurface
+      || Type() == XCAFKinObjects_PairType_RollingSurface)
+    return Handle(Geom_Surface)::DownCast(myGeom.Last());
+  return nullptr;
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_HighOrderPairObject.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_HighOrderPairObject.hxx
@@ -1,0 +1,218 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_HighOrderPairObject_HeaderFile
+#define _XCAFKinObjects_HighOrderPairObject_HeaderFile
+
+#include <Geom_Geometry.hxx>
+#include <XCAFKinObjects_PairObject.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+
+class Geom_Curve;
+class Geom_Surface;
+class Geom_RectangularTrimmedSurface;
+class Geom_TrimmedCurve;
+
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_HighOrderPairObject, XCAFKinObjects_PairObject)
+
+//! Object for high order kinematic pairs, which are characterized by higher complexity
+//! and typically involve interactions between curves and surfaces.
+//!
+//! Supported high order pair types include:
+//! - XCAFKinObjects_PairType_PointOnSurface: A point constrained to move on a surface
+//! - XCAFKinObjects_PairType_SlidingSurface: Two surfaces that slide against each other
+//! - XCAFKinObjects_PairType_RollingSurface: Two surfaces that roll against each other
+//! - XCAFKinObjects_PairType_PointOnPlanarCurve: A point constrained to move on a planar curve
+//! - XCAFKinObjects_PairType_SlidingCurve: Two curves that slide against each other
+//! - XCAFKinObjects_PairType_RollingCurve: Two curves that roll against each other
+//! - XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve: A flexible connection that can move
+//! along a curve
+//!
+//! Each pair type has specific geometric definitions and constraints that can be stored
+//! using this object. The object can store curves, surfaces, and limit values depending
+//! on the specific pair type.
+class XCAFKinObjects_HighOrderPairObject : public XCAFKinObjects_PairObject
+{
+
+public:
+  //! Default constructor.
+  //! Creates an empty high order pair object with undefined type.
+  Standard_EXPORT XCAFKinObjects_HighOrderPairObject();
+
+  //! Copy constructor.
+  //! @param theObj Source high order pair object to copy from
+  Standard_EXPORT XCAFKinObjects_HighOrderPairObject(
+    const Handle(XCAFKinObjects_HighOrderPairObject)& theObj);
+
+  //! Sets the type of the high order pair and initializes appropriate data structures.
+  //! Different pair types require different geometric representations and limit values.
+  //! @param theType Type of kinematic pair to set
+  Standard_EXPORT void SetType(const XCAFKinObjects_PairType theType) Standard_OVERRIDE;
+
+  //! Sets the orientation flag for the pair.
+  //! @param theOrientation Orientation value to set (true/false)
+  void SetOrientation(const Standard_Boolean theOrientation) { myOrientation = theOrientation; }
+
+  //! Returns the orientation flag value.
+  //! @return Current orientation flag
+  Standard_Boolean Orientation() const { return myOrientation; }
+
+  //! Sets all limit values for the pair from an array.
+  //! The array size must match the expected number of limits for the pair type.
+  //! @param theLimits Array containing limit values
+  Standard_EXPORT void SetAllLimits(const Handle(TColStd_HArray1OfReal)& theLimits)
+    Standard_OVERRIDE;
+
+  //! Checks if the pair has defined limit values.
+  //! @return true if limits are defined, false otherwise
+  Standard_EXPORT Standard_Boolean HasLimits() const Standard_OVERRIDE;
+
+  //! Returns all limit values for the pair.
+  //! @return Array containing all limit values, or NULL if no limits are defined
+  Handle(TColStd_HArray1OfReal) GetAllLimits() const Standard_OVERRIDE
+  {
+
+    if (HasLimits())
+      return myLimits;
+    return nullptr;
+  }
+
+  //! Sets low limit of rotation attribute (only for SlidingSurface and RollingSurface pairs).
+  //! @param theLimit Lower rotation limit value
+  Standard_EXPORT void SetRotationLowLimit(const Standard_Real theLimit);
+
+  //! Gets low rotation limit (only valid for SlidingSurface and RollingSurface pairs).
+  //! @return Lower rotation limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real RotationLowLimit();
+
+  //! Sets upper limit of rotation attribute (only for SlidingSurface and RollingSurface pairs).
+  //! @param theLimit Upper rotation limit value
+  Standard_EXPORT void SetRotationUpperLimit(const Standard_Real theLimit);
+
+  //! Gets upper rotation limit (only valid for SlidingSurface and RollingSurface pairs).
+  //! @return Upper rotation limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real RotationUpperLimit();
+
+  //! Sets low limit of yaw angle (only for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @param theLimit Lower yaw angle limit value
+  Standard_EXPORT void SetLowLimitYaw(const Standard_Real theLimit);
+
+  //! Gets low limit of yaw angle (only valid for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @return Lower yaw angle limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real LowLimitYaw();
+
+  //! Sets upper limit of yaw angle (only for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @param theLimit Upper yaw angle limit value
+  Standard_EXPORT void SetUpperLimitYaw(const Standard_Real theLimit);
+
+  //! Gets upper limit of yaw angle (only valid for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @return Upper yaw angle limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real UpperLimitYaw();
+
+  //! Sets low limit of roll angle (only for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @param theLimit Lower roll angle limit value
+  Standard_EXPORT void SetLowLimitRoll(const Standard_Real theLimit);
+
+  //! Gets low limit of roll angle (only valid for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @return Lower roll angle limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real LowLimitRoll();
+
+  //! Sets upper limit of roll angle (only for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @param theLimit Upper roll angle limit value
+  Standard_EXPORT void SetUpperLimitRoll(const Standard_Real theLimit);
+
+  //! Gets upper limit of roll angle (only valid for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @return Upper roll angle limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real UpperLimitRoll();
+
+  //! Sets low limit of pitch angle (only for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @param theLimit Lower pitch angle limit value
+  Standard_EXPORT void SetLowLimitPitch(const Standard_Real theLimit);
+
+  //! Gets low limit of pitch angle (only valid for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @return Lower pitch angle limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real LowLimitPitch();
+
+  //! Sets upper limit of pitch angle (only for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @param theLimit Upper pitch angle limit value
+  Standard_EXPORT void SetUpperLimitPitch(const Standard_Real theLimit);
+
+  //! Gets upper limit of pitch angle (only valid for PointOnPlanarCurve and PointOnSurface pairs).
+  //! @return Upper pitch angle limit value, or 0 if not applicable
+  Standard_EXPORT Standard_Real UpperLimitPitch();
+
+  //! Sets curve attribute (only for PointOnPlanarCurve and LinearFlexibleAndPlanarCurve pairs).
+  //! @param theCurve Curve geometry to set
+  Standard_EXPORT void SetCurve(const Handle(Geom_Curve)& theCurve);
+
+  //! Gets curve attribute (only valid for PointOnPlanarCurve and LinearFlexibleAndPlanarCurve
+  //! pairs).
+  //! @return Handle to the curve, or NULL if not applicable
+  Standard_EXPORT Handle(Geom_Curve) Curve() const;
+
+  //! Sets first curve attribute (only for SlidingCurve and RollingCurve pairs).
+  //! @param theCurve First curve geometry to set
+  Standard_EXPORT void SetFirstCurve(const Handle(Geom_Curve)& theCurve);
+
+  //! Gets first curve attribute (only valid for SlidingCurve and RollingCurve pairs).
+  //! @return Handle to the first curve, or NULL if not applicable
+  Standard_EXPORT Handle(Geom_Curve) FirstCurve() const;
+
+  //! Sets second curve attribute (only for SlidingCurve and RollingCurve pairs).
+  //! @param theCurve Second curve geometry to set
+  Standard_EXPORT void SetSecondCurve(const Handle(Geom_Curve)& theCurve);
+
+  //! Gets second curve attribute (only valid for SlidingCurve and RollingCurve pairs).
+  //! @return Handle to the second curve, or NULL if not applicable
+  Standard_EXPORT Handle(Geom_Curve) SecondCurve() const;
+
+  //! Sets surface attribute (only for PointOnSurface pairs).
+  //! @param theSurface Surface geometry to set
+  Standard_EXPORT void SetSurface(const Handle(Geom_Surface)& theSurface);
+
+  //! Gets surface attribute (only valid for PointOnSurface pairs).
+  //! @return Handle to the surface, or NULL if not applicable
+  Standard_EXPORT Handle(Geom_Surface) Surface() const;
+
+  //! Sets first surface attribute (only for SlidingSurface and RollingSurface pairs).
+  //! @param theSurface First surface geometry to set
+  Standard_EXPORT void SetFirstSurface(const Handle(Geom_Surface)& theSurface);
+
+  //! Gets first surface attribute (only valid for SlidingSurface and RollingSurface pairs).
+  //! @return Handle to the first surface, or NULL if not applicable
+  Standard_EXPORT Handle(Geom_Surface) FirstSurface() const;
+
+  //! Sets second surface attribute (only for SlidingSurface and RollingSurface pairs).
+  //! @param theSurface Second surface geometry to set
+  Standard_EXPORT void SetSecondSurface(const Handle(Geom_Surface)& theSurface);
+
+  //! Gets second surface attribute (only valid for SlidingSurface and RollingSurface pairs).
+  //! @return Handle to the second surface, or NULL if not applicable
+  Standard_EXPORT Handle(Geom_Surface) SecondSurface() const;
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_HighOrderPairObject, XCAFKinObjects_PairObject)
+
+private:
+  //! Orientation flag for the kinematic pair
+  Standard_Boolean myOrientation;
+  //! Array of limit values, size depends on pair type
+  Handle(TColStd_HArray1OfReal) myLimits;
+  //! Geometric elements (curves or surfaces) for the pair
+  NCollection_Array1<Handle(Geom_Geometry)> myGeom;
+  //! Flag indicating if limits are defined
+  Standard_Boolean myIsRanged;
+};
+
+#endif // _XCAFKinObjects_HighOrderPairObject_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPair.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPair.cxx
@@ -1,0 +1,409 @@
+// Created on: 2020-03-17
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFKinObjects_KinematicPair.hxx>
+#include <BRep_Builder.hxx>
+#include <gp_Pln.hxx>
+#include <Standard_Dump.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Standard_GUID.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <TDataStd_AsciiString.hxx>
+#include <TDataStd_Integer.hxx>
+#include <TDataStd_Name.hxx>
+#include <TDataStd_Real.hxx>
+#include <TDataStd_RealArray.hxx>
+#include <TDataStd_UAttribute.hxx>
+#include <TDataXtd_Geometry.hxx>
+#include <TDataXtd_Plane.hxx>
+#include <TDF_ChildIterator.hxx>
+#include <TNaming_Builder.hxx>
+#include <TNaming_Tool.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <XCAFDoc.hxx>
+#include <XCAFKinObjects_HighOrderPairObject.hxx>
+#include <XCAFKinObjects_LowOrderPairObject.hxx>
+#include <XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx>
+#include <XCAFKinObjects_PairObject.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_KinematicPair, TDF_Attribute)
+
+enum ChildLab
+{
+  ChildLab_FirstTrsf = 1,
+  ChildLab_SecondTrsf,
+  ChildLab_FirstGeomParam,
+  ChildLab_SecondGeomParam,
+};
+
+//=================================================================================================
+
+XCAFKinObjects_KinematicPair::XCAFKinObjects_KinematicPair()
+{
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPair::GetID()
+{
+  static Standard_GUID PairID("89FB0996-A8B8-4085-87A9-63AB5D56D8C1");
+  return PairID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPair::getUID()
+{
+  static Standard_GUID PairUID("89FB0996-A8B8-4085-87A9-63AB5D56D8C2");
+  return PairUID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPair::getLimitsID()
+{
+  static Standard_GUID KinematicLimitsID("8A9E9B60-7CA1-45F1-882A-42390D4DB894");
+  return KinematicLimitsID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPair::getParamsID()
+{
+  static Standard_GUID KinematicParamsID("6BE4AAD0-36BE-4D17-B65C-0B2062E04D92");
+  return KinematicParamsID;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_KinematicPair::IsValidLabel(const TDF_Label& theLabel)
+{
+  TDataStd_UAttribute::Set(theLabel, XCAFKinObjects_KinematicPair::getUID());
+  Handle(TDataStd_UAttribute) anAttr;
+  return theLabel.FindAttribute(XCAFKinObjects_KinematicPair::getUID(), anAttr);
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_KinematicPair) XCAFKinObjects_KinematicPair::Set(const TDF_Label& theLabel)
+{
+  TDataStd_UAttribute::Set(theLabel, XCAFKinObjects_KinematicPair::getUID());
+  Handle(XCAFKinObjects_KinematicPair) anAttr;
+  if (!theLabel.FindAttribute(XCAFKinObjects_KinematicPair::GetID(), anAttr))
+  {
+    anAttr = new XCAFKinObjects_KinematicPair();
+    theLabel.AddAttribute(anAttr);
+  }
+  return anAttr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPair::SetObject(const Handle(XCAFKinObjects_PairObject)& theObject)
+{
+  Backup();
+
+  // Common attributes
+  if (!theObject->Name().IsEmpty())
+    TDataStd_Name::Set(Label(), theObject->Name());
+  TDataStd_Integer::Set(Label(), theObject->Type());
+  TDataXtd_Plane::Set(Label().FindChild(ChildLab_FirstTrsf),
+                      gp_Pln(theObject->FirstTransformation()));
+  TDataXtd_Plane::Set(Label().FindChild(ChildLab_SecondTrsf),
+                      gp_Pln(theObject->SecondTransformation()));
+
+  if (theObject->HasLimits())
+  {
+    Handle(TDataStd_RealArray) aLimitsAttr;
+    aLimitsAttr =
+      TDataStd_RealArray::Set(Label(), getLimitsID(), 1, theObject->GetAllLimits()->Length());
+    aLimitsAttr->ChangeArray(theObject->GetAllLimits());
+  }
+
+  // Low order pairs
+  if (theObject->Type() == XCAFKinObjects_PairType_Universal
+      || theObject->Type() == XCAFKinObjects_PairType_Homokinetic)
+  {
+    Handle(XCAFKinObjects_LowOrderPairObject) anObject =
+      Handle(XCAFKinObjects_LowOrderPairObject)::DownCast(theObject);
+    TDataStd_Real::Set(Label(), getParamsID(), anObject->SkewAngle());
+  }
+
+  // Low order pairs with motion coupling
+  if (theObject->Type() >= XCAFKinObjects_PairType_Screw
+      && theObject->Type() <= XCAFKinObjects_PairType_LinearFlexibleAndPinion)
+  {
+    Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling) anObject =
+      Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling)::DownCast(theObject);
+    if (!anObject->GetAllParams().IsNull() && !anObject->GetAllParams()->IsEmpty())
+    {
+      Handle(TDataStd_RealArray) aParamsAttr;
+      aParamsAttr =
+        TDataStd_RealArray::Set(Label(), getParamsID(), 1, anObject->GetAllParams()->Upper());
+      aParamsAttr->ChangeArray(anObject->GetAllParams());
+    }
+  }
+
+  // High order pairs
+  if (theObject->Type() >= XCAFKinObjects_PairType_PointOnSurface
+      && theObject->Type() <= XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+  {
+    Handle(XCAFKinObjects_HighOrderPairObject) anObject =
+      Handle(XCAFKinObjects_HighOrderPairObject)::DownCast(theObject);
+    TDataStd_Integer::Set(Label(), getParamsID(), (Standard_Integer)anObject->Orientation());
+    BRep_Builder aBuilder;
+    if (theObject->Type() == XCAFKinObjects_PairType_PointOnSurface && !anObject->Surface().IsNull())
+    {
+      TopoDS_Face aFace;
+      aBuilder.MakeFace(aFace, anObject->Surface(), Precision::Confusion());
+      TNaming_Builder aTNBuild(Label().FindChild(ChildLab_FirstGeomParam));
+      aTNBuild.Generated(aFace);
+    }
+    if (theObject->Type() == XCAFKinObjects_PairType_SlidingSurface
+        || theObject->Type() == XCAFKinObjects_PairType_RollingSurface)
+    {
+      TopoDS_Face aFace1, aFace2;
+      if (!anObject->FirstSurface().IsNull())
+      {
+        aBuilder.MakeFace(aFace1, anObject->FirstSurface(), Precision::Confusion());
+        TNaming_Builder aTNBuild1(Label().FindChild(ChildLab_FirstGeomParam));
+        aTNBuild1.Generated(aFace1);
+      }
+      if (!anObject->SecondSurface().IsNull())
+      {
+        aBuilder.MakeFace(aFace2, anObject->SecondSurface(), Precision::Confusion());
+        TNaming_Builder aTNBuild2(Label().FindChild(ChildLab_SecondGeomParam));
+        aTNBuild2.Generated(aFace2);
+      }
+    }
+    if ((theObject->Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+         || theObject->Type() == XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+        && !anObject->Curve().IsNull())
+    {
+      TopoDS_Edge anEdge;
+      aBuilder.MakeEdge(anEdge, anObject->Curve(), Precision::Confusion());
+      TNaming_Builder aTNBuild(Label().FindChild(ChildLab_FirstGeomParam));
+      aTNBuild.Generated(anEdge);
+    }
+    if (anObject->Type() == XCAFKinObjects_PairType_SlidingCurve
+        || anObject->Type() == XCAFKinObjects_PairType_RollingCurve)
+    {
+      TopoDS_Edge anEdge1, anEdge2;
+      if (!anObject->FirstCurve().IsNull())
+      {
+        aBuilder.MakeEdge(anEdge1, anObject->FirstCurve(), Precision::Confusion());
+        TNaming_Builder aTNBuild1(Label().FindChild(ChildLab_FirstGeomParam));
+        aTNBuild1.Generated(anEdge1);
+      }
+      if (!anObject->SecondCurve().IsNull())
+      {
+        aBuilder.MakeEdge(anEdge2, anObject->SecondCurve(), Precision::Confusion());
+        TNaming_Builder aTNBuild2(Label().FindChild(ChildLab_SecondGeomParam));
+        aTNBuild2.Generated(anEdge2);
+      }
+    }
+  }
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_PairObject) XCAFKinObjects_KinematicPair::GetObject() const
+{
+  // Type
+  Handle(TDataStd_Integer)      aTypeAttr;
+  Handle(XCAFKinObjects_PairObject) anObject = new XCAFKinObjects_PairObject();
+  if (Label().FindAttribute(TDataStd_Integer::GetID(), aTypeAttr))
+  {
+    int aType = aTypeAttr->Get();
+    if (aType >= XCAFKinObjects_PairType_FullyConstrained && aType <= XCAFKinObjects_PairType_Unconstrained)
+      anObject = new XCAFKinObjects_LowOrderPairObject();
+    else if (aType >= XCAFKinObjects_PairType_Screw
+             && aType <= XCAFKinObjects_PairType_LinearFlexibleAndPinion)
+      anObject = new XCAFKinObjects_LowOrderPairObjectWithCoupling();
+    else if (aType >= XCAFKinObjects_PairType_PointOnSurface
+             && aType <= XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+      anObject = new XCAFKinObjects_HighOrderPairObject();
+    anObject->SetType((XCAFKinObjects_PairType)aType);
+  }
+
+  // Name
+  Handle(TDataStd_Name) aNameAttr;
+  if (Label().FindAttribute(TDataStd_Name::GetID(), aNameAttr))
+    anObject->SetName(aNameAttr->Get());
+
+  // Transformations
+  Handle(TDataXtd_Plane) aTrsfAttr;
+  if (Label().FindChild(ChildLab_FirstTrsf).FindAttribute(TDataXtd_Plane::GetID(), aTrsfAttr))
+  {
+    gp_Pln aPlane;
+    TDataXtd_Geometry::Plane(aTrsfAttr->Label(), aPlane);
+    anObject->SetFirstTransformation(aPlane.Position());
+  }
+  if (Label().FindChild(ChildLab_SecondTrsf).FindAttribute(TDataXtd_Plane::GetID(), aTrsfAttr))
+  {
+    gp_Pln aPlane;
+    TDataXtd_Geometry::Plane(aTrsfAttr->Label(), aPlane);
+    anObject->SetSecondTransformation(aPlane.Position());
+  }
+
+  // Limits
+  Handle(TDataStd_RealArray) aLimitsAttr;
+  if (Label().FindAttribute(getLimitsID(), aLimitsAttr))
+  {
+    Handle(TColStd_HArray1OfReal) aLimitsArray = aLimitsAttr->Array();
+    anObject->SetAllLimits(aLimitsArray);
+  }
+
+  // Low order pairs
+  if (anObject->Type() == XCAFKinObjects_PairType_Universal
+      || anObject->Type() == XCAFKinObjects_PairType_Homokinetic)
+  {
+    Handle(XCAFKinObjects_LowOrderPairObject) aDefObject =
+      Handle(XCAFKinObjects_LowOrderPairObject)::DownCast(anObject);
+    Handle(TDataStd_Real) aParamAttr;
+    if (Label().FindAttribute(getParamsID(), aParamAttr))
+    {
+      aDefObject->SetSkewAngle(aParamAttr->Get());
+    }
+  }
+
+  // Low order pairs with motion coupling
+  if (anObject->Type() >= XCAFKinObjects_PairType_Screw
+      && anObject->Type() <= XCAFKinObjects_PairType_LinearFlexibleAndPinion)
+  {
+    Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling) aDefObject =
+      Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling)::DownCast(anObject);
+    Handle(TDataStd_RealArray) aParamsAttr;
+    if (Label().FindAttribute(getParamsID(), aParamsAttr))
+    {
+      Handle(TColStd_HArray1OfReal) aParamsArray = aParamsAttr->Array();
+      aDefObject->SetAllParams(aParamsAttr->Array());
+    }
+  }
+
+  // High order pairs
+  if (anObject->Type() >= XCAFKinObjects_PairType_PointOnSurface
+      && anObject->Type() <= XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+  {
+    Handle(XCAFKinObjects_HighOrderPairObject) aDefObject =
+      Handle(XCAFKinObjects_HighOrderPairObject)::DownCast(anObject);
+    Handle(TDataStd_Integer) anOrienAttr;
+    if (Label().FindAttribute(getParamsID(), anOrienAttr))
+    {
+      aDefObject->SetOrientation(anOrienAttr->Get() != 0);
+    }
+
+    Handle(TNaming_NamedShape) aNS;
+    if (anObject->Type() == XCAFKinObjects_PairType_PointOnSurface)
+    {
+      if (Label()
+            .FindChild(ChildLab_FirstGeomParam)
+            .FindAttribute(TNaming_NamedShape::GetID(), aNS))
+      {
+        TopoDS_Face aFace = TopoDS::Face(TNaming_Tool::GetShape(aNS));
+        aDefObject->SetSurface(BRep_Tool::Surface(aFace));
+      }
+    }
+    if (anObject->Type() == XCAFKinObjects_PairType_SlidingSurface
+        || anObject->Type() == XCAFKinObjects_PairType_RollingSurface)
+    {
+      if (Label()
+            .FindChild(ChildLab_FirstGeomParam)
+            .FindAttribute(TNaming_NamedShape::GetID(), aNS))
+      {
+        TopoDS_Face aFace = TopoDS::Face(TNaming_Tool::GetShape(aNS));
+        aDefObject->SetFirstSurface(BRep_Tool::Surface(aFace));
+      }
+      if (Label()
+            .FindChild(ChildLab_SecondGeomParam)
+            .FindAttribute(TNaming_NamedShape::GetID(), aNS))
+      {
+        TopoDS_Face aFace = TopoDS::Face(TNaming_Tool::GetShape(aNS));
+        aDefObject->SetSecondSurface(BRep_Tool::Surface(aFace));
+      }
+    }
+    if (anObject->Type() == XCAFKinObjects_PairType_PointOnPlanarCurve
+        || anObject->Type() == XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve)
+    {
+      if (Label()
+            .FindChild(ChildLab_FirstGeomParam)
+            .FindAttribute(TNaming_NamedShape::GetID(), aNS))
+      {
+        TopoDS_Edge   anEdge = TopoDS::Edge(TNaming_Tool::GetShape(aNS));
+        Standard_Real aFirst, aLast;
+        aDefObject->SetCurve(BRep_Tool::Curve(anEdge, aFirst, aLast));
+      }
+    }
+    if (anObject->Type() == XCAFKinObjects_PairType_SlidingCurve
+        || anObject->Type() == XCAFKinObjects_PairType_RollingCurve)
+    {
+      if (Label()
+            .FindChild(ChildLab_FirstGeomParam)
+            .FindAttribute(TNaming_NamedShape::GetID(), aNS))
+      {
+        TopoDS_Edge   anEdge = TopoDS::Edge(TNaming_Tool::GetShape(aNS));
+        Standard_Real aFirst, aLast;
+        aDefObject->SetFirstCurve(BRep_Tool::Curve(anEdge, aFirst, aLast));
+      }
+      if (Label()
+            .FindChild(ChildLab_SecondGeomParam)
+            .FindAttribute(TNaming_NamedShape::GetID(), aNS))
+      {
+        TopoDS_Edge   anEdge = TopoDS::Edge(TNaming_Tool::GetShape(aNS));
+        Standard_Real aFirst, aLast;
+        aDefObject->SetSecondCurve(BRep_Tool::Curve(anEdge, aFirst, aLast));
+      }
+    }
+  }
+
+  return anObject;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPair::ID() const
+{
+  return GetID();
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPair::Restore(const Handle(TDF_Attribute)& /*theWith*/) {}
+
+//=================================================================================================
+
+Handle(TDF_Attribute) XCAFKinObjects_KinematicPair::NewEmpty() const
+{
+  return new XCAFKinObjects_KinematicPair();
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPair::Paste(const Handle(TDF_Attribute)& /*theInfo*/,
+                                     const Handle(TDF_RelocationTable)& /*theRT*/) const
+{
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPair::DumpJson(Standard_OStream& theOStream,
+                                        Standard_Integer  theDepth) const
+{
+  OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
+
+  OCCT_DUMP_BASE_CLASS(theOStream, theDepth, TDF_Attribute)
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPair.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPair.cxx
@@ -52,9 +52,7 @@ enum ChildLab
 
 //=================================================================================================
 
-XCAFKinObjects_KinematicPair::XCAFKinObjects_KinematicPair()
-{
-}
+XCAFKinObjects_KinematicPair::XCAFKinObjects_KinematicPair() {}
 
 //=================================================================================================
 
@@ -166,7 +164,8 @@ void XCAFKinObjects_KinematicPair::SetObject(const Handle(XCAFKinObjects_PairObj
       Handle(XCAFKinObjects_HighOrderPairObject)::DownCast(theObject);
     TDataStd_Integer::Set(Label(), getParamsID(), (Standard_Integer)anObject->Orientation());
     BRep_Builder aBuilder;
-    if (theObject->Type() == XCAFKinObjects_PairType_PointOnSurface && !anObject->Surface().IsNull())
+    if (theObject->Type() == XCAFKinObjects_PairType_PointOnSurface
+        && !anObject->Surface().IsNull())
     {
       TopoDS_Face aFace;
       aBuilder.MakeFace(aFace, anObject->Surface(), Precision::Confusion());
@@ -224,12 +223,13 @@ void XCAFKinObjects_KinematicPair::SetObject(const Handle(XCAFKinObjects_PairObj
 Handle(XCAFKinObjects_PairObject) XCAFKinObjects_KinematicPair::GetObject() const
 {
   // Type
-  Handle(TDataStd_Integer)      aTypeAttr;
+  Handle(TDataStd_Integer)          aTypeAttr;
   Handle(XCAFKinObjects_PairObject) anObject = new XCAFKinObjects_PairObject();
   if (Label().FindAttribute(TDataStd_Integer::GetID(), aTypeAttr))
   {
     int aType = aTypeAttr->Get();
-    if (aType >= XCAFKinObjects_PairType_FullyConstrained && aType <= XCAFKinObjects_PairType_Unconstrained)
+    if (aType >= XCAFKinObjects_PairType_FullyConstrained
+        && aType <= XCAFKinObjects_PairType_Unconstrained)
       anObject = new XCAFKinObjects_LowOrderPairObject();
     else if (aType >= XCAFKinObjects_PairType_Screw
              && aType <= XCAFKinObjects_PairType_LinearFlexibleAndPinion)
@@ -394,14 +394,14 @@ Handle(TDF_Attribute) XCAFKinObjects_KinematicPair::NewEmpty() const
 //=================================================================================================
 
 void XCAFKinObjects_KinematicPair::Paste(const Handle(TDF_Attribute)& /*theInfo*/,
-                                     const Handle(TDF_RelocationTable)& /*theRT*/) const
+                                         const Handle(TDF_RelocationTable)& /*theRT*/) const
 {
 }
 
 //=================================================================================================
 
 void XCAFKinObjects_KinematicPair::DumpJson(Standard_OStream& theOStream,
-                                        Standard_Integer  theDepth) const
+                                            Standard_Integer  theDepth) const
 {
   OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
 

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPair.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPair.hxx
@@ -1,0 +1,145 @@
+// Created on: 2020-03-17
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_KinematicPair_HeaderFile
+#define _XCAFKinObjects_KinematicPair_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_Type.hxx>
+
+#include <TDF_Attribute.hxx>
+class Standard_GUID;
+class TDF_Label;
+class TDF_Attribute;
+class TDF_RelocationTable;
+class XCAFKinObjects_PairObject;
+
+// resolve name collisions with WinAPI headers
+#ifdef GetObject
+  #undef GetObject
+#endif
+
+class XCAFKinObjects_KinematicPair;
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_KinematicPair, TDF_Attribute)
+
+//! Attribute to store kinematic pair data within XCAF document structure.
+//!
+//! A kinematic pair represents a constraint between two links in a kinematic mechanism,
+//! defining how they can move relative to each other. Examples include revolute joints,
+//! prismatic joints, spherical joints, etc.
+//!
+//! The attribute itself does not contain data directly, but serves as a way to
+//! store/collect necessary standard attributes from the label and its children. The attribute
+//! is not stored directly in the OCAF document but is identified by a UAttribute with a
+//! special GUID.
+//!
+//! Use the static IsValidLabel() method to check if a label contains this attribute
+//! instead of using the common Label.FindAttribute() method.
+//!
+//! The attribute manages child labels with the following structure:
+//! - Child label 1: First transformation data
+//! - Child label 2: Second transformation data
+//! - Child label 3: First geometric parameters
+//! - Child label 4: Second geometric parameters
+class XCAFKinObjects_KinematicPair : public TDF_Attribute
+{
+
+public:
+  //! Default constructor.
+  //! Creates an empty kinematic pair attribute.
+  Standard_EXPORT XCAFKinObjects_KinematicPair();
+
+  //! Returns the GUID for kinematic pair attributes.
+  //! @return Standard_GUID identifying kinematic pair attributes
+  Standard_EXPORT static const Standard_GUID& GetID();
+
+  //! Checks if the given label has a UAttribute with the necessary GUID.
+  //! This method determines if a label represents a kinematic pair.
+  //! @param theLabel Label to check
+  //! @return true if the label represents a kinematic pair, false otherwise
+  Standard_EXPORT static Standard_Boolean IsValidLabel(const TDF_Label& theLabel);
+
+  //! Creates (if does not exist) or retrieves a kinematic pair attribute on the specified label.
+  //! Also ensures the label has the required UAttribute with special GUID.
+  //! @param theLabel Label where kinematic pair attribute should be created or found
+  //! @return Handle to the kinematic pair attribute
+  Standard_EXPORT static Handle(XCAFKinObjects_KinematicPair) Set(const TDF_Label& theLabel);
+
+  //! Returns the GUID identifying this attribute.
+  //! @return Standard_GUID of this attribute
+  Standard_EXPORT const Standard_GUID& ID() const Standard_OVERRIDE;
+
+  //! Restores the attribute from another attribute.
+  //! This implementation is empty as the attribute does not directly store data.
+  //! @param theWith Attribute to restore from
+  Standard_EXPORT void Restore(const Handle(TDF_Attribute)& theWith) Standard_OVERRIDE;
+
+  //! Creates a new empty attribute.
+  //! @return Handle to the new attribute
+  Standard_EXPORT Handle(TDF_Attribute) NewEmpty() const Standard_OVERRIDE;
+
+  //! Pastes the attribute into another attribute.
+  //! This implementation is empty as the attribute does not directly store data.
+  //! @param theInfo Target attribute to paste into
+  //! @param theRT Relocation table
+  Standard_EXPORT void Paste(const Handle(TDF_Attribute)&       theInfo,
+                             const Handle(TDF_RelocationTable)& theRT) const Standard_OVERRIDE;
+
+  //! Updates parent's label and its sub-labels with data taken from thePairObject.
+  //! Old data associated with the label will be lost. This method stores all
+  //! necessary information like type, name, transformations, limits, and geometry.
+  //!
+  //! Different types of pair objects are handled according to their specific requirements:
+  //! - Low order pairs (simple joints like revolute, prismatic)
+  //! - Low order pairs with motion coupling (like screw)
+  //! - High order pairs (more complex joints involving curves and surfaces)
+  //!
+  //! @param thePairObject Kinematic pair object containing the data to be stored
+  Standard_EXPORT void SetObject(const Handle(XCAFKinObjects_PairObject)& thePairObject);
+
+  //! Returns a kinematic pair object reconstructed from the data stored in the
+  //! parent's label and its sub-labels.
+  //!
+  //! The method creates an appropriate type of object (low order, with coupling, or high order)
+  //! based on the stored pair type, and populates it with all necessary data including name,
+  //! transformations, limits, parameters, and geometry.
+  //!
+  //! @return Handle to the reconstructed kinematic pair object
+  Standard_EXPORT Handle(XCAFKinObjects_PairObject) GetObject() const;
+
+  //! Dumps the content of this attribute into the JSON stream.
+  //! @param theOStream Output stream where JSON data will be written
+  //! @param theDepth Recursion depth for JSON structure (-1 for maximum depth)
+  Standard_EXPORT virtual void DumpJson(Standard_OStream& theOStream,
+                                        Standard_Integer  theDepth = -1) const Standard_OVERRIDE;
+
+private:
+  //! Returns the GUID for limits attributes used by kinematic pairs.
+  //! @return Standard_GUID for limits attributes
+  Standard_EXPORT static const Standard_GUID& getLimitsID();
+
+  //! Returns the GUID for parameter attributes used by kinematic pairs.
+  //! @return Standard_GUID for parameter attributes
+  Standard_EXPORT static const Standard_GUID& getParamsID();
+
+  //! Returns the special GUID of UAttribute that indicates a label contains
+  //! XCAFKinObjects_KinematicPair attribute.
+  //! @return Standard_GUID for identifying kinematic pair labels
+  Standard_EXPORT static const Standard_GUID& getUID();
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_KinematicPair, TDF_Attribute)
+};
+
+#endif

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.cxx
@@ -33,9 +33,7 @@ IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_KinematicPairValue, TDF_Attribute)
 
 //=================================================================================================
 
-XCAFKinObjects_KinematicPairValue::XCAFKinObjects_KinematicPairValue()
-{
-}
+XCAFKinObjects_KinematicPairValue::XCAFKinObjects_KinematicPairValue() {}
 
 //=================================================================================================
 
@@ -64,8 +62,9 @@ Standard_Boolean XCAFKinObjects_KinematicPairValue::IsValidLabel(const TDF_Label
 
 //=================================================================================================
 
-Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set(const TDF_Label& theValue,
-                                                                         const TDF_Label& theJoint)
+Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set(
+  const TDF_Label& theValue,
+  const TDF_Label& theJoint)
 {
   TDataStd_UAttribute::Set(theValue, XCAFKinObjects_KinematicPairValue::getUID());
   Handle(XCAFKinObjects_KinematicPairValue) anAttr;
@@ -94,7 +93,8 @@ Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set
 
 //=================================================================================================
 
-Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set(const TDF_Label& theValue)
+Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set(
+  const TDF_Label& theValue)
 {
   TDataStd_UAttribute::Set(theValue, XCAFKinObjects_KinematicPairValue::getUID());
   Handle(XCAFKinObjects_KinematicPairValue) anAttr;
@@ -109,7 +109,8 @@ Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set
 
 //=================================================================================================
 
-void XCAFKinObjects_KinematicPairValue::SetObject(const Handle(XCAFKinObjects_PairValueObject)& theObject)
+void XCAFKinObjects_KinematicPairValue::SetObject(
+  const Handle(XCAFKinObjects_PairValueObject)& theObject)
 {
   Backup();
 
@@ -133,7 +134,7 @@ void XCAFKinObjects_KinematicPairValue::SetObject(const Handle(XCAFKinObjects_Pa
 Handle(XCAFKinObjects_PairValueObject) XCAFKinObjects_KinematicPairValue::GetObject() const
 {
   // Type
-  Handle(TDataStd_Integer)           aTypeAttr;
+  Handle(TDataStd_Integer)               aTypeAttr;
   Handle(XCAFKinObjects_PairValueObject) anObject = new XCAFKinObjects_PairValueObject();
   if (Label().FindAttribute(TDataStd_Integer::GetID(), aTypeAttr))
   {
@@ -173,14 +174,14 @@ Handle(TDF_Attribute) XCAFKinObjects_KinematicPairValue::NewEmpty() const
 //=================================================================================================
 
 void XCAFKinObjects_KinematicPairValue::Paste(const Handle(TDF_Attribute)& /*theInfo*/,
-                                          const Handle(TDF_RelocationTable)& /*theRT*/) const
+                                              const Handle(TDF_RelocationTable)& /*theRT*/) const
 {
 }
 
 //=================================================================================================
 
 void XCAFKinObjects_KinematicPairValue::DumpJson(Standard_OStream& theOStream,
-                                             Standard_Integer  theDepth) const
+                                                 Standard_Integer  theDepth) const
 {
   OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
 

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.cxx
@@ -1,0 +1,188 @@
+// Created on: 2020-03-30
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFKinObjects_KinematicPairValue.hxx>
+
+#include <XCAFDoc.hxx>
+#include <XCAFKinObjects_KinematicPair.hxx>
+#include <XCAFKinObjects_PairValueObject.hxx>
+#include <Standard_Dump.hxx>
+#include <Standard_GUID.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <TDataStd_Name.hxx>
+#include <TDataStd_Integer.hxx>
+#include <TDataStd_RealArray.hxx>
+#include <TDataStd_TreeNode.hxx>
+#include <TDataStd_UAttribute.hxx>
+#include <TDF_ChildIterator.hxx>
+#include <XCAFDoc.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_KinematicPairValue, TDF_Attribute)
+
+//=================================================================================================
+
+XCAFKinObjects_KinematicPairValue::XCAFKinObjects_KinematicPairValue()
+{
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPairValue::GetID()
+{
+  static Standard_GUID PairValueID("4F451E46-0AC9-4270-90E4-D96605CDE635");
+  return PairValueID;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPairValue::getUID()
+{
+  static Standard_GUID PairUID("4F451E46-0AC9-4270-90E4-D96605CDE636");
+  return PairUID;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_KinematicPairValue::IsValidLabel(const TDF_Label& theLabel)
+{
+  TDataStd_UAttribute::Set(theLabel, XCAFKinObjects_KinematicPairValue::getUID());
+  Handle(TDataStd_UAttribute) anAttr;
+  return theLabel.FindAttribute(XCAFKinObjects_KinematicPairValue::getUID(), anAttr);
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set(const TDF_Label& theValue,
+                                                                         const TDF_Label& theJoint)
+{
+  TDataStd_UAttribute::Set(theValue, XCAFKinObjects_KinematicPairValue::getUID());
+  Handle(XCAFKinObjects_KinematicPairValue) anAttr;
+  if (!theValue.FindAttribute(XCAFKinObjects_KinematicPairValue::GetID(), anAttr))
+  {
+    anAttr = new XCAFKinObjects_KinematicPairValue();
+    theValue.AddAttribute(anAttr);
+  }
+
+  // check for exist old reference
+  Handle(TDataStd_TreeNode) aJointNode, aValueNode;
+  if (theValue.FindAttribute(XCAFDoc::KinematicRefJointGUID(), aValueNode))
+  {
+    if (aValueNode->HasFather() && aValueNode->Father()->Label() == theJoint)
+      return anAttr;
+    aValueNode->Remove();
+  }
+
+  // Add reference to Joint
+  aValueNode = TDataStd_TreeNode::Set(theJoint, XCAFDoc::KinematicRefJointGUID());
+  aJointNode = TDataStd_TreeNode::Set(theValue, XCAFDoc::KinematicRefJointGUID());
+
+  aValueNode->Append(aJointNode);
+  return anAttr;
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_KinematicPairValue) XCAFKinObjects_KinematicPairValue::Set(const TDF_Label& theValue)
+{
+  TDataStd_UAttribute::Set(theValue, XCAFKinObjects_KinematicPairValue::getUID());
+  Handle(XCAFKinObjects_KinematicPairValue) anAttr;
+  if (!theValue.FindAttribute(XCAFKinObjects_KinematicPairValue::GetID(), anAttr))
+  {
+    anAttr = new XCAFKinObjects_KinematicPairValue();
+    theValue.AddAttribute(anAttr);
+  }
+
+  return anAttr;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPairValue::SetObject(const Handle(XCAFKinObjects_PairValueObject)& theObject)
+{
+  Backup();
+
+  // Check validity of object
+  if (theObject->GetAllValues()->Length() == 0)
+  {
+    return;
+  }
+  TCollection_AsciiString aName = "Value ";
+  aName.AssignCat(TCollection_AsciiString(Label().Tag()));
+  TDataStd_Name::Set(Label(), aName);
+  TDataStd_Integer::Set(Label(), theObject->Type());
+
+  Handle(TDataStd_RealArray) aValuesAttr;
+  aValuesAttr = TDataStd_RealArray::Set(Label(), 1, theObject->GetAllValues()->Length());
+  aValuesAttr->ChangeArray(theObject->GetAllValues());
+}
+
+//=================================================================================================
+
+Handle(XCAFKinObjects_PairValueObject) XCAFKinObjects_KinematicPairValue::GetObject() const
+{
+  // Type
+  Handle(TDataStd_Integer)           aTypeAttr;
+  Handle(XCAFKinObjects_PairValueObject) anObject = new XCAFKinObjects_PairValueObject();
+  if (Label().FindAttribute(TDataStd_Integer::GetID(), aTypeAttr))
+  {
+    int aType = aTypeAttr->Get();
+    anObject->SetType((XCAFKinObjects_PairType)aType);
+  }
+
+  // Values
+  Handle(TDataStd_RealArray) aValuesAttr;
+  if (Label().FindAttribute(TDataStd_RealArray::GetID(), aValuesAttr))
+  {
+    Handle(TColStd_HArray1OfReal) aValuesArray = aValuesAttr->Array();
+    anObject->SetAllValues(aValuesArray);
+  }
+
+  return anObject;
+}
+
+//=================================================================================================
+
+const Standard_GUID& XCAFKinObjects_KinematicPairValue::ID() const
+{
+  return GetID();
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPairValue::Restore(const Handle(TDF_Attribute)& /*theWith*/) {}
+
+//=================================================================================================
+
+Handle(TDF_Attribute) XCAFKinObjects_KinematicPairValue::NewEmpty() const
+{
+  return new XCAFKinObjects_KinematicPairValue();
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPairValue::Paste(const Handle(TDF_Attribute)& /*theInfo*/,
+                                          const Handle(TDF_RelocationTable)& /*theRT*/) const
+{
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_KinematicPairValue::DumpJson(Standard_OStream& theOStream,
+                                             Standard_Integer  theDepth) const
+{
+  OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
+
+  OCCT_DUMP_BASE_CLASS(theOStream, theDepth, TDF_Attribute)
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.hxx
@@ -34,58 +34,99 @@ class XCAFKinObjects_PairValueObject;
 class XCAFKinObjects_KinematicPairValue;
 DEFINE_STANDARD_HANDLE(XCAFKinObjects_KinematicPairValue, TDF_Attribute)
 
-//! Attribute to store kinematic pair value.
-//! This parameter is an additional attribute for kinematic pair attribute,
-//! which characterizes the pair for one of the mechanism states.
-//! It is prohibited to store inconsistent data:
-//! - to store this attribute not of the same type as the type of linked the pair.
+//! Attribute to store kinematic pair value within XCAF document structure.
 //!
-//! The attribute itsels does not contain any data only a way to store/collect
-//! necessary standard attributes from the label, so the attribute
-//! does not stored to OCAF document only a UAttribute with special GUID.
-//! Use static IsValidLabel() method to check if the label contains this attribute
-//! instead of common Label.FindAttribute().
+//! A kinematic pair value represents a specific state or configuration of a
+//! kinematic pair. It characterizes how a joint is positioned or oriented for a
+//! particular mechanism state. For example, in a revolute joint, the value might
+//! represent a specific rotation angle.
+//!
+//! This attribute is associated with a joint through a reference (tree node) and
+//! is typically organized under state labels. It is important that the value type
+//! is consistent with the referenced joint's type.
+//!
+//! The attribute itself does not directly contain data but serves as a way to
+//! store/collect necessary standard attributes from the label. The attribute
+//! is not stored directly in the OCAF document but is identified by a UAttribute
+//! with a special GUID.
+//!
+//! Use the static IsValidLabel() method to check if a label contains this attribute
+//! instead of using the common Label.FindAttribute() method.
 class XCAFKinObjects_KinematicPairValue : public TDF_Attribute
 {
 
 public:
+  //! Default constructor.
+  //! Creates an empty kinematic pair value attribute.
   Standard_EXPORT XCAFKinObjects_KinematicPairValue();
 
+  //! Returns the GUID for kinematic pair value attributes.
+  //! @return Standard_GUID identifying kinematic pair value attributes
   Standard_EXPORT static const Standard_GUID& GetID();
 
-  //! Checks if the given label has UAttribute with the necessary GUID.
-  //! param[in] theLabel - label to check.
-  //! \return result of check.
+  //! Checks if the given label has a UAttribute with the necessary GUID.
+  //! This method determines if a label represents a kinematic pair value.
+  //! @param theLabel Label to check
+  //! @return true if the label represents a kinematic pair value, false otherwise
   Standard_EXPORT static Standard_Boolean IsValidLabel(const TDF_Label& theLabel);
 
+  //! Creates (if does not exist) or retrieves a kinematic pair value attribute on the
+  //! specified label and associates it with the specified joint.
+  //! Also establishes a reference from the value to the joint using tree nodes.
+  //! @param theValue Label where to create or find the kinematic pair value attribute
+  //! @param theJoint Label of the joint to associate with the value
+  //! @return Handle to the kinematic pair value attribute
   Standard_EXPORT static Handle(XCAFKinObjects_KinematicPairValue) Set(const TDF_Label& theValue,
-                                                                   const TDF_Label& theJoint);
+                                                                       const TDF_Label& theJoint);
 
+  //! Creates (if does not exist) or retrieves a kinematic pair value attribute on the
+  //! specified label without associating it with any joint.
+  //! @param theValue Label where to create or find the kinematic pair value attribute
+  //! @return Handle to the kinematic pair value attribute
   Standard_EXPORT static Handle(XCAFKinObjects_KinematicPairValue) Set(const TDF_Label& theValue);
 
+  //! Returns the GUID identifying this attribute.
+  //! @return Standard_GUID of this attribute
   Standard_EXPORT const Standard_GUID& ID() const Standard_OVERRIDE;
 
+  //! Restores the attribute from another attribute.
+  //! This implementation is empty as the attribute does not directly store data.
+  //! @param theWith Attribute to restore from
   Standard_EXPORT void Restore(const Handle(TDF_Attribute)& theWith) Standard_OVERRIDE;
 
+  //! Creates a new empty attribute.
+  //! @return Handle to the new attribute
   Standard_EXPORT Handle(TDF_Attribute) NewEmpty() const Standard_OVERRIDE;
 
+  //! Pastes the attribute into another attribute.
+  //! This implementation is empty as the attribute does not directly store data.
+  //! @param theInfo Target attribute to paste into
+  //! @param theRT Relocation table
   Standard_EXPORT void Paste(const Handle(TDF_Attribute)&       theInfo,
                              const Handle(TDF_RelocationTable)& theRT) const Standard_OVERRIDE;
 
-  //! Updates parent's label and its sub-labels with data taken from thePairValueObject.
-  //! Old data associated with the label will be lost.
+  //! Updates the parent's label with data taken from thePairValueObject.
+  //! Stores the type and values from the object into attributes on the label.
+  //! The object must contain valid values (non-empty array).
+  //! @param thePairValueObject Kinematic pair value object containing the data to be stored
   Standard_EXPORT void SetObject(const Handle(XCAFKinObjects_PairValueObject)& thePairValueObject);
 
-  //! Returns kinematic pair value object data taken from the parent's label and its sub-labels.
+  //! Returns a kinematic pair value object reconstructed from the data stored in the
+  //! parent's label.
+  //! Creates a new object and populates it with the type and values from the label's attributes.
+  //! @return Handle to the reconstructed kinematic pair value object
   Standard_EXPORT Handle(XCAFKinObjects_PairValueObject) GetObject() const;
 
-  //! Dumps the content of me into the stream
+  //! Dumps the content of this attribute into the JSON stream.
+  //! @param theOStream Output stream where JSON data will be written
+  //! @param theDepth Recursion depth for JSON structure (-1 for maximum depth)
   Standard_EXPORT virtual void DumpJson(Standard_OStream& theOStream,
                                         Standard_Integer  theDepth = -1) const Standard_OVERRIDE;
 
 private:
-  //! Special GUID of UAttribute to indicate that this labeland its children contains
+  //! Returns the special GUID of UAttribute that indicates a label contains
   //! XCAFKinObjects_KinematicPairValue attribute.
+  //! @return Standard_GUID for identifying kinematic pair value labels
   Standard_EXPORT static const Standard_GUID& getUID();
 
   DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_KinematicPairValue, TDF_Attribute)

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_KinematicPairValue.hxx
@@ -1,0 +1,94 @@
+// Created on: 2020-03-30
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_KinematicPairValue_HeaderFile
+#define _XCAFKinObjects_KinematicPairValue_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_Type.hxx>
+
+#include <TDF_Attribute.hxx>
+class Standard_GUID;
+class TDF_Label;
+class TDF_Attribute;
+class TDF_RelocationTable;
+class XCAFKinObjects_PairValueObject;
+
+// resolve name collisions with WinAPI headers
+#ifdef GetObject
+  #undef GetObject
+#endif
+
+class XCAFKinObjects_KinematicPairValue;
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_KinematicPairValue, TDF_Attribute)
+
+//! Attribute to store kinematic pair value.
+//! This parameter is an additional attribute for kinematic pair attribute,
+//! which characterizes the pair for one of the mechanism states.
+//! It is prohibited to store inconsistent data:
+//! - to store this attribute not of the same type as the type of linked the pair.
+//!
+//! The attribute itsels does not contain any data only a way to store/collect
+//! necessary standard attributes from the label, so the attribute
+//! does not stored to OCAF document only a UAttribute with special GUID.
+//! Use static IsValidLabel() method to check if the label contains this attribute
+//! instead of common Label.FindAttribute().
+class XCAFKinObjects_KinematicPairValue : public TDF_Attribute
+{
+
+public:
+  Standard_EXPORT XCAFKinObjects_KinematicPairValue();
+
+  Standard_EXPORT static const Standard_GUID& GetID();
+
+  //! Checks if the given label has UAttribute with the necessary GUID.
+  //! param[in] theLabel - label to check.
+  //! \return result of check.
+  Standard_EXPORT static Standard_Boolean IsValidLabel(const TDF_Label& theLabel);
+
+  Standard_EXPORT static Handle(XCAFKinObjects_KinematicPairValue) Set(const TDF_Label& theValue,
+                                                                   const TDF_Label& theJoint);
+
+  Standard_EXPORT static Handle(XCAFKinObjects_KinematicPairValue) Set(const TDF_Label& theValue);
+
+  Standard_EXPORT const Standard_GUID& ID() const Standard_OVERRIDE;
+
+  Standard_EXPORT void Restore(const Handle(TDF_Attribute)& theWith) Standard_OVERRIDE;
+
+  Standard_EXPORT Handle(TDF_Attribute) NewEmpty() const Standard_OVERRIDE;
+
+  Standard_EXPORT void Paste(const Handle(TDF_Attribute)&       theInfo,
+                             const Handle(TDF_RelocationTable)& theRT) const Standard_OVERRIDE;
+
+  //! Updates parent's label and its sub-labels with data taken from thePairValueObject.
+  //! Old data associated with the label will be lost.
+  Standard_EXPORT void SetObject(const Handle(XCAFKinObjects_PairValueObject)& thePairValueObject);
+
+  //! Returns kinematic pair value object data taken from the parent's label and its sub-labels.
+  Standard_EXPORT Handle(XCAFKinObjects_PairValueObject) GetObject() const;
+
+  //! Dumps the content of me into the stream
+  Standard_EXPORT virtual void DumpJson(Standard_OStream& theOStream,
+                                        Standard_Integer  theDepth = -1) const Standard_OVERRIDE;
+
+private:
+  //! Special GUID of UAttribute to indicate that this labeland its children contains
+  //! XCAFKinObjects_KinematicPairValue attribute.
+  Standard_EXPORT static const Standard_GUID& getUID();
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_KinematicPairValue, TDF_Attribute)
+};
+
+#endif

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObject.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObject.cxx
@@ -1,0 +1,113 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFKinObjects_LowOrderPairObject.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_LowOrderPairObject, XCAFKinObjects_PairObject)
+
+//=================================================================================================
+
+XCAFKinObjects_LowOrderPairObject::XCAFKinObjects_LowOrderPairObject()
+{
+  myMinRotationX    = -Precision::Infinite();
+  myMaxRotationX    = Precision::Infinite();
+  myMinRotationY    = -Precision::Infinite();
+  myMaxRotationY    = Precision::Infinite();
+  myMinRotationZ    = -Precision::Infinite();
+  myMaxRotationZ    = Precision::Infinite();
+  myMinTranslationX = -Precision::Infinite();
+  myMaxTranslationX = Precision::Infinite();
+  myMinTranslationY = -Precision::Infinite();
+  myMaxTranslationY = Precision::Infinite();
+  myMinTranslationZ = -Precision::Infinite();
+  myMaxTranslationZ = Precision::Infinite();
+  myIsRanged        = Standard_False;
+}
+
+//=================================================================================================
+
+XCAFKinObjects_LowOrderPairObject::XCAFKinObjects_LowOrderPairObject(
+  const Handle(XCAFKinObjects_LowOrderPairObject)& theObj)
+{
+  SetName(theObj->Name());
+  SetType(theObj->Type());
+  SetFirstTransformation(theObj->FirstTransformation());
+  SetSecondTransformation(theObj->SecondTransformation());
+  myMinRotationX    = theObj->myMinRotationX;
+  myMaxRotationX    = theObj->myMaxRotationX;
+  myMinRotationY    = theObj->myMinRotationY;
+  myMaxRotationY    = theObj->myMaxRotationY;
+  myMinRotationZ    = theObj->myMinRotationZ;
+  myMaxRotationZ    = theObj->myMaxRotationZ;
+  myMinTranslationX = theObj->myMinTranslationX;
+  myMaxTranslationX = theObj->myMaxTranslationX;
+  myMinTranslationY = theObj->myMinTranslationY;
+  myMaxTranslationY = theObj->myMaxTranslationY;
+  myMinTranslationZ = theObj->myMinTranslationZ;
+  myMaxTranslationZ = theObj->myMaxTranslationZ;
+  myIsRanged        = theObj->HasLimits();
+}
+
+//=================================================================================================
+
+Handle(TColStd_HArray1OfReal) XCAFKinObjects_LowOrderPairObject::GetAllLimits() const
+{
+  Handle(TColStd_HArray1OfReal) aLimitArray;
+  if (!HasLimits())
+    return aLimitArray;
+  aLimitArray                  = new TColStd_HArray1OfReal(1, 12);
+  aLimitArray->ChangeValue(1)  = myMinRotationX;
+  aLimitArray->ChangeValue(2)  = myMaxRotationX;
+  aLimitArray->ChangeValue(3)  = myMinRotationY;
+  aLimitArray->ChangeValue(4)  = myMaxRotationY;
+  aLimitArray->ChangeValue(5)  = myMinRotationZ;
+  aLimitArray->ChangeValue(6)  = myMaxRotationZ;
+  aLimitArray->ChangeValue(7)  = myMinTranslationX;
+  aLimitArray->ChangeValue(8)  = myMaxTranslationX;
+  aLimitArray->ChangeValue(9)  = myMinTranslationY;
+  aLimitArray->ChangeValue(10) = myMaxTranslationY;
+  aLimitArray->ChangeValue(11) = myMinTranslationZ;
+  aLimitArray->ChangeValue(12) = myMaxTranslationZ;
+  return aLimitArray;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_LowOrderPairObject::HasLimits() const
+{
+  return myIsRanged;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObject::SetAllLimits(const Handle(TColStd_HArray1OfReal)& theLimits)
+{
+  if (theLimits->Length() != 12)
+    return;
+  myMinRotationX    = theLimits->Value(1);
+  myMaxRotationX    = theLimits->Value(2);
+  myMinRotationY    = theLimits->Value(3);
+  myMaxRotationY    = theLimits->Value(4);
+  myMinRotationZ    = theLimits->Value(5);
+  myMaxRotationZ    = theLimits->Value(6);
+  myMinTranslationX = theLimits->Value(7);
+  myMaxTranslationX = theLimits->Value(8);
+  myMinTranslationY = theLimits->Value(9);
+  myMaxTranslationY = theLimits->Value(10);
+  myMinTranslationZ = theLimits->Value(11);
+  myMaxTranslationZ = theLimits->Value(12);
+  myIsRanged        = Standard_True;
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObject.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObject.hxx
@@ -1,0 +1,267 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_LowOrderPairObject_HeaderFile
+#define _XCAFKinObjects_LowOrderPairObject_HeaderFile
+
+#include <XCAFKinObjects_PairObject.hxx>
+
+class TColStd_HArray1OfReal;
+
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_LowOrderPairObject, XCAFKinObjects_PairObject)
+
+// clang-format off
+//! Object for low order kinematic pairs that represent standard mechanical joints
+//! with common degrees of freedom and constraints.
+//!
+//! Low order pairs constrain the relative movement between two bodies in a well-defined manner.
+//! Each pair has a specific combination of allowed and restricted degrees of freedom (DOF),
+//! represented as a tuple of 6 boolean values <rX, rY, rZ, tX, tY, tZ> where:
+//! - rX, rY, rZ: rotation around X, Y, and Z axes respectively
+//! - tX, tY, tZ: translation along X, Y, and Z axes respectively
+//! - T: allowed movement (true)
+//! - F: restricted movement (false)
+//! Supported low order pair types include:
+//! - XCAFKinObjects_PairType_FullyConstrained <F, F, F, F, F, F> - No DOF, rigid connection
+//! - XCAFKinObjects_PairType_Revolute         <F, F, T, F, F, F> - 1 DOF, rotation around Z only
+//! - XCAFKinObjects_PairType_Prismatic        <F, F, F, T, F, F> - 1 DOF, translation along X only
+//! - XCAFKinObjects_PairType_Cylindrical      <F, F, T, F, F, T> - 2 DOF, rotation and translation on same axis
+//! - XCAFKinObjects_PairType_Universal        <T, F, T, F, F, F> - 2 DOF, rotation around X and Z (with skew angle)
+//! - XCAFKinObjects_PairType_Homokinetic      <T, F, T, F, F, F> - 2 DOF, similar to Universal but with constant velocity
+//! - XCAFKinObjects_PairType_SphericalWithPin <F, T, T, F, F, F> - 2 DOF, rotation around Y and Z
+//! - XCAFKinObjects_PairType_Spherical        <T, T, T, F, F, F> - 3 DOF, rotation around all axes
+//! - XCAFKinObjects_PairType_Planar           <T, F, F, T, T, F> - 3 DOF, rotation around X and translation along X and Y
+//! - XCAFKinObjects_PairType_Unconstrained    <T, T, T, T, T, T> - 6 DOF, no constraints
+// clang-format on
+class XCAFKinObjects_LowOrderPairObject : public XCAFKinObjects_PairObject
+{
+
+public:
+  //! Default constructor.
+  //! Creates an empty low order pair object with all limits set to infinity (no constraints).
+  Standard_EXPORT XCAFKinObjects_LowOrderPairObject();
+
+  //! Copy constructor.
+  //! @param theObj Source low order pair object to copy from
+  Standard_EXPORT XCAFKinObjects_LowOrderPairObject(
+    const Handle(XCAFKinObjects_LowOrderPairObject)& theObj);
+
+  //! Sets the minimum rotation limit around X axis.
+  //! @param theLimit Minimum rotation value in radians
+  void SetMinRotationX(const Standard_Real theLimit)
+  {
+    myMinRotationX = theLimit;
+    myIsRanged     = Standard_True;
+  }
+
+  //! Returns the minimum rotation limit around X axis.
+  //! @return Minimum rotation value in radians
+  Standard_Real MinRotationX() const { return myMinRotationX; }
+
+  //! Sets the maximum rotation limit around X axis.
+  //! @param theLimit Maximum rotation value in radians
+  void SetMaxRotationX(const Standard_Real theLimit)
+  {
+    myMaxRotationX = theLimit;
+    myIsRanged     = Standard_True;
+  }
+
+  //! Returns the maximum rotation limit around X axis.
+  //! @return Maximum rotation value in radians
+  Standard_Real MaxRotationX() const { return myMaxRotationX; }
+
+  //! Sets the minimum rotation limit around Y axis.
+  //! @param theLimit Minimum rotation value in radians
+  void SetMinRotationY(const Standard_Real theLimit)
+  {
+    myMinRotationY = theLimit;
+    myIsRanged     = Standard_True;
+  }
+
+  //! Returns the minimum rotation limit around Y axis.
+  //! @return Minimum rotation value in radians
+  Standard_Real MinRotationY() const { return myMinRotationY; }
+
+  //! Sets the maximum rotation limit around Y axis.
+  //! @param theLimit Maximum rotation value in radians
+  void SetMaxRotationY(const Standard_Real theLimit)
+  {
+    myMaxRotationY = theLimit;
+    myIsRanged     = Standard_True;
+  }
+
+  //! Returns the maximum rotation limit around Y axis.
+  //! @return Maximum rotation value in radians
+  Standard_Real MaxRotationY() const { return myMaxRotationY; }
+
+  //! Sets the minimum rotation limit around Z axis.
+  //! @param theLimit Minimum rotation value in radians
+  void SetMinRotationZ(const Standard_Real theLimit)
+  {
+    myMinRotationZ = theLimit;
+    myIsRanged     = Standard_True;
+  }
+
+  //! Returns the minimum rotation limit around Z axis.
+  //! @return Minimum rotation value in radians
+  Standard_Real MinRotationZ() const { return myMinRotationZ; }
+
+  //! Sets the maximum rotation limit around Z axis.
+  //! @param theLimit Maximum rotation value in radians
+  void SetMaxRotationZ(const Standard_Real theLimit)
+  {
+    myMaxRotationZ = theLimit;
+    myIsRanged     = Standard_True;
+  }
+
+  //! Returns the maximum rotation limit around Z axis.
+  //! @return Maximum rotation value in radians
+  Standard_Real MaxRotationZ() const { return myMaxRotationZ; }
+
+  //! Sets the minimum translation limit along X axis.
+  //! @param theLimit Minimum translation value
+  void SetMinTranslationX(const Standard_Real theLimit)
+  {
+    myMinTranslationX = theLimit;
+    myIsRanged        = Standard_True;
+  }
+
+  //! Returns the minimum translation limit along X axis.
+  //! @return Minimum translation value
+  Standard_Real MinTranslationX() const { return myMinTranslationX; }
+
+  //! Sets the maximum translation limit along X axis.
+  //! @param theLimit Maximum translation value
+  void SetMaxTranslationX(const Standard_Real theLimit)
+  {
+    myMaxTranslationX = theLimit;
+    myIsRanged        = Standard_True;
+  }
+
+  //! Returns the maximum translation limit along X axis.
+  //! @return Maximum translation value
+  Standard_Real MaxTranslationX() const { return myMaxTranslationX; }
+
+  //! Sets the minimum translation limit along Y axis.
+  //! @param theLimit Minimum translation value
+  void SetMinTranslationY(const Standard_Real theLimit)
+  {
+    myMinTranslationY = theLimit;
+    myIsRanged        = Standard_True;
+  }
+
+  //! Returns the minimum translation limit along Y axis.
+  //! @return Minimum translation value
+  Standard_Real MinTranslationY() const { return myMinTranslationY; }
+
+  //! Sets the maximum translation limit along Y axis.
+  //! @param theLimit Maximum translation value
+  void SetMaxTranslationY(const Standard_Real theLimit)
+  {
+    myMaxTranslationY = theLimit;
+    myIsRanged        = Standard_True;
+  }
+
+  //! Returns the maximum translation limit along Y axis.
+  //! @return Maximum translation value
+  Standard_Real MaxTranslationY() const { return myMaxTranslationY; }
+
+  //! Sets the minimum translation limit along Z axis.
+  //! @param theLimit Minimum translation value
+  void SetMinTranslationZ(const Standard_Real theLimit)
+  {
+    myMinTranslationZ = theLimit;
+    myIsRanged        = Standard_True;
+  }
+
+  //! Returns the minimum translation limit along Z axis.
+  //! @return Minimum translation value
+  Standard_Real MinTranslationZ() const { return myMinTranslationZ; }
+
+  //! Sets the maximum translation limit along Z axis.
+  //! @param theLimit Maximum translation value
+  void SetMaxTranslationZ(const Standard_Real theLimit)
+  {
+    myMaxTranslationZ = theLimit;
+    myIsRanged        = Standard_True;
+  }
+
+  //! Returns the maximum translation limit along Z axis.
+  //! @return Maximum translation value
+  Standard_Real MaxTranslationZ() const { return myMaxTranslationZ; }
+
+  //! Sets the skew angle parameter for Universal or Homokinetic pairs.
+  //! This angle defines the offset between the two rotation axes.
+  //! Only applicable for XCAFKinObjects_PairType_Universal and XCAFKinObjects_PairType_Homokinetic.
+  //! @param theAngle Skew angle value in radians
+  void SetSkewAngle(const Standard_Real theAngle)
+  {
+    if (Type() == XCAFKinObjects_PairType_Universal
+        || Type() == XCAFKinObjects_PairType_Homokinetic)
+      mySkewAngle = theAngle;
+  }
+
+  //! Returns the skew angle parameter for Universal or Homokinetic pairs.
+  //! @return Skew angle value in radians, or 0 if not applicable for this pair type
+  Standard_Real SkewAngle() const
+  {
+    if (Type() == XCAFKinObjects_PairType_Universal
+        || Type() == XCAFKinObjects_PairType_Homokinetic)
+      return mySkewAngle;
+    else
+      return 0;
+  }
+
+  //! Creates and returns an array containing all limit values in a standard order.
+  //! The array contains 12 values representing min/max values for rotation and translation
+  //! around and along the X, Y and Z axes, ordered as:
+  //! [minRotX, maxRotX, minRotY, maxRotY, minRotZ, maxRotZ,
+  //!  minTransX, maxTransX, minTransY, maxTransY, minTransZ, maxTransZ]
+  //! @return Array containing all limit values or NULL if no limits defined
+  Standard_EXPORT Handle(TColStd_HArray1OfReal) GetAllLimits() const Standard_OVERRIDE;
+
+  //! Checks if any limits are defined for this kinematic pair.
+  //! @return true if at least one limit value has been defined, false otherwise
+  Standard_EXPORT virtual Standard_Boolean HasLimits() const Standard_OVERRIDE;
+
+  //! Sets all limit values from an array.
+  //! The array must contain 12 values representing min/max values for rotation and translation
+  //! around and along the X, Y and Z axes, ordered as:
+  //! [minRotX, maxRotX, minRotY, maxRotY, minRotZ, maxRotZ,
+  //!  minTransX, maxTransX, minTransY, maxTransY, minTransZ, maxTransZ]
+  //! @param theLimits Array containing all limit values to set
+  Standard_EXPORT void SetAllLimits(const Handle(TColStd_HArray1OfReal)& theLimits)
+    Standard_OVERRIDE;
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_LowOrderPairObject, XCAFKinObjects_PairObject)
+
+private:
+  Standard_Real    myMinRotationX;    //!< Minimum limit for rotation around X axis (in radians)
+  Standard_Real    myMaxRotationX;    //!< Maximum limit for rotation around X axis (in radians)
+  Standard_Real    myMinRotationY;    //!< Minimum limit for rotation around Y axis (in radians)
+  Standard_Real    myMaxRotationY;    //!< Maximum limit for rotation around Y axis (in radians)
+  Standard_Real    myMinRotationZ;    //!< Minimum limit for rotation around Z axis (in radians)
+  Standard_Real    myMaxRotationZ;    //!< Maximum limit for rotation around Z axis (in radians)
+  Standard_Real    myMinTranslationX; //!< Minimum limit for translation along X axis
+  Standard_Real    myMaxTranslationX; //!< Maximum limit for translation along X axis
+  Standard_Real    myMinTranslationY; //!< Minimum limit for translation along Y axis
+  Standard_Real    myMaxTranslationY; //!< Maximum limit for translation along Y axis
+  Standard_Real    myMinTranslationZ; //!< Minimum limit for translation along Z axis
+  Standard_Real    myMaxTranslationZ; //!< Maximum limit for translation along Z axis
+  Standard_Real    mySkewAngle;       //!< Skew angle parameter for universal/homokinetic pairs
+  Standard_Boolean myIsRanged;        //!< Flag indicating if any limits are defined
+};
+
+#endif // _XCAFKinObjects_LowOrderPairObject_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.cxx
@@ -1,0 +1,249 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_LowOrderPairObjectWithCoupling, XCAFKinObjects_PairObject)
+
+//=================================================================================================
+
+XCAFKinObjects_LowOrderPairObjectWithCoupling::XCAFKinObjects_LowOrderPairObjectWithCoupling()
+{
+  myIsRanged   = Standard_False;
+  myLowLimit   = -Precision::Infinite();
+  myUpperLimit = Precision::Infinite();
+  myParams     = NULL;
+}
+
+//=================================================================================================
+
+XCAFKinObjects_LowOrderPairObjectWithCoupling::XCAFKinObjects_LowOrderPairObjectWithCoupling(
+  const Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling)& theObj)
+{
+  SetName(theObj->Name());
+  SetType(theObj->Type());
+  SetFirstTransformation(theObj->FirstTransformation());
+  SetSecondTransformation(theObj->SecondTransformation());
+  myIsRanged   = theObj->HasLimits();
+  myLowLimit   = theObj->LowLimit();
+  myUpperLimit = theObj->UpperLimit();
+  myParams     = theObj->GetAllParams();
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetType(const XCAFKinObjects_PairType theType)
+{
+  XCAFKinObjects_PairObject::SetType(theType);
+  if (theType == XCAFKinObjects_PairType_Gear)
+    myParams = new TColStd_HArray1OfReal(1, 5);
+  else
+    myParams = new TColStd_HArray1OfReal(1, 1);
+}
+
+//=================================================================================================
+
+Handle(TColStd_HArray1OfReal) XCAFKinObjects_LowOrderPairObjectWithCoupling::GetAllLimits() const
+{
+  Handle(TColStd_HArray1OfReal) aLimitArray;
+  if (!HasLimits())
+  {
+    return aLimitArray;
+  }
+  aLimitArray                 = new TColStd_HArray1OfReal(1, 2);
+  aLimitArray->ChangeValue(1) = myLowLimit;
+  aLimitArray->ChangeValue(2) = myUpperLimit;
+  return aLimitArray;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetPitch(const Standard_Real thePitch)
+{
+  if (Type() == XCAFKinObjects_PairType_Screw)
+  {
+    myParams->ChangeFirst() = thePitch;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::Pitch() const
+{
+  if (Type() == XCAFKinObjects_PairType_Screw)
+  {
+    return myParams->First();
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetPinionRadius(const Standard_Real theRadius)
+{
+  if (Type() == XCAFKinObjects_PairType_RackAndPinion
+      || Type() == XCAFKinObjects_PairType_LinearFlexibleAndPinion)
+  {
+    myParams->ChangeFirst() = theRadius;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::PinionRadius() const
+{
+  if (Type() == XCAFKinObjects_PairType_RackAndPinion
+      || Type() == XCAFKinObjects_PairType_LinearFlexibleAndPinion)
+  {
+    return myParams->First();
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetRadiusFirstLink(const Standard_Real theRadius)
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    myParams->ChangeFirst() = theRadius;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::RadiusFirstLink() const
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    return myParams->First();
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetRadiusSecondLink(const Standard_Real theRadius)
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    myParams->ChangeValue(2) = theRadius;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::RadiusSecondLink() const
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    return myParams->Value(2);
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetBevel(const Standard_Real theBevel)
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    myParams->ChangeValue(3) = theBevel;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::Bevel() const
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    return myParams->Value(3);
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetHelicalAngle(const Standard_Real theAngle)
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    myParams->ChangeValue(4) = theAngle;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::HelicalAngle() const
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    return myParams->Value(4);
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetGearRatio(const Standard_Real theGearRatio)
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    myParams->ChangeValue(5) = theGearRatio;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::GearRatio() const
+{
+  if (Type() == XCAFKinObjects_PairType_Gear)
+  {
+    return myParams->Value(5);
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetAllParams(
+  const Handle(TColStd_HArray1OfReal)& theParams)
+{
+  if (theParams->Length() == myParams->Length())
+  {
+    myParams = theParams;
+  }
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_LowOrderPairObjectWithCoupling::HasLimits() const
+{
+  return myIsRanged;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetAllLimits(
+  const Handle(TColStd_HArray1OfReal)& theLimits)
+{
+  if (theLimits->Length() == 2)
+  {
+    myIsRanged   = Standard_True;
+    myLowLimit   = theLimits->Value(1);
+    myUpperLimit = theLimits->Value(2);
+  }
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.cxx
@@ -114,7 +114,8 @@ Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::PinionRadius() cons
 
 //=================================================================================================
 
-void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetRadiusFirstLink(const Standard_Real theRadius)
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetRadiusFirstLink(
+  const Standard_Real theRadius)
 {
   if (Type() == XCAFKinObjects_PairType_Gear)
   {
@@ -135,7 +136,8 @@ Standard_Real XCAFKinObjects_LowOrderPairObjectWithCoupling::RadiusFirstLink() c
 
 //=================================================================================================
 
-void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetRadiusSecondLink(const Standard_Real theRadius)
+void XCAFKinObjects_LowOrderPairObjectWithCoupling::SetRadiusSecondLink(
+  const Standard_Real theRadius)
 {
   if (Type() == XCAFKinObjects_PairType_Gear)
   {

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx
@@ -21,117 +21,169 @@
 
 DEFINE_STANDARD_HANDLE(XCAFKinObjects_LowOrderPairObjectWithCoupling, XCAFKinObjects_PairObject)
 
-//! \class XCAFKinObjects_LowOrderPairObjectWithCoupling
-//! \brief Object for low order kinematic pairs with motion coupling:
-//! - XCAFKinObjects_PairType_Screw
-//! - XCAFKinObjects_PairType_RackAndPinion
-//! - XCAFKinObjects_PairType_Gear
-//! - XCAFKinObjects_PairType_LinearFlexibleAndPinion
+//! Object for low order kinematic pairs with motion coupling that represent
+//! mechanical joints where the movement of one component is directly linked to
+//! the movement of another component through a specific mechanical relationship.
+//!
+//! These pairs have additional parameters that define the coupling relationship
+//! between the movements. Supported pair types include:
+//! - XCAFKinObjects_PairType_Screw: Rotation is coupled with translation along the
+//!   same axis according to the pitch parameter (like a screw thread)
+//! - XCAFKinObjects_PairType_RackAndPinion: Rotation of the pinion is coupled with
+//!   linear translation of the rack
+//! - XCAFKinObjects_PairType_Gear: Rotation of one gear is coupled with rotation
+//!   of another gear according to their radii
+//! - XCAFKinObjects_PairType_LinearFlexibleAndPinion: Linear motion is coupled with
+//!   rotational motion through a flexible connection
 class XCAFKinObjects_LowOrderPairObjectWithCoupling : public XCAFKinObjects_PairObject
 {
 
 public:
+  //! Default constructor.
+  //! Creates an empty low order pair object with motion coupling and initializes
+  //! limits to infinity (no constraints).
   Standard_EXPORT XCAFKinObjects_LowOrderPairObjectWithCoupling();
 
+  //! Copy constructor.
+  //! @param theObj Source low order pair object with motion coupling to copy from
   Standard_EXPORT XCAFKinObjects_LowOrderPairObjectWithCoupling(
     const Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling)& theObj);
 
+  //! Sets the type of the low order pair with motion coupling and initializes
+  //! appropriate parameter arrays based on the type.
+  //! For Gear pairs, creates a parameter array with 5 elements.
+  //! For other types, creates a parameter array with 1 element.
+  //! @param theType Type of kinematic pair to set
   Standard_EXPORT void SetType(const XCAFKinObjects_PairType theType) Standard_OVERRIDE;
 
+  //! Sets the lower limit of the motion range.
+  //! @param theLimit Lower limit value
   void SetLowLimit(const Standard_Real theLimit)
   {
     myIsRanged = Standard_True;
     myLowLimit = theLimit;
   }
 
+  //! Returns the lower limit of the motion range.
+  //! @return Lower limit value
   Standard_Real LowLimit() const { return myLowLimit; }
 
+  //! Sets the upper limit of the motion range.
+  //! @param theLimit Upper limit value
   void SetUpperLimit(const Standard_Real theLimit)
   {
     myIsRanged   = Standard_True;
     myUpperLimit = theLimit;
   }
 
+  //! Returns the upper limit of the motion range.
+  //! @return Upper limit value
   Standard_Real UpperLimit() const { return myUpperLimit; }
 
-  //! Creates array with all limits
-  //! \return created array
+  //! Creates and returns an array containing both limit values.
+  //! The array contains 2 values: [lowLimit, upperLimit]
+  //! @return Array containing limit values or NULL if no limits defined
   Standard_EXPORT Handle(TColStd_HArray1OfReal) GetAllLimits() const Standard_OVERRIDE;
 
-  //! Sets pitch parameter (only for Screw)
-  //! \param[in] thePitch parameter value
+  //! Sets the pitch parameter for Screw pairs.
+  //! The pitch defines the linear displacement per revolution.
+  //! Only applicable for XCAFKinObjects_PairType_Screw.
+  //! @param thePitch Pitch value (linear displacement per revolution)
   Standard_EXPORT void SetPitch(const Standard_Real thePitch);
 
-  //! Gets pitch parameter (only for Screw)
-  //! \return parameter value
+  //! Returns the pitch parameter for Screw pairs.
+  //! @return Pitch value, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real Pitch() const;
 
-  //! Sets pinion radius parameter (only for RackAndPinion)
-  //! \param[in] theRadius parameter value
+  //! Sets the pinion radius parameter for RackAndPinion or LinearFlexibleAndPinion pairs.
+  //! Only applicable for XCAFKinObjects_PairType_RackAndPinion and
+  //! XCAFKinObjects_PairType_LinearFlexibleAndPinion.
+  //! @param theRadius Radius value of the pinion
   Standard_EXPORT void SetPinionRadius(const Standard_Real theRadius);
 
-  //! Gets pinion radius parameter (only for RackAndPinion)
-  //! \return parameter value
+  //! Returns the pinion radius parameter for RackAndPinion or LinearFlexibleAndPinion pairs.
+  //! @return Pinion radius value, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real PinionRadius() const;
 
-  //! Sets first link radius parameter (only for Gear)
-  //! \param[in] theRadius parameter value
+  //! Sets the first link radius parameter for Gear pairs.
+  //! Only applicable for XCAFKinObjects_PairType_Gear.
+  //! @param theRadius Radius value of the first gear
   Standard_EXPORT void SetRadiusFirstLink(const Standard_Real theRadius);
 
-  //! Gets first link radius parameter (only for Gear)
-  //! \return parameter value
+  //! Returns the first link radius parameter for Gear pairs.
+  //! @return First gear radius value, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real RadiusFirstLink() const;
 
-  //! Sets second link radius parameter (only for Gear)
-  //! \param[in] theRadius parameter value
+  //! Sets the second link radius parameter for Gear pairs.
+  //! Only applicable for XCAFKinObjects_PairType_Gear.
+  //! @param theRadius Radius value of the second gear
   Standard_EXPORT void SetRadiusSecondLink(const Standard_Real theRadius);
 
-  //! Gets second link radius parameter (only for Gear)
-  //! \return parameter value
+  //! Returns the second link radius parameter for Gear pairs.
+  //! @return Second gear radius value, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real RadiusSecondLink() const;
 
-  //! Sets bevel parameter (only for Gear)
-  //! \param[in] theBevel parameter value
+  //! Sets the bevel parameter for Gear pairs.
+  //! The bevel parameter defines the angle between gear axes for bevel gears.
+  //! Only applicable for XCAFKinObjects_PairType_Gear.
+  //! @param theBevel Bevel angle value in radians
   Standard_EXPORT void SetBevel(const Standard_Real theBevel);
 
-  //! Gets bevel parameter (only for Gear)
-  //! \return parameter value
+  //! Returns the bevel parameter for Gear pairs.
+  //! @return Bevel angle value in radians, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real Bevel() const;
 
-  //! Sets helical angle parameter (only for Gear)
-  //! \param[in] theAngle parameter value
+  //! Sets the helical angle parameter for Gear pairs.
+  //! The helical angle defines the angle of the gear teeth relative to the axis of rotation.
+  //! Only applicable for XCAFKinObjects_PairType_Gear.
+  //! @param theAngle Helical angle value in radians
   Standard_EXPORT void SetHelicalAngle(const Standard_Real theAngle);
 
-  //! Gets helical angle parameter (only for Gear)
-  //! \return parameter value
+  //! Returns the helical angle parameter for Gear pairs.
+  //! @return Helical angle value in radians, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real HelicalAngle() const;
 
-  //! Sets gear ratio parameter (only for Gear)
-  //! \param[in] theGearRatio parameter value
+  //! Sets the gear ratio parameter for Gear pairs.
+  //! Only applicable for XCAFKinObjects_PairType_Gear.
+  //! @param theGearRatio Gear ratio value
   Standard_EXPORT void SetGearRatio(const Standard_Real theGearRatio);
 
-  //! Gets gear ratio parameter (only for Gear)
-  //! \return parameter value
+  //! Returns the gear ratio parameter for Gear pairs.
+  //! @return Gear ratio value, or 0 if not applicable for this pair type
   Standard_EXPORT Standard_Real GearRatio() const;
 
-  //! Sets all parameters as an array
-  //! \param[in] theParams array of parameters
+  //! Sets all parameters from an array.
+  //! The array size must match the expected number of parameters for the pair type:
+  //! - 1 parameter for Screw, RackAndPinion, and LinearFlexibleAndPinion pairs
+  //! - 5 parameters for Gear pairs
+  //! @param theParams Array containing parameter values
   Standard_EXPORT void SetAllParams(const Handle(TColStd_HArray1OfReal)& theParams);
 
+  //! Returns the array containing all parameter values for the pair.
+  //! @return Array of parameter values
   Handle(TColStd_HArray1OfReal) GetAllParams() const { return myParams; }
 
+  //! Checks if any limits are defined for this kinematic pair.
+  //! @return true if at least one limit value has been defined, false otherwise
   Standard_EXPORT Standard_Boolean HasLimits() const Standard_OVERRIDE;
 
+  //! Sets both limit values from an array.
+  //! The array must contain exactly 2 values: [lowLimit, upperLimit]
+  //! @param theLimits Array containing limit values to set
   Standard_EXPORT void SetAllLimits(const Handle(TColStd_HArray1OfReal)& theLimits)
     Standard_OVERRIDE;
 
   DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_LowOrderPairObjectWithCoupling, XCAFKinObjects_PairObject)
 
 private:
-  Standard_Real                 myLowLimit;   //!< low limit of motion range
-  Standard_Real                 myUpperLimit; //!< upper limit of motion range
-  Handle(TColStd_HArray1OfReal) myParams;     //!< additional parameters of kinematic pair
-  Standard_Boolean              myIsRanged;   //!< flag "is limits defined"
+  //! Lower limit of motion range
+  Standard_Real myLowLimit;
+  //! Upper limit of motion range
+  Standard_Real myUpperLimit;
+  //! Array of coupling parameters specific to the pair type
+  Handle(TColStd_HArray1OfReal) myParams;
+  //! Flag indicating if any limits are defined
+  Standard_Boolean myIsRanged;
 };
 
 #endif // _XCAFKinObjects_LowOrderPairObjectWithCoupling_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_LowOrderPairObjectWithCoupling.hxx
@@ -1,0 +1,137 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_LowOrderPairObjectWithCoupling_HeaderFile
+#define _XCAFKinObjects_LowOrderPairObjectWithCoupling_HeaderFile
+
+#include <XCAFKinObjects_PairObject.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_LowOrderPairObjectWithCoupling, XCAFKinObjects_PairObject)
+
+//! \class XCAFKinObjects_LowOrderPairObjectWithCoupling
+//! \brief Object for low order kinematic pairs with motion coupling:
+//! - XCAFKinObjects_PairType_Screw
+//! - XCAFKinObjects_PairType_RackAndPinion
+//! - XCAFKinObjects_PairType_Gear
+//! - XCAFKinObjects_PairType_LinearFlexibleAndPinion
+class XCAFKinObjects_LowOrderPairObjectWithCoupling : public XCAFKinObjects_PairObject
+{
+
+public:
+  Standard_EXPORT XCAFKinObjects_LowOrderPairObjectWithCoupling();
+
+  Standard_EXPORT XCAFKinObjects_LowOrderPairObjectWithCoupling(
+    const Handle(XCAFKinObjects_LowOrderPairObjectWithCoupling)& theObj);
+
+  Standard_EXPORT void SetType(const XCAFKinObjects_PairType theType) Standard_OVERRIDE;
+
+  void SetLowLimit(const Standard_Real theLimit)
+  {
+    myIsRanged = Standard_True;
+    myLowLimit = theLimit;
+  }
+
+  Standard_Real LowLimit() const { return myLowLimit; }
+
+  void SetUpperLimit(const Standard_Real theLimit)
+  {
+    myIsRanged   = Standard_True;
+    myUpperLimit = theLimit;
+  }
+
+  Standard_Real UpperLimit() const { return myUpperLimit; }
+
+  //! Creates array with all limits
+  //! \return created array
+  Standard_EXPORT Handle(TColStd_HArray1OfReal) GetAllLimits() const Standard_OVERRIDE;
+
+  //! Sets pitch parameter (only for Screw)
+  //! \param[in] thePitch parameter value
+  Standard_EXPORT void SetPitch(const Standard_Real thePitch);
+
+  //! Gets pitch parameter (only for Screw)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real Pitch() const;
+
+  //! Sets pinion radius parameter (only for RackAndPinion)
+  //! \param[in] theRadius parameter value
+  Standard_EXPORT void SetPinionRadius(const Standard_Real theRadius);
+
+  //! Gets pinion radius parameter (only for RackAndPinion)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real PinionRadius() const;
+
+  //! Sets first link radius parameter (only for Gear)
+  //! \param[in] theRadius parameter value
+  Standard_EXPORT void SetRadiusFirstLink(const Standard_Real theRadius);
+
+  //! Gets first link radius parameter (only for Gear)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real RadiusFirstLink() const;
+
+  //! Sets second link radius parameter (only for Gear)
+  //! \param[in] theRadius parameter value
+  Standard_EXPORT void SetRadiusSecondLink(const Standard_Real theRadius);
+
+  //! Gets second link radius parameter (only for Gear)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real RadiusSecondLink() const;
+
+  //! Sets bevel parameter (only for Gear)
+  //! \param[in] theBevel parameter value
+  Standard_EXPORT void SetBevel(const Standard_Real theBevel);
+
+  //! Gets bevel parameter (only for Gear)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real Bevel() const;
+
+  //! Sets helical angle parameter (only for Gear)
+  //! \param[in] theAngle parameter value
+  Standard_EXPORT void SetHelicalAngle(const Standard_Real theAngle);
+
+  //! Gets helical angle parameter (only for Gear)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real HelicalAngle() const;
+
+  //! Sets gear ratio parameter (only for Gear)
+  //! \param[in] theGearRatio parameter value
+  Standard_EXPORT void SetGearRatio(const Standard_Real theGearRatio);
+
+  //! Gets gear ratio parameter (only for Gear)
+  //! \return parameter value
+  Standard_EXPORT Standard_Real GearRatio() const;
+
+  //! Sets all parameters as an array
+  //! \param[in] theParams array of parameters
+  Standard_EXPORT void SetAllParams(const Handle(TColStd_HArray1OfReal)& theParams);
+
+  Handle(TColStd_HArray1OfReal) GetAllParams() const { return myParams; }
+
+  Standard_EXPORT Standard_Boolean HasLimits() const Standard_OVERRIDE;
+
+  Standard_EXPORT void SetAllLimits(const Handle(TColStd_HArray1OfReal)& theLimits)
+    Standard_OVERRIDE;
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_LowOrderPairObjectWithCoupling, XCAFKinObjects_PairObject)
+
+private:
+  Standard_Real                 myLowLimit;   //!< low limit of motion range
+  Standard_Real                 myUpperLimit; //!< upper limit of motion range
+  Handle(TColStd_HArray1OfReal) myParams;     //!< additional parameters of kinematic pair
+  Standard_Boolean              myIsRanged;   //!< flag "is limits defined"
+};
+
+#endif // _XCAFKinObjects_LowOrderPairObjectWithCoupling_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.cxx
@@ -23,7 +23,8 @@ XCAFKinObjects_PairObject::XCAFKinObjects_PairObject() {}
 
 //=================================================================================================
 
-XCAFKinObjects_PairObject::XCAFKinObjects_PairObject(const Handle(XCAFKinObjects_PairObject)& theObj)
+XCAFKinObjects_PairObject::XCAFKinObjects_PairObject(
+  const Handle(XCAFKinObjects_PairObject)& theObj)
 {
   myName  = theObj->myName;
   myType  = theObj->myType;

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.cxx
@@ -1,0 +1,32 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <XCAFKinObjects_PairObject.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_PairObject, Standard_Transient)
+
+//=================================================================================================
+
+XCAFKinObjects_PairObject::XCAFKinObjects_PairObject() {}
+
+//=================================================================================================
+
+XCAFKinObjects_PairObject::XCAFKinObjects_PairObject(const Handle(XCAFKinObjects_PairObject)& theObj)
+{
+  myName  = theObj->myName;
+  myType  = theObj->myType;
+  myTrsf1 = theObj->myTrsf1;
+  myTrsf2 = theObj->myTrsf2;
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.hxx
@@ -25,45 +25,93 @@
 
 DEFINE_STANDARD_HANDLE(XCAFKinObjects_PairObject, Standard_Transient)
 
-//! \class XCAFKinObjects_PairObject
-//! \brief Main parent object for kinematic pairs
+//! Base class for kinematic pair objects that represent mechanical joints or constraints
+//! between two rigid bodies in a kinematic system.
+//!
+//! This class provides common properties and methods for all types of kinematic pairs,
+//! including identification, transformations, and limit management. Specific joint types
+//! are implemented in derived classes:
+//! - XCAFKinObjects_LowOrderPairObject: For standard joints with simple degrees of freedom
+//! - XCAFKinObjects_LowOrderPairObjectWithCoupling: For joints with coupled motion
+//! - XCAFKinObjects_HighOrderPairObject: For advanced joints involving curves and surfaces
+//!
+//! Each kinematic pair defines the relative position and permissible motion between
+//! two linked components through their transformation coordinate systems.
 class XCAFKinObjects_PairObject : public Standard_Transient
 {
 
 public:
+  //! Default constructor.
+  //! Creates an empty kinematic pair object with default transformation systems.
   Standard_EXPORT XCAFKinObjects_PairObject();
 
+  //! Copy constructor.
+  //! @param theObj Source kinematic pair object to copy from
   Standard_EXPORT XCAFKinObjects_PairObject(const Handle(XCAFKinObjects_PairObject)& theObj);
 
+  //! Sets the name of the kinematic pair.
+  //! @param theName Name to assign to this kinematic pair
   void SetName(const TCollection_AsciiString& theName) { myName = theName; }
 
+  //! Returns the name of the kinematic pair.
+  //! @return Current name of the kinematic pair
   TCollection_AsciiString Name() const { return myName; }
 
+  //! Sets the type of the kinematic pair.
+  //! This method is virtual and may be overridden in derived classes
+  //! to provide additional type-specific initialization.
+  //! @param theType Type of kinematic pair to set
   void virtual SetType(const XCAFKinObjects_PairType theType) { myType = theType; }
 
+  //! Returns the type of the kinematic pair.
+  //! @return Type of kinematic pair as an enumeration value
   XCAFKinObjects_PairType Type() const { return myType; }
 
+  //! Sets the coordinate system of the first connected component.
+  //! This coordinate system defines the position and orientation of the first component
+  //! at the joint location, and serves as a reference for motion constraints.
+  //! @param theTrsf Coordinate system to set
   void SetFirstTransformation(const gp_Ax3& theTrsf) { myTrsf1 = theTrsf; }
 
+  //! Returns the coordinate system of the first connected component.
+  //! @return Coordinate system of the first component
   gp_Ax3 FirstTransformation() const { return myTrsf1; }
 
+  //! Sets the coordinate system of the second connected component.
+  //! This coordinate system defines the position and orientation of the second component
+  //! at the joint location, and serves as a reference for motion constraints.
+  //! @param theTrsf Coordinate system to set
   void SetSecondTransformation(const gp_Ax3& theTrsf) { myTrsf2 = theTrsf; }
 
+  //! Returns the coordinate system of the second connected component.
+  //! @return Coordinate system of the second component
   gp_Ax3 SecondTransformation() const { return myTrsf2; }
 
+  //! Sets all limit values for the kinematic pair from an array.
+  //! This is a virtual method that must be implemented in derived classes
+  //! to handle pair-specific limit structures.
+  //! @param theLimits Array containing limit values
   Standard_EXPORT virtual void SetAllLimits(const Handle(TColStd_HArray1OfReal)& /*theLimits*/) {};
 
+  //! Checks if the kinematic pair has defined limit values.
+  //! This is a virtual method that should be implemented in derived classes
+  //! to handle pair-specific limit checking.
+  //! @return true if limits are defined, false otherwise
   Standard_EXPORT virtual Standard_Boolean HasLimits() const { return Standard_False; };
 
+  //! Returns all limit values for the kinematic pair.
+  //! This is a virtual method that should be implemented in derived classes
+  //! to return their specific limit values.
+  //! @return Array containing all limit values or NULL if no limits defined
   virtual Handle(TColStd_HArray1OfReal) GetAllLimits() const { return NULL; }
 
   DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_PairObject, Standard_Transient)
 
 private:
-  TCollection_AsciiString myName;  //!< name of kinematic pair
-  XCAFKinObjects_PairType     myType;  //!< type of kinematic pair
-  gp_Ax3                  myTrsf1; //!< first transformation element
-  gp_Ax3                  myTrsf2; //!< second transformation element
+  TCollection_AsciiString myName;  //!< Name of the kinematic pair for identification
+  XCAFKinObjects_PairType myType;  //!< Type of the kinematic pair defining its behavior
+  gp_Ax3                  myTrsf1; //!< Coordinate system of the first connected component
+  gp_Ax3                  myTrsf2; //!< Coordinate system of the second connected component
 };
 
 #endif // _XCAFKinObjects_PairObject_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairObject.hxx
@@ -1,0 +1,69 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_PairObject_HeaderFile
+#define _XCAFKinObjects_PairObject_HeaderFile
+
+#include <gp_Ax3.hxx>
+#include <Standard.hxx>
+#include <Standard_Type.hxx>
+#include <TCollection_AsciiString.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <XCAFKinObjects_PairType.hxx>
+
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_PairObject, Standard_Transient)
+
+//! \class XCAFKinObjects_PairObject
+//! \brief Main parent object for kinematic pairs
+class XCAFKinObjects_PairObject : public Standard_Transient
+{
+
+public:
+  Standard_EXPORT XCAFKinObjects_PairObject();
+
+  Standard_EXPORT XCAFKinObjects_PairObject(const Handle(XCAFKinObjects_PairObject)& theObj);
+
+  void SetName(const TCollection_AsciiString& theName) { myName = theName; }
+
+  TCollection_AsciiString Name() const { return myName; }
+
+  void virtual SetType(const XCAFKinObjects_PairType theType) { myType = theType; }
+
+  XCAFKinObjects_PairType Type() const { return myType; }
+
+  void SetFirstTransformation(const gp_Ax3& theTrsf) { myTrsf1 = theTrsf; }
+
+  gp_Ax3 FirstTransformation() const { return myTrsf1; }
+
+  void SetSecondTransformation(const gp_Ax3& theTrsf) { myTrsf2 = theTrsf; }
+
+  gp_Ax3 SecondTransformation() const { return myTrsf2; }
+
+  Standard_EXPORT virtual void SetAllLimits(const Handle(TColStd_HArray1OfReal)& /*theLimits*/) {};
+
+  Standard_EXPORT virtual Standard_Boolean HasLimits() const { return Standard_False; };
+
+  virtual Handle(TColStd_HArray1OfReal) GetAllLimits() const { return NULL; }
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_PairObject, Standard_Transient)
+
+private:
+  TCollection_AsciiString myName;  //!< name of kinematic pair
+  XCAFKinObjects_PairType     myType;  //!< type of kinematic pair
+  gp_Ax3                  myTrsf1; //!< first transformation element
+  gp_Ax3                  myTrsf2; //!< second transformation element
+};
+
+#endif // _XCAFKinObjects_PairObject_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairType.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairType.hxx
@@ -1,0 +1,53 @@
+// Created on: 2020-03-16
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_PairType_HeaderFile
+#define _XCAFKinObjects_PairType_HeaderFile
+
+//! Defines types of kinemtic pairs
+enum XCAFKinObjects_PairType
+{
+  // Auxiliary type
+  XCAFKinObjects_PairType_NoType,
+
+  // Low order pairs
+  XCAFKinObjects_PairType_FullyConstrained, // no DOF
+  XCAFKinObjects_PairType_Revolute,         // one rotation DOF
+  XCAFKinObjects_PairType_Prismatic,        // one translation DOF
+  XCAFKinObjects_PairType_Cylindrical,      // one rotation and one translation DOF
+  XCAFKinObjects_PairType_Universal,        // two rotation DOF
+  XCAFKinObjects_PairType_Homokinetic,      // two uniform rotation DOF
+  XCAFKinObjects_PairType_SphericalWithPin, // two rotation DOF
+  XCAFKinObjects_PairType_Spherical,        // three rotation DOF
+  XCAFKinObjects_PairType_Planar,           // one rotation and two translation DOF
+  XCAFKinObjects_PairType_Unconstrained,    // three rotation and three translation DOF
+
+  // Low order pairs with motion coupling
+  XCAFKinObjects_PairType_Screw,
+  XCAFKinObjects_PairType_RackAndPinion,
+  XCAFKinObjects_PairType_Gear,
+  XCAFKinObjects_PairType_LinearFlexibleAndPinion,
+
+  // High order pairs
+  XCAFKinObjects_PairType_PointOnSurface,
+  XCAFKinObjects_PairType_SlidingSurface,
+  XCAFKinObjects_PairType_RollingSurface,
+  XCAFKinObjects_PairType_PointOnPlanarCurve,
+  XCAFKinObjects_PairType_SlidingCurve,
+  XCAFKinObjects_PairType_RollingCurve,
+  XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve
+};
+
+#endif // _XCAFKinObjects_PairType_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairType.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairType.hxx
@@ -16,37 +16,68 @@
 #ifndef _XCAFKinObjects_PairType_HeaderFile
 #define _XCAFKinObjects_PairType_HeaderFile
 
-//! Defines types of kinemtic pairs
+//! Enumeration defining types of kinematic pairs that represent different kinds of joints
+//! and constraints between rigid bodies in kinematic systems.
+//! The enumeration includes three major categories:
+//! - Low order pairs: Simple mechanical joints with well-defined degrees of freedom (DOF)
+//! - Low order pairs with motion coupling: Joints where movement in one direction causes movement
+//! in another
+//! - High order pairs: Complex joints with advanced surface or curve interactions
 enum XCAFKinObjects_PairType
 {
   // Auxiliary type
+  //! Default value representing no specific type
   XCAFKinObjects_PairType_NoType,
 
   // Low order pairs
-  XCAFKinObjects_PairType_FullyConstrained, // no DOF
-  XCAFKinObjects_PairType_Revolute,         // one rotation DOF
-  XCAFKinObjects_PairType_Prismatic,        // one translation DOF
-  XCAFKinObjects_PairType_Cylindrical,      // one rotation and one translation DOF
-  XCAFKinObjects_PairType_Universal,        // two rotation DOF
-  XCAFKinObjects_PairType_Homokinetic,      // two uniform rotation DOF
-  XCAFKinObjects_PairType_SphericalWithPin, // two rotation DOF
-  XCAFKinObjects_PairType_Spherical,        // three rotation DOF
-  XCAFKinObjects_PairType_Planar,           // one rotation and two translation DOF
-  XCAFKinObjects_PairType_Unconstrained,    // three rotation and three translation DOF
+  //! Rigid connection with no degrees of freedom (DOF) between connected bodies
+  XCAFKinObjects_PairType_FullyConstrained,
+  //! Connection with single rotational DOF around one axis (like a door hinge)
+  XCAFKinObjects_PairType_Revolute,
+  //! Connection with single translational DOF along one axis (like a sliding drawer)
+  XCAFKinObjects_PairType_Prismatic,
+  //! Connection with one rotational and one translational DOF along same axis (like a screw without
+  //! pitch)
+  XCAFKinObjects_PairType_Cylindrical,
+  //! Connection with two rotational DOFs around different axes (like a universal joint)
+  XCAFKinObjects_PairType_Universal,
+  //! Similar to universal joint but with constant velocity in rotation (like a CV joint in
+  //! vehicles)
+  XCAFKinObjects_PairType_Homokinetic,
+  //! Connection with two rotational DOFs with a pin limiting the third rotation
+  XCAFKinObjects_PairType_SphericalWithPin,
+  //! Connection with three rotational DOFs around a point (like a ball-and-socket joint)
+  XCAFKinObjects_PairType_Spherical,
+  //! Connection with one rotational and two translational DOFs (like an object sliding on a plane)
+  XCAFKinObjects_PairType_Planar,
+  //! Connection with no constraints - three rotational and three translational DOFs
+  XCAFKinObjects_PairType_Unconstrained,
 
   // Low order pairs with motion coupling
+  //! Connection where rotation causes translation along same axis with specified pitch (like a
+  //! leadscrew)
   XCAFKinObjects_PairType_Screw,
+  //! Connection where linear motion of rack causes rotation of pinion and vice versa
   XCAFKinObjects_PairType_RackAndPinion,
+  //! Connection where rotation of one gear causes rotation of another with specified gear ratio
   XCAFKinObjects_PairType_Gear,
+  //! Connection with flexible linear element coupled to pinion rotation (like a belt drive)
   XCAFKinObjects_PairType_LinearFlexibleAndPinion,
 
   // High order pairs
+  //! Connection constraining a point to move on a surface
   XCAFKinObjects_PairType_PointOnSurface,
+  //! Connection where two surfaces slide against each other
   XCAFKinObjects_PairType_SlidingSurface,
+  //! Connection where two surfaces roll against each other without sliding
   XCAFKinObjects_PairType_RollingSurface,
+  //! Connection constraining a point to move along a planar curve
   XCAFKinObjects_PairType_PointOnPlanarCurve,
+  //! Connection where two curves slide against each other
   XCAFKinObjects_PairType_SlidingCurve,
+  //! Connection where two curves roll against each other without sliding
   XCAFKinObjects_PairType_RollingCurve,
+  //! Connection with flexible linear element constrained to move along a planar curve
   XCAFKinObjects_PairType_LinearFlexibleAndPlanarCurve
 };
 

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.cxx
@@ -264,7 +264,7 @@ Standard_Real XCAFKinObjects_PairValueObject::GetSecondTranslation() const
 //=================================================================================================
 
 void XCAFKinObjects_PairValueObject::SetFirstPointOnSurface(const Standard_Real theU,
-                                                        const Standard_Real theV)
+                                                            const Standard_Real theV)
 {
   switch (myType)
   {
@@ -288,7 +288,7 @@ void XCAFKinObjects_PairValueObject::SetFirstPointOnSurface(const Standard_Real 
 //=================================================================================================
 
 Standard_Boolean XCAFKinObjects_PairValueObject::GetFirstPointOnSurface(Standard_Real& theU,
-                                                                    Standard_Real& theV) const
+                                                                        Standard_Real& theV) const
 {
   switch (myType)
   {
@@ -313,7 +313,7 @@ Standard_Boolean XCAFKinObjects_PairValueObject::GetFirstPointOnSurface(Standard
 //=================================================================================================
 
 void XCAFKinObjects_PairValueObject::SetSecondPointOnSurface(const Standard_Real theU,
-                                                         const Standard_Real theV)
+                                                             const Standard_Real theV)
 {
   if (myType != XCAFKinObjects_PairType_SlidingSurface)
     return;
@@ -324,7 +324,7 @@ void XCAFKinObjects_PairValueObject::SetSecondPointOnSurface(const Standard_Real
 //=================================================================================================
 
 Standard_Boolean XCAFKinObjects_PairValueObject::GetSecondPointOnSurface(Standard_Real& theU,
-                                                                     Standard_Real& theV) const
+                                                                         Standard_Real& theV) const
 {
   if (myType != XCAFKinObjects_PairType_SlidingSurface)
     return Standard_False;
@@ -393,8 +393,8 @@ Standard_Real XCAFKinObjects_PairValueObject::GetSecondPointOnCurve() const
 //=================================================================================================
 
 void XCAFKinObjects_PairValueObject::SetYPR(const Standard_Real theYaw,
-                                        const Standard_Real thePitch,
-                                        const Standard_Real theRoll)
+                                            const Standard_Real thePitch,
+                                            const Standard_Real theRoll)
 {
   switch (myType)
   {
@@ -422,8 +422,8 @@ void XCAFKinObjects_PairValueObject::SetYPR(const Standard_Real theYaw,
 //=================================================================================================
 
 Standard_Boolean XCAFKinObjects_PairValueObject::GetYPR(Standard_Real& theYaw,
-                                                    Standard_Real& thePitch,
-                                                    Standard_Real& theRoll) const
+                                                        Standard_Real& thePitch,
+                                                        Standard_Real& theRoll) const
 {
   switch (myType)
   {

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.cxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.cxx
@@ -1,0 +1,482 @@
+// Created on: 2020-03-27
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gp_Ax2.hxx>
+#include <XCAFKinObjects_PairValueObject.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(XCAFKinObjects_PairValueObject, Standard_Transient)
+
+//=================================================================================================
+
+XCAFKinObjects_PairValueObject::XCAFKinObjects_PairValueObject()
+{
+  myValues = NULL;
+}
+
+//=================================================================================================
+
+XCAFKinObjects_PairValueObject::XCAFKinObjects_PairValueObject(
+  const Handle(XCAFKinObjects_PairValueObject)& theObj)
+{
+  myType   = theObj->myType;
+  myValues = theObj->myValues;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetType(const XCAFKinObjects_PairType theType)
+{
+  myType                     = theType;
+  Standard_Integer aNbParams = 0;
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Revolute:
+      aNbParams = 1;
+      break;
+    case XCAFKinObjects_PairType_Prismatic:
+      aNbParams = 1;
+      break;
+    case XCAFKinObjects_PairType_Cylindrical:
+      aNbParams = 2;
+      break;
+    case XCAFKinObjects_PairType_Universal:
+    case XCAFKinObjects_PairType_Homokinetic:
+      aNbParams = 2;
+      break;
+    case XCAFKinObjects_PairType_SphericalWithPin:
+    case XCAFKinObjects_PairType_Spherical:
+      aNbParams = 3;
+      break;
+    case XCAFKinObjects_PairType_Planar:
+      aNbParams = 3;
+      break;
+    case XCAFKinObjects_PairType_Unconstrained:
+      aNbParams = 9;
+      break;
+    case XCAFKinObjects_PairType_Screw:
+      aNbParams = 1;
+      break;
+    case XCAFKinObjects_PairType_RackAndPinion:
+      aNbParams = 1;
+      break;
+    case XCAFKinObjects_PairType_Gear:
+      aNbParams = 1;
+      break;
+    case XCAFKinObjects_PairType_PointOnSurface:
+      aNbParams = 5;
+      break;
+    case XCAFKinObjects_PairType_SlidingSurface:
+      aNbParams = 5;
+      break;
+    case XCAFKinObjects_PairType_RollingSurface:
+      aNbParams = 3;
+      break;
+    case XCAFKinObjects_PairType_PointOnPlanarCurve:
+      aNbParams = 4;
+      break;
+    case XCAFKinObjects_PairType_SlidingCurve:
+      aNbParams = 2;
+      break;
+    case XCAFKinObjects_PairType_RollingCurve:
+      aNbParams = 1;
+      break;
+    default:
+      break;
+  }
+
+  if (aNbParams == 0)
+    myValues = NULL;
+  else
+    myValues = new TColStd_HArray1OfReal(1, aNbParams);
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetFirstRotation(const Standard_Real theRotation)
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Revolute:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_Cylindrical:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_Universal:
+    case XCAFKinObjects_PairType_Homokinetic:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_Planar:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_Screw:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_Gear:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_SlidingSurface:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    case XCAFKinObjects_PairType_RollingSurface:
+      myValues->ChangeValue(1) = theRotation;
+      break;
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_PairValueObject::GetFirstRotation() const
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Revolute:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_Cylindrical:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_Universal:
+    case XCAFKinObjects_PairType_Homokinetic:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_Planar:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_Screw:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_Gear:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_SlidingSurface:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_RollingSurface:
+      return myValues->Value(1);
+    default:
+      break;
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetSecondRotation(const Standard_Real theRotation)
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Universal:
+    case XCAFKinObjects_PairType_Homokinetic:
+      myValues->ChangeValue(2) = theRotation;
+      break;
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_PairValueObject::GetSecondRotation() const
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Universal:
+    case XCAFKinObjects_PairType_Homokinetic:
+      return myValues->Value(2);
+    default:
+      break;
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetFirstTranslation(const Standard_Real theTranslation)
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Prismatic:
+      myValues->ChangeValue(1) = theTranslation;
+      break;
+    case XCAFKinObjects_PairType_Cylindrical:
+      myValues->ChangeValue(2) = theTranslation;
+      break;
+    case XCAFKinObjects_PairType_Planar:
+      myValues->ChangeValue(2) = theTranslation;
+      break;
+    case XCAFKinObjects_PairType_RackAndPinion:
+      myValues->ChangeValue(1) = theTranslation;
+      break;
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_PairValueObject::GetFirstTranslation() const
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_Prismatic:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_Cylindrical:
+      return myValues->Value(2);
+    case XCAFKinObjects_PairType_Planar:
+      return myValues->Value(2);
+    case XCAFKinObjects_PairType_RackAndPinion:
+      return myValues->Value(1);
+    default:
+      break;
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetSecondTranslation(const Standard_Real theTranslation)
+{
+  if (myType == XCAFKinObjects_PairType_Planar)
+  {
+    myValues->ChangeValue(3) = theTranslation;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_PairValueObject::GetSecondTranslation() const
+{
+  if (myType == XCAFKinObjects_PairType_Planar)
+  {
+    return myValues->Value(3);
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetFirstPointOnSurface(const Standard_Real theU,
+                                                        const Standard_Real theV)
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_PointOnSurface:
+      myValues->ChangeValue(1) = theU;
+      myValues->ChangeValue(2) = theV;
+      break;
+    case XCAFKinObjects_PairType_SlidingSurface:
+      myValues->ChangeValue(2) = theU;
+      myValues->ChangeValue(3) = theV;
+      break;
+    case XCAFKinObjects_PairType_RollingSurface:
+      myValues->ChangeValue(2) = theU;
+      myValues->ChangeValue(3) = theV;
+      break;
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_PairValueObject::GetFirstPointOnSurface(Standard_Real& theU,
+                                                                    Standard_Real& theV) const
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_PointOnSurface:
+      theU = myValues->Value(1);
+      theV = myValues->Value(2);
+      return Standard_True;
+    case XCAFKinObjects_PairType_SlidingSurface:
+      theU = myValues->Value(2);
+      theV = myValues->Value(3);
+      return Standard_True;
+    case XCAFKinObjects_PairType_RollingSurface:
+      theU = myValues->Value(2);
+      theV = myValues->Value(3);
+      return Standard_True;
+    default:
+      break;
+  }
+  return Standard_False;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetSecondPointOnSurface(const Standard_Real theU,
+                                                         const Standard_Real theV)
+{
+  if (myType != XCAFKinObjects_PairType_SlidingSurface)
+    return;
+  myValues->ChangeValue(4) = theU;
+  myValues->ChangeValue(5) = theV;
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_PairValueObject::GetSecondPointOnSurface(Standard_Real& theU,
+                                                                     Standard_Real& theV) const
+{
+  if (myType != XCAFKinObjects_PairType_SlidingSurface)
+    return Standard_False;
+  theU = myValues->Value(4);
+  theV = myValues->Value(5);
+  return Standard_True;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetFirstPointOnCurve(const Standard_Real theT)
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_PointOnPlanarCurve:
+      myValues->ChangeValue(1) = theT;
+      break;
+    case XCAFKinObjects_PairType_SlidingCurve:
+      myValues->ChangeValue(1) = theT;
+      break;
+    case XCAFKinObjects_PairType_RollingCurve:
+      myValues->ChangeValue(1) = theT;
+      break;
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_PairValueObject::GetFirstPointOnCurve() const
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_PointOnPlanarCurve:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_SlidingCurve:
+      return myValues->Value(1);
+    case XCAFKinObjects_PairType_RollingCurve:
+      return myValues->Value(1);
+    default:
+      break;
+  }
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetSecondPointOnCurve(const Standard_Real theT)
+{
+  if (myType == XCAFKinObjects_PairType_SlidingCurve)
+  {
+    myValues->ChangeValue(2) = theT;
+  }
+}
+
+//=================================================================================================
+
+Standard_Real XCAFKinObjects_PairValueObject::GetSecondPointOnCurve() const
+{
+  if (myType == XCAFKinObjects_PairType_SlidingCurve)
+    return myValues->Value(2);
+  return 0;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetYPR(const Standard_Real theYaw,
+                                        const Standard_Real thePitch,
+                                        const Standard_Real theRoll)
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_SphericalWithPin:
+    case XCAFKinObjects_PairType_Spherical:
+      myValues->ChangeValue(1) = theYaw;
+      myValues->ChangeValue(2) = thePitch;
+      myValues->ChangeValue(3) = theRoll;
+      break;
+    case XCAFKinObjects_PairType_PointOnSurface:
+      myValues->ChangeValue(3) = theYaw;
+      myValues->ChangeValue(4) = thePitch;
+      myValues->ChangeValue(5) = theRoll;
+      break;
+    case XCAFKinObjects_PairType_PointOnPlanarCurve:
+      myValues->ChangeValue(2) = theYaw;
+      myValues->ChangeValue(3) = thePitch;
+      myValues->ChangeValue(4) = theRoll;
+      break;
+    default:
+      break;
+  }
+}
+
+//=================================================================================================
+
+Standard_Boolean XCAFKinObjects_PairValueObject::GetYPR(Standard_Real& theYaw,
+                                                    Standard_Real& thePitch,
+                                                    Standard_Real& theRoll) const
+{
+  switch (myType)
+  {
+    case XCAFKinObjects_PairType_SphericalWithPin:
+    case XCAFKinObjects_PairType_Spherical:
+      theYaw   = myValues->Value(1);
+      thePitch = myValues->Value(2);
+      theRoll  = myValues->Value(3);
+      return Standard_True;
+    case XCAFKinObjects_PairType_PointOnSurface:
+      theYaw   = myValues->Value(3);
+      thePitch = myValues->Value(4);
+      theRoll  = myValues->Value(5);
+      return Standard_True;
+    case XCAFKinObjects_PairType_PointOnPlanarCurve:
+      theYaw   = myValues->Value(2);
+      thePitch = myValues->Value(3);
+      theRoll  = myValues->Value(4);
+      return Standard_True;
+    default:
+      break;
+  }
+  return Standard_False;
+}
+
+//=================================================================================================
+
+void XCAFKinObjects_PairValueObject::SetTransformation(const gp_Ax2& theTrsf)
+{
+  if (myType != XCAFKinObjects_PairType_Unconstrained)
+    return;
+
+  myValues->ChangeValue(1) = theTrsf.Location().X();
+  myValues->ChangeValue(2) = theTrsf.Location().Y();
+  myValues->ChangeValue(3) = theTrsf.Location().Z();
+  myValues->ChangeValue(4) = theTrsf.Direction().X();
+  myValues->ChangeValue(5) = theTrsf.Direction().Y();
+  myValues->ChangeValue(6) = theTrsf.Direction().Z();
+  myValues->ChangeValue(7) = theTrsf.XDirection().X();
+  myValues->ChangeValue(8) = theTrsf.XDirection().Y();
+  myValues->ChangeValue(9) = theTrsf.XDirection().Z();
+}
+
+//=================================================================================================
+
+gp_Ax2 XCAFKinObjects_PairValueObject::GetTransformation()
+{
+  if (myType != XCAFKinObjects_PairType_Unconstrained)
+    return gp_Ax2();
+
+  gp_Pnt aLoc(myValues->Value(1), myValues->Value(2), myValues->Value(3));
+  gp_Dir aDir(myValues->Value(4), myValues->Value(5), myValues->Value(6));
+  gp_Dir aXDir(myValues->Value(7), myValues->Value(8), myValues->Value(9));
+  gp_Ax2 aResult = gp_Ax2(aLoc, aDir, aXDir);
+  return aResult;
+}

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.hxx
@@ -25,142 +25,235 @@ DEFINE_STANDARD_HANDLE(XCAFKinObjects_PairValueObject, Standard_Transient)
 
 class gp_Ax2;
 
-//! \class XCAFKinObjects_PairValueObject
-//! \brief Object to store and process current position
-//! of kinematic pair.
-//! NoType - no values,
+//! Object to store and process current position or state of a kinematic pair.
 //!
-//! FullyConstrained - no values,
-//! Revolute - angle,
-//! Prismatic - length,
-//! Cylindrical - angle + length,
-//! Universal - angle + angle,
-//! Homokinetic - angle + angle,
-//! SphericalWithPin - ypr,
-//! Spherical - ypr,
-//! Planar - angle + length + length,
-//! Unconstrained - ax2,
+//! Each kinematic pair type requires different value parameters to define its state:
 //!
-//! Screw - angle,
-//! RackAndPinion - length,
-//! Gear - angle,
+//! Basic low order pairs:
+//! - XCAFKinObjects_PairType_NoType - no values
+//! - XCAFKinObjects_PairType_FullyConstrained - no values
+//! - XCAFKinObjects_PairType_Revolute - angle (rotation)
+//! - XCAFKinObjects_PairType_Prismatic - length (translation)
+//! - XCAFKinObjects_PairType_Cylindrical - angle + length (rotation and translation)
+//! - XCAFKinObjects_PairType_Universal - angle + angle (two rotations)
+//! - XCAFKinObjects_PairType_Homokinetic - angle + angle (two rotations)
+//! - XCAFKinObjects_PairType_SphericalWithPin - yaw, pitch, roll (three rotation angles)
+//! - XCAFKinObjects_PairType_Spherical - yaw, pitch, roll (three rotation angles)
+//! - XCAFKinObjects_PairType_Planar - angle + length + length (rotation and two translations)
+//! - XCAFKinObjects_PairType_Unconstrained - ax2 (complete transformation)
 //!
-//! PointOnSurface pnt on surface + ypr,
-//! SlidingSurface - angle + pnt on surface + pnt on surface,
-//! RollingSurface - angle + pnt on surface,
-//! PointOnPlanarCurve pnt on curve + ypr,
-//! SlidingCurve - pnt on curve + pnt on curve,
-//! RollingCurve - pnt on curve
+//! Low order pairs with motion coupling:
+//! - XCAFKinObjects_PairType_Screw - angle (rotation that determines translation via pitch)
+//! - XCAFKinObjects_PairType_RackAndPinion - length (translation that determines rotation)
+//! - XCAFKinObjects_PairType_Gear - angle (rotation of first gear that determines rotation of
+//! second)
 //!
-//! ypr - three angles: yaw, pitch, roll
-//! point on surface - (u,v)
-//! point on curve - (t)
-//! ax2 - consists of location and two directions
+//! High order pairs:
+//! - XCAFKinObjects_PairType_PointOnSurface - (u,v) + yaw, pitch, roll (point on surface +
+//! orientation)
+//! - XCAFKinObjects_PairType_SlidingSurface - angle + (u1,v1) + (u2,v2) (rotation + two points on
+//! surfaces)
+//! - XCAFKinObjects_PairType_RollingSurface - angle + (u,v) (rotation + point on surface)
+//! - XCAFKinObjects_PairType_PointOnPlanarCurve - t + yaw, pitch, roll (point on curve +
+//! orientation)
+//! - XCAFKinObjects_PairType_SlidingCurve - t1 + t2 (two points on curves)
+//! - XCAFKinObjects_PairType_RollingCurve - t (point on curve)
 class XCAFKinObjects_PairValueObject : public Standard_Transient
 {
 
 public:
+  //! Default constructor.
+  //! Creates an empty pair value object with undefined type and no values.
   Standard_EXPORT XCAFKinObjects_PairValueObject();
 
-  Standard_EXPORT XCAFKinObjects_PairValueObject(const Handle(XCAFKinObjects_PairValueObject)& theObj);
+  //! Copy constructor.
+  //! @param theObj Source pair value object to copy from
+  Standard_EXPORT XCAFKinObjects_PairValueObject(
+    const Handle(XCAFKinObjects_PairValueObject)& theObj);
 
+  //! Sets the type of the kinematic pair and initializes appropriate value array.
+  //! Different pair types require different numbers of values to define their state.
+  //! @param theType Type of kinematic pair to set
   Standard_EXPORT void SetType(const XCAFKinObjects_PairType theType);
 
+  //! Returns the type of the kinematic pair.
+  //! @return Type of kinematic pair as an enumeration value
   XCAFKinObjects_PairType Type() const { return myType; }
 
+  //! Sets all values for the pair state from an array.
+  //! The array size must match the size required by the pair type.
+  //! @param theValues Array containing all value parameters
   void SetAllValues(const Handle(TColStd_HArray1OfReal)& theValues)
   {
     if (myValues->Length() == theValues->Length())
       myValues = theValues;
   };
 
+  //! Returns all values for the pair state.
+  //! @return Array containing all value parameters
   Handle(TColStd_HArray1OfReal) GetAllValues() const { return myValues; }
 
-  // Rotations
-
+  //! Sets the rotation value for pairs with single rotation parameter.
+  //! Convenience method that calls SetFirstRotation.
+  //! @param theRotation Rotation angle in radians
   void SetRotation(const Standard_Real theRotation) { SetFirstRotation(theRotation); }
 
+  //! Gets the rotation value for pairs with single rotation parameter.
+  //! Convenience method that calls GetFirstRotation.
+  //! @return Rotation angle in radians
   Standard_Real GetRotation() const { return GetFirstRotation(); }
 
+  //! Sets the first rotation value for pairs with rotation parameters.
+  //! Applicable for Revolute, Cylindrical, Universal, Homokinetic, Planar,
+  //! Screw, Gear, SlidingSurface, and RollingSurface pairs.
+  //! @param theRotation Rotation angle in radians
   Standard_EXPORT void SetFirstRotation(const Standard_Real theRotation);
 
+  //! Gets the first rotation value for pairs with rotation parameters.
+  //! @return First rotation angle in radians, or 0 if not applicable
   Standard_EXPORT Standard_Real GetFirstRotation() const;
 
+  //! Sets the second rotation value for pairs with multiple rotation parameters.
+  //! Currently only applicable for Universal and Homokinetic pairs.
+  //! @param theRotation Second rotation angle in radians
   Standard_EXPORT void SetSecondRotation(const Standard_Real theRotation);
 
+  //! Gets the second rotation value for pairs with multiple rotation parameters.
+  //! @return Second rotation angle in radians, or 0 if not applicable
   Standard_EXPORT Standard_Real GetSecondRotation() const;
 
-  // Translations
-
+  //! Sets the translation value for pairs with single translation parameter.
+  //! Convenience method that calls SetFirstTranslation.
+  //! @param theTranslation Translation distance
   void SetTranslation(const Standard_Real theTranslation) { SetFirstTranslation(theTranslation); }
 
+  //! Gets the translation value for pairs with single translation parameter.
+  //! Convenience method that calls GetFirstTranslation.
+  //! @return Translation distance
   Standard_Real GetTranslation() const { return GetFirstTranslation(); }
 
+  //! Sets the first translation value for pairs with translation parameters.
+  //! Applicable for Prismatic, Cylindrical, Planar, and RackAndPinion pairs.
+  //! @param theTranslation Translation distance
   Standard_EXPORT void SetFirstTranslation(const Standard_Real theTranslation);
 
+  //! Gets the first translation value for pairs with translation parameters.
+  //! @return First translation distance, or 0 if not applicable
   Standard_EXPORT Standard_Real GetFirstTranslation() const;
 
+  //! Sets the second translation value for pairs with multiple translation parameters.
+  //! Currently only applicable for Planar pairs.
+  //! @param theTranslation Second translation distance
   Standard_EXPORT void SetSecondTranslation(const Standard_Real theTranslation);
 
+  //! Gets the second translation value for pairs with multiple translation parameters.
+  //! @return Second translation distance, or 0 if not applicable
   Standard_EXPORT Standard_Real GetSecondTranslation() const;
 
-  // Points on surface
-
+  //! Sets the point on surface parameters for pairs with single point on surface.
+  //! Convenience method that calls SetFirstPointOnSurface.
+  //! @param theU U parameter on surface
+  //! @param theV V parameter on surface
   void SetPointOnSurface(const Standard_Real theU, const Standard_Real theV)
   {
     SetFirstPointOnSurface(theU, theV);
   }
 
+  //! Gets the point on surface parameters for pairs with single point on surface.
+  //! Convenience method that calls GetFirstPointOnSurface.
+  //! @param theU [out] U parameter on surface
+  //! @param theV [out] V parameter on surface
+  //! @return true if values were retrieved successfully, false otherwise
   Standard_Boolean GetPointOnSurface(Standard_Real& theU, Standard_Real& theV) const
   {
     return GetFirstPointOnSurface(theU, theV);
   }
 
+  //! Sets the first point on surface parameters.
+  //! Applicable for PointOnSurface, SlidingSurface, and RollingSurface pairs.
+  //! @param theU U parameter on first surface
+  //! @param theV V parameter on first surface
   Standard_EXPORT void SetFirstPointOnSurface(const Standard_Real theU, const Standard_Real theV);
 
+  //! Gets the first point on surface parameters.
+  //! @param theU [out] U parameter on first surface
+  //! @param theV [out] V parameter on first surface
+  //! @return true if values were retrieved successfully, false otherwise
   Standard_EXPORT Standard_Boolean GetFirstPointOnSurface(Standard_Real& theU,
                                                           Standard_Real& theV) const;
 
+  //! Sets the second point on surface parameters.
+  //! Applicable only for SlidingSurface pairs.
+  //! @param theU U parameter on second surface
+  //! @param theV V parameter on second surface
   Standard_EXPORT void SetSecondPointOnSurface(const Standard_Real theU, const Standard_Real theV);
 
+  //! Gets the second point on surface parameters.
+  //! @param theU [out] U parameter on second surface
+  //! @param theV [out] V parameter on second surface
+  //! @return true if values were retrieved successfully, false otherwise
   Standard_EXPORT Standard_Boolean GetSecondPointOnSurface(Standard_Real& theU,
                                                            Standard_Real& theV) const;
 
-  // Points on curve
-
+  //! Sets the point on curve parameter for pairs with single point on curve.
+  //! Convenience method that calls SetFirstPointOnCurve.
+  //! @param theT Parameter on curve
   void SetPointOnCurve(const Standard_Real theT) { SetFirstPointOnCurve(theT); }
 
+  //! Gets the point on curve parameter for pairs with single point on curve.
+  //! Convenience method that calls GetFirstPointOnCurve.
+  //! @return Parameter on curve
   Standard_Real GetPointOnCurve() const { return GetFirstPointOnCurve(); }
 
+  //! Sets the first point on curve parameter.
+  //! Applicable for PointOnPlanarCurve, SlidingCurve, and RollingCurve pairs.
+  //! @param theT Parameter on first curve
   Standard_EXPORT void SetFirstPointOnCurve(const Standard_Real theT);
 
+  //! Gets the first point on curve parameter.
+  //! @return Parameter on first curve, or 0 if not applicable
   Standard_EXPORT Standard_Real GetFirstPointOnCurve() const;
 
+  //! Sets the second point on curve parameter.
+  //! Applicable only for SlidingCurve pairs.
+  //! @param theT Parameter on second curve
   Standard_EXPORT void SetSecondPointOnCurve(const Standard_Real theT);
 
+  //! Gets the second point on curve parameter.
+  //! @return Parameter on second curve, or 0 if not applicable
   Standard_EXPORT Standard_Real GetSecondPointOnCurve() const;
 
-  // YPR
-
+  //! Sets yaw, pitch, roll orientation angles.
+  //! Applicable for SphericalWithPin, Spherical, PointOnSurface, and PointOnPlanarCurve pairs.
+  //! @param theYaw Yaw angle in radians
+  //! @param thePitch Pitch angle in radians
+  //! @param theRoll Roll angle in radians
   Standard_EXPORT void SetYPR(const Standard_Real theYaw,
                               const Standard_Real thePitch,
                               const Standard_Real theRoll);
 
+  //! Gets yaw, pitch, roll orientation angles.
+  //! @param theYaw [out] Yaw angle in radians
+  //! @param thePitch [out] Pitch angle in radians
+  //! @param theRoll [out] Roll angle in radians
+  //! @return true if values were retrieved successfully, false otherwise
   Standard_EXPORT Standard_Boolean GetYPR(Standard_Real& theYaw,
                                           Standard_Real& thePitch,
                                           Standard_Real& theRoll) const;
 
-  // Transformation
-
+  //! Sets the complete transformation for Unconstrained pairs.
+  //! @param theTrsf Coordinate system defining the transformation
   Standard_EXPORT void SetTransformation(const gp_Ax2& theTrsf);
 
+  //! Gets the complete transformation for Unconstrained pairs.
+  //! @return Coordinate system representing the transformation
   Standard_EXPORT gp_Ax2 GetTransformation();
 
   DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_PairValueObject, Standard_Transient)
 
 private:
-  XCAFKinObjects_PairType           myType;   //!< type of kinematic pair
-  Handle(TColStd_HArray1OfReal) myValues; //!< all values in a line
+  XCAFKinObjects_PairType myType; //!< Type of kinematic pair defining the required state parameters
+  Handle(TColStd_HArray1OfReal) myValues; //!< Array containing all state parameter values
 };
 
 #endif // _XCAFKinObjects_PairValueObject_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.hxx
+++ b/src/DataExchange/TKXCAF/XCAFKinObjects/XCAFKinObjects_PairValueObject.hxx
@@ -1,0 +1,166 @@
+// Created on: 2020-03-27
+// Created by: Irina KRYLOVA
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _XCAFKinObjects_PairValueObject_HeaderFile
+#define _XCAFKinObjects_PairValueObject_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_Type.hxx>
+#include <TColStd_HArray1OfReal.hxx>
+#include <XCAFKinObjects_PairType.hxx>
+
+DEFINE_STANDARD_HANDLE(XCAFKinObjects_PairValueObject, Standard_Transient)
+
+class gp_Ax2;
+
+//! \class XCAFKinObjects_PairValueObject
+//! \brief Object to store and process current position
+//! of kinematic pair.
+//! NoType - no values,
+//!
+//! FullyConstrained - no values,
+//! Revolute - angle,
+//! Prismatic - length,
+//! Cylindrical - angle + length,
+//! Universal - angle + angle,
+//! Homokinetic - angle + angle,
+//! SphericalWithPin - ypr,
+//! Spherical - ypr,
+//! Planar - angle + length + length,
+//! Unconstrained - ax2,
+//!
+//! Screw - angle,
+//! RackAndPinion - length,
+//! Gear - angle,
+//!
+//! PointOnSurface pnt on surface + ypr,
+//! SlidingSurface - angle + pnt on surface + pnt on surface,
+//! RollingSurface - angle + pnt on surface,
+//! PointOnPlanarCurve pnt on curve + ypr,
+//! SlidingCurve - pnt on curve + pnt on curve,
+//! RollingCurve - pnt on curve
+//!
+//! ypr - three angles: yaw, pitch, roll
+//! point on surface - (u,v)
+//! point on curve - (t)
+//! ax2 - consists of location and two directions
+class XCAFKinObjects_PairValueObject : public Standard_Transient
+{
+
+public:
+  Standard_EXPORT XCAFKinObjects_PairValueObject();
+
+  Standard_EXPORT XCAFKinObjects_PairValueObject(const Handle(XCAFKinObjects_PairValueObject)& theObj);
+
+  Standard_EXPORT void SetType(const XCAFKinObjects_PairType theType);
+
+  XCAFKinObjects_PairType Type() const { return myType; }
+
+  void SetAllValues(const Handle(TColStd_HArray1OfReal)& theValues)
+  {
+    if (myValues->Length() == theValues->Length())
+      myValues = theValues;
+  };
+
+  Handle(TColStd_HArray1OfReal) GetAllValues() const { return myValues; }
+
+  // Rotations
+
+  void SetRotation(const Standard_Real theRotation) { SetFirstRotation(theRotation); }
+
+  Standard_Real GetRotation() const { return GetFirstRotation(); }
+
+  Standard_EXPORT void SetFirstRotation(const Standard_Real theRotation);
+
+  Standard_EXPORT Standard_Real GetFirstRotation() const;
+
+  Standard_EXPORT void SetSecondRotation(const Standard_Real theRotation);
+
+  Standard_EXPORT Standard_Real GetSecondRotation() const;
+
+  // Translations
+
+  void SetTranslation(const Standard_Real theTranslation) { SetFirstTranslation(theTranslation); }
+
+  Standard_Real GetTranslation() const { return GetFirstTranslation(); }
+
+  Standard_EXPORT void SetFirstTranslation(const Standard_Real theTranslation);
+
+  Standard_EXPORT Standard_Real GetFirstTranslation() const;
+
+  Standard_EXPORT void SetSecondTranslation(const Standard_Real theTranslation);
+
+  Standard_EXPORT Standard_Real GetSecondTranslation() const;
+
+  // Points on surface
+
+  void SetPointOnSurface(const Standard_Real theU, const Standard_Real theV)
+  {
+    SetFirstPointOnSurface(theU, theV);
+  }
+
+  Standard_Boolean GetPointOnSurface(Standard_Real& theU, Standard_Real& theV) const
+  {
+    return GetFirstPointOnSurface(theU, theV);
+  }
+
+  Standard_EXPORT void SetFirstPointOnSurface(const Standard_Real theU, const Standard_Real theV);
+
+  Standard_EXPORT Standard_Boolean GetFirstPointOnSurface(Standard_Real& theU,
+                                                          Standard_Real& theV) const;
+
+  Standard_EXPORT void SetSecondPointOnSurface(const Standard_Real theU, const Standard_Real theV);
+
+  Standard_EXPORT Standard_Boolean GetSecondPointOnSurface(Standard_Real& theU,
+                                                           Standard_Real& theV) const;
+
+  // Points on curve
+
+  void SetPointOnCurve(const Standard_Real theT) { SetFirstPointOnCurve(theT); }
+
+  Standard_Real GetPointOnCurve() const { return GetFirstPointOnCurve(); }
+
+  Standard_EXPORT void SetFirstPointOnCurve(const Standard_Real theT);
+
+  Standard_EXPORT Standard_Real GetFirstPointOnCurve() const;
+
+  Standard_EXPORT void SetSecondPointOnCurve(const Standard_Real theT);
+
+  Standard_EXPORT Standard_Real GetSecondPointOnCurve() const;
+
+  // YPR
+
+  Standard_EXPORT void SetYPR(const Standard_Real theYaw,
+                              const Standard_Real thePitch,
+                              const Standard_Real theRoll);
+
+  Standard_EXPORT Standard_Boolean GetYPR(Standard_Real& theYaw,
+                                          Standard_Real& thePitch,
+                                          Standard_Real& theRoll) const;
+
+  // Transformation
+
+  Standard_EXPORT void SetTransformation(const gp_Ax2& theTrsf);
+
+  Standard_EXPORT gp_Ax2 GetTransformation();
+
+  DEFINE_STANDARD_RTTIEXT(XCAFKinObjects_PairValueObject, Standard_Transient)
+
+private:
+  XCAFKinObjects_PairType           myType;   //!< type of kinematic pair
+  Handle(TColStd_HArray1OfReal) myValues; //!< all values in a line
+};
+
+#endif // _XCAFKinObjects_PairValueObject_HeaderFile


### PR DESCRIPTION
- Implemented XCAFDoc_KinematicTool class to manage kinematic attributes and operations
- Implemented methods for setting and getting parameters specific to screw, rack and pinion, and gear types.
- Added support for limits on motion range with appropriate getter and setter methods.
- Created base class XCAFKinObjects_PairObject to encapsulate common properties and methods for kinematic pairs.
- Developed XCAFKinObjects_PairValueObject to manage current positions and values of kinematic pairs.
- Defined XCAFKinObjects_PairType enumeration to categorize various types of kinematic pairs.