### PR TITLE
Add vtkFiltersGeometry module dependency to IVtkDraw

### DIFF
--- a/src/Visualization/TKIVtk/EXTERNLIB.cmake
+++ b/src/Visualization/TKIVtk/EXTERNLIB.cmake
@@ -18,5 +18,6 @@ set(OCCT_TKIVtk_EXTERNAL_LIBS
   vtkRenderingFreeType
   vtkRenderingFreeTypeOpenGL
   vtkFiltersGeneral
+  vtkFiltersGeometry
   vtkInteractionStyle
 )


### PR DESCRIPTION
`IVtkDraw.cxx` includes `vtkGeometryFilter.h`, that can be found in the `Filters/Geometry` VTK module. Make sure the module is included correctly to avoid build errors.

Fixes a build error (VTK & OCCT master branch, linux):
```
/OCCT/src/Draw/TKIVtkDraw/IVtkDraw/IVtkDraw.cxx:61:10: fatal error: 'vtkGeometryFilter.h' file not found
   61 | #include <vtkGeometryFilter.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
1 error generated.
```
