### PR TITLE
Documentation - Fix various typos and comment uniformity

### DIFF
--- a/src/FoundationClasses/TKMath/math/math_NewtonFunctionSetRoot.hxx
+++ b/src/FoundationClasses/TKMath/math/math_NewtonFunctionSetRoot.hxx
@@ -42,7 +42,7 @@ public:
   Standard_EXPORT math_NewtonFunctionSetRoot(math_FunctionSetWithDerivatives& theFunction,
                                              const math_Vector&               theXTolerance,
                                              const Standard_Real              theFTolerance,
-                                             const Standard_Integer tehNbIterations = 100);
+                                             const Standard_Integer theNbIterations = 100);
 
   //! This constructor should be used in a sub-class to initialize
   //! correctly all the fields of this class.


### PR DESCRIPTION
Fixes typo found in source variable name.  
I conducted a search and found many hits for `theNbIterations` in comparison to `tehNbIterations` which was unique.

This hasn't been tested and I apologize for not formatting the commit title and message well.