### PR TITLE
Coding - Reneview Standard Macro

### DIFF
--- a/src/FoundationClasses/TKernel/Standard/Standard_Macro.hxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_Macro.hxx
@@ -52,7 +52,7 @@
 //!   Standard_MACRO_DEPRECATED("Use NEW_MACRO instead") \
 //!   ((x) * 2)
 //! @endcode
-#if 0 // Disabled untill global renames for 8.0.0 are completed.
+#if 0 // Disabled until global renames for 8.0.0 are completed.
   #define Standard_MACRO_DEPRECATED(theMsg) Standard_DEPRECATED_WARNING(theMsg)
 #else
   #define Standard_MACRO_DEPRECATED(theMsg)


### PR DESCRIPTION
Deprecate legacy macro wrappers for C++11/C++17 features
Add Standard_MACRO_DEPRECATED and simplify feature macros