### PR TITLE
Data Exchange, STEP - Replace String typedef and global temp buffers in StepData_StepReaderData

### DIFF
--- a/src/DataExchange/TKDESTEP/StepData/StepData_StepReaderData.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_StepReaderData.cxx
@@ -62,7 +62,7 @@ IMPLEMENT_STANDARD_RTTIEXT(StepData_StepReaderData, Interface_FileReaderData)
 
 #define Maxlst 64
 
-static Standard_Integer acceptvoid = 0;
+static const Standard_Integer acceptvoid = 0;
 
 // ----------  Fonctions Utilitaires  ----------
 


### PR DESCRIPTION
- Remove typedef TCollection_HAsciiString String and global statics (txtmes, initstr, subl)
- Use explicit TCollection_HAsciiString for message handles and function-local char txtmes buffers, drop constructor initstr logic, and update error/warning formatting.
- Reduce global mutable state and clarify message handling.