### PR TITLE
Data Exchange - Supplemental Geometry, add import of coordinate systems

### DIFF
--- a/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd.cxx
+++ b/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd.cxx
@@ -209,6 +209,10 @@ Standard_OStream& TDataXtd::Print(const TDataXtd_GeometryEnum G, Standard_OStrea
       s << "CYLINDER";
       break;
     }
+    case TDataXtd_PLACEMENT: {
+      s << "PLACEMENT";
+      break;
+    }
     default: {
       s << "UNKNOWN";
       break;

--- a/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_Geometry.hxx
+++ b/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_Geometry.hxx
@@ -26,6 +26,8 @@ class TDF_Label;
 class TNaming_NamedShape;
 class gp_Pnt;
 class gp_Ax1;
+class gp_Ax2;
+class gp_Ax3;
 class gp_Lin;
 class gp_Circ;
 class gp_Elips;
@@ -110,6 +112,18 @@ public:
   //! topological attribute S and the cylinder G.
   Standard_EXPORT static Standard_Boolean Cylinder(const Handle(TNaming_NamedShape)& S,
                                                    gp_Cylinder&                      G);
+
+  //! Retrieve the placement data to theCS from the given label.
+  //! param theL [in]  label
+  //! param theCS [out] placement coordinate system
+  //! return true if placement found
+  Standard_EXPORT static Standard_Boolean Placement(const TDF_Label& theL, gp_Ax3& theCS);
+
+  //! Retrieve the placement data to theCS from the given label.
+  //! param theL [in]  label
+  //! param theCS [out] placement coordinate system
+  //! return true if placement found
+  Standard_EXPORT static Standard_Boolean Placement(const TDF_Label& theL, gp_Ax2& theCS);
 
   //! Returns the GUID for geometry attributes.
   Standard_EXPORT static const Standard_GUID& GetID();

--- a/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_GeometryEnum.hxx
+++ b/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_GeometryEnum.hxx
@@ -26,7 +26,8 @@ enum TDataXtd_GeometryEnum
   TDataXtd_ELLIPSE,
   TDataXtd_SPLINE,
   TDataXtd_PLANE,
-  TDataXtd_CYLINDER
+  TDataXtd_CYLINDER,
+  TDataXtd_PLACEMENT
 };
 
 #endif // _TDataXtd_GeometryEnum_HeaderFile

--- a/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_Placement.cxx
+++ b/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_Placement.cxx
@@ -13,12 +13,19 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <BRepBuilderAPI_MakeVertex.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
 #include <Standard_GUID.hxx>
 #include <Standard_Type.hxx>
+#include <TDataStd_RealArray.hxx>
 #include <TDataXtd_Placement.hxx>
 #include <TDF_Attribute.hxx>
 #include <TDF_Label.hxx>
 #include <TDF_RelocationTable.hxx>
+#include <TNaming_Builder.hxx>
+#include <TNaming_NamedShape.hxx>
+#include <TopoDS.hxx>
 
 IMPLEMENT_DERIVED_ATTRIBUTE(TDataXtd_Placement, TDataStd_GenericEmpty)
 
@@ -41,6 +48,44 @@ Handle(TDataXtd_Placement) TDataXtd_Placement::Set(const TDF_Label& L)
     L.AddAttribute(A);
   }
   return A;
+}
+
+//=================================================================================================
+
+Handle(TDataXtd_Placement) TDataXtd_Placement::Set(const TDF_Label& theL, const gp_Ax3& theCS)
+{
+  const Handle(TDataXtd_Placement) anAttr = Set(theL);
+
+  gp_Pnt          aLocPoint = theCS.Location();
+  TNaming_Builder aB(theL);
+  aB.Generated(BRepBuilderAPI_MakeVertex(aLocPoint));
+
+  Handle(TColStd_HArray1OfReal) aCSArr = new TColStd_HArray1OfReal(1, 9);
+  aCSArr->SetValue(1, theCS.Direction().X());
+  aCSArr->SetValue(2, theCS.Direction().Y());
+  aCSArr->SetValue(3, theCS.Direction().Z());
+  aCSArr->SetValue(4, theCS.XDirection().X());
+  aCSArr->SetValue(5, theCS.XDirection().Y());
+  aCSArr->SetValue(6, theCS.XDirection().Z());
+  aCSArr->SetValue(7, theCS.YDirection().X());
+  aCSArr->SetValue(8, theCS.YDirection().Y());
+  aCSArr->SetValue(9, theCS.YDirection().Z());
+
+  Handle(TDataStd_RealArray) aLoc = TDataStd_RealArray::Set(theL, 1, 9);
+  if (!aLoc.IsNull())
+  {
+    aLoc->ChangeArray(aCSArr);
+  }
+
+  return anAttr;
+}
+
+//=================================================================================================
+
+Handle(TDataXtd_Placement) TDataXtd_Placement::Set(const TDF_Label& theL, const gp_Ax2& theCS)
+{
+  gp_Ax3 aCS(theCS.Location(), theCS.Direction(), theCS.XDirection());
+  return Set(theL, aCS);
 }
 
 //=================================================================================================

--- a/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_Placement.hxx
+++ b/src/ApplicationFramework/TKCAF/TDataXtd/TDataXtd_Placement.hxx
@@ -17,9 +17,12 @@
 #define _TDataXtd_Placement_HeaderFile
 
 #include <TDataStd_GenericEmpty.hxx>
+
+class gp_Ax2;
+class gp_Ax3;
+class TDataXtd_Placement;
 class TDF_Label;
 
