### PR TITLE
Coding - Add RTTI support for TFunction_Logbook class

### DIFF
--- a/src/ApplicationFramework/TKLCAF/TFunction/TFunction_Logbook.cxx
+++ b/src/ApplicationFramework/TKLCAF/TFunction/TFunction_Logbook.cxx
@@ -22,6 +22,8 @@
 #include <TFunction_Logbook.hxx>
 #include <Standard_GUID.hxx>
 
+IMPLEMENT_STANDARD_RTTIEXT(TFunction_Logbook, TDF_Attribute)
+
 //=======================================================================
 // function : GetID
 // purpose  : Static method to get an ID

--- a/src/ApplicationFramework/TKLCAF/TFunction/TFunction_Logbook.hxx
+++ b/src/ApplicationFramework/TKLCAF/TFunction/TFunction_Logbook.hxx
@@ -116,6 +116,8 @@ public:
   //! Prints th data of the attributes (touched, impacted and valid labels).
   Standard_EXPORT virtual Standard_OStream& Dump(Standard_OStream& anOS) const Standard_OVERRIDE;
 
+  DEFINE_STANDARD_RTTIEXT(TFunction_Logbook, TDF_Attribute)
+
 private:
   TDF_LabelMap     myTouched;
   TDF_LabelMap     myImpacted;


### PR DESCRIPTION
This PR adds the  `DEFINE_STANDARD_RTTIEXT` and `IMPLEMENT_STANDARD_RTTIEXT` macros to TFunction_Logbook class.

Improves on development tooling when using `Inspector` and on  `BinLDrivers_DocumentStorageDriver` warning messages.
| Before | After |
|------------|--------|
| <img width="389" height="144" alt="image" src="https://github.com/user-attachments/assets/252e0045-8358-4aad-b50f-d0169d2cd2bc" /> | <img width="377" height="144" alt="image" src="https://github.com/user-attachments/assets/1014e376-2dcb-495e-a4ff-54c58d08f595" />|
| BinLDrivers_DocumentStorageDriver: warning: attribute driver for type TDF_Attribute not found  | BinLDrivers_DocumentStorageDriver: warning: attribute driver for type TFunction_Logbook not found |
