### PR TITLE
Data Exchange, Step Export - Preserving control directives

### DIFF
--- a/src/DataExchange/TKDESTEP/GTests/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/GTests/FILES.cmake
@@ -3,6 +3,7 @@ set(OCCT_TKDESTEP_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKDESTEP_GTests_FILES
     STEPConstruct_RenderingProperties_Test.cxx
+    StepData_StepWriter_Test.cxx
     StepTidy_BaseTestFixture.pxx
     StepTidy_Axis2Placement3dReducer_Test.cxx
     StepTidy_CartesianPointReducer_Test.cxx

--- a/src/DataExchange/TKDESTEP/GTests/StepData_StepWriter_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepData_StepWriter_Test.cxx
@@ -1,0 +1,160 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <StepData_StepWriter.hxx>
+#include <TCollection_AsciiString.hxx>
+
+#include <gtest/gtest.h>
+
+// Test CleanTextForSend with basic character escaping
+TEST(StepData_StepWriterTest, CleanTextForSend_BasicEscaping)
+{
+  // Test single quote escaping
+  TCollection_AsciiString anInput1("text with 'single quotes'");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "text with ''single quotes''");
+
+  // Test backslash escaping
+  TCollection_AsciiString anInput2("path\\with\\backslashes");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "path\\\\with\\\\backslashes");
+
+  // Test newline escaping
+  TCollection_AsciiString anInput3("line1\nline2");
+  TCollection_AsciiString aResult3 = StepData_StepWriter::CleanTextForSend(anInput3);
+  EXPECT_STREQ(aResult3.ToCString(), "line1\\N\\line2");
+
+  // Test tab escaping
+  TCollection_AsciiString anInput4("text\twith\ttabs");
+  TCollection_AsciiString aResult4 = StepData_StepWriter::CleanTextForSend(anInput4);
+  EXPECT_STREQ(aResult4.ToCString(), "text\\T\\with\\T\\tabs");
+}
+
+// Test CleanTextForSend with control directives preservation
+TEST(StepData_StepWriterTest, CleanTextForSend_ControlDirectivePreservation)
+{
+  // Test \X\ control directive preservation
+  TCollection_AsciiString anInput1("text with \\XA7\\ section sign");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "text with \\XA7\\ section sign");
+
+  // Test \X2\ control directive preservation
+  TCollection_AsciiString anInput2("\\X2\\03C0\\X0\\ is pi");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "\\X2\\03C0\\X0\\ is pi");
+
+  // Test \X4\ control directive preservation
+  TCollection_AsciiString anInput3("emoji \\X4\\001F600\\X0\\ face");
+  TCollection_AsciiString aResult3 = StepData_StepWriter::CleanTextForSend(anInput3);
+  EXPECT_STREQ(aResult3.ToCString(), "emoji \\X4\\001F600\\X0\\ face");
+
+  // Test \S\ control directive preservation
+  TCollection_AsciiString anInput4("text with \\S\\ directive");
+  TCollection_AsciiString aResult4 = StepData_StepWriter::CleanTextForSend(anInput4);
+  EXPECT_STREQ(aResult4.ToCString(), "text with \\S\\ directive");
+
+  // Test \P\ control directive preservation
+  TCollection_AsciiString anInput5("\\PA\\ code page setting");
+  TCollection_AsciiString aResult5 = StepData_StepWriter::CleanTextForSend(anInput5);
+  EXPECT_STREQ(aResult5.ToCString(), "\\PA\\ code page setting");
+}
+
+// Test CleanTextForSend with existing \N\ and \T\ directive preservation
+TEST(StepData_StepWriterTest, CleanTextForSend_ExistingDirectivePreservation)
+{
+  // Test existing \N\ directive preservation
+  TCollection_AsciiString anInput1("line1\\N\\line2");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "line1\\N\\line2");
+
+  // Test existing \T\ directive preservation
+  TCollection_AsciiString anInput2("text\\T\\with\\T\\tab");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "text\\T\\with\\T\\tab");
+}
+
+// Test CleanTextForSend with mixed content
+TEST(StepData_StepWriterTest, CleanTextForSend_MixedContent)
+{
+  // Test quotes outside control directives
+  TCollection_AsciiString anInput1("see \\XA7\\ section and 'quotes'");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "see \\XA7\\ section and ''quotes''");
+
+  // Test backslashes outside control directives
+  TCollection_AsciiString anInput2("\\XA7\\ and path\\file");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "\\XA7\\ and path\\\\file");
+
+  // Test complex mixture
+  TCollection_AsciiString anInput3("prefix \\X2\\03B103B2\\X0\\ 'text' with\ttab");
+  TCollection_AsciiString aResult3 = StepData_StepWriter::CleanTextForSend(anInput3);
+  EXPECT_STREQ(aResult3.ToCString(), "prefix \\X2\\03B103B2\\X0\\ ''text'' with\\T\\tab");
+}
+
+// Test CleanTextForSend with edge cases
+TEST(StepData_StepWriterTest, CleanTextForSend_EdgeCases)
+{
+  // Test empty string
+  TCollection_AsciiString anInput1("");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "");
+
+  // Test string with only quotes
+  TCollection_AsciiString anInput2("''");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "''''");
+
+  // Test string with only control directive
+  TCollection_AsciiString anInput3("\\XA7\\");
+  TCollection_AsciiString aResult3 = StepData_StepWriter::CleanTextForSend(anInput3);
+  EXPECT_STREQ(aResult3.ToCString(), "\\XA7\\");
+
+  // Test consecutive control directives
+  TCollection_AsciiString anInput4("\\XA7\\\\XB6\\");
+  TCollection_AsciiString aResult4 = StepData_StepWriter::CleanTextForSend(anInput4);
+  EXPECT_STREQ(aResult4.ToCString(), "\\XA7\\\\XB6\\");
+}
+
+// Test CleanTextForSend with malformed but safe input
+TEST(StepData_StepWriterTest, CleanTextForSend_MalformedInput)
+{
+  // Test incomplete control directive (should be treated as regular text)
+  TCollection_AsciiString anInput1("incomplete \\X and 'quotes'");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "incomplete \\\\X and ''quotes''");
+
+  // Test partial control directive
+  TCollection_AsciiString anInput2("partial \\XA and more");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "partial \\\\XA and more");
+}
+
+// Test CleanTextForSend hex sequence detection
+TEST(StepData_StepWriterTest, CleanTextForSend_HexSequenceDetection)
+{
+  // Test valid hex sequences in \X2\ directive
+  TCollection_AsciiString anInput1("\\X2\\03B103B203B3\\X0\\");
+  TCollection_AsciiString aResult1 = StepData_StepWriter::CleanTextForSend(anInput1);
+  EXPECT_STREQ(aResult1.ToCString(), "\\X2\\03B103B203B3\\X0\\");
+
+  // Test valid hex sequences in \X4\ directive
+  TCollection_AsciiString anInput2("\\X4\\001F600001F638\\X0\\");
+  TCollection_AsciiString aResult2 = StepData_StepWriter::CleanTextForSend(anInput2);
+  EXPECT_STREQ(aResult2.ToCString(), "\\X4\\001F600001F638\\X0\\");
+
+  // Test text around hex sequences
+  TCollection_AsciiString anInput3("start \\X2\\03C0\\X0\\ end");
+  TCollection_AsciiString aResult3 = StepData_StepWriter::CleanTextForSend(anInput3);
+  EXPECT_STREQ(aResult3.ToCString(), "start \\X2\\03C0\\X0\\ end");
+}

