### PR TITLE
Coding, RWGltf_CafWriter - fix gltf dashed edges

### DIFF
--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -2030,7 +2030,7 @@ void RWGltf_CafWriter::writePrimArray(const RWGltf_GltfFace&         theGltfFace
     switch (theGltfFace.Shape.ShapeType())
     {
       case TopAbs_EDGE:
-        myWriter->Int(RWGltf_GltfPrimitiveMode_Lines);
+        myWriter->Int(RWGltf_GltfPrimitiveMode_LineStrip);
         break;
       case TopAbs_VERTEX:
         myWriter->Int(RWGltf_GltfPrimitiveMode_Points);

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
@@ -233,7 +233,7 @@ bool RWGltf_ExtrasParser::parseNumber(const RWGltf_JsonValue& theValue,
   return false;
 }
 
-//=================================================================================================
+//==================================================================================================
 
 bool RWGltf_ExtrasParser::parseString(const RWGltf_JsonValue& theValue,
                                       const std::string&      theValueName)

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
@@ -178,7 +178,7 @@ Handle(TDataStd_NamedData) RWGltf_ExtrasParser::ParseExtras(
   return anExtrasParser.Parse();
 }
 
-//================================================================================================
+//=================================================================================================
 
 bool RWGltf_ExtrasParser::parseObject(const RWGltf_JsonValue& theValue,
                                       const std::string&      theValueName)
@@ -233,7 +233,7 @@ bool RWGltf_ExtrasParser::parseNumber(const RWGltf_JsonValue& theValue,
   return false;
 }
 
-//==================================================================================================
+//=================================================================================================
 
 bool RWGltf_ExtrasParser::parseString(const RWGltf_JsonValue& theValue,
                                       const std::string&      theValueName)

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
@@ -1808,7 +1808,7 @@ bool RWGltf_GltfJsonParser::gltfParsePrimArray(TopoDS_Shape&                  th
     }
   }
   if (aMode != RWGltf_GltfPrimitiveMode_Triangles && aMode != RWGltf_GltfPrimitiveMode_Lines
-      && aMode != RWGltf_GltfPrimitiveMode_Points)
+      && aMode != RWGltf_GltfPrimitiveMode_LineStrip && aMode != RWGltf_GltfPrimitiveMode_Points)
   {
     Message::SendWarning(TCollection_AsciiString() + "Primitive array within Mesh '" + theMeshId
                          + "' skipped due to unsupported mode");
@@ -1976,7 +1976,8 @@ bool RWGltf_GltfJsonParser::gltfParsePrimArray(TopoDS_Shape&                  th
         aShape = aVertices;
         break;
       }
-      case RWGltf_GltfPrimitiveMode_Lines: {
+      case RWGltf_GltfPrimitiveMode_Lines:
+      case RWGltf_GltfPrimitiveMode_LineStrip: {
         TColgp_Array1OfPnt aNodes(1, aMeshData->NbEdges());
         for (Standard_Integer anEdgeIdx = 1; anEdgeIdx <= aMeshData->NbEdges(); ++anEdgeIdx)
         {
@@ -2011,7 +2012,7 @@ bool RWGltf_GltfJsonParser::gltfParsePrimArray(TopoDS_Shape&                  th
       aShapeAttribs.RawName = theMeshName;
 
       // assign material and not color
-      if (aMode == RWGltf_GltfPrimitiveMode_Lines)
+      if (aMode == RWGltf_GltfPrimitiveMode_Lines || aMode == RWGltf_GltfPrimitiveMode_LineStrip)
       {
         aShapeAttribs.Style.SetColorCurv(aMeshData->BaseColor().GetRGB());
       }

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
@@ -178,7 +178,7 @@ Handle(TDataStd_NamedData) RWGltf_ExtrasParser::ParseExtras(
   return anExtrasParser.Parse();
 }
 
-//=================================================================================================
+//================================================================================================
 
 bool RWGltf_ExtrasParser::parseObject(const RWGltf_JsonValue& theValue,
                                       const std::string&      theValueName)

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
@@ -579,7 +579,7 @@ bool RWGltf_TriangulationReader::ReadStream(
   const TCollection_AsciiString& aName     = theSourceMesh->Id();
   const RWGltf_GltfPrimitiveMode aPrimMode = theSourceMesh->PrimitiveMode();
   if (aPrimMode != RWGltf_GltfPrimitiveMode_Triangles && aPrimMode != RWGltf_GltfPrimitiveMode_Lines
-      && aPrimMode != RWGltf_GltfPrimitiveMode_Points)
+      && aPrimMode != RWGltf_GltfPrimitiveMode_LineStrip && aPrimMode != RWGltf_GltfPrimitiveMode_Points)
   {
     Message::SendWarning(TCollection_AsciiString("Buffer '") + aName
                          + "' skipped unsupported primitive array");

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
@@ -579,7 +579,8 @@ bool RWGltf_TriangulationReader::ReadStream(
   const TCollection_AsciiString& aName     = theSourceMesh->Id();
   const RWGltf_GltfPrimitiveMode aPrimMode = theSourceMesh->PrimitiveMode();
   if (aPrimMode != RWGltf_GltfPrimitiveMode_Triangles && aPrimMode != RWGltf_GltfPrimitiveMode_Lines
-      && aPrimMode != RWGltf_GltfPrimitiveMode_LineStrip && aPrimMode != RWGltf_GltfPrimitiveMode_Points)
+      && aPrimMode != RWGltf_GltfPrimitiveMode_LineStrip
+      && aPrimMode != RWGltf_GltfPrimitiveMode_Points)
   {
     Message::SendWarning(TCollection_AsciiString("Buffer '") + aName
                          + "' skipped unsupported primitive array");


### PR DESCRIPTION
## Description

When exporting to GLTF the edges appear dashed:
![image](https://github.com/user-attachments/assets/40258128-4df0-4a3c-ad73-0e4883b92c2f)

## The Problem
The GLTF writer uses `RWGltf_GltfPrimitiveMode_Lines` as the type for edges. According to [the spec](https://www.khronos.org/opengl/wiki/primitive):
> `GL_LINES`: Vertices 0 and 1 are considered a line. Vertices 2 and 3 are considered a line. And so on.

## The Solution
Use line strips instead:
> `GL_LINE_STRIP`: The adjacent vertices are considered lines. Thus, if you pass n vertices, you will get n-1 lines. 

## Result
![image](https://github.com/user-attachments/assets/12040662-12bd-44de-8314-1c38db30d82f)



