### PR TITLE
Foundation Classes - Inline Standard_Type ctor and SubType implementations

### DIFF
--- a/src/FoundationClasses/TKernel/Standard/Standard_Type.cxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_Type.cxx
@@ -21,53 +21,6 @@
 
 IMPLEMENT_STANDARD_RTTIEXT(Standard_Type, Standard_Transient)
 
-Standard_Type::Standard_Type(const char*                  theSystemName,
-                             const char*                  theName,
-                             Standard_Size                theSize,
-                             const Handle(Standard_Type)& theParent)
-    : mySystemName(theSystemName),
-      myName(theName),
-      mySize(theSize),
-      myParent(theParent)
-{
-}
-
-Standard_Boolean Standard_Type::SubType(const Handle(Standard_Type)& theOther) const
-{
-  if (theOther.IsNull())
-  {
-    return false;
-  }
-  const Standard_Type* aTypeIter = this;
-  while (aTypeIter && theOther->mySize <= aTypeIter->mySize)
-  {
-    if (theOther.get() == aTypeIter)
-    {
-      return true;
-    }
-    aTypeIter = aTypeIter->Parent().get();
-  }
-  return false;
-}
-
-Standard_Boolean Standard_Type::SubType(const Standard_CString theName) const
-{
-  if (!theName)
-  {
-    return false;
-  }
-  const Standard_Type* aTypeIter = this;
-  while (aTypeIter)
-  {
-    if (IsEqual(theName, aTypeIter->Name()))
-    {
-      return true;
-    }
-    aTypeIter = aTypeIter->Parent().get();
-  }
-  return false;
-}
-
 void Standard_Type::Print(Standard_OStream& AStream) const
 {
   AStream << std::hex << (Standard_Address)this << " : " << std::dec << myName;

--- a/src/FoundationClasses/TKernel/Standard/Standard_Type.hxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_Type.hxx
@@ -134,11 +134,43 @@ public:
 
   //! Returns True if this type is the same as theOther, or inherits from theOther.
   //! Note that multiple inheritance is not supported.
-  Standard_EXPORT Standard_Boolean SubType(const Handle(Standard_Type)& theOther) const;
+  Standard_Boolean SubType(const Handle(Standard_Type)& theOther) const noexcept
+  {
+    if (theOther.IsNull())
+    {
+      return false;
+    }
+    const Standard_Type* aTypeIter = this;
+    while (aTypeIter && theOther->mySize <= aTypeIter->mySize)
+    {
+      if (theOther.get() == aTypeIter)
+      {
+        return true;
+      }
+      aTypeIter = aTypeIter->Parent().get();
+    }
+    return false;
+  }
 
   //! Returns True if this type is the same as theOther, or inherits from theOther.
   //! Note that multiple inheritance is not supported.
-  Standard_EXPORT Standard_Boolean SubType(const Standard_CString theOther) const;
+  Standard_Boolean SubType(const Standard_CString theOther) const noexcept
+  {
+    if (!theOther)
+    {
+      return false;
+    }
+    const Standard_Type* aTypeIter = this;
+    while (aTypeIter)
+    {
+      if (IsEqual(theOther, aTypeIter->Name()))
+      {
+        return true;
+      }
+      aTypeIter = aTypeIter->Parent().get();
+    }
+    return false;
+  }
 
   //! Prints type (address of descriptor + name) to a stream
   Standard_EXPORT void Print(Standard_OStream& theStream) const;
@@ -178,7 +210,13 @@ private:
   Standard_Type(const char*                  theSystemName,
                 const char*                  theName,
                 Standard_Size                theSize,
-                const Handle(Standard_Type)& theParent);
+                const Handle(Standard_Type)& theParent) noexcept
+      : mySystemName(theSystemName),
+        myName(theName),
+        mySize(theSize),
+        myParent(theParent)
+  {
+  }
 
 private:
   Standard_CString      mySystemName; //!< System name of the class


### PR DESCRIPTION
Move Standard_Type constructor and both SubType overloads into the header as inline implementations
Add noexcept to the SubType methods.