### PR TITLE
Fix a bug in IntAna_IntQuadQuad::NextCurve

### DIFF
--- a/src/ModelingData/TKGeomBase/IntAna/IntAna_IntQuadQuad.cxx
+++ b/src/ModelingData/TKGeomBase/IntAna/IntAna_IntQuadQuad.cxx
@@ -1576,7 +1576,7 @@ Standard_Integer IntAna_IntQuadQuad::NextCurve(const Standard_Integer I,
 {
   if (HasNextCurve(I))
   {
-    if (nextcurve[I] > 0)
+    if (nextcurve[I - 1] > 0)
     {
       theOpposite = Standard_False;
       return (nextcurve[I - 1]);


### PR DESCRIPTION
Summary:
Fixed a bug in `Standard_Integer IntAna_IntQuadQuad::NextCurve(const Standard_Integer I,
    Standard_Boolean& theOpposite) const` that caused it to return an incorrect (potentially negative) index for the next curve.

Details:
While working on low-level development using the OCCT `IntAna_IntQuadQuad` class, I encountered an issue where the `NextCurve` method consistently failed to retrieve the correct index of the next curve. Upon examining the source code, I identified a bug within the `NextCurve` function.

The logic of the code indicates that the `nextcurve` and `previouscurve` arrays store indices that are one less than the input query value `I`. However, within the `NextCurve` function, when determining whether the parameter space of the connected next curve should be reversed, it incorrectly used the original index `I` directly (`if (nextcurve[I] > 0)`).

This mismatch led to accessing the `nextcurve` array with an index `I` that was one larger than intended. Consequently, the calculated index for the next curve could become negative.

Fix:
The fix modifies the condition checking for parameter space reversal of the *connected* next curve. Instead of using `I`, it now correctly uses `I - 1` to index into the `nextcurve` array:
```cpp
if (nextcurve[I - 1] > 0) // Corrected index: I-1 instead of I