### PR TITLE
Coding - MSVC warning fix for STEP Rendering properties

### DIFF
--- a/.github/workflows/build-multiconfig-msvc.yml
+++ b/.github/workflows/build-multiconfig-msvc.yml
@@ -8,7 +8,10 @@ on:
   push:
     branches:
       - 'master'
-
+  pull_request:
+    branches:
+      - '**'
+      
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/build-multiconfig-msvc.yml
+++ b/.github/workflows/build-multiconfig-msvc.yml
@@ -8,10 +8,7 @@ on:
   push:
     branches:
       - 'master'
-  pull_request:
-    branches:
-      - '**'
-      
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_RenderingProperties.cxx
+++ b/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_RenderingProperties.cxx
@@ -237,10 +237,7 @@ Handle(StepVisual_SurfaceStyleRenderingWithProperties) STEPConstruct_RenderingPr
   // Add transparency
   Handle(StepVisual_SurfaceStyleTransparent) aTransparent = new StepVisual_SurfaceStyleTransparent;
   aTransparent->Init(myTransparency);
-
-  StepVisual_RenderingPropertiesSelect aRPS;
-  aRPS.SetValue(aTransparent);
-  aProps->SetValue(aPropIndex++, aRPS);
+  aProps->ChangeValue(aPropIndex++).SetValue(aTransparent);
 
   // Add the appropriate reflectance model based on what we have
   if (hasAmbientOnly)
@@ -250,9 +247,7 @@ Handle(StepVisual_SurfaceStyleRenderingWithProperties) STEPConstruct_RenderingPr
       new StepVisual_SurfaceStyleReflectanceAmbient;
     aAmbient->Init(myAmbientReflectance.first);
 
-    StepVisual_RenderingPropertiesSelect aRPS;
-    aRPS.SetValue(aAmbient);
-    aProps->SetValue(aPropIndex++, aRPS);
+    aProps->ChangeValue(aPropIndex++).SetValue(aAmbient);
   }
   else if (hasDiffuseAndAmbient)
   {
@@ -261,9 +256,7 @@ Handle(StepVisual_SurfaceStyleRenderingWithProperties) STEPConstruct_RenderingPr
       new StepVisual_SurfaceStyleReflectanceAmbientDiffuse;
     aAmbientDiffuse->Init(myAmbientReflectance.first, myDiffuseReflectance.first);
 
-    StepVisual_RenderingPropertiesSelect aRPS;
-    aRPS.SetValue(aAmbientDiffuse);
-    aProps->SetValue(aPropIndex++, aRPS);
+    aProps->ChangeValue(aPropIndex++).SetValue(aAmbientDiffuse);
   }
   else if (hasFullReflectance)
   {
@@ -277,9 +270,7 @@ Handle(StepVisual_SurfaceStyleRenderingWithProperties) STEPConstruct_RenderingPr
                     mySpecularExponent.first,
                     STEPConstruct_Styles::EncodeColor(mySpecularColour.first));
 
-    StepVisual_RenderingPropertiesSelect aRPS;
-    aRPS.SetValue(aFullRefl);
-    aProps->SetValue(aPropIndex++, aRPS);
+    aProps->ChangeValue(aPropIndex++).SetValue(aFullRefl);
   }
 
   // Create STEP surface style rendering with properties
@@ -400,7 +391,7 @@ void STEPConstruct_RenderingProperties::Init(
   {
     for (Standard_Integer i = 1; i <= aProperties->Length(); i++)
     {
-      StepVisual_RenderingPropertiesSelect aPropSelect = aProperties->Value(i);
+      const StepVisual_RenderingPropertiesSelect& aPropSelect = aProperties->Value(i);
 
       // Check for transparency
       Handle(StepVisual_SurfaceStyleTransparent) aTransparent =

--- a/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_RenderingProperties.cxx
+++ b/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_RenderingProperties.cxx
@@ -295,7 +295,7 @@ XCAFDoc_VisMaterialCommon STEPConstruct_RenderingProperties::CreateXCAFMaterial(
 
   // Use surface color as the base diffuse color
   aMaterial.DiffuseColor = mySurfaceColor;
-  aMaterial.Transparency = myTransparency;
+  aMaterial.Transparency = static_cast<float>(myTransparency);
   aMaterial.IsDefined    = Standard_True;
 
   // Set default values for other properties

--- a/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_RenderingProperties.hxx
+++ b/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_RenderingProperties.hxx
@@ -144,7 +144,7 @@ public:
   //! @return ColorRGBA object
   Quantity_ColorRGBA GetRGBAColor() const
   {
-    return Quantity_ColorRGBA(mySurfaceColor, 1.0 - myTransparency);
+    return Quantity_ColorRGBA(mySurfaceColor, static_cast<float>(1.0 - myTransparency));
   }
 
   //! Returns surface color


### PR DESCRIPTION
Fixed warning on MSVC compiler with name overriding and type mismatching.