### PR TITLE
Testing - Create occt artefact action

### DIFF
--- a/.github/actions/build-occt/action.yml
+++ b/.github/actions/build-occt/action.yml
@@ -78,7 +78,7 @@ runs:
       shell: bash
 
     - name: Upload install directory
-      uses: actions/upload-artifact@v4.6.2
+      uses: ./.github/actions/upload-artifacts
       with:
         name: ${{ inputs.artifact-name }}
         path: install

--- a/.github/actions/build-sample-csharp/action.yml
+++ b/.github/actions/build-sample-csharp/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Download OCCT installation
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: occt-install

--- a/.github/actions/build-sample-mfc/action.yml
+++ b/.github/actions/build-sample-mfc/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Download OCCT installation 
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: occt-install

--- a/.github/actions/build-sample-qt/action.yml
+++ b/.github/actions/build-sample-qt/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Download OCCT installation
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: occt-install

--- a/.github/actions/build-tinspector/action.yml
+++ b/.github/actions/build-tinspector/action.yml
@@ -17,7 +17,7 @@ runs:
   using: "composite"
   steps:
     - name: Download OCCT installation
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: occt-install

--- a/.github/actions/download-artifacts/action.yml
+++ b/.github/actions/download-artifacts/action.yml
@@ -12,57 +12,21 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Download archive
+    # For Windows, use standard GitHub action - no symlink issues
+    - name: Download artifacts (Windows)
+      if: runner.os == 'Windows'
+      uses: actions/download-artifact@v4.3.0
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+    
+    # For Linux/Unix, use custom workaround to handle symlinks properly
+    - name: Download archive (Unix)
+      if: runner.os != 'Windows'
       uses: actions/download-artifact@v4.3.0
       with:
         name: ${{ inputs.name }}
         path: ./download-temp
-    
-    - name: Extract archive (Windows)
-      if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $EXTRACT_PATH = "${{ inputs.path }}"
-        $ARCHIVE_FILE = "./download-temp/${{ inputs.name }}.zip"
-        
-        if (-not (Test-Path $ARCHIVE_FILE)) {
-          Write-Error "Archive file $ARCHIVE_FILE not found"
-          Get-ChildItem ./download-temp/
-          exit 1
-        }
-        
-        Write-Output "Extracting $ARCHIVE_FILE to $EXTRACT_PATH"
-        
-        # Extract and handle directory structure properly
-        if ($EXTRACT_PATH -ne ".") {
-          # Extract to temp location first
-          New-Item -ItemType Directory -Path "temp-extract" -Force | Out-Null
-          Expand-Archive -Path $ARCHIVE_FILE -DestinationPath "temp-extract" -Force
-          
-          # Move the extracted content to the desired path
-          if (Test-Path "temp-extract/install") {
-            # Remove target directory if it exists to avoid nesting
-            if (Test-Path $EXTRACT_PATH) {
-              Remove-Item -Recurse -Force $EXTRACT_PATH
-            }
-            Move-Item "temp-extract/install" $EXTRACT_PATH -Force
-          } else {
-            # If archive doesn't contain install/, move everything
-            New-Item -ItemType Directory -Path $EXTRACT_PATH -Force | Out-Null
-            Get-ChildItem "temp-extract" | Move-Item -Destination $EXTRACT_PATH -Force
-          }
-          
-          # Clean up temp directory
-          Remove-Item -Recurse -Force "temp-extract"
-        } else {
-          Expand-Archive -Path $ARCHIVE_FILE -DestinationPath $EXTRACT_PATH -Force
-        }
-        
-        Write-Output "Extraction complete"
-        Get-ChildItem $EXTRACT_PATH -ErrorAction SilentlyContinue
-        
-        # Clean up temporary download directory
-        Remove-Item -Recurse -Force ./download-temp
     
     - name: Extract archive (Unix)
       if: runner.os != 'Windows'

