### PR TITLE
Testing - Add a new compilation on Clang without PCH

### DIFF
--- a/.github/actions/build-occt/action.yml
+++ b/.github/actions/build-occt/action.yml
@@ -108,7 +108,8 @@ runs:
                 -D USE_OPENGL=ON `
                 -D BUILD_GTEST=ON `
                 -D BUILD_CPP_STANDARD=C++17 `
-                -D INSTALL_GTEST=ON ${{ inputs.additional-cmake-flags }} ..
+                -D INSTALL_GTEST=ON `
+                ${{ inputs.additional-cmake-flags }} ..
       shell: pwsh
 
     - name: Configure OCCT (Windows Clang)
@@ -140,8 +141,7 @@ runs:
                 -D BUILD_GTEST=ON `
                 -D BUILD_CPP_STANDARD=C++17 `
                 -D INSTALL_GTEST=ON `
-                -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wno-unknown-warning-option" `
-                -D CMAKE_C_FLAGS="-Werror -Wall -Wextra -Wno-unknown-warning-option" ${{ inputs.additional-cmake-flags }} ..
+                ${{ inputs.additional-cmake-flags }} ..
       shell: pwsh
 
     - name: Configure OCCT (macOS)
@@ -167,7 +167,7 @@ runs:
               -D BUILD_CPP_STANDARD=C++17 \
               -D INSTALL_GTEST=ON \
               -D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra" \
-              -D CMAKE_C_FLAGS="-Werror -Wall -Wextra" ${{ inputs.additional-cmake-flags }} ..
+              ${{ inputs.additional-cmake-flags }} ..
       shell: bash
 
     - name: Configure OCCT (Linux)
@@ -198,7 +198,7 @@ runs:
               -D BUILD_GTEST=ON \
               -D BUILD_CPP_STANDARD=C++17 \
               -D INSTALL_GTEST=ON \
-              ${{ inputs.compiler == 'clang' && '-D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra" -D CMAKE_C_FLAGS="-Werror -Wall -Wextra"' || '' }} ${{ inputs.additional-cmake-flags }} ..
+              ${{ inputs.additional-cmake-flags }} ..
       shell: bash
 
     - name: Build OCCT (Windows)

--- a/.github/actions/build-occt/action.yml
+++ b/.github/actions/build-occt/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: 'Enable VTK'
     required: false
     default: 'true'
+  build-use-pch:
+    description: 'Enable precompiled headers'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -82,7 +86,7 @@ runs:
           cmake -T host=x64 `
                 -D USE_FREETYPE=ON `
                 -D USE_TK=OFF `
-                -D BUILD_USE_PCH=ON `
+                -D BUILD_USE_PCH=${{ inputs.build-use-pch }} `
                 -D BUILD_OPT_PROFILE=Production `
                 -D BUILD_INCLUDE_SYMLINK=ON `
                 -D CMAKE_BUILD_TYPE=Release `
@@ -113,7 +117,7 @@ runs:
                 -D CMAKE_CXX_COMPILER=clang++ `
                 -D USE_FREETYPE=ON `
                 -D USE_TK=OFF `
-                -D BUILD_USE_PCH=ON `
+                -D BUILD_USE_PCH=${{ inputs.build-use-pch }} `
                 -D BUILD_OPT_PROFILE=Production `
                 -D BUILD_INCLUDE_SYMLINK=ON `
                 -D CMAKE_BUILD_TYPE=Release `
@@ -144,7 +148,7 @@ runs:
         cmake -G "Unix Makefiles" \
               -D CMAKE_C_COMPILER=${{ inputs.compiler == 'clang' && 'clang' || 'gcc' }} \
               -D CMAKE_CXX_COMPILER=${{ inputs.compiler == 'clang' && 'clang++' || 'g++' }} \
-              -D BUILD_USE_PCH=ON \
+              -D BUILD_USE_PCH=${{ inputs.build-use-pch }} \
               -D BUILD_INCLUDE_SYMLINK=ON \
               -D CMAKE_BUILD_TYPE=Release \
               -D INSTALL_DIR=${{ github.workspace }}/install \
@@ -169,7 +173,7 @@ runs:
         cmake -G "Unix Makefiles" \
               -D CMAKE_C_COMPILER=${{ inputs.compiler == 'clang' && 'clang' || 'gcc' }} \
               -D CMAKE_CXX_COMPILER=${{ inputs.compiler == 'clang' && 'clang++' || 'g++' }} \
-              -D BUILD_USE_PCH=ON \
+              -D BUILD_USE_PCH=${{ inputs.build-use-pch }} \
               -D BUILD_INCLUDE_SYMLINK=ON \
               -D BUILD_OPT_PROFILE=Production \
               -D USE_TK=OFF \

--- a/.github/actions/build-occt/action.yml
+++ b/.github/actions/build-occt/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: 'Build optimization profile'
     required: false
     default: 'Production'
+  cmake-build-type:
+    description: 'CMake build type (Release, Debug, etc)'
+    required: false
+    default: 'Release'
 
 runs:
   using: "composite"
