### PR TITLE
Draw, MacOS - remove TKIVtkDraw when VTK_USE_X is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1017,6 +1017,11 @@ foreach (OCCT_3RDPARTY_LIST ${OCCT_3RDPARTY_CMAKE_LIST})
   OCCT_INCLUDE_CMAKE_FILE (${OCCT_3RDPARTY_LIST})
 endforeach()
 
+if (DEFINED VTK_USE_X AND NOT VTK_USE_X)
+    message (STATUS "Info: TKIVtkDraw toolkits excluded due to VTK has no glx support")
+    list (REMOVE_ITEM BUILD_TOOLKITS TKIVtkDraw)
+endif()
+
 if (USE_TK)
   add_definitions (-DHAVE_TK)
 else()


### PR DESCRIPTION
fix build failure on darwin platform when USE_VTK=ON