### PR TITLE
Modeling, ShapeAnalysis_Curve - Mismatch between projected point and parameter

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/ShapeAnalysis/ShapeAnalysis_Curve.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeAnalysis/ShapeAnalysis_Curve.cxx
@@ -438,56 +438,20 @@ Standard_Real ShapeAnalysis_Curve::ProjectAct(const Adaptor3d_Curve& theCurve,
         // chosen to be 40, 20, 25, and 40 again. It is unknown why
         // these particular values were chosen, probably just because
         // they were found to be sufficient in practice.
-        ProjectOnSegments(theCurve,
-                          thePoint,
-                          40,
-                          uMin,
-                          uMax,
-                          aProjDistance,
-                          theProjPoint,
-                          theProjParam);
-        if (aProjDistance <= theTolerance)
+        for (const Standard_Integer aSegmentCount : {40, 20, 25, 40})
         {
-          return aProjDistance;
-        }
-
-        ProjectOnSegments(theCurve,
-                          thePoint,
-                          20,
-                          uMin,
-                          uMax,
-                          aProjDistance,
-                          theProjPoint,
-                          theProjParam);
-        if (aProjDistance <= theTolerance)
-        {
-          return aProjDistance;
-        }
-
-        ProjectOnSegments(theCurve,
-                          thePoint,
-                          25,
-                          uMin,
-                          uMax,
-                          aProjDistance,
-                          theProjPoint,
-                          theProjParam);
-        if (aProjDistance <= theTolerance)
-        {
-          return aProjDistance;
-        }
-
-        ProjectOnSegments(theCurve,
-                          thePoint,
-                          40,
-                          uMin,
-                          uMax,
-                          aProjDistance,
-                          theProjPoint,
-                          theProjParam);
-        if (aProjDistance <= theTolerance)
-        {
-          return aProjDistance;
+          ProjectOnSegments(theCurve,
+                            thePoint,
+                            aSegmentCount,
+                            uMin,
+                            uMax,
+                            aProjDistance,
+                            theProjPoint,
+                            theProjParam);
+          if (aProjDistance <= theTolerance)
+          {
+            return aProjDistance;
+          }
         }
 
         // Did not find a point on the curve


### PR DESCRIPTION

The result of original point projection is now saved to be returned if we couldn't find intersection of point and curve.
Minor refactoring was performed (mostly renaming of variables).