@@ -93,7 +97,7 @@ runs:
                 -D BUILD_USE_PCH=${{ inputs.build-use-pch }} `
                 -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} `
                 -D BUILD_INCLUDE_SYMLINK=ON `
-                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} `
                 -D 3RDPARTY_DIR=${{ github.workspace }}/3rdparty-vc14-64 `
                 -D INSTALL_DIR=${{ github.workspace }}/install `
                 -D USE_D3D=ON `
@@ -125,7 +129,7 @@ runs:
                 -D BUILD_USE_PCH=${{ inputs.build-use-pch }} `
                 -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} `
                 -D BUILD_INCLUDE_SYMLINK=ON `
-                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} `
                 -D 3RDPARTY_DIR=${{ github.workspace }}/3rdparty-vc14-64 `
                 -D INSTALL_DIR=${{ github.workspace }}/install `
                 -D USE_D3D=ON `
@@ -155,7 +159,7 @@ runs:
               -D BUILD_USE_PCH=${{ inputs.build-use-pch }} \
               -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} \
               -D BUILD_INCLUDE_SYMLINK=ON \
-              -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} \
               -D INSTALL_DIR=${{ github.workspace }}/install \
               -D 3RDPARTY_RAPIDJSON_DIR=${{ github.workspace }}/rapidjson-858451e5b7d1c56cf8f6d58f88cf958351837e53 \
               -D USE_RAPIDJSON=ON \
@@ -182,7 +186,7 @@ runs:
               -D BUILD_INCLUDE_SYMLINK=ON \
               -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} \
               -D USE_TK=OFF \
-              -D CMAKE_BUILD_TYPE=Release \
+              -D CMAKE_BUILD_TYPE=${{ inputs.cmake-build-type }} \
               -D INSTALL_DIR=${{ github.workspace }}/install \
               -D 3RDPARTY_RAPIDJSON_DIR=${{ github.workspace }}/rapidjson-858451e5b7d1c56cf8f6d58f88cf958351837e53 \
               -D USE_FREETYPE=ON \

--- a/.github/actions/build-occt/action.yml
+++ b/.github/actions/build-occt/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Enable precompiled headers'
     required: false
     default: 'true'
+  build-opt-profile:
+    description: 'Build optimization profile'
+    required: false
+    default: 'Production'
 
 runs:
   using: "composite"
@@ -87,7 +91,7 @@ runs:
                 -D USE_FREETYPE=ON `
                 -D USE_TK=OFF `
                 -D BUILD_USE_PCH=${{ inputs.build-use-pch }} `
-                -D BUILD_OPT_PROFILE=Production `
+                -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} `
                 -D BUILD_INCLUDE_SYMLINK=ON `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D 3RDPARTY_DIR=${{ github.workspace }}/3rdparty-vc14-64 `
@@ -118,7 +122,7 @@ runs:
                 -D USE_FREETYPE=ON `
                 -D USE_TK=OFF `
                 -D BUILD_USE_PCH=${{ inputs.build-use-pch }} `
