### PR TITLE
Configuration, CMake - Build config file is invalid

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1198,6 +1198,7 @@ if (${DRAWEXE_INDEX} GREATER -1)
   OCCT_COPY_FILE_OR_DIR ("adm/templates/draw.${SCRIPT_EXT}" "${CMAKE_BINARY_DIR}")
 endif()
 
+OCCT_MAKE_COMPILER_BITNESS()
 set (SUB_CUSTOM_NAME "custom_${COMPILER}_${COMPILER_BITNESS}.${SCRIPT_EXT}")
 
 if (WIN32)
@@ -1326,6 +1327,11 @@ else()
     set (OCCT_CUSTOM_BUILD_BIN_LIB_PATHS "export CSF_OCCTBinPath=\"@CMAKE_RUNTIME_OUTPUT_DIRECTORY@\"
     export CSF_OCCTLibPath=\"@CMAKE_ARCHIVE_OUTPUT_DIRECTORY@\"")
   endif()
+endif()
+
+# Expand OCCT_CUSTOM_BUILD_BIN_LIB_PATHS variable to resolve nested @...@ variables
+if (OCCT_CUSTOM_BUILD_BIN_LIB_PATHS)
+  string(CONFIGURE "${OCCT_CUSTOM_BUILD_BIN_LIB_PATHS}" OCCT_CUSTOM_BUILD_BIN_LIB_PATHS @ONLY)
 endif()
 
 # write current custom.bat/sh (for build directory)

--- a/adm/templates/custom.build.sh.in
+++ b/adm/templates/custom.build.sh.in
@@ -14,7 +14,7 @@ if [ "$1" == "@BIN_LETTER@" ]; then
     export FFMPEG_DIR="@3RDPARTY_FFMPEG_LIBRARY_DIR@"
     export JEMALLOC_DIR="@3RDPARTY_JEMALLOC_LIBRARY_DIR@"
 
-    if [ "x@3RDPARTY_QT_DIR" != "x" ]; then
+    if [ "x@3RDPARTY_QT_DIR@" != "x" ]; then
       export QTDIR="@3RDPARTY_QT_DIR@"
     fi
 


### PR DESCRIPTION
- Fixed missing `@` delimiter in template variable substitution for QT directory detection
- Added compiler bitness calculation before custom script generation
- Implemented nested variable expansion for custom build paths