### PR TITLE
Visualization - Unexpected moving with AIS_ViewCube

### DIFF
--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.hxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.hxx
@@ -25,6 +25,7 @@
 #include <AIS_WalkDelta.hxx>
 
 #include <gp_Pnt.hxx>
+#include <gp_Quaternion.hxx>
 #include <Graphic3d_Vec3.hxx>
 #include <NCollection_Array1.hxx>
 #include <OSD_Timer.hxx>
@@ -828,6 +829,7 @@ protected: //! @name rotation/panning transient state variables
   gp_Vec              myCamStartOpToCenter;       //!< vector from rotation gravity point to camera Center at the beginning of rotation
   gp_Vec              myCamStartOpToEye;          //!< vector from rotation gravity point to camera Eye    at the beginning of rotation
   Graphic3d_Vec3d     myRotateStartYawPitchRoll;  //!< camera yaw pitch roll at the beginning of rotation
+  gp_Quaternion       myRotateStartQuaternion;    //!< camera orientation quaternion at the beginning of rotation
   // clang-format on
 };
 

--- a/src/Visualization/TKV3d/V3d/V3d_View.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.hxx
@@ -993,7 +993,7 @@ public:
                             const Graphic3d_BufferType& theBufferType     = Graphic3d_BT_RGB,
                             const Standard_Boolean      theToAdjustAspect = Standard_True,
                             const Graphic3d_ZLayerId theTargetZLayerId = Graphic3d_ZLayerId_BotOSD,
-                            const Standard_Integer   theIsSingleLayer  = Standard_False,
+                            const Standard_Boolean   theIsSingleLayer  = Standard_False,
                             const V3d_StereoDumpOptions theStereoOptions = V3d_SDO_MONO,
                             const Standard_CString      theLightName     = "")
   {

--- a/tests/v3d/bugs/bug33746
+++ b/tests/v3d/bugs/bug33746
@@ -1,0 +1,30 @@
+puts "============"
+puts "0033746: Visualization - Unexpected moving with AIS_ViewCube"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+vclear
+vinit View1
+
+box b 0 0 -100 100 20 10
+vdisplay -dispMode 1 b
+
+vviewcube c
+vcamera -navmode fly
+
+vtop
+vfit
+vmousebutton 200 200 -button left -down
+vmousebutton 201 200 -button left -up
+if { [vreadpixel 100 200 -rgb -name] == "BLACK" } { puts "Error: wrong transformation" }
+
+vdump $::imagedir/${::casename}_top.png
+
+vbottom
+vfit
+vmousebutton 200 200 -button left -down
+vmousebutton 201 200 -button left -up
+if { [vreadpixel 100 200 -rgb -name] == "BLACK" } { puts "Error: wrong transformation" }
+
+vdump $::imagedir/${::casename}_bottom.png


### PR DESCRIPTION
Fix AIS_ViewCube rotation instability by replacing Euler angles with quaternions

Replace the problematic Euler angle-based rotation handling in AIS_ViewController
with a mathematically robust quaternion approach to eliminate unexpected PI/2
rotations when transitioning from view cube
orientations to mouse gestures.

Key improvements:
- Add myRotateStartQuaternion member to store camera orientation as quaternion
- Replace unstable Euler angle calculations with direct quaternion operations
- Eliminate gimbal lock singularities that occurred at pitch +-90°
- Maintain numerical stability across all camera orientations
- Remove arbitrary coordinate system transformations and magic number workarounds

The quaternion-based approach ensures smooth,
predictable camera behavior
regardless of the initial orientation set by the view
 cube, resolving the
core mathematical instability that caused erratic
rotations.