--- a/.github/actions/download-artifacts/action.yml
+++ b/.github/actions/download-artifacts/action.yml
@@ -1,0 +1,109 @@
+name: 'Download Platform Artifacts'
+description: 'Download and extract artifacts with proper file permissions and symlinks (cross-platform)'
+inputs:
+  name:
+    description: 'Artifact name'
+    required: true
+  path:
+    description: 'Path to extract to (optional)'
+    required: false
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Download archive
+      uses: actions/download-artifact@v4.3.0
+      with:
+        name: ${{ inputs.name }}
+        path: ./download-temp
+    
+    - name: Extract archive (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $EXTRACT_PATH = "${{ inputs.path }}"
+        $ARCHIVE_FILE = "./download-temp/${{ inputs.name }}.zip"
+        
+        if (-not (Test-Path $ARCHIVE_FILE)) {
+          Write-Error "Archive file $ARCHIVE_FILE not found"
+          Get-ChildItem ./download-temp/
+          exit 1
+        }
+        
+        Write-Output "Extracting $ARCHIVE_FILE to $EXTRACT_PATH"
+        
+        # Extract and handle directory structure properly
+        if ($EXTRACT_PATH -ne ".") {
+          # Extract to temp location first
+          New-Item -ItemType Directory -Path "temp-extract" -Force | Out-Null
+          Expand-Archive -Path $ARCHIVE_FILE -DestinationPath "temp-extract" -Force
+          
+          # Move the extracted content to the desired path
+          if (Test-Path "temp-extract/install") {
+            # Remove target directory if it exists to avoid nesting
+            if (Test-Path $EXTRACT_PATH) {
+              Remove-Item -Recurse -Force $EXTRACT_PATH
+            }
+            Move-Item "temp-extract/install" $EXTRACT_PATH -Force
+          } else {
+            # If archive doesn't contain install/, move everything
+            New-Item -ItemType Directory -Path $EXTRACT_PATH -Force | Out-Null
+            Get-ChildItem "temp-extract" | Move-Item -Destination $EXTRACT_PATH -Force
+          }
+          
+          # Clean up temp directory
+          Remove-Item -Recurse -Force "temp-extract"
+        } else {
+          Expand-Archive -Path $ARCHIVE_FILE -DestinationPath $EXTRACT_PATH -Force
+        }
+        
+        Write-Output "Extraction complete"
+        Get-ChildItem $EXTRACT_PATH -ErrorAction SilentlyContinue
+        
+        # Clean up temporary download directory
+        Remove-Item -Recurse -Force ./download-temp
+    
+    - name: Extract archive (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        EXTRACT_PATH="${{ inputs.path }}"
+        ARCHIVE_FILE="./download-temp/${{ inputs.name }}.tar.gz"
+        
+        if [ ! -f "$ARCHIVE_FILE" ]; then
+          echo "Error: Archive file $ARCHIVE_FILE not found"
+          ls -la ./download-temp/
+          exit 1
+        fi
+        
+        echo "Extracting $ARCHIVE_FILE to $EXTRACT_PATH"
+        
+        # Extract and handle directory structure properly
+        if [ "$EXTRACT_PATH" != "." ]; then
+          # Extract to temp location first
+          mkdir -p temp-extract
+          tar -xzf "$ARCHIVE_FILE" -C temp-extract
+          
+          # Move the extracted content to the desired path
+          if [ -d "temp-extract/install" ]; then
+            # Remove target directory if it exists to avoid nesting
+            rm -rf "$EXTRACT_PATH"
+            mv "temp-extract/install" "$EXTRACT_PATH"
+          else
+            # If archive doesn't contain install/, move everything
+            mkdir -p "$EXTRACT_PATH"
+            mv temp-extract/* "$EXTRACT_PATH/"
+          fi
+          
+          # Clean up temp directory
+          rm -rf temp-extract
+        else
+          tar -xzf "$ARCHIVE_FILE" -C "$EXTRACT_PATH"
+        fi
+        
+        echo "Extraction complete"
+        ls -la "$EXTRACT_PATH"
+        
+        # Clean up temporary download directory
+        rm -rf ./download-temp

--- a/.github/actions/retest-failures/action.yml
+++ b/.github/actions/retest-failures/action.yml
@@ -118,7 +118,7 @@ runs:
 
     - name: Download and extract install directory
       if: steps.check_failures.outputs.failed_count > 0
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: install

--- a/.github/actions/run-gtest/action.yml
+++ b/.github/actions/run-gtest/action.yml
@@ -25,7 +25,7 @@ runs:
   using: "composite"
   steps:
     - name: Download and extract install directory
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: install

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -53,7 +53,7 @@ runs:
       shell: bash
 
     - name: Download and extract install directory
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: ${{ inputs.install-artifact-name }}
         path: install

--- a/.github/actions/test-summary/action.yml
+++ b/.github/actions/test-summary/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
 
     - name: Download and extract install directory
-      uses: actions/download-artifact@v4.3.0
+      uses: ./.github/actions/download-artifacts
       with:
         name: install-linux-clang-x64
         path: install
@@ -54,18 +54,6 @@ runs:
         done
       shell: bash
 
-    - name: Extract master branch test results
-      run: |
-        cd install/bin/results/master/
-        for archive in *.tar.gz; do
-          if [ -f "$archive" ]; then
-            echo "Extracting $archive"
-            tar -xzf "$archive"
-            rm "$archive"
-          fi
-        done
-      shell: bash
-
     - name: Download current branch test results
       env:
         GH_TOKEN: ${{ github.token }}
@@ -73,18 +61,6 @@ runs:
         for platform in windows-x64 macos-x64 linux-clang-x64; do
           echo "Downloading results for $platform"
           gh run download -n "results-$platform" -D "install/bin/results/current/"
-        done
-      shell: bash
-
-    - name: Extract current branch test results
-      run: |
-        cd install/bin/results/current/
-        for archive in *.tar.gz; do
-          if [ -f "$archive" ]; then
-            echo "Extracting $archive"
-            tar -xzf "$archive"
-            rm "$archive"
-          fi
         done
       shell: bash
 

--- a/.github/actions/test-summary/action.yml
+++ b/.github/actions/test-summary/action.yml
@@ -54,6 +54,18 @@ runs:
         done
       shell: bash
 
+    - name: Extract master branch test results
+      run: |
+        cd install/bin/results/master/
+        for archive in *.tar.gz; do
+          if [ -f "$archive" ]; then
+            echo "Extracting $archive"
+            tar -xzf "$archive"
+            rm "$archive"
+          fi
+        done
+      shell: bash
+
     - name: Download current branch test results
       env:
         GH_TOKEN: ${{ github.token }}
@@ -61,6 +73,18 @@ runs:
         for platform in windows-x64 macos-x64 linux-clang-x64; do
           echo "Downloading results for $platform"
           gh run download -n "results-$platform" -D "install/bin/results/current/"
+        done
+      shell: bash
+
+    - name: Extract current branch test results
+      run: |
+        cd install/bin/results/current/
+        for archive in *.tar.gz; do
+          if [ -f "$archive" ]; then
+            echo "Extracting $archive"
+            tar -xzf "$archive"
+            rm "$archive"
+          fi
         done
       shell: bash
 

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -1,0 +1,58 @@
+name: 'Upload Platform Artifacts'
+description: 'Upload artifacts with proper file permissions and symlinks (cross-platform)'
+inputs:
+  name:
+    description: 'Artifact name'
+    required: true
+  path:
+    description: 'Path to archive'
+    required: true
+  retention-days:
+    description: 'Number of days to retain artifact'
+    required: false
+    default: '30'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Create archive (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $BASE_PATH = "${{ inputs.path }}"
+        $ARCHIVE_NAME = "${{ inputs.name }}.zip"
+        
+        if (Test-Path $BASE_PATH -PathType Container) {
+          Compress-Archive -Path $BASE_PATH -DestinationPath $ARCHIVE_NAME
+          Write-Output "Created archive: $ARCHIVE_NAME"
+          Get-ChildItem $ARCHIVE_NAME
+        } else {
+          Write-Error "Error: Path $BASE_PATH does not exist"
+          exit 1
+        }
+    
+    - name: Create archive (Unix)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        BASE_PATH="${{ inputs.path }}"
+        ARCHIVE_NAME="${{ inputs.name }}.tar.gz"
+        
+        if [ -d "$BASE_PATH" ]; then
+          tar -czf "$ARCHIVE_NAME" -C "$(dirname "$BASE_PATH")" "$(basename "$BASE_PATH")"
+        elif [ -f "$BASE_PATH" ]; then
+          tar -czf "$ARCHIVE_NAME" -C "$(dirname "$BASE_PATH")" "$(basename "$BASE_PATH")"
+        else
+          echo "Error: Path $BASE_PATH does not exist"
+          exit 1
+        fi
+        
+        echo "Created archive: $ARCHIVE_NAME"
+        ls -la "$ARCHIVE_NAME"
+    
+    - name: Upload archive
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.name }}.*
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/upload-artifacts/action.yml
+++ b/.github/actions/upload-artifacts/action.yml
@@ -15,22 +15,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Create archive (Windows)
+    # For Windows, use standard GitHub action - no symlink issues
+    - name: Upload artifacts (Windows)
       if: runner.os == 'Windows'
-      shell: pwsh
-      run: |
-        $BASE_PATH = "${{ inputs.path }}"
-        $ARCHIVE_NAME = "${{ inputs.name }}.zip"
-        
-        if (Test-Path $BASE_PATH -PathType Container) {
-          Compress-Archive -Path $BASE_PATH -DestinationPath $ARCHIVE_NAME
-          Write-Output "Created archive: $ARCHIVE_NAME"
-          Get-ChildItem $ARCHIVE_NAME
-        } else {
-          Write-Error "Error: Path $BASE_PATH does not exist"
-          exit 1
-        }
+      uses: actions/upload-artifact@v4.6.2
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        retention-days: ${{ inputs.retention-days }}
     
+    # For Linux/Unix, use custom workaround to handle symlinks properly
     - name: Create archive (Unix)
       if: runner.os != 'Windows'
       shell: bash
@@ -50,9 +44,10 @@ runs:
         echo "Created archive: $ARCHIVE_NAME"
         ls -la "$ARCHIVE_NAME"
     
-    - name: Upload archive
+    - name: Upload archive (Unix)
+      if: runner.os != 'Windows'
       uses: actions/upload-artifact@v4.6.2
       with:
         name: ${{ inputs.name }}
-        path: ${{ inputs.name }}.*
+        path: ${{ inputs.name }}.tar.gz
         retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
Replace actions with local implementations for downloading and uploading artifacts. Now unix files have valid symbolic links and Windows files have valid paths.