### PR TITLE
Data Exchange, GLTF - fix saving edges when Merge Faces is enabled

### DIFF
--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -2030,7 +2030,7 @@ void RWGltf_CafWriter::writePrimArray(const RWGltf_GltfFace&         theGltfFace
     switch (theGltfFace.Shape.ShapeType())
     {
       case TopAbs_EDGE:
-        myWriter->Int(RWGltf_GltfPrimitiveMode_LineStrip);
+        myWriter->Int(RWGltf_GltfPrimitiveMode_Lines);
         break;
       case TopAbs_VERTEX:
         myWriter->Int(RWGltf_GltfPrimitiveMode_Points);

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -286,7 +286,7 @@ TopAbs_ShapeEnum RWGltf_CafWriter::getShapeType(const TopoDS_Shape& theShape) co
     // Compounds are created in the case of merged faces
     TopoDS_Iterator it(theShape);
     Standard_ProgramError_Raise_if(!it.More(), "Empty compound");
-    aShapeType = it.Value().ShapeType();    
+    aShapeType = it.Value().ShapeType();
   }
 
   return aShapeType;
@@ -517,7 +517,7 @@ void RWGltf_CafWriter::saveEdgeIndices(RWGltf_GltfFace&           theGltfFace,
 {
   const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes;
   theGltfFace.NbIndexedNodes += theEdgeIter.NbNodes();
-  
+
   const Standard_Integer numSegments = Max(0, theEdgeIter.NbNodes() - 1);
   // each segment writes two indices
   theGltfFace.Indices.Count += numSegments * 2;
@@ -549,7 +549,8 @@ void RWGltf_CafWriter::saveVertexIndices(RWGltf_GltfFace&             theGltfFac
   const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes - theVertexIter.ElemLower();
   theGltfFace.NbIndexedNodes += theVertexIter.NbNodes();
   theGltfFace.Indices.Count += theVertexIter.NbNodes();
-  for (Standard_Integer anElemIter = theVertexIter.ElemLower(); anElemIter <= theVertexIter.ElemUpper();
+  for (Standard_Integer anElemIter = theVertexIter.ElemLower();
+       anElemIter <= theVertexIter.ElemUpper();
        ++anElemIter)
   {
     if (theGltfFace.Indices.ComponentType == RWGltf_GltfAccessorCompType_UInt16)
@@ -596,7 +597,8 @@ void RWGltf_CafWriter::saveIndices(RWGltf_GltfFace&                             
     }
   }
 
-  if (const RWMesh_FaceIterator* aFaceIter = dynamic_cast<const RWMesh_FaceIterator*>(&theShapeIter))
+  if (const RWMesh_FaceIterator* aFaceIter =
+        dynamic_cast<const RWMesh_FaceIterator*>(&theShapeIter))
   {
     saveTriangleIndices(theGltfFace, theBinFile, *aFaceIter, theMesh);
   }
@@ -985,7 +987,7 @@ bool RWGltf_CafWriter::writeBinData(const Handle(TDocStd_Document)& theDocument,
         aWrittenPrimData.Bind(aGltfFace->Shape, aGltfFace);
 
         Standard_Boolean wasWrittenNonFace = Standard_False;
-        TopAbs_ShapeEnum shapeType = getShapeType(aGltfFace->Shape);
+        TopAbs_ShapeEnum shapeType         = getShapeType(aGltfFace->Shape);
 
         switch (shapeType)
         {

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -515,19 +515,27 @@ void RWGltf_CafWriter::saveEdgeIndices(RWGltf_GltfFace&           theGltfFace,
                                        std::ostream&              theBinFile,
                                        const RWMesh_EdgeIterator& theEdgeIter)
 {
-  const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes - theEdgeIter.ElemLower();
+  const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes;
   theGltfFace.NbIndexedNodes += theEdgeIter.NbNodes();
-  theGltfFace.Indices.Count += theEdgeIter.NbNodes();
-  for (Standard_Integer anElemIter = theEdgeIter.ElemLower(); anElemIter <= theEdgeIter.ElemUpper();
-       ++anElemIter)
+  
+  const Standard_Integer numSegments = Max(0, theEdgeIter.NbNodes() - 1);
+  // each segment writes two indices
+  theGltfFace.Indices.Count += numSegments * 2;
+
+  for (Standard_Integer i = 0; i < numSegments; ++i)
   {
+    Standard_Integer i0 = aNodeFirst + i;
+    Standard_Integer i1 = aNodeFirst + i + 1;
+
     if (theGltfFace.Indices.ComponentType == RWGltf_GltfAccessorCompType_UInt16)
     {
-      writeVertex(theBinFile, (uint16_t)(anElemIter + aNodeFirst));
+      writeVertex(theBinFile, (uint16_t)i0);
+      writeVertex(theBinFile, (uint16_t)i1);
     }
     else
     {
-      writeVertex(theBinFile, anElemIter + aNodeFirst);
+      writeVertex(theBinFile, i0);
+      writeVertex(theBinFile, i1);
     }
   }
 }

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -283,7 +283,8 @@ TopAbs_ShapeEnum RWGltf_CafWriter::getShapeType(const TopoDS_Shape& theShape) co
   TopAbs_ShapeEnum aShapeType = theShape.ShapeType();
   if (aShapeType == TopAbs_COMPOUND)
   {
-    // Compounds are created in the case of merged faces
+    // Compounds are created in the case of merged faces.
+    // Assuming that all shapes in the compound are of the same type
     TopoDS_Iterator it(theShape);
     Standard_ProgramError_Raise_if(!it.More(), "Empty compound");
     aShapeType = it.Value().ShapeType();

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -499,12 +499,12 @@ void RWGltf_CafWriter::saveTriangleIndices(RWGltf_GltfFace&           theGltfFac
 
 void RWGltf_CafWriter::saveEdgeIndices(RWGltf_GltfFace&           theGltfFace,
                                        std::ostream&              theBinFile,
-                                       const RWMesh_EdgeIterator& theFaceIter)
+                                       const RWMesh_EdgeIterator& theEdgeIter)
 {
-  const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes - theFaceIter.ElemLower();
-  theGltfFace.NbIndexedNodes += theFaceIter.NbNodes();
-  theGltfFace.Indices.Count += theFaceIter.NbNodes();
-  for (Standard_Integer anElemIter = theFaceIter.ElemLower(); anElemIter <= theFaceIter.ElemUpper();
+  const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes - theEdgeIter.ElemLower();
+  theGltfFace.NbIndexedNodes += theEdgeIter.NbNodes();
+  theGltfFace.Indices.Count += theEdgeIter.NbNodes();
+  for (Standard_Integer anElemIter = theEdgeIter.ElemLower(); anElemIter <= theEdgeIter.ElemUpper();
        ++anElemIter)
   {
     if (theGltfFace.Indices.ComponentType == RWGltf_GltfAccessorCompType_UInt16)
@@ -522,12 +522,12 @@ void RWGltf_CafWriter::saveEdgeIndices(RWGltf_GltfFace&           theGltfFace,
 
 void RWGltf_CafWriter::saveVertexIndices(RWGltf_GltfFace&             theGltfFace,
                                          std::ostream&                theBinFile,
-                                         const RWMesh_VertexIterator& theFaceIter)
+                                         const RWMesh_VertexIterator& theVertexIter)
 {
-  const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes - theFaceIter.ElemLower();
-  theGltfFace.NbIndexedNodes += theFaceIter.NbNodes();
-  theGltfFace.Indices.Count += theFaceIter.NbNodes();
-  for (Standard_Integer anElemIter = theFaceIter.ElemLower(); anElemIter <= theFaceIter.ElemUpper();
+  const Standard_Integer aNodeFirst = theGltfFace.NbIndexedNodes - theVertexIter.ElemLower();
+  theGltfFace.NbIndexedNodes += theVertexIter.NbNodes();
+  theGltfFace.Indices.Count += theVertexIter.NbNodes();
+  for (Standard_Integer anElemIter = theVertexIter.ElemLower(); anElemIter <= theVertexIter.ElemUpper();
        ++anElemIter)
   {
     if (theGltfFace.Indices.ComponentType == RWGltf_GltfAccessorCompType_UInt16)
@@ -545,7 +545,7 @@ void RWGltf_CafWriter::saveVertexIndices(RWGltf_GltfFace&             theGltfFac
 
 void RWGltf_CafWriter::saveIndices(RWGltf_GltfFace&                               theGltfFace,
                                    std::ostream&                                  theBinFile,
-                                   const RWMesh_ShapeIterator&                    theFaceIter,
+                                   const RWMesh_ShapeIterator&                    theShapeIter,
                                    Standard_Integer&                              theAccessorNb,
                                    const std::shared_ptr<RWGltf_CafWriter::Mesh>& theMesh)
 {
@@ -574,17 +574,17 @@ void RWGltf_CafWriter::saveIndices(RWGltf_GltfFace&                             
     }
   }
 
-  if (const RWMesh_FaceIterator* aFaceIter = dynamic_cast<const RWMesh_FaceIterator*>(&theFaceIter))
+  if (const RWMesh_FaceIterator* aFaceIter = dynamic_cast<const RWMesh_FaceIterator*>(&theShapeIter))
   {
     saveTriangleIndices(theGltfFace, theBinFile, *aFaceIter, theMesh);
   }
   else if (const RWMesh_EdgeIterator* anEdgeIter =
-             dynamic_cast<const RWMesh_EdgeIterator*>(&theFaceIter))
+             dynamic_cast<const RWMesh_EdgeIterator*>(&theShapeIter))
   {
     saveEdgeIndices(theGltfFace, theBinFile, *anEdgeIter);
   }
   else if (const RWMesh_VertexIterator* aVertexIter =
-             dynamic_cast<const RWMesh_VertexIterator*>(&theFaceIter))
+             dynamic_cast<const RWMesh_VertexIterator*>(&theShapeIter))
   {
     saveVertexIndices(theGltfFace, theBinFile, *aVertexIter);
   }

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.hxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.hxx
@@ -209,6 +209,9 @@ protected:
                                          const Message_ProgressRange&                theProgress);
 
 protected:
+  //! Returns the underlying shape in case of a compound.
+  Standard_EXPORT virtual TopAbs_ShapeEnum getShapeType(const TopoDS_Shape& theShape) const;
+
   //! Return TRUE if face shape should be skipped (e.g. because it is invalid or empty).
   Standard_EXPORT virtual Standard_Boolean toSkipShape(
     const RWMesh_ShapeIterator& theShapeIter) const;

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfJsonParser.cxx
@@ -1808,7 +1808,7 @@ bool RWGltf_GltfJsonParser::gltfParsePrimArray(TopoDS_Shape&                  th
     }
   }
   if (aMode != RWGltf_GltfPrimitiveMode_Triangles && aMode != RWGltf_GltfPrimitiveMode_Lines
-      && aMode != RWGltf_GltfPrimitiveMode_LineStrip && aMode != RWGltf_GltfPrimitiveMode_Points)
+      && aMode != RWGltf_GltfPrimitiveMode_Points)
   {
     Message::SendWarning(TCollection_AsciiString() + "Primitive array within Mesh '" + theMeshId
                          + "' skipped due to unsupported mode");
@@ -1976,8 +1976,7 @@ bool RWGltf_GltfJsonParser::gltfParsePrimArray(TopoDS_Shape&                  th
         aShape = aVertices;
         break;
       }
-      case RWGltf_GltfPrimitiveMode_Lines:
-      case RWGltf_GltfPrimitiveMode_LineStrip: {
+      case RWGltf_GltfPrimitiveMode_Lines: {
         TColgp_Array1OfPnt aNodes(1, aMeshData->NbEdges());
         for (Standard_Integer anEdgeIdx = 1; anEdgeIdx <= aMeshData->NbEdges(); ++anEdgeIdx)
         {
@@ -2012,7 +2011,7 @@ bool RWGltf_GltfJsonParser::gltfParsePrimArray(TopoDS_Shape&                  th
       aShapeAttribs.RawName = theMeshName;
 
       // assign material and not color
-      if (aMode == RWGltf_GltfPrimitiveMode_Lines || aMode == RWGltf_GltfPrimitiveMode_LineStrip)
+      if (aMode == RWGltf_GltfPrimitiveMode_Lines)
       {
         aShapeAttribs.Style.SetColorCurv(aMeshData->BaseColor().GetRGB());
       }

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
@@ -579,7 +579,6 @@ bool RWGltf_TriangulationReader::ReadStream(
   const TCollection_AsciiString& aName     = theSourceMesh->Id();
   const RWGltf_GltfPrimitiveMode aPrimMode = theSourceMesh->PrimitiveMode();
   if (aPrimMode != RWGltf_GltfPrimitiveMode_Triangles && aPrimMode != RWGltf_GltfPrimitiveMode_Lines
-      && aPrimMode != RWGltf_GltfPrimitiveMode_LineStrip
       && aPrimMode != RWGltf_GltfPrimitiveMode_Points)
   {
     Message::SendWarning(TCollection_AsciiString("Buffer '") + aName


### PR DESCRIPTION
## Description
When using `SetMergeFaces(true)` with edges, the GLTF exported is invalid. The edges are not saved. Using Draco compression fails as well.

## The Problem
When a document is saved with merged faces, a Compound is created to group together the different faces. But when checking the type of the shape in several places, it's checked for either edge, vertex or defaults to face. That means that a compound of edges is also treated using the FaceIterator.

## The Solution
Look at the underlying shape of a compound. The only possibilities should be: Vertex, Edge, Face, or a Compound that contains exclusively one kind of those.

### Note
This PR undoes the change introduced in https://github.com/Open-Cascade-SAS/OCCT/pull/535. While exchanging `Lines` for `LineStrip` works for unmerged faces, where each edge is added individually, this breaks when using merge faces. Since all edges are now in the same mesh, they are all joined together, resulting in extra edges appearing between the actual edges.

Instead, the approach proposed here is to return to using Lines, but use the indices the fix the gap problem.