-class TDataXtd_Placement;
 DEFINE_STANDARD_HANDLE(TDataXtd_Placement, TDataStd_GenericEmpty)
 
 class TDataXtd_Placement : public TDataStd_GenericEmpty
@@ -35,6 +38,10 @@ public:
   //! Placement methods
   //! =================
   Standard_EXPORT static Handle(TDataXtd_Placement) Set(const TDF_Label& label);
+
+  Standard_EXPORT static Handle(TDataXtd_Placement) Set(const TDF_Label& theL, const gp_Ax3& theCS);
+
+  Standard_EXPORT static Handle(TDataXtd_Placement) Set(const TDF_Label& theL, const gp_Ax2& theCS);
 
   Standard_EXPORT TDataXtd_Placement();
 

--- a/src/ApplicationFramework/TKVCAF/TPrsStd/TPrsStd_GeometryDriver.cxx
+++ b/src/ApplicationFramework/TKVCAF/TPrsStd/TPrsStd_GeometryDriver.cxx
@@ -68,7 +68,8 @@ Standard_Boolean TPrsStd_GeometryDriver::Update(const TDF_Label&               a
 
   switch (GeomType)
   {
-    case TDataXtd_POINT: {
+    case TDataXtd_POINT:
+    case TDataXtd_PLACEMENT: {
       gp_Pnt pt;
       if (!TDataXtd_Geometry::Point(aLabel, pt))
         return Standard_False;

--- a/src/ApplicationFramework/TKXml/XmlMDataXtd/XmlMDataXtd_GeometryDriver.cxx
+++ b/src/ApplicationFramework/TKXml/XmlMDataXtd/XmlMDataXtd_GeometryDriver.cxx
@@ -36,6 +36,7 @@ IMPLEMENT_DOMSTRING(GeomEllipseString, "ellipse")
 IMPLEMENT_DOMSTRING(GeomSplineString, "slpine")
 IMPLEMENT_DOMSTRING(GeomPlaneString, "plane")
 IMPLEMENT_DOMSTRING(GeomCylinderString, "cylinder")
+IMPLEMENT_DOMSTRING(GeomPlacementString, "placement")
 
 //=================================================================================================
 
@@ -106,6 +107,8 @@ static Standard_Boolean GeometryTypeEnum(const XmlObjMgt_DOMString& theString,
       aResult = TDataXtd_PLANE;
     else if (theString.equals(::GeomCylinderString()))
       aResult = TDataXtd_CYLINDER;
+    else if (theString.equals(::GeomPlacementString()))
+      aResult = TDataXtd_PLACEMENT;
     else
       return Standard_False;
   }
@@ -135,6 +138,8 @@ static const XmlObjMgt_DOMString& GeometryTypeString(const TDataXtd_GeometryEnum
       return ::GeomPlaneString();
     case TDataXtd_CYLINDER:
       return ::GeomCylinderString();
+    case TDataXtd_PLACEMENT:
+      return ::GeomPlacementString();
 
     default:
       throw Standard_DomainError("TDataXtd_GeometryEnum; enum term unknown");

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.hxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.hxx
@@ -223,6 +223,12 @@ public:
   //! Get View mode
   Standard_EXPORT Standard_Boolean GetViewMode() const;
 
+  //! Set Supplemental geometry mode to indicate read Supplemental geometry or not.
+  Standard_EXPORT void SetSupplementalMode(const Standard_Boolean theMode);
+
+  //! Get Supplemental geometry mode
+  Standard_EXPORT Standard_Boolean GetSupplementalMode() const;
+
   const XCAFDoc_DataMapOfShapeLabel& GetShapeLabelMap() const { return myMap; }
 
   //! Sets parameters for shape processing.
@@ -357,6 +363,12 @@ protected:
     ReadViews(const Handle(XSControl_WorkSession)& theWS,
               const Handle(TDocStd_Document)&      theDoc,
               const StepData_Factors&              theLocalFactors = StepData_Factors()) const;
+
+  //! Reads non-PMI Supplemental shapes for instances defined in the STEP model
+  Standard_EXPORT Standard_Boolean
+    ReadSupplemental(const Handle(XSControl_WorkSession)& theWS,
+                     const Handle(TDocStd_Document)&      theDoc,
+                     const StepData_Factors&              theLocalFactors = StepData_Factors());
 
   //! Populates the sub-Label of the passed TDF Label with shape
   //! data associated with the given STEP Representation Item,
@@ -511,6 +523,9 @@ private:
                       const Handle(StepRepr_PropertyDefinition)& theSource,
                       NCollection_List<Handle(Transfer_Binder)>& theBinders) const;
 
+  //! Auxiliary method to create supplemental geometry label in the document.
+  void createSupplementalLabel(const Handle(XCAFDoc_ShapeTool)& theShTool);
+
 private:
   STEPControl_Reader                                                              myReader;
   NCollection_DataMap<TCollection_AsciiString, Handle(STEPCAFControl_ExternFile)> myFiles;
@@ -526,6 +541,7 @@ private:
   Standard_Boolean                                           myGDTMode;
   Standard_Boolean                                           myMatMode;
   Standard_Boolean                                           myViewMode;
+  Standard_Boolean                                           mySupplementalMode;
   NCollection_DataMap<Handle(Standard_Transient), TDF_Label> myGDTMap;
 };
 


### PR DESCRIPTION
Upgrade TDataXtd_Placement attribute to use for coordinate systems Add first step of import of supplemental geometry not connected to PMI (coordinate systems) Add mode into Step Reader to switch on/off reading of supplemental geometry.