### PR TITLE
Coding - Dangerous use of 'cin'

### DIFF
--- a/src/DataExchange/TKXSBase/IFSelect/IFSelect_Functions.cxx
+++ b/src/DataExchange/TKXSBase/IFSelect/IFSelect_Functions.cxx
@@ -3038,8 +3038,10 @@ Standard_Integer IFSelect_Functions::GiveEntityNumber(const Handle(IFSelect_Work
   Standard_Integer num = 0;
   if (!name || name[0] == '\0')
   {
-    char ligne[80];
+    constexpr size_t aBufferSize = 80;
+    char ligne[aBufferSize];
     ligne[0] = '\0';
+    std::cin.width(aBufferSize);
     std::cin >> ligne;
     //    std::cin.clear();  std::cin.getline (ligne,79);
     if (ligne[0] == '\0')

--- a/src/DataExchange/TKXSBase/IFSelect/IFSelect_Functions.cxx
+++ b/src/DataExchange/TKXSBase/IFSelect/IFSelect_Functions.cxx
@@ -3039,7 +3039,7 @@ Standard_Integer IFSelect_Functions::GiveEntityNumber(const Handle(IFSelect_Work
   if (!name || name[0] == '\0')
   {
     constexpr size_t aBufferSize = 80;
-    char ligne[aBufferSize];
+    char             ligne[aBufferSize];
     ligne[0] = '\0';
     std::cin.width(aBufferSize);
     std::cin >> ligne;

--- a/src/Draw/TKTopTest/GeometryTest/GeometryTest_ConstraintCommands.cxx
+++ b/src/Draw/TKTopTest/GeometryTest/GeometryTest_ConstraintCommands.cxx
@@ -554,7 +554,9 @@ static Standard_Integer interpol(Draw_Interpretor& di, Standard_Integer n, const
     Standard_Integer nbp, i;
     Standard_Real    x, y, z;
     iFile >> nbp;
-    char dimen[3];
+    constexpr size_t aBufferSize = 3;
+    char dimen[aBufferSize];
+    iFile.width(aBufferSize);
     iFile >> dimen;
     if (!strcmp(dimen, "3d"))
     {

--- a/src/Draw/TKTopTest/GeometryTest/GeometryTest_ConstraintCommands.cxx
+++ b/src/Draw/TKTopTest/GeometryTest/GeometryTest_ConstraintCommands.cxx
@@ -555,7 +555,7 @@ static Standard_Integer interpol(Draw_Interpretor& di, Standard_Integer n, const
     Standard_Real    x, y, z;
     iFile >> nbp;
     constexpr size_t aBufferSize = 3;
-    char dimen[aBufferSize];
+    char             dimen[aBufferSize];
     iFile.width(aBufferSize);
     iFile >> dimen;
     if (!strcmp(dimen, "3d"))

--- a/src/Draw/TKXSDRAWIGES/XSDRAWIGES/XSDRAWIGES.cxx
+++ b/src/Draw/TKXSDRAWIGES/XSDRAWIGES/XSDRAWIGES.cxx
@@ -91,8 +91,10 @@ static Standard_Integer GiveEntityNumber(const Handle(XSControl_WorkSession)& WS
   Standard_Integer num = 0;
   if (!name || name[0] == '\0')
   {
-    char ligne[80];
+    constexpr size_t aBufferSize = 80;
+    char ligne[aBufferSize];
     ligne[0] = '\0';
+    std::cin.width(aBufferSize);
     std::cin >> ligne;
     //    std::cin.clear();  std::cin.getline (ligne,79);
     if (ligne[0] == '\0')
@@ -221,7 +223,9 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
       modepri = -1;
 
       // amv 26.09.2003 : this is used to avoid error of enter's symbol
-      char str[80];
+      constexpr size_t aBufferSize = 80;
+      char str[aBufferSize];
+      std::cin.width(aBufferSize);
       std::cin >> str;
       modepri = Draw::Atoi(str);
     }
@@ -267,7 +271,9 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
                   << std::flush;
         answer = -1;
         // amv 26.09.2003
-        char str_a[80];
+        constexpr size_t aBufferSize = 80;
+        char str_a[aBufferSize];
+        std::cin.width(aBufferSize);
         std::cin >> str_a;
         answer = Draw::Atoi(str_a);
       }
@@ -454,7 +460,9 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
                     << std::flush;
           answer = -1;
           // anv 26.09.2003
-          char str_answer[80];
+          constexpr size_t aBufferSize = 80;
+          char str_answer[aBufferSize];
+          std::cin.width(aBufferSize);
           std::cin >> str_answer;
           answer = Draw::Atoi(str_answer);
         }

--- a/src/Draw/TKXSDRAWIGES/XSDRAWIGES/XSDRAWIGES.cxx
+++ b/src/Draw/TKXSDRAWIGES/XSDRAWIGES/XSDRAWIGES.cxx
@@ -92,7 +92,7 @@ static Standard_Integer GiveEntityNumber(const Handle(XSControl_WorkSession)& WS
   if (!name || name[0] == '\0')
   {
     constexpr size_t aBufferSize = 80;
-    char ligne[aBufferSize];
+    char             ligne[aBufferSize];
     ligne[0] = '\0';
     std::cin.width(aBufferSize);
     std::cin >> ligne;
@@ -224,7 +224,7 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
 
       // amv 26.09.2003 : this is used to avoid error of enter's symbol
       constexpr size_t aBufferSize = 80;
-      char str[aBufferSize];
+      char             str[aBufferSize];
       std::cin.width(aBufferSize);
       std::cin >> str;
       modepri = Draw::Atoi(str);
@@ -272,7 +272,7 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
         answer = -1;
         // amv 26.09.2003
         constexpr size_t aBufferSize = 80;
-        char str_a[aBufferSize];
+        char             str_a[aBufferSize];
         std::cin.width(aBufferSize);
         std::cin >> str_a;
         answer = Draw::Atoi(str_a);
@@ -461,7 +461,7 @@ static Standard_Integer igesbrep(Draw_Interpretor& theDI,
           answer = -1;
           // anv 26.09.2003
           constexpr size_t aBufferSize = 80;
-          char str_answer[aBufferSize];
+          char             str_answer[aBufferSize];
           std::cin.width(aBufferSize);
           std::cin >> str_answer;
           answer = Draw::Atoi(str_answer);


### PR DESCRIPTION
Refactor input buffer allocation to use constexpr for improved readability and safety