### PR TITLE
Configuration - Fix link errors on macOS when not building using vcpkg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -776,10 +776,11 @@ endif()
 # the platform specific variables.
 if (BUILD_USE_VCPKG)
   project (OCCT)
-  if (APPLE)
-    # set Apple specific variables
-    occt_set_apple_csf_vars()
-  endif()
+endif()
+
+if (APPLE)
+  # set Apple specific variables
+  occt_set_apple_csf_vars()
 endif()
 
 # copying clang-format file to the root of the project


### PR DESCRIPTION
When building for macOS not using `vcpkg`, the build fails for some libraries because macOS-specific frameworks are not linked.

This problem is caused by this code in [`CMakeLists.txt`](https://github.com/Open-Cascade-SAS/OCCT/blob/508700117cf4d41b99087deed2b05f93e751e5cf/CMakeLists.txt#L777C1-L783C8) 

```cmake
if (BUILD_USE_VCPKG)
  project (OCCT)
  if (APPLE)
    # set Apple specific variables
    occt_set_apple_csf_vars()
  endif()
endif() 
```

This pull request moves the `if (APPLE)` block outside the `if (BUILD_USE_VCPKG)` which allows OCCT to built without errors from macOS. 

