### PR TITLE
Foundation Classes - Improve NCollection vector constructors

### DIFF
--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Vec2.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Vec2.hxx
@@ -42,16 +42,21 @@ public:
   static constexpr int Length() noexcept { return 2; }
 
   //! Empty constructor. Construct the zero vector.
-  constexpr NCollection_Vec2() noexcept { v[0] = v[1] = Element_t(0); }
+  constexpr NCollection_Vec2() noexcept
+      : v{Element_t(0), Element_t(0)}
+  {
+  }
 
   //! Initialize ALL components of vector within specified value.
-  explicit constexpr NCollection_Vec2(const Element_t theXY) noexcept { v[0] = v[1] = theXY; }
+  explicit constexpr NCollection_Vec2(const Element_t theXY) noexcept
+      : v{theXY, theXY}
+  {
+  }
 
   //! Per-component constructor.
   explicit constexpr NCollection_Vec2(const Element_t theX, const Element_t theY) noexcept
+      : v{theX, theY}
   {
-    v[0] = theX;
-    v[1] = theY;
   }
 
   //! Conversion constructor (explicitly converts some 2-component vector with other element type
@@ -61,9 +66,8 @@ public:
   //! @param theOtherVec2 the 2-component vector that needs to be converted
   template <typename OtherElement_t>
   explicit constexpr NCollection_Vec2(const NCollection_Vec2<OtherElement_t>& theOtherVec2) noexcept
+      : v{static_cast<Element_t>(theOtherVec2[0]), static_cast<Element_t>(theOtherVec2[1])}
   {
-    v[0] = static_cast<Element_t>(theOtherVec2[0]);
-    v[1] = static_cast<Element_t>(theOtherVec2[1]);
   }
 
   //! Assign new values to the vector.

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Vec3.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Vec3.hxx
@@ -58,31 +58,30 @@ public:
   static constexpr int Length() noexcept { return 3; }
 
   //! Empty constructor. Construct the zero vector.
-  NCollection_Vec3() { std::memset(this, 0, sizeof(NCollection_Vec3)); }
+  constexpr NCollection_Vec3() noexcept
+      : v{Element_t(0), Element_t(0), Element_t(0)}
+  {
+  }
 
   //! Initialize ALL components of vector within specified value.
   explicit constexpr NCollection_Vec3(Element_t theValue) noexcept
+      : v{theValue, theValue, theValue}
   {
-    v[0] = v[1] = v[2] = theValue;
   }
 
   //! Per-component constructor.
   explicit constexpr NCollection_Vec3(const Element_t theX,
                                       const Element_t theY,
                                       const Element_t theZ) noexcept
+      : v{theX, theY, theZ}
   {
-    v[0] = theX;
-    v[1] = theY;
-    v[2] = theZ;
   }
 
   //! Constructor from 2-components vector + optional 3rd value.
   explicit constexpr NCollection_Vec3(const NCollection_Vec2<Element_t>& theVec2,
                                       Element_t theZ = Element_t(0)) noexcept
+      : v{theVec2[0], theVec2[1], theZ}
   {
-    v[0] = theVec2[0];
-    v[1] = theVec2[1];
-    v[2] = theZ;
   }
 
   //! Conversion constructor (explicitly converts some 3-component vector with other element type
@@ -92,10 +91,10 @@ public:
   //! @param theOtherVec3 the 3-component vector that needs to be converted
   template <typename OtherElement_t>
   explicit constexpr NCollection_Vec3(const NCollection_Vec3<OtherElement_t>& theOtherVec3) noexcept
+      : v{static_cast<Element_t>(theOtherVec3[0]),
+          static_cast<Element_t>(theOtherVec3[1]),
+          static_cast<Element_t>(theOtherVec3[2])}
   {
-    v[0] = static_cast<Element_t>(theOtherVec3[0]);
-    v[1] = static_cast<Element_t>(theOtherVec3[1]);
-    v[2] = static_cast<Element_t>(theOtherVec3[2]);
   }
 
   //! Assign new values to the vector.

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Vec4.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Vec4.hxx
@@ -31,12 +31,15 @@ public:
   static constexpr int Length() noexcept { return 4; }
 
   //! Empty constructor. Construct the zero vector.
-  NCollection_Vec4() { std::memset(this, 0, sizeof(NCollection_Vec4)); }
+  constexpr NCollection_Vec4() noexcept
+      : v{Element_t(0), Element_t(0), Element_t(0), Element_t(0)}
+  {
+  }
 
   //! Initialize ALL components of vector within specified value.
   explicit constexpr NCollection_Vec4(const Element_t theValue) noexcept
+      : v{theValue, theValue, theValue, theValue}
   {
-    v[0] = v[1] = v[2] = v[3] = theValue;
   }
 
   //! Per-component constructor.
@@ -44,19 +47,14 @@ public:
                                       const Element_t theY,
                                       const Element_t theZ,
                                       const Element_t theW) noexcept
+      : v{theX, theY, theZ, theW}
   {
-    v[0] = theX;
-    v[1] = theY;
-    v[2] = theZ;
-    v[3] = theW;
   }
 
   //! Constructor from 2-components vector.
   explicit constexpr NCollection_Vec4(const NCollection_Vec2<Element_t>& theVec2) noexcept
+      : v{theVec2[0], theVec2[1], Element_t(0), Element_t(0)}
   {
-    v[0] = theVec2[0];
-    v[1] = theVec2[1];
-    v[2] = v[3] = Element_t(0);
   }
 
   //! Constructor from 3-components vector + optional 4th value.
@@ -74,11 +72,11 @@ public:
   //! @param theOtherVec4 the 4-component vector that needs to be converted
   template <typename OtherElement_t>
   explicit constexpr NCollection_Vec4(const NCollection_Vec4<OtherElement_t>& theOtherVec4) noexcept
+      : v{static_cast<Element_t>(theOtherVec4[0]),
+          static_cast<Element_t>(theOtherVec4[1]),
+          static_cast<Element_t>(theOtherVec4[2]),
+          static_cast<Element_t>(theOtherVec4[3])}
   {
-    v[0] = static_cast<Element_t>(theOtherVec4[0]);
-    v[1] = static_cast<Element_t>(theOtherVec4[1]);
-    v[2] = static_cast<Element_t>(theOtherVec4[2]);
-    v[3] = static_cast<Element_t>(theOtherVec4[3]);
   }
 
   //! Assign new values to the vector.


### PR DESCRIPTION
- Updated constructors in NCollection_Vec2, NCollection_Vec3, and NCollection_Vec4 to use initializer lists instead of assignment, enhancing readability and potentially optimizing performance.
- Ensured all constructors are marked as constexpr and noexcept where applicable.