--- a/src/DataExchange/TKDESTEP/StepData/StepData_StepWriter.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_StepWriter.cxx
@@ -1166,12 +1166,12 @@ TCollection_AsciiString StepData_StepWriter::CleanTextForSend(
   const TCollection_AsciiString& theText)
 {
   TCollection_AsciiString aResult;
-  Standard_Integer        aNb = theText.Length();
+  const Standard_Integer  aNb = theText.Length();
 
   // Process characters from beginning to end
   for (Standard_Integer anI = 1; anI <= aNb; anI++)
   {
-    char anUncar = theText.Value(anI);
+    const char anUncar = theText.Value(anI);
 
     // Check if we're at the start of a control directive
     Standard_Boolean anIsDirective    = Standard_False;
@@ -1183,7 +1183,7 @@ TCollection_AsciiString StepData_StepWriter::CleanTextForSend(
       // Check for \X2\ and \X4\ patterns first (need exactly 4 characters: \X2\)
       if (anI + 3 <= aNb && theText.Value(anI + 1) == 'X' && theText.Value(anI + 3) == '\\')
       {
-        char aThirdChar = theText.Value(anI + 2);
+        const char aThirdChar = theText.Value(anI + 2);
 
         // \X2, \X4, \X0 patterns - special control sequences
         if (aThirdChar == '2' || aThirdChar == '4' || aThirdChar == '0')
@@ -1211,17 +1211,11 @@ TCollection_AsciiString StepData_StepWriter::CleanTextForSend(
       // Check for \X{HH}\ pattern (need exactly 5 characters: \X{HH}\)
       else if (anI + 4 <= aNb && theText.Value(anI + 1) == 'X' && theText.Value(anI + 4) == '\\')
       {
-        char aThirdChar  = theText.Value(anI + 2);
-        char aFourthChar = theText.Value(anI + 3);
+        const char aThirdChar  = theText.Value(anI + 2);
+        const char aFourthChar = theText.Value(anI + 3);
 
         // Regular \X{HH}\ pattern - check for two hex characters
-        Standard_Boolean aThirdIsHex =
-          ((aThirdChar >= '0' && aThirdChar <= '9') || (aThirdChar >= 'A' && aThirdChar <= 'F')
-           || (aThirdChar >= 'a' && aThirdChar <= 'f'));
-        Standard_Boolean aFourthIsHex =
-          ((aFourthChar >= '0' && aFourthChar <= '9') || (aFourthChar >= 'A' && aFourthChar <= 'F')
-           || (aFourthChar >= 'a' && aFourthChar <= 'f'));
-        if (aThirdIsHex && aFourthIsHex)
+        if (std::isxdigit(aThirdChar) && std::isxdigit(aFourthChar))
         {
           anIsDirective    = Standard_True;
           aDirectiveLength = 5; // Control directive with two hex chars
@@ -1230,7 +1224,7 @@ TCollection_AsciiString StepData_StepWriter::CleanTextForSend(
       // Check for \S, \N, \T patterns (need exactly 3 characters: \S\)
       else if (anI + 2 <= aNb && theText.Value(anI + 2) == '\\')
       {
-        char aSecondChar = theText.Value(anI + 1);
+        const char aSecondChar = theText.Value(anI + 1);
         if (aSecondChar == 'S' || aSecondChar == 'N' || aSecondChar == 'T')
         {
           anIsDirective    = Standard_True;
@@ -1240,8 +1234,12 @@ TCollection_AsciiString StepData_StepWriter::CleanTextForSend(
       // Check for \P{char}\ patterns (need exactly 4 characters: \P{char}\)
       else if (anI + 3 <= aNb && theText.Value(anI + 1) == 'P' && theText.Value(anI + 3) == '\\')
       {
-        anIsDirective    = Standard_True;
-        aDirectiveLength = 4; // P directive with parameter
+        const char aSecondChar = theText.Value(anI + 2);
+        if (std::isalpha(aSecondChar))
+        {
+          anIsDirective    = Standard_True;
+          aDirectiveLength = 4; // P directive with parameter
+        }
       }
     }
 

--- a/src/DataExchange/TKDESTEP/StepData/StepData_StepWriter.hxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_StepWriter.hxx
@@ -267,6 +267,37 @@ public:
   //! then clears it
   Standard_EXPORT Standard_Boolean Print(Standard_OStream& S);
 
+  //! Static helper function to prepare text for STEP file output while preserving
+  //! existing ISO 10303-21 control directives.
+  //!
+  //! This function processes input text and escapes special characters (quotes, backslashes,
+  //! newlines, tabs) for STEP file format compliance, while carefully preserving any existing
+  //! control directives that may already be present in the input string.
+  //!
+  //! Supported control directive patterns that are preserved:
+  //! - \X{HH}\ : Single byte character encoding (U+0000 to U+00FF)
+  //! - \X2\{HHHH}...\X0\ : UTF-16 character encoding
+  //! - \X4\{HHHHHHHH}...\X0\ : UTF-32 character encoding
+  //! - \S\ : Latin codepoint character with current code page
+  //! - \P{A-I}\ : Code page control directive
+  //! - \N\ : Newline directive (preserved as-is)
+  //! - \T\ : Tab directive (preserved as-is)
+  //!
+  //! Character escaping performed (only on non-directive content):
+  //! - Single quote (') -> double quote ('')
+  //! - Backslash (\) -> double backslash (\\)
+  //! - Newline character -> \N\ directive
+  //! - Tab character -> \T\ directive
+  //!
+  //! Example:
+  //!   Input:  "text with \XA7\ and 'quotes'"
+  //!   Output: "text with \XA7\ and ''quotes''"
+  //!
+  //! @param theText The input text string to be processed
+  //! @return Processed text with preserved control directives and escaped special characters
+  Standard_EXPORT static TCollection_AsciiString CleanTextForSend(
+    const TCollection_AsciiString& theText);
+
 protected:
 private:
   //! adds a string to current line; first flushes it if full


### PR DESCRIPTION
Fixed issue when control directives inside existed text is corrupted during export.
Added GTest to validate conversion