### PR TITLE
Foundation Classes - math Container allignment

### DIFF
--- a/src/FoundationClasses/TKMath/math/math_DoubleTab.hxx
+++ b/src/FoundationClasses/TKMath/math/math_DoubleTab.hxx
@@ -25,8 +25,6 @@
 #include <Standard_Real.hxx>
 #include <Standard_Boolean.hxx>
 
-#include <array>
-
 class math_DoubleTab
 {
   static const Standard_Integer THE_BUFFER_SIZE = 16;
@@ -44,7 +42,7 @@ public:
       : myBuffer{},
         myArray(
           (theUpperRow - theLowerRow + 1) * (theUpperCol - theLowerCol + 1) <= THE_BUFFER_SIZE
-            ? NCollection_Array2<Standard_Real>(*myBuffer.data(),
+            ? NCollection_Array2<Standard_Real>(*myBuffer,
                                                 theLowerRow,
                                                 theUpperRow,
                                                 theLowerCol,
@@ -116,8 +114,8 @@ public:
   ~math_DoubleTab() = default;
 
 private:
-  std::array<Standard_Real, THE_BUFFER_SIZE> myBuffer;
-  NCollection_Array2<Standard_Real>          myArray;
+  STANDARD_ALIGNED(32, Standard_Real, myBuffer)[THE_BUFFER_SIZE];
+  NCollection_Array2<Standard_Real> myArray;
 };
 
 #endif // _math_DoubleTab_HeaderFile

--- a/src/FoundationClasses/TKMath/math/math_VectorBase.hxx
+++ b/src/FoundationClasses/TKMath/math/math_VectorBase.hxx
@@ -16,6 +16,7 @@
 #define _math_VectorBase_HeaderFile
 
 #include <NCollection_Array1.hxx>
+#include <Standard_DefineAlloc.hxx>
 #include <gp_XY.hxx>
 #include <gp_XYZ.hxx>
 
@@ -25,8 +26,6 @@
 #endif
 
 #include <math_Matrix.hxx>
-
-#include <array>
 
 //! This class implements the real vector abstract data type.
 //! Vectors can have an arbitrary range which must be defined at
@@ -313,8 +312,8 @@ protected:
   inline void SetLower(const Standard_Integer theLower);
 
 private:
-  std::array<TheItemType, THE_BUFFER_SIZE> myBuffer;
-  NCollection_Array1<TheItemType>          Array;
+  STANDARD_ALIGNED(32, TheItemType, myBuffer)[THE_BUFFER_SIZE];
+  NCollection_Array1<TheItemType> Array;
 };
 
 #include <math_VectorBase.lxx>

--- a/src/FoundationClasses/TKMath/math/math_VectorBase.lxx
+++ b/src/FoundationClasses/TKMath/math/math_VectorBase.lxx
@@ -22,7 +22,7 @@
 template <typename TheItemType>
 math_VectorBase<TheItemType>::math_VectorBase(const Standard_Integer theLower,
                                               const Standard_Integer theUpper)
-    : Array(*myBuffer.data(),
+    : Array(*myBuffer,
             theLower,
             theUpper,
             (theUpper - theLower + 1 <= math_VectorBase::THE_BUFFER_SIZE))
@@ -33,7 +33,7 @@ template <typename TheItemType>
 math_VectorBase<TheItemType>::math_VectorBase(const Standard_Integer theLower,
                                               const Standard_Integer theUpper,
                                               const TheItemType      theInitialValue)
-    : Array(*myBuffer.data(),
+    : Array(*myBuffer,
             theLower,
             theUpper,
             (theUpper - theLower + 1 <= math_VectorBase::THE_BUFFER_SIZE))
@@ -51,7 +51,7 @@ math_VectorBase<TheItemType>::math_VectorBase(const TheItemType*     theTab,
 
 template <typename TheItemType>
 math_VectorBase<TheItemType>::math_VectorBase(const gp_XY& theOther)
-    : Array(*myBuffer.data(), 1, 2)
+    : Array(*myBuffer, 1, 2)
 {
   Array(1) = static_cast<TheItemType>(theOther.X());
   Array(2) = static_cast<TheItemType>(theOther.Y());
@@ -59,7 +59,7 @@ math_VectorBase<TheItemType>::math_VectorBase(const gp_XY& theOther)
 
 template <typename TheItemType>
 math_VectorBase<TheItemType>::math_VectorBase(const gp_XYZ& theOther)
-    : Array(*myBuffer.data(), 1, 3)
+    : Array(*myBuffer, 1, 3)
 {
   Array(1) = static_cast<TheItemType>(theOther.X());
   Array(2) = static_cast<TheItemType>(theOther.Y());


### PR DESCRIPTION
Refactor math_DoubleTab and math_VectorBase to use aligned arrays instead of std::array for improved memory alignment