### PR TITLE
Modeling Algorithms - XCAFDoc_Editor::RescaleGeometry does not rescale translation of roots reference

### DIFF
--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_AssemblyGraph.cxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_AssemblyGraph.cxx
@@ -127,12 +127,12 @@ void XCAFDoc_AssemblyGraph::buildGraph(const TDF_Label& theLabel)
   {
     TDF_Label aLabel = it.Value();
 
-    TDF_Label anOriginal;
+    TDF_Label        anOriginal;
     Standard_Integer aRootId, anIdToProceed;
     if (!myShapeTool->GetReferredShape(aLabel, anOriginal))
     {
-      anOriginal = aLabel;
-      aRootId = addNode(anOriginal, 0);
+      anOriginal    = aLabel;
+      aRootId       = addNode(anOriginal, 0);
       anIdToProceed = aRootId;
     }
     else

--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_AssemblyGraph.cxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_AssemblyGraph.cxx
@@ -128,18 +128,29 @@ void XCAFDoc_AssemblyGraph::buildGraph(const TDF_Label& theLabel)
     TDF_Label aLabel = it.Value();
 
     TDF_Label anOriginal;
+    Standard_Integer aRootId, anIdToProceed;
     if (!myShapeTool->GetReferredShape(aLabel, anOriginal))
+    {
       anOriginal = aLabel;
+      aRootId = addNode(anOriginal, 0);
+      anIdToProceed = aRootId;
+    }
+    else
+    {
+      aRootId = addNode(aLabel, 0);
+      if (aRootId == 0)
+        continue;
+      anIdToProceed = addNode(anOriginal, aRootId);
+    }
 
-    const Standard_Integer aRootId = addNode(anOriginal, 0);
-    if (aRootId == 0)
+    if (aRootId == 0 || anIdToProceed == 0)
       continue;
 
     myRoots.Add(aRootId);
 
     // Add components (the objects nested into the current one).
     if (myShapeTool->IsAssembly(anOriginal))
-      addComponents(anOriginal, aRootId);
+      addComponents(anOriginal, anIdToProceed);
   }
 }
 
@@ -208,7 +219,7 @@ Standard_Integer XCAFDoc_AssemblyGraph::addNode(const TDF_Label&       theLabel,
     else
       aNodeType = NodeType_Subassembly;
   }
-  else if (myShapeTool->IsComponent(theLabel))
+  else if (myShapeTool->IsReference(theLabel))
   {
     aNodeType = NodeType_Occurrence;
   }

--- a/tests/bugs/xde/ar10850
+++ b/tests/bugs/xde/ar10850
@@ -1,0 +1,17 @@
+puts "AR10850 - XCAFDoc_Editor::RescaleGeometry does not rescale translation of roots references"
+
+pload OCAF
+Close D -silent
+XOpen [locate_data_file "ar10850_3D-EYE_chair_OCC_noscale.xbf"] D
+
+XGetOneShape a D
+set ref_diag [eval distpp [bounding a]]
+
+XRescaleGeometry D 0.001
+
+XGetOneShape a D
+set diag [eval distpp [bounding a]]
+
+checkreal "bounding box diagonal" $diag [expr $ref_diag * 0.001] 0 0.001
+
+Close D


### PR DESCRIPTION
Add processing of roots, which are transformed references of parts/assemblies.