### PR TITLE
Modelling - Add option to not build history in BRepFill_PipeShell

### DIFF
--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
@@ -213,7 +213,8 @@ BRepFill_PipeShell::BRepFill_PipeShell(const TopoDS_Wire& Spine)
       myIsAutomaticLaw(Standard_False),
       myTrihedron(GeomFill_IsCorrectedFrenet),
       myTransition(BRepFill_Modified),
-      myStatus(GeomFill_PipeOk)
+      myStatus(GeomFill_PipeOk),
+      myIsBuildHistory(Standard_True)
 {
   myLocation.Nullify();
   mySection.Nullify();
@@ -785,7 +786,10 @@ Standard_Boolean BRepFill_PipeShell::Build()
         myShape.Closed(Standard_True);
     }
 
-    BuildHistory(MkSw);
+    if (myIsBuildHistory)
+    {
+      BuildHistory(MkSw);
+    }
   }
   else
   {

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.hxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.hxx
@@ -122,6 +122,18 @@ public:
   //! spine
   Standard_EXPORT void SetForceApproxC1(const Standard_Boolean ForceApproxC1);
 
+  //! Sets the build history flag.
+  //! If set to True, the pipe shell will store the history of the sections
+  //! and the spine, which can be used for further modifications or analysis.
+  inline void SetIsBuildHistory(const Standard_Boolean theIsBuildHistory)
+  {
+    myIsBuildHistory = theIsBuildHistory;
+  }
+
+  //! Returns the build history flag.
+  //! If True, the pipe shell stores the history of the sections and the spine.
+  inline bool IsBuildHistory() const { return myIsBuildHistory; }
+
   //! Set an section. The correspondence with the spine, will be automatically performed.
   Standard_EXPORT void Add(const TopoDS_Shape&    Profile,
                            const Standard_Boolean WithContact    = Standard_False,
@@ -246,6 +258,7 @@ private:
   BRepFill_TransitionStyle           myTransition;
   GeomFill_PipeError                 myStatus;
   Standard_Real                      myErrorOnSurf;
+  Standard_Boolean                   myIsBuildHistory;
 };
 
 #endif // _BRepFill_PipeShell_HeaderFile

--- a/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_MakePipeShell.hxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_MakePipeShell.hxx
@@ -274,13 +274,24 @@ public:
 
   Standard_EXPORT Standard_Real ErrorOnSurface() const;
 
+  //! Sets the build history flag.
+  //! If set to True, the pipe shell will store the history of the sections
+  //! and the spine, which can be used for further modifications or analysis.
+  inline void SetIsBuildHistory(const Standard_Boolean theIsBuildHistory)
+  {
+    myPipe->SetIsBuildHistory(theIsBuildHistory);
+  }
+
+  //! Returns the build history flag.
+  //! If True, the pipe shell stores the history of the sections and the spine.
+  inline bool IsBuildHistory() const { return myPipe->IsBuildHistory(); }
+
   //! Returns the list of original profiles
   void Profiles(TopTools_ListOfShape& theProfiles) { myPipe->Profiles(theProfiles); }
 
   //! Returns the spine
   const TopoDS_Wire& Spine() { return myPipe->Spine(); }
 
-protected:
 private:
   Handle(BRepFill_PipeShell) myPipe;
 };


### PR DESCRIPTION
Flag myIsBuildHistory is added to BRepFill_PipeShell, by default it is set to true.
Public methods to read and set new flag is added to BRepFill_PipeShell interface.
Methods to read and set flag in inderlying BRepFill_PipeShell are added to BRepOffsetAPI_MakePipeShell interface.