### PR TITLE
Coding - Add conversion utilities for STEP geometrical and visual enumerations

### DIFF
--- a/src/DataExchange/TKDESTEP/RWStepBasic/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/FILES.cmake
@@ -14,6 +14,7 @@ set(OCCT_RWStepBasic_FILES
   RWStepBasic_RWActionRequestSolution.pxx
   RWStepBasic_RWAddress.cxx
   RWStepBasic_RWAddress.pxx
+  RWStepBasic_RWAheadOrBehind.pxx
   RWStepBasic_RWApplicationContext.cxx
   RWStepBasic_RWApplicationContext.pxx
   RWStepBasic_RWApplicationContextElement.cxx
@@ -208,6 +209,7 @@ set(OCCT_RWStepBasic_FILES
   RWStepBasic_RWSecurityClassification.pxx
   RWStepBasic_RWSecurityClassificationLevel.cxx
   RWStepBasic_RWSecurityClassificationLevel.pxx
+  RWStepBasic_RWSiPrefix.pxx
   RWStepBasic_RWSiUnit.cxx
   RWStepBasic_RWSiUnit.pxx
   RWStepBasic_RWSiUnitAndAreaUnit.cxx
@@ -228,10 +230,12 @@ set(OCCT_RWStepBasic_FILES
   RWStepBasic_RWSiUnitAndTimeUnit.pxx
   RWStepBasic_RWSiUnitAndVolumeUnit.cxx
   RWStepBasic_RWSiUnitAndVolumeUnit.pxx
+  RWStepBasic_RWSiUnitName.pxx
   RWStepBasic_RWSolidAngleMeasureWithUnit.cxx
   RWStepBasic_RWSolidAngleMeasureWithUnit.pxx
   RWStepBasic_RWSolidAngleUnit.cxx
   RWStepBasic_RWSolidAngleUnit.pxx
+  RWStepBasic_RWSource.pxx
   RWStepBasic_RWThermodynamicTemperatureUnit.cxx
   RWStepBasic_RWThermodynamicTemperatureUnit.pxx
   RWStepBasic_RWUncertaintyMeasureWithUnit.cxx

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWAheadOrBehind.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWAheadOrBehind.pxx
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepBasic_RWAheadOrBehind_HeaderFile
+#define _RWStepBasic_RWAheadOrBehind_HeaderFile
+
+#include <StepBasic_AheadOrBehind.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepBasic_RWAheadOrBehind
+{
+static constexpr char aobAhead[]  = ".AHEAD.";
+static constexpr char aobExact[]  = ".EXACT.";
+static constexpr char aobBehind[] = ".BEHIND.";
+
+//! Convert StepBasic_AheadOrBehind to string
+//! @param theSourceEnum The StepBasic_AheadOrBehind value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepBasic_AheadOrBehind theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepBasic_aobAhead:
+      return aobAhead;
+    case StepBasic_aobExact:
+      return aobExact;
+    case StepBasic_aobBehind:
+      return aobBehind;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepBasic_AheadOrBehind
+//! @param theAheadOrBehindStr The string to convert
+//! @param theResultEnum The corresponding StepBasic_AheadOrBehind value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString   theAheadOrBehindStr,
+                          StepBasic_AheadOrBehind& theResultEnum)
+{
+  if (IsEqual(theAheadOrBehindStr, aobAhead))
+  {
+    theResultEnum = StepBasic_aobAhead;
+  }
+  else if (IsEqual(theAheadOrBehindStr, aobExact))
+  {
+    theResultEnum = StepBasic_aobExact;
+  }
+  else if (IsEqual(theAheadOrBehindStr, aobBehind))
+  {
+    theResultEnum = StepBasic_aobBehind;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+
+} // namespace RWStepBasic_RWAheadOrBehind
+
+#endif // _RWStepBasic_RWAheadOrBehind_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWCoordinatedUniversalTimeOffset.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWCoordinatedUniversalTimeOffset.cxx
@@ -17,10 +17,7 @@
 #include <StepData_StepWriter.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : AheadOrBehind ---
-static TCollection_AsciiString aobAhead(".AHEAD.");
-static TCollection_AsciiString aobExact(".EXACT.");
-static TCollection_AsciiString aobBehind(".BEHIND.");
+#include "RWStepBasic_RWAheadOrBehind.pxx"
 
 RWStepBasic_RWCoordinatedUniversalTimeOffset::RWStepBasic_RWCoordinatedUniversalTimeOffset() {}
 
@@ -63,14 +60,10 @@ void RWStepBasic_RWCoordinatedUniversalTimeOffset::ReadStep(
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (aobAhead.IsEqual(text))
-      aSense = StepBasic_aobAhead;
-    else if (aobExact.IsEqual(text))
-      aSense = StepBasic_aobExact;
-    else if (aobBehind.IsEqual(text))
-      aSense = StepBasic_aobBehind;
-    else
+    if (!RWStepBasic_RWAheadOrBehind::ConvertToEnum(text, aSense))
+    {
       ach->AddFail("Enumeration ahead_or_behind has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (sense) is not an enumeration");
@@ -103,16 +96,5 @@ void RWStepBasic_RWCoordinatedUniversalTimeOffset::WriteStep(
 
   // --- own field : sense ---
 
-  switch (ent->Sense())
-  {
-    case StepBasic_aobAhead:
-      SW.SendEnum(aobAhead);
-      break;
-    case StepBasic_aobExact:
-      SW.SendEnum(aobExact);
-      break;
-    case StepBasic_aobBehind:
-      SW.SendEnum(aobBehind);
-      break;
-  }
+  SW.SendEnum(RWStepBasic_RWAheadOrBehind::ConvertToString(ent->Sense()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource.cxx
@@ -20,10 +20,7 @@
 #include <StepData_StepWriter.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : Source ---
-static TCollection_AsciiString sBought(".BOUGHT.");
-static TCollection_AsciiString sNotKnown(".NOT_KNOWN.");
-static TCollection_AsciiString sMade(".MADE.");
+#include "RWStepBasic_RWSource.pxx"
 
 RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource::
   RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource()
@@ -66,14 +63,10 @@ void RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (sBought.IsEqual(text))
-      aMakeOrBuy = StepBasic_sBought;
-    else if (sNotKnown.IsEqual(text))
-      aMakeOrBuy = StepBasic_sNotKnown;
-    else if (sMade.IsEqual(text))
-      aMakeOrBuy = StepBasic_sMade;
-    else
+    if (!RWStepBasic_RWSource::ConvertToEnum(text, aMakeOrBuy))
+    {
       ach->AddFail("Enumeration source has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (make_or_buy) is not an enumeration");
@@ -102,18 +95,7 @@ void RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource::WriteStep(
 
   // --- own field : makeOrBuy ---
 
-  switch (ent->MakeOrBuy())
-  {
-    case StepBasic_sBought:
-      SW.SendEnum(sBought);
-      break;
-    case StepBasic_sNotKnown:
-      SW.SendEnum(sNotKnown);
-      break;
-    case StepBasic_sMade:
-      SW.SendEnum(sMade);
-      break;
-  }
+  SW.SendEnum(RWStepBasic_RWSource::ConvertToString(ent->MakeOrBuy()));
 }
 
 void RWStepBasic_RWProductDefinitionFormationWithSpecifiedSource::Share(

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiPrefix.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiPrefix.pxx
@@ -1,0 +1,161 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepBasic_RWSiPrefix_HeaderFile
+#define _RWStepBasic_RWSiPrefix_HeaderFile
+
+#include <StepBasic_SiPrefix.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepBasic_RWSiPrefix
+{
+static constexpr char spExa[]   = ".EXA.";
+static constexpr char spPico[]  = ".PICO.";
+static constexpr char spMega[]  = ".MEGA.";
+static constexpr char spFemto[] = ".FEMTO.";
+static constexpr char spAtto[]  = ".ATTO.";
+static constexpr char spCenti[] = ".CENTI.";
+static constexpr char spNano[]  = ".NANO.";
+static constexpr char spHecto[] = ".HECTO.";
+static constexpr char spMicro[] = ".MICRO.";
+static constexpr char spTera[]  = ".TERA.";
+static constexpr char spGiga[]  = ".GIGA.";
+static constexpr char spMilli[] = ".MILLI.";
+static constexpr char spPeta[]  = ".PETA.";
+static constexpr char spDeci[]  = ".DECI.";
+static constexpr char spKilo[]  = ".KILO.";
+static constexpr char spDeca[]  = ".DECA.";
+
+//! Convert StepBasic_SiPrefix to string
+//! @param theSourceEnum The StepBasic_SiPrefix value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepBasic_SiPrefix theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepBasic_spExa:
+      return spExa;
+    case StepBasic_spPico:
+      return spPico;
+    case StepBasic_spMega:
+      return spMega;
+    case StepBasic_spFemto:
+      return spFemto;
+    case StepBasic_spAtto:
+      return spAtto;
+    case StepBasic_spCenti:
+      return spCenti;
+    case StepBasic_spNano:
+      return spNano;
+    case StepBasic_spHecto:
+      return spHecto;
+    case StepBasic_spMicro:
+      return spMicro;
+    case StepBasic_spTera:
+      return spTera;
+    case StepBasic_spGiga:
+      return spGiga;
+    case StepBasic_spMilli:
+      return spMilli;
+    case StepBasic_spPeta:
+      return spPeta;
+    case StepBasic_spDeci:
+      return spDeci;
+    case StepBasic_spKilo:
+      return spKilo;
+    case StepBasic_spDeca:
+      return spDeca;
+  }
+  return nullptr; // Default value
+}
+
+//! Convert string to StepBasic_SiPrefix
+//! @param thePrefixStr The string to convert
+//! @param theResultEnum The corresponding StepBasic_SiPrefix value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString thePrefixStr, StepBasic_SiPrefix& theResultEnum)
+{
+  if (IsEqual(thePrefixStr, spExa))
+  {
+    theResultEnum = StepBasic_spExa;
+  }
+  else if (IsEqual(thePrefixStr, spPico))
+  {
+    theResultEnum = StepBasic_spPico;
+  }
+  else if (IsEqual(thePrefixStr, spMega))
+  {
+    theResultEnum = StepBasic_spMega;
+  }
+  else if (IsEqual(thePrefixStr, spFemto))
+  {
+    theResultEnum = StepBasic_spFemto;
+  }
+  else if (IsEqual(thePrefixStr, spAtto))
+  {
+    theResultEnum = StepBasic_spAtto;
+  }
+  else if (IsEqual(thePrefixStr, spCenti))
+  {
+    theResultEnum = StepBasic_spCenti;
+  }
+  else if (IsEqual(thePrefixStr, spNano))
+  {
+    theResultEnum = StepBasic_spNano;
+  }
+  else if (IsEqual(thePrefixStr, spHecto))
+  {
+    theResultEnum = StepBasic_spHecto;
+  }
+  else if (IsEqual(thePrefixStr, spMicro))
+  {
+    theResultEnum = StepBasic_spMicro;
+  }
+  else if (IsEqual(thePrefixStr, spTera))
+  {
+    theResultEnum = StepBasic_spTera;
+  }
+  else if (IsEqual(thePrefixStr, spGiga))
+  {
+    theResultEnum = StepBasic_spGiga;
+  }
+  else if (IsEqual(thePrefixStr, spMilli))
+  {
+    theResultEnum = StepBasic_spMilli;
+  }
+  else if (IsEqual(thePrefixStr, spPeta))
+  {
+    theResultEnum = StepBasic_spPeta;
+  }
+  else if (IsEqual(thePrefixStr, spDeci))
+  {
+    theResultEnum = StepBasic_spDeci;
+  }
+  else if (IsEqual(thePrefixStr, spKilo))
+  {
+    theResultEnum = StepBasic_spKilo;
+  }
+  else if (IsEqual(thePrefixStr, spDeca))
+  {
+    theResultEnum = StepBasic_spDeca;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+
+} // namespace RWStepBasic_RWSiPrefix
+
+#endif // _RWStepBasic_RWSiPrefix_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnit.cxx
@@ -18,53 +18,8 @@
 #include <StepData_StepWriter.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : SiPrefix ---
-static TCollection_AsciiString spExa(".EXA.");
-static TCollection_AsciiString spPico(".PICO.");
-static TCollection_AsciiString spMega(".MEGA.");
-static TCollection_AsciiString spFemto(".FEMTO.");
-static TCollection_AsciiString spAtto(".ATTO.");
-static TCollection_AsciiString spCenti(".CENTI.");
-static TCollection_AsciiString spNano(".NANO.");
-static TCollection_AsciiString spHecto(".HECTO.");
-static TCollection_AsciiString spMicro(".MICRO.");
-static TCollection_AsciiString spTera(".TERA.");
-static TCollection_AsciiString spGiga(".GIGA.");
-static TCollection_AsciiString spMilli(".MILLI.");
-static TCollection_AsciiString spPeta(".PETA.");
-static TCollection_AsciiString spDeci(".DECI.");
-static TCollection_AsciiString spKilo(".KILO.");
-static TCollection_AsciiString spDeca(".DECA.");
-
-// --- Enum : SiUnitName ---
-static TCollection_AsciiString sunHertz(".HERTZ.");
-static TCollection_AsciiString sunDegreeCelsius(".DEGREE_CELSIUS.");
-static TCollection_AsciiString sunSiemens(".SIEMENS.");
-static TCollection_AsciiString sunSievert(".SIEVERT.");
-static TCollection_AsciiString sunLux(".LUX.");
-static TCollection_AsciiString sunWatt(".WATT.");
-static TCollection_AsciiString sunOhm(".OHM.");
-static TCollection_AsciiString sunSecond(".SECOND.");
-static TCollection_AsciiString sunBecquerel(".BECQUEREL.");
-static TCollection_AsciiString sunPascal(".PASCAL.");
-static TCollection_AsciiString sunHenry(".HENRY.");
-static TCollection_AsciiString sunTesla(".TESLA.");
-static TCollection_AsciiString sunVolt(".VOLT.");
-static TCollection_AsciiString sunJoule(".JOULE.");
-static TCollection_AsciiString sunKelvin(".KELVIN.");
-static TCollection_AsciiString sunAmpere(".AMPERE.");
-static TCollection_AsciiString sunGram(".GRAM.");
-static TCollection_AsciiString sunSteradian(".STERADIAN.");
-static TCollection_AsciiString sunMole(".MOLE.");
-static TCollection_AsciiString sunLumen(".LUMEN.");
-static TCollection_AsciiString sunGray(".GRAY.");
-static TCollection_AsciiString sunCandela(".CANDELA.");
-static TCollection_AsciiString sunFarad(".FARAD.");
-static TCollection_AsciiString sunRadian(".RADIAN.");
-static TCollection_AsciiString sunNewton(".NEWTON.");
-static TCollection_AsciiString sunMetre(".METRE.");
-static TCollection_AsciiString sunWeber(".WEBER.");
-static TCollection_AsciiString sunCoulomb(".COULOMB.");
+#include "RWStepBasic_RWSiPrefix.pxx"
+#include "RWStepBasic_RWSiUnitName.pxx"
 
 RWStepBasic_RWSiUnit::RWStepBasic_RWSiUnit() {}
 
@@ -90,12 +45,16 @@ void RWStepBasic_RWSiUnit::ReadStep(const Handle(StepData_StepReaderData)& data,
     if (data->ParamType(num, 2) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 2);
-      hasAprefix            = DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
+      {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
+      }
     }
     else
+    {
       ach->AddFail("Parameter #2 (prefix) is not an enumeration");
+    }
   }
 
   // --- own field : name ---
@@ -103,8 +62,10 @@ void RWStepBasic_RWSiUnit::ReadStep(const Handle(StepData_StepReaderData)& data,
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (!DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
+    {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (name) is not an enumeration");
@@ -123,218 +84,10 @@ void RWStepBasic_RWSiUnit::WriteStep(StepData_StepWriter&            SW,
   // --- own field : prefix ---
   Standard_Boolean hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- own field : name ---
-  SW.SendEnum(EncodeName(ent->Name()));
-}
-
-Standard_Boolean RWStepBasic_RWSiUnit::DecodePrefix(StepBasic_SiPrefix&    aPrefix,
-                                                    const Standard_CString text) const
-{
-  if (spExa.IsEqual(text))
-    aPrefix = StepBasic_spExa;
-  else if (spPico.IsEqual(text))
-    aPrefix = StepBasic_spPico;
-  else if (spMega.IsEqual(text))
-    aPrefix = StepBasic_spMega;
-  else if (spFemto.IsEqual(text))
-    aPrefix = StepBasic_spFemto;
-  else if (spAtto.IsEqual(text))
-    aPrefix = StepBasic_spAtto;
-  else if (spCenti.IsEqual(text))
-    aPrefix = StepBasic_spCenti;
-  else if (spNano.IsEqual(text))
-    aPrefix = StepBasic_spNano;
-  else if (spHecto.IsEqual(text))
-    aPrefix = StepBasic_spHecto;
-  else if (spMicro.IsEqual(text))
-    aPrefix = StepBasic_spMicro;
-  else if (spTera.IsEqual(text))
-    aPrefix = StepBasic_spTera;
-  else if (spGiga.IsEqual(text))
-    aPrefix = StepBasic_spGiga;
-  else if (spMilli.IsEqual(text))
-    aPrefix = StepBasic_spMilli;
-  else if (spPeta.IsEqual(text))
-    aPrefix = StepBasic_spPeta;
-  else if (spDeci.IsEqual(text))
-    aPrefix = StepBasic_spDeci;
-  else if (spKilo.IsEqual(text))
-    aPrefix = StepBasic_spKilo;
-  else if (spDeca.IsEqual(text))
-    aPrefix = StepBasic_spDeca;
-  else
-    return Standard_False;
-  return Standard_True;
-}
-
-Standard_Boolean RWStepBasic_RWSiUnit::DecodeName(StepBasic_SiUnitName&  aName,
-                                                  const Standard_CString text) const
-{
-  if (sunHertz.IsEqual(text))
-    aName = StepBasic_sunHertz;
-  else if (sunDegreeCelsius.IsEqual(text))
-    aName = StepBasic_sunDegreeCelsius;
-  else if (sunSiemens.IsEqual(text))
-    aName = StepBasic_sunSiemens;
-  else if (sunSievert.IsEqual(text))
-    aName = StepBasic_sunSievert;
-  else if (sunLux.IsEqual(text))
-    aName = StepBasic_sunLux;
-  else if (sunWatt.IsEqual(text))
-    aName = StepBasic_sunWatt;
-  else if (sunOhm.IsEqual(text))
-    aName = StepBasic_sunOhm;
-  else if (sunSecond.IsEqual(text))
-    aName = StepBasic_sunSecond;
-  else if (sunBecquerel.IsEqual(text))
-    aName = StepBasic_sunBecquerel;
-  else if (sunPascal.IsEqual(text))
-    aName = StepBasic_sunPascal;
-  else if (sunHenry.IsEqual(text))
-    aName = StepBasic_sunHenry;
-  else if (sunTesla.IsEqual(text))
-    aName = StepBasic_sunTesla;
-  else if (sunVolt.IsEqual(text))
-    aName = StepBasic_sunVolt;
-  else if (sunJoule.IsEqual(text))
-    aName = StepBasic_sunJoule;
-  else if (sunKelvin.IsEqual(text))
-    aName = StepBasic_sunKelvin;
-  else if (sunAmpere.IsEqual(text))
-    aName = StepBasic_sunAmpere;
-  else if (sunGram.IsEqual(text))
-    aName = StepBasic_sunGram;
-  else if (sunSteradian.IsEqual(text))
-    aName = StepBasic_sunSteradian;
-  else if (sunMole.IsEqual(text))
-    aName = StepBasic_sunMole;
-  else if (sunLumen.IsEqual(text))
-    aName = StepBasic_sunLumen;
-  else if (sunGray.IsEqual(text))
-    aName = StepBasic_sunGray;
-  else if (sunCandela.IsEqual(text))
-    aName = StepBasic_sunCandela;
-  else if (sunFarad.IsEqual(text))
-    aName = StepBasic_sunFarad;
-  else if (sunRadian.IsEqual(text))
-    aName = StepBasic_sunRadian;
-  else if (sunNewton.IsEqual(text))
-    aName = StepBasic_sunNewton;
-  else if (sunMetre.IsEqual(text))
-    aName = StepBasic_sunMetre;
-  else if (sunWeber.IsEqual(text))
-    aName = StepBasic_sunWeber;
-  else if (sunCoulomb.IsEqual(text))
-    aName = StepBasic_sunCoulomb;
-  else
-    return Standard_False;
-  return Standard_True;
-}
-
-TCollection_AsciiString RWStepBasic_RWSiUnit::EncodePrefix(const StepBasic_SiPrefix aPrefix) const
-{
-  switch (aPrefix)
-  {
-    case StepBasic_spExa:
-      return spExa;
-    case StepBasic_spPico:
-      return spPico;
-    case StepBasic_spMega:
-      return spMega;
-    case StepBasic_spFemto:
-      return spFemto;
-    case StepBasic_spAtto:
-      return spAtto;
-    case StepBasic_spCenti:
-      return spCenti;
-    case StepBasic_spNano:
-      return spNano;
-    case StepBasic_spHecto:
-      return spHecto;
-    case StepBasic_spMicro:
-      return spMicro;
-    case StepBasic_spTera:
-      return spTera;
-    case StepBasic_spGiga:
-      return spGiga;
-    case StepBasic_spMilli:
-      return spMilli;
-    case StepBasic_spPeta:
-      return spPeta;
-    case StepBasic_spDeci:
-      return spDeci;
-    case StepBasic_spKilo:
-      return spKilo;
-    case StepBasic_spDeca:
-      return spDeca;
-  }
-  return TCollection_AsciiString("");
-}
-
-TCollection_AsciiString RWStepBasic_RWSiUnit::EncodeName(const StepBasic_SiUnitName aName) const
-{
-  switch (aName)
-  {
-    case StepBasic_sunHertz:
-      return sunHertz;
-    case StepBasic_sunDegreeCelsius:
-      return sunDegreeCelsius;
-    case StepBasic_sunSiemens:
-      return sunSiemens;
-    case StepBasic_sunSievert:
-      return sunSievert;
-    case StepBasic_sunLux:
-      return sunLux;
-    case StepBasic_sunWatt:
-      return sunWatt;
-    case StepBasic_sunOhm:
-      return sunOhm;
-    case StepBasic_sunSecond:
-      return sunSecond;
-    case StepBasic_sunBecquerel:
-      return sunBecquerel;
-    case StepBasic_sunPascal:
-      return sunPascal;
-    case StepBasic_sunHenry:
-      return sunHenry;
-    case StepBasic_sunTesla:
-      return sunTesla;
-    case StepBasic_sunVolt:
-      return sunVolt;
-    case StepBasic_sunJoule:
-      return sunJoule;
-    case StepBasic_sunKelvin:
-      return sunKelvin;
-    case StepBasic_sunAmpere:
-      return sunAmpere;
-    case StepBasic_sunGram:
-      return sunGram;
-    case StepBasic_sunSteradian:
-      return sunSteradian;
-    case StepBasic_sunMole:
-      return sunMole;
-    case StepBasic_sunLumen:
-      return sunLumen;
-    case StepBasic_sunGray:
-      return sunGray;
-    case StepBasic_sunCandela:
-      return sunCandela;
-    case StepBasic_sunFarad:
-      return sunFarad;
-    case StepBasic_sunRadian:
-      return sunRadian;
-    case StepBasic_sunNewton:
-      return sunNewton;
-    case StepBasic_sunMetre:
-      return sunMetre;
-    case StepBasic_sunWeber:
-      return sunWeber;
-    case StepBasic_sunCoulomb:
-      return sunCoulomb;
-  }
-  return TCollection_AsciiString("");
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnit.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnit.pxx
@@ -47,16 +47,6 @@ public:
   Standard_HIDDEN void WriteStep(StepData_StepWriter&            SW,
                                  const Handle(StepBasic_SiUnit)& ent) const;
 
-  Standard_HIDDEN Standard_Boolean DecodePrefix(StepBasic_SiPrefix&    aPrefix,
-                                                const Standard_CString text) const;
-
-  Standard_HIDDEN Standard_Boolean DecodeName(StepBasic_SiUnitName&  aName,
-                                              const Standard_CString text) const;
-
-  Standard_HIDDEN TCollection_AsciiString EncodePrefix(const StepBasic_SiPrefix aPrefix) const;
-
-  Standard_HIDDEN TCollection_AsciiString EncodeName(const StepBasic_SiUnitName aName) const;
-
 protected:
 private:
 };

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndAreaUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndAreaUnit.cxx
@@ -14,12 +14,14 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndAreaUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiUnitAndAreaUnit.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 RWStepBasic_RWSiUnitAndAreaUnit::RWStepBasic_RWSiUnitAndAreaUnit() {}
 
@@ -48,7 +50,6 @@ void RWStepBasic_RWSiUnitAndAreaUnit::ReadStep(const Handle(StepData_StepReaderD
   if (!data->CheckNbParams(num, 2, ach, "si_unit"))
     return;
 
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -56,7 +57,7 @@ void RWStepBasic_RWSiUnitAndAreaUnit::ReadStep(const Handle(StepData_StepReaderD
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -74,7 +75,7 @@ void RWStepBasic_RWSiUnitAndAreaUnit::ReadStep(const Handle(StepData_StepReaderD
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -99,12 +100,11 @@ void RWStepBasic_RWSiUnitAndAreaUnit::WriteStep(
   SW.Send(ent->Dimensions());
   SW.StartEntity("SI_UNIT");
 
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndLengthUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndLengthUnit.cxx
@@ -13,7 +13,6 @@
 
 // pdn 24.12.98 t3d_opt.stp: treatment of unsorted uncertanties
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndLengthUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -21,6 +20,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 RWStepBasic_RWSiUnitAndLengthUnit::RWStepBasic_RWSiUnitAndLengthUnit() {}
 
@@ -59,7 +61,6 @@ void RWStepBasic_RWSiUnitAndLengthUnit::ReadStep(
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -67,7 +68,7 @@ void RWStepBasic_RWSiUnitAndLengthUnit::ReadStep(
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -86,7 +87,7 @@ void RWStepBasic_RWSiUnitAndLengthUnit::ReadStep(
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -121,13 +122,12 @@ void RWStepBasic_RWSiUnitAndLengthUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndMassUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndMassUnit.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndMassUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -19,6 +18,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 //=================================================================================================
 
@@ -60,7 +62,6 @@ void RWStepBasic_RWSiUnitAndMassUnit::ReadStep(const Handle(StepData_StepReaderD
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -68,7 +69,7 @@ void RWStepBasic_RWSiUnitAndMassUnit::ReadStep(const Handle(StepData_StepReaderD
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -87,7 +88,7 @@ void RWStepBasic_RWSiUnitAndMassUnit::ReadStep(const Handle(StepData_StepReaderD
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -122,13 +123,12 @@ void RWStepBasic_RWSiUnitAndMassUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndPlaneAngleUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndPlaneAngleUnit.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndPlaneAngleUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -19,6 +18,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 RWStepBasic_RWSiUnitAndPlaneAngleUnit::RWStepBasic_RWSiUnitAndPlaneAngleUnit() {}
 
@@ -50,7 +52,6 @@ void RWStepBasic_RWSiUnitAndPlaneAngleUnit::ReadStep(
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -58,7 +59,7 @@ void RWStepBasic_RWSiUnitAndPlaneAngleUnit::ReadStep(
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -77,7 +78,7 @@ void RWStepBasic_RWSiUnitAndPlaneAngleUnit::ReadStep(
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -111,13 +112,12 @@ void RWStepBasic_RWSiUnitAndPlaneAngleUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndRatioUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndRatioUnit.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndRatioUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -19,6 +18,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 RWStepBasic_RWSiUnitAndRatioUnit::RWStepBasic_RWSiUnitAndRatioUnit() {}
 
@@ -51,7 +53,6 @@ void RWStepBasic_RWSiUnitAndRatioUnit::ReadStep(
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -59,7 +60,7 @@ void RWStepBasic_RWSiUnitAndRatioUnit::ReadStep(
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -78,7 +79,7 @@ void RWStepBasic_RWSiUnitAndRatioUnit::ReadStep(
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -112,13 +113,12 @@ void RWStepBasic_RWSiUnitAndRatioUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndSolidAngleUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndSolidAngleUnit.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndSolidAngleUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -19,6 +18,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 RWStepBasic_RWSiUnitAndSolidAngleUnit::RWStepBasic_RWSiUnitAndSolidAngleUnit() {}
 
@@ -45,7 +47,6 @@ void RWStepBasic_RWSiUnitAndSolidAngleUnit::ReadStep(
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -53,7 +54,7 @@ void RWStepBasic_RWSiUnitAndSolidAngleUnit::ReadStep(
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -72,7 +73,7 @@ void RWStepBasic_RWSiUnitAndSolidAngleUnit::ReadStep(
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -108,15 +109,14 @@ void RWStepBasic_RWSiUnitAndSolidAngleUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 
   // --- Instance of plex component SolidAngleUnit ---
   SW.StartEntity("SOLID_ANGLE_UNIT");

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -19,6 +18,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 //=================================================================================================
 
@@ -52,7 +54,6 @@ void RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit::ReadStep(
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -60,7 +61,7 @@ void RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit::ReadStep(
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -79,7 +80,7 @@ void RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit::ReadStep(
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -117,15 +118,14 @@ void RWStepBasic_RWSiUnitAndThermodynamicTemperatureUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 
   // --- Instance of plex component SolidAngleUnit ---
   SW.StartEntity("THERMODYNAMIC_TEMPERATURE_UNIT");

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndTimeUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndTimeUnit.cxx
@@ -11,7 +11,6 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndTimeUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiPrefix.hxx>
@@ -19,6 +18,9 @@
 #include <StepBasic_SiUnitName.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 //=================================================================================================
 
@@ -48,7 +50,6 @@ void RWStepBasic_RWSiUnitAndTimeUnit::ReadStep(const Handle(StepData_StepReaderD
     return;
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -56,7 +57,7 @@ void RWStepBasic_RWSiUnitAndTimeUnit::ReadStep(const Handle(StepData_StepReaderD
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -75,7 +76,7 @@ void RWStepBasic_RWSiUnitAndTimeUnit::ReadStep(const Handle(StepData_StepReaderD
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -117,15 +118,14 @@ void RWStepBasic_RWSiUnitAndTimeUnit::WriteStep(
   SW.StartEntity("SI_UNIT");
 
   // --- field : prefix ---
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
   // --- field : name ---
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
 
   // --- Instance of plex component TimeUnit ---
   SW.StartEntity("TIME_UNIT");

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndVolumeUnit.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitAndVolumeUnit.cxx
@@ -14,12 +14,14 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
-#include "RWStepBasic_RWSiUnit.pxx"
 #include "RWStepBasic_RWSiUnitAndVolumeUnit.pxx"
 #include <StepBasic_DimensionalExponents.hxx>
 #include <StepBasic_SiUnitAndVolumeUnit.hxx>
 #include <StepData_StepReaderData.hxx>
 #include <StepData_StepWriter.hxx>
+
+#include "RWStepBasic_RWSiUnitName.pxx"
+#include "RWStepBasic_RWSiPrefix.pxx"
 
 RWStepBasic_RWSiUnitAndVolumeUnit::RWStepBasic_RWSiUnitAndVolumeUnit() {}
 
@@ -45,7 +47,6 @@ void RWStepBasic_RWSiUnitAndVolumeUnit::ReadStep(
   if (!data->CheckNbParams(num, 2, ach, "si_unit"))
     return;
 
-  RWStepBasic_RWSiUnit reader;
   StepBasic_SiPrefix   aPrefix    = StepBasic_spExa;
   Standard_Boolean     hasAprefix = Standard_False;
   if (data->IsParamDefined(num, 1))
@@ -53,7 +54,7 @@ void RWStepBasic_RWSiUnitAndVolumeUnit::ReadStep(
     if (data->ParamType(num, 1) == Interface_ParamEnum)
     {
       Standard_CString text = data->ParamCValue(num, 1);
-      hasAprefix            = reader.DecodePrefix(aPrefix, text);
+      hasAprefix            = RWStepBasic_RWSiPrefix::ConvertToEnum(text, aPrefix);
       if (!hasAprefix)
       {
         ach->AddFail("Enumeration si_prefix has not an allowed value");
@@ -71,7 +72,7 @@ void RWStepBasic_RWSiUnitAndVolumeUnit::ReadStep(
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (!reader.DecodeName(aName, text))
+    if (!RWStepBasic_RWSiUnitName::ConvertToEnum(text, aName))
     {
       ach->AddFail("Enumeration si_unit_name has not an allowed value");
       return;
@@ -99,13 +100,12 @@ void RWStepBasic_RWSiUnitAndVolumeUnit::WriteStep(
   SW.Send(ent->Dimensions());
   SW.StartEntity("SI_UNIT");
 
-  RWStepBasic_RWSiUnit writer;
   Standard_Boolean     hasAprefix = ent->HasPrefix();
   if (hasAprefix)
-    SW.SendEnum(writer.EncodePrefix(ent->Prefix()));
+    SW.SendEnum(RWStepBasic_RWSiPrefix::ConvertToString(ent->Prefix()));
   else
     SW.SendUndef();
 
-  SW.SendEnum(writer.EncodeName(ent->Name()));
+  SW.SendEnum(RWStepBasic_RWSiUnitName::ConvertToString(ent->Name()));
   SW.StartEntity("VOLUME_UNIT");
 }

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitName.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSiUnitName.pxx
@@ -1,0 +1,244 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepBasic_RWSiUnitName_HeaderFile
+#define _RWStepBasic_RWSiUnitName_HeaderFile
+
+#include <StepBasic_SiUnitName.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepBasic_RWSiUnitName
+{
+static constexpr char sunHertz[]         = ".HERTZ.";
+static constexpr char sunDegreeCelsius[] = ".DEGREE_CELSIUS.";
+static constexpr char sunSiemens[]       = ".SIEMENS.";
+static constexpr char sunSievert[]       = ".SIEVERT.";
+static constexpr char sunLux[]           = ".LUX.";
+static constexpr char sunWatt[]          = ".WATT.";
+static constexpr char sunOhm[]           = ".OHM.";
+static constexpr char sunSecond[]        = ".SECOND.";
+static constexpr char sunBecquerel[]     = ".BECQUEREL.";
+static constexpr char sunPascal[]        = ".PASCAL.";
+static constexpr char sunHenry[]         = ".HENRY.";
+static constexpr char sunTesla[]         = ".TESLA.";
+static constexpr char sunVolt[]          = ".VOLT.";
+static constexpr char sunJoule[]         = ".JOULE.";
+static constexpr char sunKelvin[]        = ".KELVIN.";
+static constexpr char sunAmpere[]        = ".AMPERE.";
+static constexpr char sunGram[]          = ".GRAM.";
+static constexpr char sunSteradian[]     = ".STERADIAN.";
+static constexpr char sunMole[]          = ".MOLE.";
+static constexpr char sunLumen[]         = ".LUMEN.";
+static constexpr char sunGray[]          = ".GRAY.";
+static constexpr char sunCandela[]       = ".CANDELA.";
+static constexpr char sunFarad[]         = ".FARAD.";
+static constexpr char sunRadian[]        = ".RADIAN.";
+static constexpr char sunNewton[]        = ".NEWTON.";
+static constexpr char sunMetre[]         = ".METRE.";
+static constexpr char sunWeber[]         = ".WEBER.";
+static constexpr char sunCoulomb[]       = ".COULOMB.";
+
+//! Convert StepBasic_SiUnitName to string
+//! @param theNameEnum The StepBasic_SiUnitName value to convert
+//! @return The corresponding string representation
+static const char* ConvertToString(const StepBasic_SiUnitName theNameEnum)
+{
+  switch (theNameEnum)
+  {
+    case StepBasic_sunHertz:
+      return sunHertz;
+    case StepBasic_sunDegreeCelsius:
+      return sunDegreeCelsius;
+    case StepBasic_sunSiemens:
+      return sunSiemens;
+    case StepBasic_sunSievert:
+      return sunSievert;
+    case StepBasic_sunLux:
+      return sunLux;
+    case StepBasic_sunWatt:
+      return sunWatt;
+    case StepBasic_sunOhm:
+      return sunOhm;
+    case StepBasic_sunSecond:
+      return sunSecond;
+    case StepBasic_sunBecquerel:
+      return sunBecquerel;
+    case StepBasic_sunPascal:
+      return sunPascal;
+    case StepBasic_sunHenry:
+      return sunHenry;
+    case StepBasic_sunTesla:
+      return sunTesla;
+    case StepBasic_sunVolt:
+      return sunVolt;
+    case StepBasic_sunJoule:
+      return sunJoule;
+    case StepBasic_sunKelvin:
+      return sunKelvin;
+    case StepBasic_sunAmpere:
+      return sunAmpere;
+    case StepBasic_sunGram:
+      return sunGram;
+    case StepBasic_sunSteradian:
+      return sunSteradian;
+    case StepBasic_sunMole:
+      return sunMole;
+    case StepBasic_sunLumen:
+      return sunLumen;
+    case StepBasic_sunGray:
+      return sunGray;
+    case StepBasic_sunCandela:
+      return sunCandela;
+    case StepBasic_sunFarad:
+      return sunFarad;
+    case StepBasic_sunRadian:
+      return sunRadian;
+    case StepBasic_sunNewton:
+      return sunNewton;
+    case StepBasic_sunMetre:
+      return sunMetre;
+    case StepBasic_sunWeber:
+      return sunWeber;
+    case StepBasic_sunCoulomb:
+      return sunCoulomb;
+  }
+  return nullptr; // Default value
+}
+
+//! Convert string to StepBasic_SiUnitName
+//! @param theNameStr The string to convert
+//! @param theResultEnum The corresponding StepBasic_SiUnitName value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString theNameStr, StepBasic_SiUnitName& theResultEnum)
+{
+  if (IsEqual(theNameStr, sunHertz))
+  {
+    theResultEnum = StepBasic_sunHertz;
+  }
+  else if (IsEqual(theNameStr, sunDegreeCelsius))
+  {
+    theResultEnum = StepBasic_sunDegreeCelsius;
+  }
+  else if (IsEqual(theNameStr, sunSiemens))
+  {
+    theResultEnum = StepBasic_sunSiemens;
+  }
+  else if (IsEqual(theNameStr, sunSievert))
+  {
+    theResultEnum = StepBasic_sunSievert;
+  }
+  else if (IsEqual(theNameStr, sunLux))
+  {
+    theResultEnum = StepBasic_sunLux;
+  }
+  else if (IsEqual(theNameStr, sunWatt))
+  {
+    theResultEnum = StepBasic_sunWatt;
+  }
+  else if (IsEqual(theNameStr, sunOhm))
+  {
+    theResultEnum = StepBasic_sunOhm;
+  }
+  else if (IsEqual(theNameStr, sunSecond))
+  {
+    theResultEnum = StepBasic_sunSecond;
+  }
+  else if (IsEqual(theNameStr, sunBecquerel))
+  {
+    theResultEnum = StepBasic_sunBecquerel;
+  }
+  else if (IsEqual(theNameStr, sunPascal))
+  {
+    theResultEnum = StepBasic_sunPascal;
+  }
+  else if (IsEqual(theNameStr, sunHenry))
+  {
+    theResultEnum = StepBasic_sunHenry;
+  }
+  else if (IsEqual(theNameStr, sunTesla))
+  {
+    theResultEnum = StepBasic_sunTesla;
+  }
+  else if (IsEqual(theNameStr, sunVolt))
+  {
+    theResultEnum = StepBasic_sunVolt;
+  }
+  else if (IsEqual(theNameStr, sunJoule))
+  {
+    theResultEnum = StepBasic_sunJoule;
+  }
+  else if (IsEqual(theNameStr, sunKelvin))
+  {
+    theResultEnum = StepBasic_sunKelvin;
+  }
+  else if (IsEqual(theNameStr, sunAmpere))
+  {
+    theResultEnum = StepBasic_sunAmpere;
+  }
+  else if (IsEqual(theNameStr, sunGram))
+  {
+    theResultEnum = StepBasic_sunGram;
+  }
+  else if (IsEqual(theNameStr, sunSteradian))
+  {
+    theResultEnum = StepBasic_sunSteradian;
+  }
+  else if (IsEqual(theNameStr, sunMole))
+  {
+    theResultEnum = StepBasic_sunMole;
+  }
+  else if (IsEqual(theNameStr, sunLumen))
+  {
+    theResultEnum = StepBasic_sunLumen;
+  }
+  else if (IsEqual(theNameStr, sunGray))
+  {
+    theResultEnum = StepBasic_sunGray;
+  }
+  else if (IsEqual(theNameStr, sunCandela))
+  {
+    theResultEnum = StepBasic_sunCandela;
+  }
+  else if (IsEqual(theNameStr, sunFarad))
+  {
+    theResultEnum = StepBasic_sunFarad;
+  }
+  else if (IsEqual(theNameStr, sunRadian))
+  {
+    theResultEnum = StepBasic_sunRadian;
+  }
+  else if (IsEqual(theNameStr, sunNewton))
+  {
+    theResultEnum = StepBasic_sunNewton;
+  }
+  else if (IsEqual(theNameStr, sunMetre))
+  {
+    theResultEnum = StepBasic_sunMetre;
+  }
+  else if (IsEqual(theNameStr, sunWeber))
+  {
+    theResultEnum = StepBasic_sunWeber;
+  }
+  else if (IsEqual(theNameStr, sunCoulomb))
+  {
+    theResultEnum = StepBasic_sunCoulomb;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+
+} // namespace RWStepBasic_RWSiUnitName
+#endif // _RWStepBasic_RWSiUnitName_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSource.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepBasic/RWStepBasic_RWSource.pxx
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepBasic_RWSource_HeaderFile
+#define _RWStepBasic_RWSource_HeaderFile
+
+#include <StepBasic_Source.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepBasic_RWSource
+{
+static constexpr char sBought[]   = ".BOUGHT.";
+static constexpr char sNotKnown[] = ".NOT_KNOWN.";
+static constexpr char sMade[]     = ".MADE.";
+
+//! Convert StepBasic_Source to string
+//! @param theSourceEnum The StepBasic_Source value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepBasic_Source theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepBasic_sBought:
+      return sBought;
+    case StepBasic_sNotKnown:
+      return sNotKnown;
+    case StepBasic_sMade:
+      return sMade;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepBasic_Source
+//! @param theSourceStr The string to convert
+//! @param theResultEnum The corresponding StepBasic_Source value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString theSourceStr, StepBasic_Source& theResultEnum)
+{
+  if (IsEqual(theSourceStr, sBought))
+  {
+    theResultEnum = StepBasic_sBought;
+  }
+  else if (IsEqual(theSourceStr, sNotKnown))
+  {
+    theResultEnum = StepBasic_sNotKnown;
+  }
+  else if (IsEqual(theSourceStr, sMade))
+  {
+    theResultEnum = StepBasic_sMade;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepBasic_RWSource
+
+#endif // _RWStepBasic_RWSource_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/FILES.cmake
@@ -25,12 +25,14 @@ set(OCCT_RWStepGeom_FILES
   RWStepGeom_RWBSplineCurve.cxx
   RWStepGeom_RWBSplineCurve.pxx
   RWStepGeom_RWBSplineCurveWithKnots.cxx
+  RWStepGeom_RWBSplineCurveForm.pxx
   RWStepGeom_RWBSplineCurveWithKnots.pxx
   RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve.cxx
   RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve.pxx
   RWStepGeom_RWBSplineSurface.cxx
   RWStepGeom_RWBSplineSurface.pxx
   RWStepGeom_RWBSplineSurfaceWithKnots.cxx
+  RWStepGeom_RWBSplineSurfaceForm.pxx
   RWStepGeom_RWBSplineSurfaceWithKnots.pxx
   RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface.cxx
   RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface.pxx
@@ -86,7 +88,9 @@ set(OCCT_RWStepGeom_FILES
   RWStepGeom_RWHyperbola.pxx
   RWStepGeom_RWIntersectionCurve.cxx
   RWStepGeom_RWIntersectionCurve.pxx
+  RWStepGeom_RWKnotType.pxx
   RWStepGeom_RWLine.cxx
+  RWStepGeom_RWKnotType.pxx
   RWStepGeom_RWLine.pxx
   RWStepGeom_RWOffsetCurve3d.cxx
   RWStepGeom_RWOffsetCurve3d.pxx
@@ -114,6 +118,7 @@ set(OCCT_RWStepGeom_FILES
   RWStepGeom_RWPointReplica.pxx
   RWStepGeom_RWPolyline.cxx
   RWStepGeom_RWPolyline.pxx
+  RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx
   RWStepGeom_RWQuasiUniformCurve.cxx
   RWStepGeom_RWQuasiUniformCurve.pxx
   RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve.cxx
@@ -156,6 +161,7 @@ set(OCCT_RWStepGeom_FILES
   RWStepGeom_RWSweptSurface.pxx
   RWStepGeom_RWToroidalSurface.cxx
   RWStepGeom_RWToroidalSurface.pxx
+  RWStepGeom_RWTransitionCode.pxx
   RWStepGeom_RWTrimmedCurve.cxx
   RWStepGeom_RWTrimmedCurve.pxx
   RWStepGeom_RWUniformCurve.cxx

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurve.cxx
@@ -22,13 +22,7 @@
 #include <StepGeom_HArray1OfCartesianPoint.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWBSplineCurve::RWStepGeom_RWBSplineCurve() {}
 
@@ -83,20 +77,10 @@ void RWStepGeom_RWBSplineCurve::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (curve_form) is not an enumeration");
@@ -141,27 +125,7 @@ void RWStepGeom_RWBSplineCurve::WriteStep(StepData_StepWriter&                 S
 
   // --- own field : curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
 
   // --- own field : closedCurve ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurveForm.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurveForm.pxx
@@ -1,0 +1,90 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepGeom_RWBSplineCurveForm_HeaderFile
+#define _RWStepGeom_RWBSplineCurveForm_HeaderFile
+
+#include <StepGeom_BSplineCurveForm.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepGeom_RWBSplineCurveForm
+{
+static constexpr char bscfEllipticArc[]   = ".ELLIPTIC_ARC.";
+static constexpr char bscfPolylineForm[]  = ".POLYLINE_FORM.";
+static constexpr char bscfParabolicArc[]  = ".PARABOLIC_ARC.";
+static constexpr char bscfCircularArc[]   = ".CIRCULAR_ARC.";
+static constexpr char bscfUnspecified[]   = ".UNSPECIFIED.";
+static constexpr char bscfHyperbolicArc[] = ".HYPERBOLIC_ARC.";
+
+//! Convert StepGeom_BSplineCurveForm to string
+//! @param theSourceEnum The StepGeom_BSplineCurveForm value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepGeom_BSplineCurveForm theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepGeom_bscfEllipticArc:
+      return bscfEllipticArc;
+    case StepGeom_bscfPolylineForm:
+      return bscfPolylineForm;
+    case StepGeom_bscfParabolicArc:
+      return bscfParabolicArc;
+    case StepGeom_bscfCircularArc:
+      return bscfCircularArc;
+    case StepGeom_bscfUnspecified:
+      return bscfUnspecified;
+    case StepGeom_bscfHyperbolicArc:
+      return bscfHyperbolicArc;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepGeom_BSplineCurveForm
+//! @param theFormString The string to convert
+//! @param theResultEnum The corresponding StepGeom_BSplineCurveForm value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString theFormString, StepGeom_BSplineCurveForm& theResultEnum)
+{
+  if (IsEqual(theFormString, bscfEllipticArc))
+  {
+    theResultEnum = StepGeom_bscfEllipticArc;
+  }
+  else if (IsEqual(theFormString, bscfPolylineForm))
+  {
+    theResultEnum = StepGeom_bscfPolylineForm;
+  }
+  else if (IsEqual(theFormString, bscfParabolicArc))
+  {
+    theResultEnum = StepGeom_bscfParabolicArc;
+  }
+  else if (IsEqual(theFormString, bscfCircularArc))
+  {
+    theResultEnum = StepGeom_bscfCircularArc;
+  }
+  else if (IsEqual(theFormString, bscfUnspecified))
+  {
+    theResultEnum = StepGeom_bscfUnspecified;
+  }
+  else if (IsEqual(theFormString, bscfHyperbolicArc))
+  {
+    theResultEnum = StepGeom_bscfHyperbolicArc;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepGeom_RWBSplineCurveForm
+
+#endif // _RWStepGeom_RWBSplineCurveForm_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurveWithKnots.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurveWithKnots.cxx
@@ -25,19 +25,8 @@
 #include <TColStd_HArray1OfInteger.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : KnotType ---
-static TCollection_AsciiString ktUniformKnots(".UNIFORM_KNOTS.");
-static TCollection_AsciiString ktQuasiUniformKnots(".QUASI_UNIFORM_KNOTS.");
-static TCollection_AsciiString ktPiecewiseBezierKnots(".PIECEWISE_BEZIER_KNOTS.");
-static TCollection_AsciiString ktUnspecified(".UNSPECIFIED.");
-
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
+#include "RWStepGeom_RWKnotType.pxx"
 
 RWStepGeom_RWBSplineCurveWithKnots::RWStepGeom_RWBSplineCurveWithKnots() {}
 
@@ -98,20 +87,10 @@ void RWStepGeom_RWBSplineCurveWithKnots::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (curve_form) is not an enumeration");
@@ -168,16 +147,10 @@ void RWStepGeom_RWBSplineCurveWithKnots::ReadStep(
   if (data->ParamType(num, 9) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 9);
-    if (ktUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktUniformKnots;
-    else if (ktQuasiUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktQuasiUniformKnots;
-    else if (ktPiecewiseBezierKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktPiecewiseBezierKnots;
-    else if (ktUnspecified.IsEqual(text))
-      aKnotSpec = StepGeom_ktUnspecified;
-    else
+    if (!RWStepGeom_RWKnotType::ConvertToEnum(text, aKnotSpec))
+    {
       ach->AddFail("Enumeration knot_type has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #9 (knot_spec) is not an enumeration");
@@ -219,27 +192,7 @@ void RWStepGeom_RWBSplineCurveWithKnots::WriteStep(
 
   // --- inherited field curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
 
   // --- inherited field closedCurve ---
 
@@ -269,21 +222,7 @@ void RWStepGeom_RWBSplineCurveWithKnots::WriteStep(
 
   // --- own field : knotSpec ---
 
-  switch (ent->KnotSpec())
-  {
-    case StepGeom_ktUniformKnots:
-      SW.SendEnum(ktUniformKnots);
-      break;
-    case StepGeom_ktQuasiUniformKnots:
-      SW.SendEnum(ktQuasiUniformKnots);
-      break;
-    case StepGeom_ktPiecewiseBezierKnots:
-      SW.SendEnum(ktPiecewiseBezierKnots);
-      break;
-    case StepGeom_ktUnspecified:
-      SW.SendEnum(ktUnspecified);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWKnotType::ConvertToString(ent->KnotSpec()));
 }
 
 void RWStepGeom_RWBSplineCurveWithKnots::Share(const Handle(StepGeom_BSplineCurveWithKnots)& ent,

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve.cxx
@@ -30,19 +30,8 @@
 #include <TColStd_HArray1OfInteger.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
-
-// --- Enum : KnotType ---
-static TCollection_AsciiString ktUniformKnots(".UNIFORM_KNOTS.");
-static TCollection_AsciiString ktQuasiUniformKnots(".QUASI_UNIFORM_KNOTS.");
-static TCollection_AsciiString ktPiecewiseBezierKnots(".PIECEWISE_BEZIER_KNOTS.");
-static TCollection_AsciiString ktUnspecified(".UNSPECIFIED.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
+#include "RWStepGeom_RWKnotType.pxx"
 
 RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve::
   RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve()
@@ -102,20 +91,10 @@ void RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve::ReadStep(
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (curve_form) is not an enumeration");
@@ -180,16 +159,10 @@ void RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve::ReadStep(
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (ktUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktUniformKnots;
-    else if (ktQuasiUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktQuasiUniformKnots;
-    else if (ktPiecewiseBezierKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktPiecewiseBezierKnots;
-    else if (ktUnspecified.IsEqual(text))
-      aKnotSpec = StepGeom_ktUnspecified;
-    else
+    if (!RWStepGeom_RWKnotType::ConvertToEnum(text, aKnotSpec))
+    {
       ach->AddFail("Enumeration knot_type has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (knot_spec) is not an enumeration");
@@ -286,27 +259,8 @@ void RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve::WriteStep(
   SW.CloseSub();
   // --- field : curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
+
   // --- field : closedCurve ---
 
   SW.SendLogical(ent->ClosedCurve());
@@ -335,21 +289,7 @@ void RWStepGeom_RWBSplineCurveWithKnotsAndRationalBSplineCurve::WriteStep(
   SW.CloseSub();
   // --- field : knotSpec ---
 
-  switch (ent->KnotSpec())
-  {
-    case StepGeom_ktUniformKnots:
-      SW.SendEnum(ktUniformKnots);
-      break;
-    case StepGeom_ktQuasiUniformKnots:
-      SW.SendEnum(ktQuasiUniformKnots);
-      break;
-    case StepGeom_ktPiecewiseBezierKnots:
-      SW.SendEnum(ktPiecewiseBezierKnots);
-      break;
-    case StepGeom_ktUnspecified:
-      SW.SendEnum(ktUnspecified);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWKnotType::ConvertToString(ent->KnotSpec()));
 
   // --- Instance of plex component Curve ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurface.cxx
@@ -22,18 +22,7 @@
 #include <StepGeom_HArray2OfCartesianPoint.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWBSplineSurface::RWStepGeom_RWBSplineSurface() {}
 
@@ -102,30 +91,10 @@ void RWStepGeom_RWBSplineSurface::ReadStep(const Handle(StepData_StepReaderData)
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (surface_form) is not an enumeration");
@@ -194,42 +163,7 @@ void RWStepGeom_RWBSplineSurface::WriteStep(StepData_StepWriter&                
 
   // --- own field : surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
 
   // --- own field : uClosed ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurfaceForm.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurfaceForm.pxx
@@ -1,0 +1,126 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepGeom_RWBSplineSurfaceForm_HeaderFile
+#define _RWStepGeom_RWBSplineSurfaceForm_HeaderFile
+
+#include <StepGeom_BSplineSurfaceForm.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepGeom_RWBSplineSurfaceForm
+{
+static constexpr char bssfSurfOfLinearExtrusion[] = (".SURF_OF_LINEAR_EXTRUSION.");
+static constexpr char bssfPlaneSurf[]             = (".PLANE_SURF.");
+static constexpr char bssfGeneralisedCone[]       = (".GENERALISED_CONE.");
+static constexpr char bssfToroidalSurf[]          = (".TOROIDAL_SURF.");
+static constexpr char bssfConicalSurf[]           = (".CONICAL_SURF.");
+static constexpr char bssfSphericalSurf[]         = (".SPHERICAL_SURF.");
+static constexpr char bssfUnspecified[]           = (".UNSPECIFIED.");
+static constexpr char bssfRuledSurf[]             = (".RULED_SURF.");
+static constexpr char bssfSurfOfRevolution[]      = (".SURF_OF_REVOLUTION.");
+static constexpr char bssfCylindricalSurf[]       = (".CYLINDRICAL_SURF.");
+static constexpr char bssfQuadricSurf[]           = (".QUADRIC_SURF.");
+
+//! Convert StepGeom_BSplineSurfaceForm to string
+//! @param theSourceEnum The StepGeom_BSplineSurfaceForm value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepGeom_BSplineSurfaceForm theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepGeom_bssfSurfOfLinearExtrusion:
+      return bssfSurfOfLinearExtrusion;
+    case StepGeom_bssfPlaneSurf:
+      return bssfPlaneSurf;
+    case StepGeom_bssfGeneralisedCone:
+      return bssfGeneralisedCone;
+    case StepGeom_bssfToroidalSurf:
+      return bssfToroidalSurf;
+    case StepGeom_bssfConicalSurf:
+      return bssfConicalSurf;
+    case StepGeom_bssfSphericalSurf:
+      return bssfSphericalSurf;
+    case StepGeom_bssfUnspecified:
+      return bssfUnspecified;
+    case StepGeom_bssfRuledSurf:
+      return bssfRuledSurf;
+    case StepGeom_bssfSurfOfRevolution:
+      return bssfSurfOfRevolution;
+    case StepGeom_bssfCylindricalSurf:
+      return bssfCylindricalSurf;
+    case StepGeom_bssfQuadricSurf:
+      return bssfQuadricSurf;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepGeom_BSplineSurfaceForm
+//! @param theFormString The string to convert
+//! @param theResultEnum The corresponding StepGeom_BSplineSurfaceForm value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString       theFormString,
+                          StepGeom_BSplineSurfaceForm& theResultEnum)
+{
+  if (IsEqual(theFormString, bssfSurfOfLinearExtrusion))
+  {
+    theResultEnum = StepGeom_bssfSurfOfLinearExtrusion;
+  }
+  else if (IsEqual(theFormString, bssfPlaneSurf))
+  {
+    theResultEnum = StepGeom_bssfPlaneSurf;
+  }
+  else if (IsEqual(theFormString, bssfGeneralisedCone))
+  {
+    theResultEnum = StepGeom_bssfGeneralisedCone;
+  }
+  else if (IsEqual(theFormString, bssfToroidalSurf))
+  {
+    theResultEnum = StepGeom_bssfToroidalSurf;
+  }
+  else if (IsEqual(theFormString, bssfConicalSurf))
+  {
+    theResultEnum = StepGeom_bssfConicalSurf;
+  }
+  else if (IsEqual(theFormString, bssfSphericalSurf))
+  {
+    theResultEnum = StepGeom_bssfSphericalSurf;
+  }
+  else if (IsEqual(theFormString, bssfUnspecified))
+  {
+    theResultEnum = StepGeom_bssfUnspecified;
+  }
+  else if (IsEqual(theFormString, bssfRuledSurf))
+  {
+    theResultEnum = StepGeom_bssfRuledSurf;
+  }
+  else if (IsEqual(theFormString, bssfSurfOfRevolution))
+  {
+    theResultEnum = StepGeom_bssfSurfOfRevolution;
+  }
+  else if (IsEqual(theFormString, bssfCylindricalSurf))
+  {
+    theResultEnum = StepGeom_bssfCylindricalSurf;
+  }
+  else if (IsEqual(theFormString, bssfQuadricSurf))
+  {
+    theResultEnum = StepGeom_bssfQuadricSurf;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepGeom_RWBSplineSurfaceForm
+
+#endif // _RWStepGeom_RWBSplineSurfaceForm_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurfaceWithKnots.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurfaceWithKnots.cxx
@@ -25,24 +25,8 @@
 #include <TColStd_HArray1OfInteger.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : KnotType ---
-static TCollection_AsciiString ktUniformKnots(".UNIFORM_KNOTS.");
-static TCollection_AsciiString ktQuasiUniformKnots(".QUASI_UNIFORM_KNOTS.");
-static TCollection_AsciiString ktPiecewiseBezierKnots(".PIECEWISE_BEZIER_KNOTS.");
-static TCollection_AsciiString ktUnspecified(".UNSPECIFIED.");
-
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
+#include "RWStepGeom_RWKnotType.pxx"
 
 RWStepGeom_RWBSplineSurfaceWithKnots::RWStepGeom_RWBSplineSurfaceWithKnots() {}
 
@@ -112,30 +96,10 @@ void RWStepGeom_RWBSplineSurfaceWithKnots::ReadStep(
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (surface_form) is not an enumeration");
@@ -232,16 +196,10 @@ void RWStepGeom_RWBSplineSurfaceWithKnots::ReadStep(
   if (data->ParamType(num, 13) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 13);
-    if (ktUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktUniformKnots;
-    else if (ktQuasiUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktQuasiUniformKnots;
-    else if (ktPiecewiseBezierKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktPiecewiseBezierKnots;
-    else if (ktUnspecified.IsEqual(text))
-      aKnotSpec = StepGeom_ktUnspecified;
-    else
+    if (!RWStepGeom_RWKnotType::ConvertToEnum(text, aKnotSpec))
+    {
       ach->AddFail("Enumeration knot_type has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #13 (knot_spec) is not an enumeration");
@@ -298,42 +256,7 @@ void RWStepGeom_RWBSplineSurfaceWithKnots::WriteStep(
 
   // --- inherited field surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
 
   // --- inherited field uClosed ---
 
@@ -385,21 +308,7 @@ void RWStepGeom_RWBSplineSurfaceWithKnots::WriteStep(
 
   // --- own field : knotSpec ---
 
-  switch (ent->KnotSpec())
-  {
-    case StepGeom_ktUniformKnots:
-      SW.SendEnum(ktUniformKnots);
-      break;
-    case StepGeom_ktQuasiUniformKnots:
-      SW.SendEnum(ktQuasiUniformKnots);
-      break;
-    case StepGeom_ktPiecewiseBezierKnots:
-      SW.SendEnum(ktPiecewiseBezierKnots);
-      break;
-    case StepGeom_ktUnspecified:
-      SW.SendEnum(ktUnspecified);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWKnotType::ConvertToString(ent->KnotSpec()));
 }
 
 void RWStepGeom_RWBSplineSurfaceWithKnots::Share(

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface.cxx
@@ -29,24 +29,8 @@
 #include <TColStd_HArray1OfReal.hxx>
 #include <TColStd_HArray2OfReal.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
-
-// --- Enum : KnotType ---
-static TCollection_AsciiString ktUniformKnots(".UNIFORM_KNOTS.");
-static TCollection_AsciiString ktQuasiUniformKnots(".QUASI_UNIFORM_KNOTS.");
-static TCollection_AsciiString ktPiecewiseBezierKnots(".PIECEWISE_BEZIER_KNOTS.");
-static TCollection_AsciiString ktUnspecified(".UNSPECIFIED.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
+#include "RWStepGeom_RWKnotType.pxx"
 
 RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface::
   RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface()
@@ -117,30 +101,10 @@ void RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (surface_form) is not an enumeration");
@@ -242,16 +206,10 @@ void RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface::ReadStep(
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (ktUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktUniformKnots;
-    else if (ktQuasiUniformKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktQuasiUniformKnots;
-    else if (ktPiecewiseBezierKnots.IsEqual(text))
-      aKnotSpec = StepGeom_ktPiecewiseBezierKnots;
-    else if (ktUnspecified.IsEqual(text))
-      aKnotSpec = StepGeom_ktUnspecified;
-    else
+    if (!RWStepGeom_RWKnotType::ConvertToEnum(text, aKnotSpec))
+    {
       ach->AddFail("Enumeration knot_type has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (knot_spec) is not an enumeration");
@@ -367,43 +325,7 @@ void RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface::WriteStep(
   }
   SW.CloseSub();
   // --- field : surfaceForm ---
-
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
   // --- field : uClosed ---
 
   SW.SendLogical(ent->UClosed());
@@ -451,21 +373,7 @@ void RWStepGeom_RWBSplineSurfaceWithKnotsAndRationalBSplineSurface::WriteStep(
   SW.CloseSub();
   // --- field : knotSpec ---
 
-  switch (ent->KnotSpec())
-  {
-    case StepGeom_ktUniformKnots:
-      SW.SendEnum(ktUniformKnots);
-      break;
-    case StepGeom_ktQuasiUniformKnots:
-      SW.SendEnum(ktQuasiUniformKnots);
-      break;
-    case StepGeom_ktPiecewiseBezierKnots:
-      SW.SendEnum(ktPiecewiseBezierKnots);
-      break;
-    case StepGeom_ktUnspecified:
-      SW.SendEnum(ktUnspecified);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWKnotType::ConvertToString(ent->KnotSpec()));
 
   // --- Instance of plex component GeometricRepresentationItem ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierCurve.cxx
@@ -21,13 +21,7 @@
 #include <StepGeom_CartesianPoint.hxx>
 #include <StepGeom_HArray1OfCartesianPoint.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWBezierCurve::RWStepGeom_RWBezierCurve() {}
 
@@ -82,20 +76,10 @@ void RWStepGeom_RWBezierCurve::ReadStep(const Handle(StepData_StepReaderData)& d
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (curve_form) is not an enumeration");
@@ -140,27 +124,7 @@ void RWStepGeom_RWBezierCurve::WriteStep(StepData_StepWriter&                SW,
 
   // --- inherited field curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
 
   // --- inherited field closedCurve ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierCurveAndRationalBSplineCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierCurveAndRationalBSplineCurve.cxx
@@ -22,13 +22,7 @@
 #include <StepGeom_HArray1OfCartesianPoint.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWBezierCurveAndRationalBSplineCurve::RWStepGeom_RWBezierCurveAndRationalBSplineCurve()
 {
@@ -94,20 +88,10 @@ void RWStepGeom_RWBezierCurveAndRationalBSplineCurve::ReadStep(
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (curve_form) is not an enumeration");
@@ -212,28 +196,7 @@ void RWStepGeom_RWBezierCurveAndRationalBSplineCurve::WriteStep(
   }
   SW.CloseSub();
   // --- field : curveForm ---
-
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
   // --- field : closedCurve ---
 
   SW.SendLogical(ent->ClosedCurve());

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierSurface.cxx
@@ -21,18 +21,7 @@
 #include <StepGeom_CartesianPoint.hxx>
 #include <StepGeom_HArray2OfCartesianPoint.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWBezierSurface::RWStepGeom_RWBezierSurface() {}
 
@@ -101,30 +90,11 @@ void RWStepGeom_RWBezierSurface::ReadStep(const Handle(StepData_StepReaderData)&
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (surface_form) is not an enumeration");
@@ -193,42 +163,7 @@ void RWStepGeom_RWBezierSurface::WriteStep(StepData_StepWriter&                 
 
   // --- inherited field surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
 
   // --- inherited field uClosed ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface.cxx
@@ -22,18 +22,7 @@
 #include <StepGeom_HArray2OfCartesianPoint.hxx>
 #include <TColStd_HArray2OfReal.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface::
   RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface()
@@ -113,30 +102,10 @@ void RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (surface_form) is not an enumeration");
@@ -267,42 +236,8 @@ void RWStepGeom_RWBezierSurfaceAndRationalBSplineSurface::WriteStep(
   SW.CloseSub();
   // --- field : surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
+
   // --- field : uClosed ---
 
   SW.SendLogical(ent->UClosed());

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWCompositeCurveSegment.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWCompositeCurveSegment.cxx
@@ -20,12 +20,7 @@
 #include <StepGeom_TransitionCode.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : TransitionCode ---
-static TCollection_AsciiString tcDiscontinuous(".DISCONTINUOUS.");
-static TCollection_AsciiString tcContSameGradientSameCurvature(
-  ".CONT_SAME_GRADIENT_SAME_CURVATURE.");
-static TCollection_AsciiString tcContSameGradient(".CONT_SAME_GRADIENT.");
-static TCollection_AsciiString tcContinuous(".CONTINUOUS.");
+#include "RWStepGeom_RWTransitionCode.pxx"
 
 RWStepGeom_RWCompositeCurveSegment::RWStepGeom_RWCompositeCurveSegment() {}
 
@@ -47,16 +42,10 @@ void RWStepGeom_RWCompositeCurveSegment::ReadStep(
   if (data->ParamType(num, 1) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 1);
-    if (tcDiscontinuous.IsEqual(text))
-      aTransition = StepGeom_tcDiscontinuous;
-    else if (tcContSameGradientSameCurvature.IsEqual(text))
-      aTransition = StepGeom_tcContSameGradientSameCurvature;
-    else if (tcContSameGradient.IsEqual(text))
-      aTransition = StepGeom_tcContSameGradient;
-    else if (tcContinuous.IsEqual(text))
-      aTransition = StepGeom_tcContinuous;
-    else
+    if (!RWStepGeom_RWTransitionCode::ConvertToEnum(text, aTransition))
+    {
       ach->AddFail("Enumeration transition_code has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #1 (transition) is not an enumeration");
@@ -85,21 +74,7 @@ void RWStepGeom_RWCompositeCurveSegment::WriteStep(
 
   // --- own field : transition ---
 
-  switch (ent->Transition())
-  {
-    case StepGeom_tcDiscontinuous:
-      SW.SendEnum(tcDiscontinuous);
-      break;
-    case StepGeom_tcContSameGradientSameCurvature:
-      SW.SendEnum(tcContSameGradientSameCurvature);
-      break;
-    case StepGeom_tcContSameGradient:
-      SW.SendEnum(tcContSameGradient);
-      break;
-    case StepGeom_tcContinuous:
-      SW.SendEnum(tcContinuous);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWTransitionCode::ConvertToString(ent->Transition()));
 
   // --- own field : sameSense ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWIntersectionCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWIntersectionCurve.cxx
@@ -20,10 +20,7 @@
 #include <StepGeom_PcurveOrSurface.hxx>
 #include <StepGeom_PreferredSurfaceCurveRepresentation.hxx>
 
-// --- Enum : PreferredSurfaceCurveRepresentation ---
-static TCollection_AsciiString pscrPcurveS2(".PCURVE_S2.");
-static TCollection_AsciiString pscrPcurveS1(".PCURVE_S1.");
-static TCollection_AsciiString pscrCurve3d(".CURVE_3D.");
+#include "RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx"
 
 RWStepGeom_RWIntersectionCurve::RWStepGeom_RWIntersectionCurve() {}
 
@@ -73,14 +70,11 @@ void RWStepGeom_RWIntersectionCurve::ReadStep(const Handle(StepData_StepReaderDa
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (pscrPcurveS2.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS2;
-    else if (pscrPcurveS1.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS1;
-    else if (pscrCurve3d.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrCurve3d;
-    else
+    if (!RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToEnum(text,
+                                                                         aMasterRepresentation))
+    {
       ach->AddFail("Enumeration preferred_surface_curve_representation has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (master_representation) is not an enumeration");
@@ -113,18 +107,8 @@ void RWStepGeom_RWIntersectionCurve::WriteStep(StepData_StepWriter&             
 
   // --- inherited field masterRepresentation ---
 
-  switch (ent->MasterRepresentation())
-  {
-    case StepGeom_pscrPcurveS2:
-      SW.SendEnum(pscrPcurveS2);
-      break;
-    case StepGeom_pscrPcurveS1:
-      SW.SendEnum(pscrPcurveS1);
-      break;
-    case StepGeom_pscrCurve3d:
-      SW.SendEnum(pscrCurve3d);
-      break;
-  }
+  SW.SendEnum(
+    RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToString(ent->MasterRepresentation()));
 }
 
 void RWStepGeom_RWIntersectionCurve::Share(const Handle(StepGeom_IntersectionCurve)& ent,

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWKnotType.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWKnotType.pxx
@@ -1,0 +1,81 @@
+// Created on: 1995-12-01
+// Created by: EXPRESS->CDL V0.2 Translator
+// Copyright (c) 1995-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepGeom_RWKnotType_HeaderFile
+#define _RWStepGeom_RWKnotType_HeaderFile
+
+#include <StepGeom_KnotType.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepGeom_RWKnotType
+{
+
+static constexpr char ktUniformKnots[]         = (".UNIFORM_KNOTS.");
+static constexpr char ktQuasiUniformKnots[]    = (".QUASI_UNIFORM_KNOTS.");
+static constexpr char ktPiecewiseBezierKnots[] = (".PIECEWISE_BEZIER_KNOTS.");
+static constexpr char ktUnspecified[]          = (".UNSPECIFIED.");
+
+//! Convert StepGeom_KnotType to string
+//! @param theSourceEnum The StepGeom_KnotType value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepGeom_KnotType theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepGeom_ktUniformKnots:
+      return ktUniformKnots;
+    case StepGeom_ktQuasiUniformKnots:
+      return ktQuasiUniformKnots;
+    case StepGeom_ktPiecewiseBezierKnots:
+      return ktPiecewiseBezierKnots;
+    case StepGeom_ktUnspecified:
+      return ktUnspecified;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepGeom_KnotType
+//! @param theKnotTypeString The string to convert
+//! @param theResultEnum The corresponding StepGeom_KnotType value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString theKnotTypeString,
+                          StepGeom_KnotType&     theResultEnum)
+{
+  if (IsEqual(theKnotTypeString, ktUniformKnots))
+  {
+    theResultEnum = StepGeom_ktUniformKnots;
+  }
+  else if (IsEqual(theKnotTypeString, ktQuasiUniformKnots))
+  {
+    theResultEnum = StepGeom_ktQuasiUniformKnots;
+  }
+  else if (IsEqual(theKnotTypeString, ktPiecewiseBezierKnots))
+  {
+    theResultEnum = StepGeom_ktPiecewiseBezierKnots;
+  }
+  else if (IsEqual(theKnotTypeString, ktUnspecified))
+  {
+    theResultEnum = StepGeom_ktUnspecified;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepGeom_RWKnotType
+
+#endif // _RWStepGeom_RWKnotType_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepGeom_RWPreferredSurfaceCurveRepresentation_HeaderFile
+#define _RWStepGeom_RWPreferredSurfaceCurveRepresentation_HeaderFile
+
+#include <StepGeom_PreferredSurfaceCurveRepresentation.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepGeom_RWPreferredSurfaceCurveRepresentation
+{
+static constexpr char pscrPcurveS2[] = ".PCURVE_S2.";
+static constexpr char pscrPcurveS1[] = ".PCURVE_S1.";
+static constexpr char pscrCurve3d[]  = ".CURVE_3D.";
+
+//! Convert StepGeom_PreferredSurfaceCurveRepresentation to string
+//! @param theSourceEnum The StepGeom_PreferredSurfaceCurveRepresentation value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepGeom_PreferredSurfaceCurveRepresentation theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepGeom_pscrPcurveS2:
+      return pscrPcurveS2;
+    case StepGeom_pscrPcurveS1:
+      return pscrPcurveS1;
+    case StepGeom_pscrCurve3d:
+      return pscrCurve3d;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepGeom_PreferredSurfaceCurveRepresentation
+//! @param theRepresentationStr The string to convert
+//! @param theResultEnum The corresponding StepGeom_PreferredSurfaceCurveRepresentation value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString                        theRepresentationStr,
+                          StepGeom_PreferredSurfaceCurveRepresentation& theResultEnum)
+{
+  if (IsEqual(theRepresentationStr, pscrPcurveS2))
+  {
+    theResultEnum = StepGeom_pscrPcurveS2;
+  }
+  else if (IsEqual(theRepresentationStr, pscrPcurveS1))
+  {
+    theResultEnum = StepGeom_pscrPcurveS1;
+  }
+  else if (IsEqual(theRepresentationStr, pscrCurve3d))
+  {
+    theResultEnum = StepGeom_pscrCurve3d;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepGeom_RWPreferredSurfaceCurveRepresentation
+
+#endif // _RWStepGeom_RWPreferredSurfaceCurveRepresentation_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformCurve.cxx
@@ -18,13 +18,7 @@
 #include <StepData_StepWriter.hxx>
 #include <StepGeom_QuasiUniformCurve.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWQuasiUniformCurve::RWStepGeom_RWQuasiUniformCurve() {}
 
@@ -79,20 +73,10 @@ void RWStepGeom_RWQuasiUniformCurve::ReadStep(const Handle(StepData_StepReaderDa
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (curve_form) is not an enumeration");
@@ -137,27 +121,7 @@ void RWStepGeom_RWQuasiUniformCurve::WriteStep(StepData_StepWriter&             
 
   // --- inherited field curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
 
   // --- inherited field closedCurve ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve.cxx
@@ -19,13 +19,7 @@
 #include <StepGeom_QuasiUniformCurveAndRationalBSplineCurve.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve::
   RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve()
@@ -85,20 +79,10 @@ void RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve::ReadStep(
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (curve_form) is not an enumeration");
@@ -207,27 +191,7 @@ void RWStepGeom_RWQuasiUniformCurveAndRationalBSplineCurve::WriteStep(
   SW.CloseSub();
   // --- field : curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
   // --- field : closedCurve ---
 
   SW.SendLogical(ent->ClosedCurve());

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformSurface.cxx
@@ -18,18 +18,7 @@
 #include <StepData_StepWriter.hxx>
 #include <StepGeom_QuasiUniformSurface.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWQuasiUniformSurface::RWStepGeom_RWQuasiUniformSurface() {}
 
@@ -99,30 +88,10 @@ void RWStepGeom_RWQuasiUniformSurface::ReadStep(
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (surface_form) is not an enumeration");
@@ -192,42 +161,7 @@ void RWStepGeom_RWQuasiUniformSurface::WriteStep(
 
   // --- inherited field surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
 
   // --- inherited field uClosed ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface.cxx
@@ -19,18 +19,7 @@
 #include <StepGeom_QuasiUniformSurfaceAndRationalBSplineSurface.hxx>
 #include <TColStd_HArray2OfReal.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface::
   RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface()
@@ -103,30 +92,10 @@ void RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (surface_form) is not an enumeration");
@@ -260,42 +229,8 @@ void RWStepGeom_RWQuasiUniformSurfaceAndRationalBSplineSurface::WriteStep(
   SW.CloseSub();
   // --- field : surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
+
   // --- field : uClosed ---
 
   SW.SendLogical(ent->UClosed());

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWRationalBSplineCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWRationalBSplineCurve.cxx
@@ -20,13 +20,7 @@
 #include <StepGeom_RationalBSplineCurve.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWRationalBSplineCurve::RWStepGeom_RWRationalBSplineCurve() {}
 
@@ -82,20 +76,10 @@ void RWStepGeom_RWRationalBSplineCurve::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (curve_form) is not an enumeration");
@@ -164,27 +148,7 @@ void RWStepGeom_RWRationalBSplineCurve::WriteStep(
 
   // --- inherited field curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
 
   // --- inherited field closedCurve ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWRationalBSplineSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWRationalBSplineSurface.cxx
@@ -20,18 +20,7 @@
 #include <StepGeom_RationalBSplineSurface.hxx>
 #include <TColStd_HArray2OfReal.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWRationalBSplineSurface::RWStepGeom_RWRationalBSplineSurface() {}
 
@@ -101,30 +90,10 @@ void RWStepGeom_RWRationalBSplineSurface::ReadStep(
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (surface_form) is not an enumeration");
@@ -220,42 +189,7 @@ void RWStepGeom_RWRationalBSplineSurface::WriteStep(
 
   // --- inherited field surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
 
   // --- inherited field uClosed ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWReparametrisedCompositeCurveSegment.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWReparametrisedCompositeCurveSegment.cxx
@@ -19,12 +19,7 @@
 #include <StepGeom_ReparametrisedCompositeCurveSegment.hxx>
 #include <StepGeom_TransitionCode.hxx>
 
-// --- Enum : TransitionCode ---
-static TCollection_AsciiString tcDiscontinuous(".DISCONTINUOUS.");
-static TCollection_AsciiString tcContSameGradientSameCurvature(
-  ".CONT_SAME_GRADIENT_SAME_CURVATURE.");
-static TCollection_AsciiString tcContSameGradient(".CONT_SAME_GRADIENT.");
-static TCollection_AsciiString tcContinuous(".CONTINUOUS.");
+#include "RWStepGeom_RWTransitionCode.pxx"
 
 RWStepGeom_RWReparametrisedCompositeCurveSegment::RWStepGeom_RWReparametrisedCompositeCurveSegment()
 {
@@ -48,16 +43,10 @@ void RWStepGeom_RWReparametrisedCompositeCurveSegment::ReadStep(
   if (data->ParamType(num, 1) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 1);
-    if (tcDiscontinuous.IsEqual(text))
-      aTransition = StepGeom_tcDiscontinuous;
-    else if (tcContSameGradientSameCurvature.IsEqual(text))
-      aTransition = StepGeom_tcContSameGradientSameCurvature;
-    else if (tcContSameGradient.IsEqual(text))
-      aTransition = StepGeom_tcContSameGradient;
-    else if (tcContinuous.IsEqual(text))
-      aTransition = StepGeom_tcContinuous;
-    else
+    if (!RWStepGeom_RWTransitionCode::ConvertToEnum(text, aTransition))
+    {
       ach->AddFail("Enumeration transition_code has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #1 (transition) is not an enumeration");
@@ -92,21 +81,7 @@ void RWStepGeom_RWReparametrisedCompositeCurveSegment::WriteStep(
 
   // --- inherited field transition ---
 
-  switch (ent->Transition())
-  {
-    case StepGeom_tcDiscontinuous:
-      SW.SendEnum(tcDiscontinuous);
-      break;
-    case StepGeom_tcContSameGradientSameCurvature:
-      SW.SendEnum(tcContSameGradientSameCurvature);
-      break;
-    case StepGeom_tcContSameGradient:
-      SW.SendEnum(tcContSameGradient);
-      break;
-    case StepGeom_tcContinuous:
-      SW.SendEnum(tcContinuous);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWTransitionCode::ConvertToString(ent->Transition()));
 
   // --- inherited field sameSense ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSeamCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSeamCurve.cxx
@@ -18,10 +18,7 @@
 #include <StepData_StepWriter.hxx>
 #include <StepGeom_SeamCurve.hxx>
 
-// --- Enum : PreferredSurfaceCurveRepresentation ---
-static TCollection_AsciiString pscrPcurveS2(".PCURVE_S2.");
-static TCollection_AsciiString pscrPcurveS1(".PCURVE_S1.");
-static TCollection_AsciiString pscrCurve3d(".CURVE_3D.");
+#include "RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx"
 
 RWStepGeom_RWSeamCurve::RWStepGeom_RWSeamCurve() {}
 
@@ -76,14 +73,10 @@ void RWStepGeom_RWSeamCurve::ReadStep(const Handle(StepData_StepReaderData)& dat
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (pscrPcurveS2.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS2;
-    else if (pscrPcurveS1.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS1;
-    else if (pscrCurve3d.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrCurve3d;
-    else
+    if (!RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToEnum(text, aMasterRepresentation))
+    {
       ach->AddFail("Enumeration preferred_surface_curve_representation has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (master_representation) is not an enumeration");
@@ -116,18 +109,7 @@ void RWStepGeom_RWSeamCurve::WriteStep(StepData_StepWriter&              SW,
 
   // --- inherited field masterRepresentation ---
 
-  switch (ent->MasterRepresentation())
-  {
-    case StepGeom_pscrPcurveS2:
-      SW.SendEnum(pscrPcurveS2);
-      break;
-    case StepGeom_pscrPcurveS1:
-      SW.SendEnum(pscrPcurveS1);
-      break;
-    case StepGeom_pscrCurve3d:
-      SW.SendEnum(pscrCurve3d);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToString(ent->MasterRepresentation()));
 }
 
 void RWStepGeom_RWSeamCurve::Share(const Handle(StepGeom_SeamCurve)& ent,

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSurfaceCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSurfaceCurve.cxx
@@ -19,10 +19,7 @@
 #include <StepGeom_SurfaceCurve.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : PreferredSurfaceCurveRepresentation ---
-static TCollection_AsciiString pscrPcurveS2(".PCURVE_S2.");
-static TCollection_AsciiString pscrPcurveS1(".PCURVE_S1.");
-static TCollection_AsciiString pscrCurve3d(".CURVE_3D.");
+#include "RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx"
 
 RWStepGeom_RWSurfaceCurve::RWStepGeom_RWSurfaceCurve() {}
 
@@ -72,14 +69,10 @@ void RWStepGeom_RWSurfaceCurve::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (pscrPcurveS2.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS2;
-    else if (pscrPcurveS1.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS1;
-    else if (pscrCurve3d.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrCurve3d;
-    else
+    if (!RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToEnum(text, aMasterRepresentation))
+    {
       ach->AddFail("Enumeration preferred_surface_curve_representation has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (master_representation) is not an enumeration");
@@ -115,18 +108,7 @@ void RWStepGeom_RWSurfaceCurve::WriteStep(StepData_StepWriter&                 S
 
   // --- own field : masterRepresentation ---
 
-  switch (ent->MasterRepresentation())
-  {
-    case StepGeom_pscrPcurveS2:
-      SW.SendEnum(pscrPcurveS2);
-      break;
-    case StepGeom_pscrPcurveS1:
-      SW.SendEnum(pscrPcurveS1);
-      break;
-    case StepGeom_pscrCurve3d:
-      SW.SendEnum(pscrCurve3d);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToString(ent->MasterRepresentation()));
 }
 
 void RWStepGeom_RWSurfaceCurve::Share(const Handle(StepGeom_SurfaceCurve)& ent,

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSurfaceCurveAndBoundedCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSurfaceCurveAndBoundedCurve.cxx
@@ -29,10 +29,7 @@
 #include <StepGeom_SurfaceCurveAndBoundedCurve.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : PreferredSurfaceCurveRepresentation ---
-static TCollection_AsciiString pscrPcurveS2(".PCURVE_S2.");
-static TCollection_AsciiString pscrPcurveS1(".PCURVE_S1.");
-static TCollection_AsciiString pscrCurve3d(".CURVE_3D.");
+#include "RWStepGeom_RWPreferredSurfaceCurveRepresentation.pxx"
 
 RWStepGeom_RWSurfaceCurveAndBoundedCurve::RWStepGeom_RWSurfaceCurveAndBoundedCurve() {}
 
@@ -90,14 +87,10 @@ void RWStepGeom_RWSurfaceCurveAndBoundedCurve::ReadStep(
   if (data->ParamType(num1, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num1, 3);
-    if (pscrPcurveS2.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS2;
-    else if (pscrPcurveS1.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrPcurveS1;
-    else if (pscrCurve3d.IsEqual(text))
-      aMasterRepresentation = StepGeom_pscrCurve3d;
-    else
+    if (!RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToEnum(text, aMasterRepresentation))
+    {
       ach->AddFail("Enumeration preferred_surface_curve_representation has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (master_representation) is not an enumeration");
@@ -139,18 +132,8 @@ void RWStepGeom_RWSurfaceCurveAndBoundedCurve::WriteStep(
   SW.CloseSub();
 
   // --- own field : masterRepresentation ---
-  switch (ent->MasterRepresentation())
-  {
-    case StepGeom_pscrPcurveS2:
-      SW.SendEnum(pscrPcurveS2);
-      break;
-    case StepGeom_pscrPcurveS1:
-      SW.SendEnum(pscrPcurveS1);
-      break;
-    case StepGeom_pscrCurve3d:
-      SW.SendEnum(pscrCurve3d);
-      break;
-  }
+  SW.SendEnum(
+    RWStepGeom_RWPreferredSurfaceCurveRepresentation::ConvertToString(ent->MasterRepresentation()));
 }
 
 void RWStepGeom_RWSurfaceCurveAndBoundedCurve::Share(

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSurfacePatch.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWSurfacePatch.cxx
@@ -20,12 +20,7 @@
 #include <StepGeom_TransitionCode.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : TransitionCode ---
-static TCollection_AsciiString tcDiscontinuous(".DISCONTINUOUS.");
-static TCollection_AsciiString tcContSameGradientSameCurvature(
-  ".CONT_SAME_GRADIENT_SAME_CURVATURE.");
-static TCollection_AsciiString tcContSameGradient(".CONT_SAME_GRADIENT.");
-static TCollection_AsciiString tcContinuous(".CONTINUOUS.");
+#include "RWStepGeom_RWTransitionCode.pxx"
 
 RWStepGeom_RWSurfacePatch::RWStepGeom_RWSurfacePatch() {}
 
@@ -57,16 +52,10 @@ void RWStepGeom_RWSurfacePatch::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (tcDiscontinuous.IsEqual(text))
-      aUTransition = StepGeom_tcDiscontinuous;
-    else if (tcContSameGradientSameCurvature.IsEqual(text))
-      aUTransition = StepGeom_tcContSameGradientSameCurvature;
-    else if (tcContSameGradient.IsEqual(text))
-      aUTransition = StepGeom_tcContSameGradient;
-    else if (tcContinuous.IsEqual(text))
-      aUTransition = StepGeom_tcContinuous;
-    else
+    if (!RWStepGeom_RWTransitionCode::ConvertToEnum(text, aUTransition))
+    {
       ach->AddFail("Enumeration transition_code has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #2 (u_transition) is not an enumeration");
@@ -77,16 +66,10 @@ void RWStepGeom_RWSurfacePatch::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (tcDiscontinuous.IsEqual(text))
-      aVTransition = StepGeom_tcDiscontinuous;
-    else if (tcContSameGradientSameCurvature.IsEqual(text))
-      aVTransition = StepGeom_tcContSameGradientSameCurvature;
-    else if (tcContSameGradient.IsEqual(text))
-      aVTransition = StepGeom_tcContSameGradient;
-    else if (tcContinuous.IsEqual(text))
-      aVTransition = StepGeom_tcContinuous;
-    else
+    if (!RWStepGeom_RWTransitionCode::ConvertToEnum(text, aVTransition))
+    {
       ach->AddFail("Enumeration transition_code has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (v_transition) is not an enumeration");
@@ -118,39 +101,11 @@ void RWStepGeom_RWSurfacePatch::WriteStep(StepData_StepWriter&                 S
 
   // --- own field : uTransition ---
 
-  switch (ent->UTransition())
-  {
-    case StepGeom_tcDiscontinuous:
-      SW.SendEnum(tcDiscontinuous);
-      break;
-    case StepGeom_tcContSameGradientSameCurvature:
-      SW.SendEnum(tcContSameGradientSameCurvature);
-      break;
-    case StepGeom_tcContSameGradient:
-      SW.SendEnum(tcContSameGradient);
-      break;
-    case StepGeom_tcContinuous:
-      SW.SendEnum(tcContinuous);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWTransitionCode::ConvertToString(ent->UTransition()));
 
   // --- own field : vTransition ---
 
-  switch (ent->VTransition())
-  {
-    case StepGeom_tcDiscontinuous:
-      SW.SendEnum(tcDiscontinuous);
-      break;
-    case StepGeom_tcContSameGradientSameCurvature:
-      SW.SendEnum(tcContSameGradientSameCurvature);
-      break;
-    case StepGeom_tcContSameGradient:
-      SW.SendEnum(tcContSameGradient);
-      break;
-    case StepGeom_tcContinuous:
-      SW.SendEnum(tcContinuous);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWTransitionCode::ConvertToString(ent->VTransition()));
 
   // --- own field : uSense ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWTransitionCode.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWTransitionCode.pxx
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepGeom_RWTransitionCode_HeaderFile
+#define _RWStepGeom_RWTransitionCode_HeaderFile
+
+#include <StepGeom_TransitionCode.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepGeom_RWTransitionCode
+{
+static constexpr char tcDiscontinuous[]                 = ".DISCONTINUOUS.";
+static constexpr char tcContSameGradientSameCurvature[] = ".CONT_SAME_GRADIENT_SAME_CURVATURE.";
+static constexpr char tcContSameGradient[]              = ".CONT_SAME_GRADIENT.";
+static constexpr char tcContinuous[]                    = ".CONTINUOUS.";
+
+//! Convert StepGeom_TransitionCode to string
+//! @param theTransitionCodeEnum The StepGeom_TransitionCode value to convert
+//! @return The corresponding string representation
+static const char* ConvertToString(const StepGeom_TransitionCode theTransitionCodeEnum)
+{
+  switch (theTransitionCodeEnum)
+  {
+    case StepGeom_tcDiscontinuous:
+      return tcDiscontinuous;
+    case StepGeom_tcContSameGradientSameCurvature:
+      return tcContSameGradientSameCurvature;
+    case StepGeom_tcContSameGradient:
+      return tcContSameGradient;
+    case StepGeom_tcContinuous:
+      return tcContinuous;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepGeom_TransitionCode
+//! @param theTransitionCodeStr The string to convert
+//! @param theResultEnum The corresponding StepGeom_TransitionCode value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString   theTransitionCodeStr,
+                          StepGeom_TransitionCode& theResultEnum)
+{
+  if (IsEqual(theTransitionCodeStr, tcDiscontinuous))
+  {
+    theResultEnum = StepGeom_tcDiscontinuous;
+  }
+  else if (IsEqual(theTransitionCodeStr, tcContSameGradientSameCurvature))
+  {
+    theResultEnum = StepGeom_tcContSameGradientSameCurvature;
+  }
+  else if (IsEqual(theTransitionCodeStr, tcContSameGradient))
+  {
+    theResultEnum = StepGeom_tcContSameGradient;
+  }
+  else if (IsEqual(theTransitionCodeStr, tcContinuous))
+  {
+    theResultEnum = StepGeom_tcContinuous;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepGeom_RWTransitionCode
+
+#endif // _RWStepGeom_RWTransitionCode_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWTrimmedCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWTrimmedCurve.cxx
@@ -22,10 +22,7 @@
 #include <StepGeom_TrimmingSelect.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : TrimmingPreference ---
-static TCollection_AsciiString tpParameter(".PARAMETER.");
-static TCollection_AsciiString tpUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString tpCartesian(".CARTESIAN.");
+#include "RWStepGeom_RWTrimmingPreference.pxx"
 
 RWStepGeom_RWTrimmedCurve::RWStepGeom_RWTrimmedCurve() {}
 
@@ -102,14 +99,10 @@ void RWStepGeom_RWTrimmedCurve::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 6) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 6);
-    if (tpParameter.IsEqual(text))
-      aMasterRepresentation = StepGeom_tpParameter;
-    else if (tpUnspecified.IsEqual(text))
-      aMasterRepresentation = StepGeom_tpUnspecified;
-    else if (tpCartesian.IsEqual(text))
-      aMasterRepresentation = StepGeom_tpCartesian;
-    else
+    if (!RWStepGeom_RWTrimmingPreference::ConvertToEnum(text, aMasterRepresentation))
+    {
       ach->AddFail("Enumeration trimming_preference has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #6 (master_representation) is not an enumeration");
@@ -155,18 +148,7 @@ void RWStepGeom_RWTrimmedCurve::WriteStep(StepData_StepWriter&                 S
 
   // --- own field : masterRepresentation ---
 
-  switch (ent->MasterRepresentation())
-  {
-    case StepGeom_tpParameter:
-      SW.SendEnum(tpParameter);
-      break;
-    case StepGeom_tpUnspecified:
-      SW.SendEnum(tpUnspecified);
-      break;
-    case StepGeom_tpCartesian:
-      SW.SendEnum(tpCartesian);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWTrimmingPreference::ConvertToString(ent->MasterRepresentation()));
 }
 
 void RWStepGeom_RWTrimmedCurve::Share(const Handle(StepGeom_TrimmedCurve)& ent,

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWTrimmingPreference.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWTrimmingPreference.pxx
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepGeom_RWTrimmingPreference_HeaderFile
+#define _RWStepGeom_RWTrimmingPreference_HeaderFile
+
+#include <StepGeom_TrimmingPreference.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepGeom_RWTrimmingPreference
+{
+static constexpr char tpParameter[]   = ".PARAMETER.";
+static constexpr char tpUnspecified[] = ".UNSPECIFIED.";
+static constexpr char tpCartesian[]   = ".CARTESIAN.";
+
+//! Convert StepGeom_TrimmingPreference to string
+//! @param theSourceEnum The StepGeom_TrimmingPreference value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepGeom_TrimmingPreference theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepGeom_tpParameter:
+      return tpParameter;
+    case StepGeom_tpUnspecified:
+      return tpUnspecified;
+    case StepGeom_tpCartesian:
+      return tpCartesian;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepGeom_TrimmingPreference
+//! @param thePreferenceStr The string to convert
+//! @param theResultEnum The corresponding StepGeom_TrimmingPreference value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString thePreferenceStr, StepGeom_TrimmingPreference& theResultEnum)
+{
+  if (IsEqual(thePreferenceStr, tpParameter))
+  {
+    theResultEnum = StepGeom_tpParameter;
+  }
+  else if (IsEqual(thePreferenceStr, tpUnspecified))
+  {
+    theResultEnum = StepGeom_tpUnspecified;
+  }
+  else if (IsEqual(thePreferenceStr, tpCartesian))
+  {
+    theResultEnum = StepGeom_tpCartesian;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepGeom_RWTrimmingPreference
+
+#endif // _RWStepGeom_RWTrimmingPreference_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformCurve.cxx
@@ -18,13 +18,7 @@
 #include <StepData_StepWriter.hxx>
 #include <StepGeom_UniformCurve.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include "RWStepGeom_RWBSplineCurveForm.pxx"
 
 RWStepGeom_RWUniformCurve::RWStepGeom_RWUniformCurve() {}
 
@@ -79,20 +73,10 @@ void RWStepGeom_RWUniformCurve::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    {
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (curve_form) is not an enumeration");
@@ -137,27 +121,7 @@ void RWStepGeom_RWUniformCurve::WriteStep(StepData_StepWriter&                 S
 
   // --- inherited field curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
 
   // --- inherited field closedCurve ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformCurveAndRationalBSplineCurve.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformCurveAndRationalBSplineCurve.cxx
@@ -21,13 +21,7 @@
 #include <StepGeom_UniformCurveAndRationalBSplineCurve.hxx>
 #include <TColStd_HArray1OfReal.hxx>
 
-// --- Enum : BSplineCurveForm ---
-static TCollection_AsciiString bscfEllipticArc(".ELLIPTIC_ARC.");
-static TCollection_AsciiString bscfPolylineForm(".POLYLINE_FORM.");
-static TCollection_AsciiString bscfParabolicArc(".PARABOLIC_ARC.");
-static TCollection_AsciiString bscfCircularArc(".CIRCULAR_ARC.");
-static TCollection_AsciiString bscfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bscfHyperbolicArc(".HYPERBOLIC_ARC.");
+#include <RWStepGeom_RWBSplineCurveForm.pxx>
 
 RWStepGeom_RWUniformCurveAndRationalBSplineCurve::RWStepGeom_RWUniformCurveAndRationalBSplineCurve()
 {
@@ -86,20 +80,10 @@ void RWStepGeom_RWUniformCurveAndRationalBSplineCurve::ReadStep(
   if (data->ParamType(num, 3) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 3);
-    if (bscfEllipticArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfEllipticArc;
-    else if (bscfPolylineForm.IsEqual(text))
-      aCurveForm = StepGeom_bscfPolylineForm;
-    else if (bscfParabolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfParabolicArc;
-    else if (bscfCircularArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfCircularArc;
-    else if (bscfUnspecified.IsEqual(text))
-      aCurveForm = StepGeom_bscfUnspecified;
-    else if (bscfHyperbolicArc.IsEqual(text))
-      aCurveForm = StepGeom_bscfHyperbolicArc;
-    else
+    if (!RWStepGeom_RWBSplineCurveForm::ConvertToEnum(text, aCurveForm))
+    { 
       ach->AddFail("Enumeration b_spline_curve_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #3 (curve_form) is not an enumeration");
@@ -208,27 +192,8 @@ void RWStepGeom_RWUniformCurveAndRationalBSplineCurve::WriteStep(
   SW.CloseSub();
   // --- field : curveForm ---
 
-  switch (ent->CurveForm())
-  {
-    case StepGeom_bscfEllipticArc:
-      SW.SendEnum(bscfEllipticArc);
-      break;
-    case StepGeom_bscfPolylineForm:
-      SW.SendEnum(bscfPolylineForm);
-      break;
-    case StepGeom_bscfParabolicArc:
-      SW.SendEnum(bscfParabolicArc);
-      break;
-    case StepGeom_bscfCircularArc:
-      SW.SendEnum(bscfCircularArc);
-      break;
-    case StepGeom_bscfUnspecified:
-      SW.SendEnum(bscfUnspecified);
-      break;
-    case StepGeom_bscfHyperbolicArc:
-      SW.SendEnum(bscfHyperbolicArc);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineCurveForm::ConvertToString(ent->CurveForm()));
+ 
   // --- field : closedCurve ---
 
   SW.SendLogical(ent->ClosedCurve());

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformSurface.cxx
@@ -18,18 +18,7 @@
 #include <StepData_StepWriter.hxx>
 #include <StepGeom_UniformSurface.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWUniformSurface::RWStepGeom_RWUniformSurface() {}
 
@@ -98,30 +87,10 @@ void RWStepGeom_RWUniformSurface::ReadStep(const Handle(StepData_StepReaderData)
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (surface_form) is not an enumeration");
@@ -190,42 +159,7 @@ void RWStepGeom_RWUniformSurface::WriteStep(StepData_StepWriter&                
 
   // --- inherited field surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
 
   // --- inherited field uClosed ---
 

--- a/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepGeom/RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface.cxx
@@ -21,18 +21,7 @@
 #include <StepGeom_UniformSurfaceAndRationalBSplineSurface.hxx>
 #include <TColStd_HArray2OfReal.hxx>
 
-// --- Enum : BSplineSurfaceForm ---
-static TCollection_AsciiString bssfSurfOfLinearExtrusion(".SURF_OF_LINEAR_EXTRUSION.");
-static TCollection_AsciiString bssfPlaneSurf(".PLANE_SURF.");
-static TCollection_AsciiString bssfGeneralisedCone(".GENERALISED_CONE.");
-static TCollection_AsciiString bssfToroidalSurf(".TOROIDAL_SURF.");
-static TCollection_AsciiString bssfConicalSurf(".CONICAL_SURF.");
-static TCollection_AsciiString bssfSphericalSurf(".SPHERICAL_SURF.");
-static TCollection_AsciiString bssfUnspecified(".UNSPECIFIED.");
-static TCollection_AsciiString bssfRuledSurf(".RULED_SURF.");
-static TCollection_AsciiString bssfSurfOfRevolution(".SURF_OF_REVOLUTION.");
-static TCollection_AsciiString bssfCylindricalSurf(".CYLINDRICAL_SURF.");
-static TCollection_AsciiString bssfQuadricSurf(".QUADRIC_SURF.");
+#include "RWStepGeom_RWBSplineSurfaceForm.pxx"
 
 RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface::
   RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface()
@@ -105,30 +94,10 @@ void RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface::ReadStep(
   if (data->ParamType(num, 4) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 4);
-    if (bssfSurfOfLinearExtrusion.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfLinearExtrusion;
-    else if (bssfPlaneSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfPlaneSurf;
-    else if (bssfGeneralisedCone.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfGeneralisedCone;
-    else if (bssfToroidalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfToroidalSurf;
-    else if (bssfConicalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfConicalSurf;
-    else if (bssfSphericalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSphericalSurf;
-    else if (bssfUnspecified.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfUnspecified;
-    else if (bssfRuledSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfRuledSurf;
-    else if (bssfSurfOfRevolution.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfSurfOfRevolution;
-    else if (bssfCylindricalSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfCylindricalSurf;
-    else if (bssfQuadricSurf.IsEqual(text))
-      aSurfaceForm = StepGeom_bssfQuadricSurf;
-    else
+    if (!RWStepGeom_RWBSplineSurfaceForm::ConvertToEnum(text, aSurfaceForm))
+    {
       ach->AddFail("Enumeration b_spline_surface_form has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #4 (surface_form) is not an enumeration");
@@ -262,42 +231,8 @@ void RWStepGeom_RWUniformSurfaceAndRationalBSplineSurface::WriteStep(
   SW.CloseSub();
   // --- field : surfaceForm ---
 
-  switch (ent->SurfaceForm())
-  {
-    case StepGeom_bssfSurfOfLinearExtrusion:
-      SW.SendEnum(bssfSurfOfLinearExtrusion);
-      break;
-    case StepGeom_bssfPlaneSurf:
-      SW.SendEnum(bssfPlaneSurf);
-      break;
-    case StepGeom_bssfGeneralisedCone:
-      SW.SendEnum(bssfGeneralisedCone);
-      break;
-    case StepGeom_bssfToroidalSurf:
-      SW.SendEnum(bssfToroidalSurf);
-      break;
-    case StepGeom_bssfConicalSurf:
-      SW.SendEnum(bssfConicalSurf);
-      break;
-    case StepGeom_bssfSphericalSurf:
-      SW.SendEnum(bssfSphericalSurf);
-      break;
-    case StepGeom_bssfUnspecified:
-      SW.SendEnum(bssfUnspecified);
-      break;
-    case StepGeom_bssfRuledSurf:
-      SW.SendEnum(bssfRuledSurf);
-      break;
-    case StepGeom_bssfSurfOfRevolution:
-      SW.SendEnum(bssfSurfOfRevolution);
-      break;
-    case StepGeom_bssfCylindricalSurf:
-      SW.SendEnum(bssfCylindricalSurf);
-      break;
-    case StepGeom_bssfQuadricSurf:
-      SW.SendEnum(bssfQuadricSurf);
-      break;
-  }
+  SW.SendEnum(RWStepGeom_RWBSplineSurfaceForm::ConvertToString(ent->SurfaceForm()));
+
   // --- field : uClosed ---
 
   SW.SendLogical(ent->UClosed());

--- a/src/DataExchange/TKDESTEP/RWStepShape/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/RWStepShape/FILES.cmake
@@ -12,6 +12,7 @@ set(OCCT_RWStepShape_FILES
   RWStepShape_RWAngularSize.pxx
   RWStepShape_RWBlock.cxx
   RWStepShape_RWBlock.pxx
+  RWStepShape_RWBooleanOperator.pxx
   RWStepShape_RWBooleanResult.cxx
   RWStepShape_RWBooleanResult.pxx
   RWStepShape_RWBoxDomain.cxx

--- a/src/DataExchange/TKDESTEP/RWStepShape/RWStepShape_RWBooleanOperator.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepShape/RWStepShape_RWBooleanOperator.pxx
@@ -1,0 +1,70 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepShape_RWBooleanOperator_HeaderFile
+#define _RWStepShape_RWBooleanOperator_HeaderFile
+
+#include <StepShape_BooleanOperator.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepShape_RWBooleanOperator
+{
+static constexpr char boDifference[]   = ".DIFFERENCE.";
+static constexpr char boIntersection[] = ".INTERSECTION.";
+static constexpr char boUnion[]        = ".UNION.";
+
+//! Convert StepShape_BooleanOperator to string
+//! @param theSourceEnum The StepShape_BooleanOperator value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepShape_BooleanOperator theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepShape_boDifference:
+      return boDifference;
+    case StepShape_boIntersection:
+      return boIntersection;
+    case StepShape_boUnion:
+      return boUnion;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepShape_BooleanOperator
+//! @param theOperatorStr The string to convert
+//! @param theResultEnum The corresponding StepShape_BooleanOperator value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString     theOperatorStr,
+                          StepShape_BooleanOperator& theResultEnum)
+{
+  if (IsEqual(theOperatorStr, boDifference))
+  {
+    theResultEnum = StepShape_boDifference;
+  }
+  else if (IsEqual(theOperatorStr, boIntersection))
+  {
+    theResultEnum = StepShape_boIntersection;
+  }
+  else if (IsEqual(theOperatorStr, boUnion))
+  {
+    theResultEnum = StepShape_boUnion;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepShape_RWBooleanOperator
+
+#endif // _RWStepShape_RWBooleanOperator_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepShape/RWStepShape_RWBooleanResult.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepShape/RWStepShape_RWBooleanResult.cxx
@@ -19,10 +19,7 @@
 #include <StepShape_SolidModel.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : BooleanOperator ---
-static TCollection_AsciiString boDifference(".DIFFERENCE.");
-static TCollection_AsciiString boIntersection(".INTERSECTION.");
-static TCollection_AsciiString boUnion(".UNION.");
+#include "RWStepShape_RWBooleanOperator.pxx"
 
 RWStepShape_RWBooleanResult::RWStepShape_RWBooleanResult() {}
 
@@ -49,14 +46,10 @@ void RWStepShape_RWBooleanResult::ReadStep(const Handle(StepData_StepReaderData)
   if (data->ParamType(num, 2) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 2);
-    if (boDifference.IsEqual(text))
-      aOperator = StepShape_boDifference;
-    else if (boIntersection.IsEqual(text))
-      aOperator = StepShape_boIntersection;
-    else if (boUnion.IsEqual(text))
-      aOperator = StepShape_boUnion;
-    else
+    if (!RWStepShape_RWBooleanOperator::ConvertToEnum(text, aOperator))
+    {
       ach->AddFail("Enumeration boolean_operator has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #2 (operator) is not an enumeration");
@@ -117,18 +110,7 @@ void RWStepShape_RWBooleanResult::WriteStep(StepData_StepWriter&                
 
   // --- own field : operator ---
 
-  switch (ent->Operator())
-  {
-    case StepShape_boDifference:
-      SW.SendEnum(boDifference);
-      break;
-    case StepShape_boIntersection:
-      SW.SendEnum(boIntersection);
-      break;
-    case StepShape_boUnion:
-      SW.SendEnum(boUnion);
-      break;
-  }
+  SW.SendEnum(RWStepShape_RWBooleanOperator::ConvertToString(ent->Operator()));
 
   // --- own field : firstOperand ---
   // --- idem au ReadStep : il faut envoyer le bon type :

--- a/src/DataExchange/TKDESTEP/RWStepVisual/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/FILES.cmake
@@ -34,6 +34,7 @@ set(OCCT_RWStepVisual_FILES
   RWStepVisual_RWCameraModelD3MultiClippingUnion.pxx
   RWStepVisual_RWCameraUsage.cxx
   RWStepVisual_RWCameraUsage.pxx
+  RWStepVisual_RWCentralOrParallel.pxx
   RWStepVisual_RWCharacterizedObjAndRepresentationAndDraughtingModel.cxx
   RWStepVisual_RWCharacterizedObjAndRepresentationAndDraughtingModel.pxx
   RWStepVisual_RWColour.cxx
@@ -116,6 +117,7 @@ set(OCCT_RWStepVisual_FILES
   RWStepVisual_RWRepositionedTessellatedItem.pxx
   RWStepVisual_RWStyledItem.cxx
   RWStepVisual_RWStyledItem.pxx
+  RWStepVisual_RWSurfaceSide.pxx
   RWStepVisual_RWSurfaceSideStyle.cxx
   RWStepVisual_RWSurfaceSideStyle.pxx
   RWStepVisual_RWSurfaceStyleBoundary.cxx
@@ -150,6 +152,7 @@ set(OCCT_RWStepVisual_FILES
   RWStepVisual_RWTemplateInstance.pxx
   RWStepVisual_RWTextLiteral.cxx
   RWStepVisual_RWTextLiteral.pxx
+  RWStepVisual_RWTextPath.pxx
   RWStepVisual_RWTextStyle.cxx
   RWStepVisual_RWTextStyle.pxx
   RWStepVisual_RWTextStyleForDefinedFont.cxx

--- a/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWCentralOrParallel.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWCentralOrParallel.pxx
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepVisual_RWCentralOrParallel_HeaderFile
+#define _RWStepVisual_RWCentralOrParallel_HeaderFile
+
+#include <StepVisual_CentralOrParallel.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepVisual_RWCentralOrParallel
+{
+static constexpr char copCentral[]  = ".CENTRAL.";
+static constexpr char copParallel[] = ".PARALLEL.";
+
+//! Convert StepVisual_CentralOrParallel to string
+//! @param theSourceEnum The StepVisual_CentralOrParallel value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepVisual_CentralOrParallel theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepVisual_copCentral:
+      return copCentral;
+    case StepVisual_copParallel:
+      return copParallel;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepVisual_CentralOrParallel
+//! @param theCentralOrParallelStr The string to convert
+//! @param theResultEnum The corresponding StepVisual_CentralOrParallel value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString theCentralOrParallelStr, StepVisual_CentralOrParallel& theResultEnum)
+{
+  if (IsEqual(theCentralOrParallelStr, copCentral))
+  {
+    theResultEnum = StepVisual_copCentral;
+  }
+  else if (IsEqual(theCentralOrParallelStr, copParallel))
+  {
+    theResultEnum = StepVisual_copParallel;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepVisual_RWCentralOrParallel
+
+#endif // _RWStepVisual_RWCentralOrParallel_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWSurfaceSide.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWSurfaceSide.pxx
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepVisual_RWSurfaceSide_HeaderFile
+#define _RWStepVisual_RWSurfaceSide_HeaderFile
+
+#include <StepVisual_SurfaceSide.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepVisual_RWSurfaceSide
+{
+static constexpr char ssNegative[] = ".NEGATIVE.";
+static constexpr char ssPositive[] = ".POSITIVE.";
+static constexpr char ssBoth[]     = ".BOTH.";
+
+//! Convert StepVisual_SurfaceSide to string
+//! @param theSourceEnum The StepVisual_SurfaceSide value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepVisual_SurfaceSide theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepVisual_ssNegative:
+      return ssNegative;
+    case StepVisual_ssPositive:
+      return ssPositive;
+    case StepVisual_ssBoth:
+      return ssBoth;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepVisual_SurfaceSide
+//! @param theSideStr The string to convert
+//! @param theResultEnum The corresponding StepVisual_SurfaceSide value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString theSideStr, StepVisual_SurfaceSide& theResultEnum)
+{
+  if (IsEqual(theSideStr, ssNegative))
+  {
+    theResultEnum = StepVisual_ssNegative;
+  }
+  else if (IsEqual(theSideStr, ssPositive))
+  {
+    theResultEnum = StepVisual_ssPositive;
+  }
+  else if (IsEqual(theSideStr, ssBoth))
+  {
+    theResultEnum = StepVisual_ssBoth;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepVisual_RWSurfaceSide
+
+#endif // _RWStepVisual_RWSurfaceSide_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWSurfaceStyleUsage.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWSurfaceStyleUsage.cxx
@@ -19,10 +19,7 @@
 #include <StepVisual_SurfaceStyleUsage.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : SurfaceSide ---
-static TCollection_AsciiString ssNegative(".NEGATIVE.");
-static TCollection_AsciiString ssPositive(".POSITIVE.");
-static TCollection_AsciiString ssBoth(".BOTH.");
+#include "RWStepVisual_RWSurfaceSide.pxx"
 
 RWStepVisual_RWSurfaceStyleUsage::RWStepVisual_RWSurfaceStyleUsage() {}
 
@@ -44,14 +41,10 @@ void RWStepVisual_RWSurfaceStyleUsage::ReadStep(
   if (data->ParamType(num, 1) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 1);
-    if (ssNegative.IsEqual(text))
-      aSide = StepVisual_ssNegative;
-    else if (ssPositive.IsEqual(text))
-      aSide = StepVisual_ssPositive;
-    else if (ssBoth.IsEqual(text))
-      aSide = StepVisual_ssBoth;
-    else
+    if (!RWStepVisual_RWSurfaceSide::ConvertToEnum(text, aSide))
+    {
       ach->AddFail("Enumeration surface_side has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #1 (side) is not an enumeration");
@@ -74,18 +67,7 @@ void RWStepVisual_RWSurfaceStyleUsage::WriteStep(
 
   // --- own field : side ---
 
-  switch (ent->Side())
-  {
-    case StepVisual_ssNegative:
-      SW.SendEnum(ssNegative);
-      break;
-    case StepVisual_ssPositive:
-      SW.SendEnum(ssPositive);
-      break;
-    case StepVisual_ssBoth:
-      SW.SendEnum(ssBoth);
-      break;
-  }
+  SW.SendEnum(RWStepVisual_RWSurfaceSide::ConvertToString(ent->Side()));
 
   // --- own field : style ---
 

--- a/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWTextLiteral.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWTextLiteral.cxx
@@ -19,11 +19,7 @@
 #include <StepVisual_TextPath.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : TextPath ---
-static TCollection_AsciiString tpUp(".UP.");
-static TCollection_AsciiString tpRight(".RIGHT.");
-static TCollection_AsciiString tpDown(".DOWN.");
-static TCollection_AsciiString tpLeft(".LEFT.");
+#include "RWStepVisual_RWTextPath.pxx"
 
 RWStepVisual_RWTextLiteral::RWStepVisual_RWTextLiteral() {}
 
@@ -68,16 +64,10 @@ void RWStepVisual_RWTextLiteral::ReadStep(const Handle(StepData_StepReaderData)&
   if (data->ParamType(num, 5) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 5);
-    if (tpUp.IsEqual(text))
-      aPath = StepVisual_tpUp;
-    else if (tpRight.IsEqual(text))
-      aPath = StepVisual_tpRight;
-    else if (tpDown.IsEqual(text))
-      aPath = StepVisual_tpDown;
-    else if (tpLeft.IsEqual(text))
-      aPath = StepVisual_tpLeft;
-    else
+    if (!RWStepVisual_RWTextPath::ConvertToEnum(text, aPath))
+    {
       ach->AddFail("Enumeration text_path has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #5 (path) is not an enumeration");
@@ -115,21 +105,7 @@ void RWStepVisual_RWTextLiteral::WriteStep(StepData_StepWriter&                 
 
   // --- own field : path ---
 
-  switch (ent->Path())
-  {
-    case StepVisual_tpUp:
-      SW.SendEnum(tpUp);
-      break;
-    case StepVisual_tpRight:
-      SW.SendEnum(tpRight);
-      break;
-    case StepVisual_tpDown:
-      SW.SendEnum(tpDown);
-      break;
-    case StepVisual_tpLeft:
-      SW.SendEnum(tpLeft);
-      break;
-  }
+  SW.SendEnum(RWStepVisual_RWTextPath::ConvertToString(ent->Path()));
 
   // --- own field : font ---
 

--- a/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWTextPath.pxx
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWTextPath.pxx
@@ -1,0 +1,77 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _RWStepVisual_RWTextPath_HeaderFile
+#define _RWStepVisual_RWTextPath_HeaderFile
+
+#include <StepVisual_TextPath.hxx>
+#include <Standard_CString.hxx>
+
+namespace RWStepVisual_RWTextPath
+{
+
+static constexpr char tpUp[]    = ".UP.";
+static constexpr char tpRight[] = ".RIGHT.";
+static constexpr char tpDown[]  = ".DOWN.";
+static constexpr char tpLeft[]  = ".LEFT.";
+
+//! Convert StepVisual_TextPath to string
+//! @param theSourceEnum The StepVisual_TextPath value to convert
+//! @return The corresponding string representation or nullptr if not found
+static const char* ConvertToString(const StepVisual_TextPath theSourceEnum)
+{
+  switch (theSourceEnum)
+  {
+    case StepVisual_tpUp:
+      return tpUp;
+    case StepVisual_tpRight:
+      return tpRight;
+    case StepVisual_tpDown:
+      return tpDown;
+    case StepVisual_tpLeft:
+      return tpLeft;
+  }
+  return nullptr;
+}
+
+//! Convert string to StepVisual_TextPath
+//! @param thePathStr The string to convert
+//! @param theResultEnum The corresponding StepVisual_TextPath value
+//! @return Standard_True if the conversion was successful, Standard_False otherwise
+static bool ConvertToEnum(const Standard_CString thePathStr, StepVisual_TextPath& theResultEnum)
+{
+  if (IsEqual(thePathStr, tpUp))
+  {
+    theResultEnum = StepVisual_tpUp;
+  }
+  else if (IsEqual(thePathStr, tpRight))
+  {
+    theResultEnum = StepVisual_tpRight;
+  }
+  else if (IsEqual(thePathStr, tpDown))
+  {
+    theResultEnum = StepVisual_tpDown;
+  }
+  else if (IsEqual(thePathStr, tpLeft))
+  {
+    theResultEnum = StepVisual_tpLeft;
+  }
+  else
+  {
+    return Standard_False;
+  }
+  return Standard_True;
+}
+} // namespace RWStepVisual_RWTextPath
+
+#endif // _RWStepVisual_RWTextPath_HeaderFile

--- a/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWViewVolume.cxx
+++ b/src/DataExchange/TKDESTEP/RWStepVisual/RWStepVisual_RWViewVolume.cxx
@@ -20,9 +20,7 @@
 #include <StepVisual_ViewVolume.hxx>
 #include <TCollection_AsciiString.hxx>
 
-// --- Enum : CentralOrParallel ---
-static TCollection_AsciiString copCentral(".CENTRAL.");
-static TCollection_AsciiString copParallel(".PARALLEL.");
+#include "RWStepVisual_RWCentralOrParallel.pxx"
 
 RWStepVisual_RWViewVolume::RWStepVisual_RWViewVolume() {}
 
@@ -43,12 +41,10 @@ void RWStepVisual_RWViewVolume::ReadStep(const Handle(StepData_StepReaderData)& 
   if (data->ParamType(num, 1) == Interface_ParamEnum)
   {
     Standard_CString text = data->ParamCValue(num, 1);
-    if (copCentral.IsEqual(text))
-      aProjectionType = StepVisual_copCentral;
-    else if (copParallel.IsEqual(text))
-      aProjectionType = StepVisual_copParallel;
-    else
+    if (!RWStepVisual_RWCentralOrParallel::ConvertToEnum(text, aProjectionType))
+    {
       ach->AddFail("Enumeration central_or_parallel has not an allowed value");
+    }
   }
   else
     ach->AddFail("Parameter #1 (projection_type) is not an enumeration");
@@ -125,15 +121,7 @@ void RWStepVisual_RWViewVolume::WriteStep(StepData_StepWriter&                 S
 
   // --- own field : projectionType ---
 
-  switch (ent->ProjectionType())
-  {
-    case StepVisual_copCentral:
-      SW.SendEnum(copCentral);
-      break;
-    case StepVisual_copParallel:
-      SW.SendEnum(copParallel);
-      break;
-  }
+  SW.SendEnum(RWStepVisual_RWCentralOrParallel::ConvertToString(ent->ProjectionType()));
 
   // --- own field : projectionPoint ---
 


### PR DESCRIPTION
- Introduced RWStepGeom_RWTransitionCode for converting StepGeom_TransitionCode to/from string representations.
- Refactored RWStepGeom_RWTrimmedCurve to utilize RWStepGeom_RWTrimmingPreference for trimming preference conversions.
- Created RWStepGeom_RWTrimmingPreference for handling StepGeom_TrimmingPreference enumerations.
- Updated RWStepGeom_RWUniformCurve and related classes to use RWStepGeom_RWBSplineCurveForm for B-spline curve form conversions.
- Added RWStepGeom_RWUniformSurface and related classes to use RWStepGeom_RWBSplineSurfaceForm for B-spline surface form conversions.
- Implemented RWStepShape_RWBooleanOperator for boolean operator conversions in STEP shapes.
- Refactored RWStepShape_RWBooleanResult to utilize RWStepShape_RWBooleanOperator for boolean operator handling.
- Introduced RWStepVisual_RWCentralOrParallel for central or parallel projection type conversions.
- Added RWStepVisual_RWSurfaceSide for surface side enumeration conversions.
- Updated RWStepVisual_RWSurfaceStyleUsage to use RWStepVisual_RWSurfaceSide for handling surface side.
- Created RWStepVisual_RWTextPath for text path enumeration conversions.
- Refactored RWStepVisual_RWTextLiteral to utilize RWStepVisual_RWTextPath for text path handling.
- Updated RWStepVisual_RWViewVolume to use RWStepVisual_RWCentralOrParallel for projection type conversions.