### PR TITLE
Coding, PerfMeter - Use NCollection_DataMap and TCollection_AsciiString

### DIFF
--- a/src/FoundationClasses/TKernel/OSD/OSD_PerfMeter.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_PerfMeter.cxx
@@ -225,13 +225,7 @@ Stopwatch* StopwatchStorage::GetStopwatch(const TCollection_AsciiString& theName
 
 Stopwatch& StopwatchStorage::CreateStopwatch(const TCollection_AsciiString& theName)
 {
-  Stopwatch* aStopwatch = myStopwatches.ChangeSeek(theName);
-  if (aStopwatch == nullptr)
-  {
-    myStopwatches.Bind(theName, Stopwatch());
-    aStopwatch = myStopwatches.ChangeSeek(theName);
-  }
-  return *aStopwatch;
+  return *myStopwatches.Bound(theName, Stopwatch());
 }
 
 //===================================================================================================


### PR DESCRIPTION
Replace std::unordered_map<std::string> and std::string usage with NCollection_DataMap<TCollection_AsciiString, Stopwatch> and TCollection_AsciiString.
Update method signatures and callers to accept TCollection_AsciiString, switch map operations to Bind/Seek/ChangeSeek/IsBound/UnBind/Clear, and adjust printing to use TCollection_AsciiString (remove std::to_string and <unordered_map> include).