### PR TITLE
Foundation Classes - Modernize NCollection_SparseArrayBase memory handling and style

### DIFF
--- a/src/FoundationClasses/TKernel/NCollection/NCollection_SparseArray.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_SparseArray.hxx
@@ -56,6 +56,8 @@ public:
   //! Explicit assignment operator
   NCollection_SparseArray& Assign(const NCollection_SparseArray& theOther)
   {
+    if (this == &theOther)
+      return *this;
     this->assign(theOther);
     return *this;
   }
@@ -63,7 +65,7 @@ public:
   //! Exchange the data of two arrays;
   //! can be used primarily to move contents of theOther into the new array
   //! in a fast way (without creation of duplicated data)
-  void Exchange(NCollection_SparseArray& theOther) { this->exchange(theOther); }
+  void Exchange(NCollection_SparseArray& theOther) noexcept { this->exchange(theOther); }
 
   //! Destructor
   virtual ~NCollection_SparseArray() { Clear(); }
@@ -138,7 +140,7 @@ public:
   {
   public:
     //! Empty constructor - for later Init
-    ConstIterator() {}
+    ConstIterator() noexcept {}
 
     //! Constructor with initialisation
     ConstIterator(const NCollection_SparseArray& theVector)
@@ -166,7 +168,7 @@ public:
   {
   public:
     //! Empty constructor - for later Init
-    Iterator() {}
+    Iterator() noexcept {}
 
     //! Constructor with initialisation
     Iterator(NCollection_SparseArray& theVector)

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_SparseArrayBase.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_SparseArrayBase.hxx
@@ -164,7 +164,7 @@ public:
     // Methods for descendant
 
     //! Empty constructor
-    Standard_EXPORT Iterator(const NCollection_SparseArrayBase* theArray = 0);
+    Standard_EXPORT Iterator(const NCollection_SparseArrayBase* theArray = nullptr);
 
     //! Initialize by the specified array
     Standard_EXPORT void init(const NCollection_SparseArrayBase* theArray);
@@ -182,9 +182,9 @@ public:
   friend class Iterator;
 
 private:
-  // Copy constructor and assignment operator are private thus not accessible
-  NCollection_SparseArrayBase(const NCollection_SparseArrayBase&);
-  void operator=(const NCollection_SparseArrayBase&);
+  // Copy constructor and assignment operator are deleted
+  NCollection_SparseArrayBase(const NCollection_SparseArrayBase&)            = delete;
+  NCollection_SparseArrayBase& operator=(const NCollection_SparseArrayBase&) = delete;
 
 protected:
   // Object life
@@ -195,7 +195,7 @@ protected:
         myBlockSize(theBlockSize),
         myNbBlocks(0),
         mySize(0),
-        myData(0)
+        myData(nullptr)
   {
   }
 
@@ -238,7 +238,7 @@ protected:
 
   //! Exchange contents of theOther and this;
   //! assumes that this and theOther have exactly the same type of arguments
-  Standard_EXPORT void exchange(NCollection_SparseArrayBase& theOther);
+  Standard_EXPORT void exchange(NCollection_SparseArrayBase& theOther) noexcept;
 
 protected:
   // Methods to be provided by descendant


### PR DESCRIPTION
Replace raw malloc/calloc/free with Standard::AllocateOptimal/Standard::Free and memset
use nullptr instead of 0, add null checks/braces, remove custom sswap in favor of std::swap, and update Iterator ctor default and deleted copy/assignment declarations.