### PR TITLE
Configuration - Fix ARCH for older 32-bit macs

### DIFF
--- a/adm/templates/env.install.sh.in
+++ b/adm/templates/env.install.sh.in
@@ -34,7 +34,7 @@ shopt -u nocasematch
 
 # ----- Set path to 3rd party and OCCT libraries -----
 anArch=`uname -m`
-if [ "$anArch" != "x86_64" ] && [ "$anArch" != "ia64" ] && [ "$anArch" != "aarch64"]; then
+if [ "$anArch" != "x86_64" ] && [ "$anArch" != "ia64" ] && [ "$anArch" != "aarch64" ] && [ "$anArch" != "arm64" ]; then
   export ARCH="32";
 else
   export ARCH="64";
@@ -43,7 +43,6 @@ fi
 aSystem=`uname -s`
 if [ "$aSystem" == "Darwin" ]; then
   export WOKSTATION="mac";
-  export ARCH="64";
 else
   export WOKSTATION="lin";
 fi

--- a/adm/templates/env.sh
+++ b/adm/templates/env.sh
@@ -60,7 +60,7 @@ shopt -u nocasematch
 
 # ----- Setup Environment Variables -----
 anArch=`uname -m`
-if [ "$anArch" != "x86_64" ] && [ "$anArch" != "ia64" ]; then
+if [ "$anArch" != "x86_64" ] && [ "$anArch" != "ia64" ] && [ "$anArch" != "aarch64" ] && [ "$anArch" != "arm64" ]; then
   export ARCH="32";
 else
   export ARCH="64";
@@ -68,7 +68,6 @@ fi
 
 if [ "$aSystem" == "Darwin" ]; then
   export WOKSTATION="mac";
-  export ARCH="64";
 else
   export WOKSTATION="lin";
 fi


### PR DESCRIPTION
Fix architecture check in environment setup scripts to include arm64