### PR TITLE
Coding - Blame ignore for gxx formatting patch

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Global formatting with new rules using clang-format 18.1.8
 a5a7b3185b83c39d5b26cfaf138b9b87b5776e59
+# Global gxx formatting with new rules
+08c84822717d207a0f5fe955eb4a2ae6309e4313


### PR DESCRIPTION
Updated file .git-blame-ignore-revs to ignore gxx formatting commit