-                -D BUILD_OPT_PROFILE=Production `
+                -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} `
                 -D BUILD_INCLUDE_SYMLINK=ON `
                 -D CMAKE_BUILD_TYPE=Release `
                 -D 3RDPARTY_DIR=${{ github.workspace }}/3rdparty-vc14-64 `
@@ -149,6 +153,7 @@ runs:
               -D CMAKE_C_COMPILER=${{ inputs.compiler == 'clang' && 'clang' || 'gcc' }} \
               -D CMAKE_CXX_COMPILER=${{ inputs.compiler == 'clang' && 'clang++' || 'g++' }} \
               -D BUILD_USE_PCH=${{ inputs.build-use-pch }} \
+              -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} \
               -D BUILD_INCLUDE_SYMLINK=ON \
               -D CMAKE_BUILD_TYPE=Release \
               -D INSTALL_DIR=${{ github.workspace }}/install \
@@ -175,7 +180,7 @@ runs:
               -D CMAKE_CXX_COMPILER=${{ inputs.compiler == 'clang' && 'clang++' || 'g++' }} \
               -D BUILD_USE_PCH=${{ inputs.build-use-pch }} \
               -D BUILD_INCLUDE_SYMLINK=ON \
-              -D BUILD_OPT_PROFILE=Production \
+              -D BUILD_OPT_PROFILE=${{ inputs.build-opt-profile }} \
               -D USE_TK=OFF \
               -D CMAKE_BUILD_TYPE=Release \
               -D INSTALL_DIR=${{ github.workspace }}/install \

--- a/.github/workflows/build-and-test-multiplatform.yml
+++ b/.github/workflows/build-and-test-multiplatform.yml
@@ -138,6 +138,7 @@ jobs:
         artifact-name: install-linux-clang-no-pch
         build-use-pch: 'false'
         build-opt-profile: 'Default'
+        additional-cmake-flags: '-D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra" -D CMAKE_C_FLAGS="-Werror -Wall -Wextra"'
 
   prepare-and-build-linux-gcc-x64:
     name: Prepare and Build on Ubuntu with GCC (x64)

--- a/.github/workflows/build-and-test-multiplatform.yml
+++ b/.github/workflows/build-and-test-multiplatform.yml
@@ -122,6 +122,22 @@ jobs:
         compiler: clang
         artifact-name: install-linux-clang-x64
 
+  prepare-and-build-linux-clang-no-pch:
+    name: Prepare and Build on Ubuntu with Clang (No PCH)
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4.1.7
+
+    - name: Build OCCT
+      uses: ./.github/actions/build-occt
+      with:
+        platform: linux
+        compiler: clang
+        artifact-name: install-linux-clang-no-pch
+        build-use-pch: 'false'
+
   prepare-and-build-linux-gcc-x64:
     name: Prepare and Build on Ubuntu with GCC (x64)
     runs-on: ubuntu-24.04

--- a/.github/workflows/build-and-test-multiplatform.yml
+++ b/.github/workflows/build-and-test-multiplatform.yml
@@ -122,9 +122,9 @@ jobs:
         compiler: clang
         artifact-name: install-linux-clang-x64
 
-  prepare-and-build-linux-clang-no-pch:
-    name: Prepare and Build on Ubuntu with Clang (No PCH)
-    runs-on: ubuntu-24.04
+  prepare-and-build-macos-clang-no-pch:
+    name: Prepare and Build on macOS with Clang (No PCH)
+    runs-on: macos-15
 
     steps:
     - name: Checkout repository
@@ -133,9 +133,9 @@ jobs:
     - name: Build OCCT
       uses: ./.github/actions/build-occt
       with:
-        platform: linux
+        platform: macos
         compiler: clang
-        artifact-name: install-linux-clang-no-pch
+        artifact-name: install-macos-clang-no-pch
         build-use-pch: 'false'
         build-opt-profile: 'Default'
         additional-cmake-flags: '-D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra" -D CMAKE_C_FLAGS="-Werror -Wall -Wextra"'

--- a/.github/workflows/build-and-test-multiplatform.yml
+++ b/.github/workflows/build-and-test-multiplatform.yml
@@ -139,6 +139,7 @@ jobs:
         build-use-pch: 'false'
         build-opt-profile: 'Default'
         additional-cmake-flags: '-D CMAKE_CXX_FLAGS="-Werror -Wall -Wextra" -D CMAKE_C_FLAGS="-Werror -Wall -Wextra"'
+        cmake-build-type: 'Debug'
 
   prepare-and-build-linux-gcc-x64:
     name: Prepare and Build on Ubuntu with GCC (x64)

--- a/.github/workflows/build-and-test-multiplatform.yml
+++ b/.github/workflows/build-and-test-multiplatform.yml
@@ -137,6 +137,7 @@ jobs:
         compiler: clang
         artifact-name: install-linux-clang-no-pch
         build-use-pch: 'false'
+        build-opt-profile: 'Default'
 
   prepare-and-build-linux-gcc-x64:
     name: Prepare and Build on Ubuntu with GCC (x64)

--- a/adm/cmake/occt_defs_flags.cmake
+++ b/adm/cmake/occt_defs_flags.cmake
@@ -151,15 +151,27 @@ elseif (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR (CMAKE_CXX_COMPIL
     # /GL (whole program optimization) is similar to -flto (Link Time Optimization) in GCC/Clang.
     # /GF (eliminate duplicate strings) doesn't have a direct equivalent in GCC/Clang, but the compilers do string pooling automatically.
     # /Gy (enable function-level linking) is similar to -ffunction-sections in GCC/Clang.
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fomit-frame-pointer -flto -ffunction-sections")
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -fomit-frame-pointer -flto -ffunction-sections")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fomit-frame-pointer")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O3 -fomit-frame-pointer")
+    
+    # Apply LTO optimization on all platforms
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -flto")
+    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -flto")
+    
+    # Apply function sections only on non-macOS platforms
+    if (NOT APPLE)
+      set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -ffunction-sections")
+      set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -ffunction-sections")
+    endif()
 
-    # Link-Time Code Generation(LTCG) is requared for Whole Program Optimisation(GL)
+    # Link-Time Code Generation (LTCG) is required for Whole Program Optimization
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -flto")
     set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -flto")
     set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} -flto")
     set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} -flto")
-    if (NOT WIN32)
+    
+    # Add garbage collection sections only on Linux (not on macOS or Windows)
+    if (NOT WIN32 AND NOT APPLE)
       set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} -Wl,--gc-sections")
       set(CMAKE_STATIC_LINKER_FLAGS_RELEASE "${CMAKE_STATIC_LINKER_FLAGS_RELEASE} -Wl,--gc-sections")
       set(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} -Wl,--gc-sections")


### PR DESCRIPTION
Updated a main workflow to validate the header and more precise warnings.
No PCH helps to validate missed headers.