### PR TITLE
Foudation Classes - Optimize map bucket indexing with power-of-2 sizing

### DIFF
--- a/src/FoundationClasses/TKMath/Poly/Poly_MergeNodesTool.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_MergeNodesTool.hxx
@@ -267,7 +267,7 @@ private:
                               const NCollection_Vec3<float>& theNorm);
 
     //! ReSize the map.
-    Standard_EXPORT void ReSize(const int theSize);
+    Standard_EXPORT void ReSize(const size_t theSize);
 
   private:
     //! Return cell index for specified 3D point and inverted cell size.
@@ -279,17 +279,17 @@ private:
     //! Hash code for integer vec3.
     Standard_EXPORT static size_t vec3iHashCode(
       const Poly_MergeNodesTool::MergedNodesMap::CellVec3i& theVec,
-      const int                                             theUpper);
+      const size_t                                          theNbBuckets);
 
     //! Compute hash code.
     Standard_EXPORT size_t hashCode(const NCollection_Vec3<float>& thePos,
                                     const NCollection_Vec3<float>& theNorm,
-                                    const int                      theUpper) const;
+                                    const size_t                   theNbBuckets) const;
 
     //! Compute hash code.
-    size_t hashCode(const Vec3AndNormal& theKey, const int theUpper) const
+    size_t hashCode(const Vec3AndNormal& theKey, const size_t theNbBuckets) const
     {
-      return hashCode(theKey.Pos, theKey.Norm, theUpper);
+      return hashCode(theKey.Pos, theKey.Norm, theNbBuckets);
     }
 
     //! Compare two vectors with inversed tolerance.

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_DataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_DataMap.hxx
@@ -236,34 +236,33 @@ public:
   }
 
   //! ReSize
-  void ReSize(const Standard_Integer N)
+  void ReSize(const size_t theN)
   {
-    NCollection_ListNode** newdata = NULL;
-    NCollection_ListNode** dummy   = NULL;
-    Standard_Integer       newBuck;
-    if (BeginResize(N, newBuck, newdata, dummy))
+    NCollection_ListNode** newdata = nullptr;
+    NCollection_ListNode** dummy   = nullptr;
+    size_t                 newBuck = 0;
+    if (BeginResize(theN, newBuck, newdata, dummy))
     {
       if (myData1)
       {
         DataMapNode** olddata = (DataMapNode**)myData1;
-        DataMapNode * p, *q;
-        for (int i = 0; i <= NbBuckets(); i++)
+        for (size_t i = 0; i < NbBuckets(); ++i)
         {
           if (olddata[i])
           {
-            p = olddata[i];
+            DataMapNode* p = olddata[i];
             while (p)
             {
-              const size_t k = HashCode(p->Key(), newBuck);
-              q              = (DataMapNode*)p->Next();
-              p->Next()      = newdata[k];
-              newdata[k]     = p;
-              p              = q;
+              const size_t  k = HashCode(p->Key(), newBuck);
+              DataMapNode*  q = (DataMapNode*)p->Next();
+              p->Next()       = newdata[k];
+              newdata[k]      = p;
+              p               = q;
             }
           }
         }
       }
-      EndResize(N, newBuck, newdata, dummy);
+      EndResize(newBuck, newdata, dummy);
     }
   }
 
@@ -598,9 +597,9 @@ protected:
     return myHasher(theKey1, theKey2);
   }
 
-  size_t HashCode(const TheKeyType& theKey, const int theUpperBound) const
+  size_t HashCode(const TheKeyType& theKey, const size_t theNbBuckets) const
   {
-    return myHasher(theKey) % theUpperBound + 1;
+    return myHasher(theKey) & (theNbBuckets - 1);
   }
 
 private:

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_DoubleMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_DoubleMap.hxx
@@ -186,36 +186,35 @@ public:
   }
 
   //! ReSize
-  void ReSize(const Standard_Integer N)
+  void ReSize(const size_t theN)
   {
-    NCollection_ListNode** ppNewData1 = NULL;
-    NCollection_ListNode** ppNewData2 = NULL;
-    Standard_Integer       newBuck;
-    if (BeginResize(N, newBuck, ppNewData1, ppNewData2))
+    NCollection_ListNode** ppNewData1 = nullptr;
+    NCollection_ListNode** ppNewData2 = nullptr;
+    size_t                 newBuck    = 0;
+    if (BeginResize(theN, newBuck, ppNewData1, ppNewData2))
     {
       if (myData1)
       {
-        DoubleMapNode *p, *q;
-        for (int i = 0; i <= NbBuckets(); i++)
+        for (size_t i = 0; i < NbBuckets(); ++i)
         {
           if (myData1[i])
           {
-            p = (DoubleMapNode*)myData1[i];
+            DoubleMapNode* p = (DoubleMapNode*)myData1[i];
             while (p)
             {
-              const size_t iK1 = HashCode1(p->Key1(), newBuck);
-              const size_t iK2 = HashCode2(p->Key2(), newBuck);
-              q                = (DoubleMapNode*)p->Next();
-              p->Next()        = ppNewData1[iK1];
-              p->Next2()       = (DoubleMapNode*)ppNewData2[iK2];
-              ppNewData1[iK1]  = p;
-              ppNewData2[iK2]  = p;
-              p                = q;
+              const size_t   iK1 = HashCode1(p->Key1(), newBuck);
+              const size_t   iK2 = HashCode2(p->Key2(), newBuck);
+              DoubleMapNode* q   = (DoubleMapNode*)p->Next();
+              p->Next()          = ppNewData1[iK1];
+              p->Next2()         = (DoubleMapNode*)ppNewData2[iK2];
+              ppNewData1[iK1]    = p;
+              ppNewData2[iK2]    = p;
+              p                  = q;
             }
           }
         }
       }
-      EndResize(N, newBuck, ppNewData1, ppNewData2);
+      EndResize(newBuck, ppNewData1, ppNewData2);
     }
   }
 
@@ -516,9 +515,9 @@ protected:
     return myHasher1(theKey1, theKey2);
   }
 
-  size_t HashCode1(const TheKey1Type& theKey, const int theUpperBound) const
+  size_t HashCode1(const TheKey1Type& theKey, const size_t theNbBuckets) const
   {
-    return myHasher1(theKey) % theUpperBound + 1;
+    return myHasher1(theKey) & (theNbBuckets - 1);
   }
 
   bool IsEqual2(const TheKey2Type& theKey1, const TheKey2Type& theKey2) const
@@ -526,9 +525,9 @@ protected:
     return myHasher2(theKey1, theKey2);
   }
 
-  size_t HashCode2(const TheKey2Type& theKey, const int theUpperBound) const
+  size_t HashCode2(const TheKey2Type& theKey, const size_t theNbBuckets) const
   {
-    return myHasher2(theKey) % theUpperBound + 1;
+    return myHasher2(theKey) & (theNbBuckets - 1);
   }
 
 protected:

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedDataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedDataMap.hxx
@@ -278,16 +278,16 @@ public:
   }
 
   //! ReSize
-  void ReSize(const Standard_Integer N)
+  void ReSize(const size_t theN)
   {
-    NCollection_ListNode** ppNewData1 = NULL;
-    NCollection_ListNode** ppNewData2 = NULL;
-    Standard_Integer       newBuck;
-    if (BeginResize(N, newBuck, ppNewData1, ppNewData2))
+    NCollection_ListNode** ppNewData1 = nullptr;
+    NCollection_ListNode** ppNewData2 = nullptr;
+    size_t                 newBuck    = 0;
+    if (BeginResize(theN, newBuck, ppNewData1, ppNewData2))
     {
       if (myData1)
       {
-        for (Standard_Integer aBucketIter = 0; aBucketIter <= NbBuckets(); ++aBucketIter)
+        for (size_t aBucketIter = 0; aBucketIter < NbBuckets(); ++aBucketIter)
         {
           if (myData1[aBucketIter])
           {
@@ -303,11 +303,10 @@ public:
           }
         }
       }
-      EndResize(N,
-                newBuck,
+      EndResize(newBuck,
                 ppNewData1,
-                (NCollection_ListNode**)
-                  Standard::Reallocate(myData2, (newBuck + 1) * sizeof(NCollection_ListNode*)));
+                static_cast<NCollection_ListNode**>(
+                  Standard::Reallocate(myData2, newBuck * sizeof(NCollection_ListNode*))));
     }
   }
 
@@ -705,9 +704,9 @@ protected:
     return myHasher(theKey1, theKey2);
   }
 
-  size_t HashCode(const TheKeyType& theKey, const int theUpperBound) const
+  size_t HashCode(const TheKeyType& theKey, const size_t theNbBuckets) const
   {
-    return myHasher(theKey) % theUpperBound + 1;
+    return myHasher(theKey) & (theNbBuckets - 1);
   }
 
 protected:

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedMap.hxx
@@ -215,16 +215,16 @@ public:
   }
 
   //! ReSize
-  void ReSize(const Standard_Integer theExtent)
+  void ReSize(const size_t theExtent)
   {
-    NCollection_ListNode** ppNewData1 = NULL;
-    NCollection_ListNode** ppNewData2 = NULL;
-    Standard_Integer       newBuck;
+    NCollection_ListNode** ppNewData1 = nullptr;
+    NCollection_ListNode** ppNewData2 = nullptr;
+    size_t                 newBuck    = 0;
     if (BeginResize(theExtent, newBuck, ppNewData1, ppNewData2))
     {
       if (myData1)
       {
-        for (Standard_Integer aBucketIter = 0; aBucketIter <= NbBuckets(); ++aBucketIter)
+        for (size_t aBucketIter = 0; aBucketIter < NbBuckets(); ++aBucketIter)
         {
           if (myData1[aBucketIter])
           {
@@ -240,11 +240,10 @@ public:
           }
         }
       }
-      EndResize(theExtent,
-                newBuck,
+      EndResize(newBuck,
                 ppNewData1,
-                (NCollection_ListNode**)
-                  Standard::Reallocate(myData2, (newBuck + 1) * sizeof(NCollection_ListNode*)));
+                static_cast<NCollection_ListNode**>(
+                  Standard::Reallocate(myData2, newBuck * sizeof(NCollection_ListNode*))));
     }
   }
 
@@ -498,9 +497,9 @@ protected:
     return myHasher(theKey1, theKey2);
   }
 
-  size_t HashCode(const TheKeyType& theKey, const int theUpperBound) const
+  size_t HashCode(const TheKeyType& theKey, const size_t theNbBuckets) const
   {
-    return myHasher(theKey) % theUpperBound + 1;
+    return myHasher(theKey) & (theNbBuckets - 1);
   }
 
 protected:

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Map.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Map.hxx
@@ -200,26 +200,25 @@ public:
   }
 
   //! ReSize
-  void ReSize(const Standard_Integer N)
+  void ReSize(const size_t theN)
   {
-    NCollection_ListNode** newdata = 0L;
-    NCollection_ListNode** dummy   = 0L;
-    Standard_Integer       newBuck;
-    if (BeginResize(N, newBuck, newdata, dummy))
+    NCollection_ListNode** newdata = nullptr;
+    NCollection_ListNode** dummy   = nullptr;
+    size_t                 newBuck = 0;
+    if (BeginResize(theN, newBuck, newdata, dummy))
     {
       if (myData1)
       {
         MapNode** olddata = (MapNode**)myData1;
-        MapNode * p, *q;
-        for (int i = 0; i <= NbBuckets(); i++)
+        for (size_t i = 0; i < NbBuckets(); ++i)
         {
           if (olddata[i])
           {
-            p = olddata[i];
+            MapNode* p = olddata[i];
             while (p)
             {
               const size_t k = HashCode(p->Key(), newBuck);
-              q              = (MapNode*)p->Next();
+              MapNode*     q = (MapNode*)p->Next();
               p->Next()      = newdata[k];
               newdata[k]     = p;
               p              = q;
@@ -227,7 +226,7 @@ public:
           }
         }
       }
-      EndResize(N, newBuck, newdata, dummy);
+      EndResize(newBuck, newdata, dummy);
     }
   }
 
@@ -517,9 +516,9 @@ protected:
     return myHasher(theKey1, theKey2);
   }
 
-  size_t HashCode(const TheKeyType& theKey, const int theUpperBound) const
+  size_t HashCode(const TheKeyType& theKey, const size_t theNbBuckets) const
   {
-    return myHasher(theKey) % theUpperBound + 1;
+    return myHasher(theKey) & (theNbBuckets - 1);
   }
 
 protected:


### PR DESCRIPTION
  - Replace prime number bucket counts with power-of-2 for faster indexing
  - Change HashCode from modulo (hash % N + 1) to bitwise AND (hash & (N-1))
  - Use size_t internally for myNbBuckets and mySize in NCollection_BaseMap
  - Update Iterator to use size_t with SIZE_MAX sentinel
  - Set minimum bucket count to 128
  - Update all derived map classes (Map, DataMap, IndexedMap, IndexedDataMap, DoubleMap) for new bucket indexing
  - Fix Poly_MergeNodesTool custom hash functions for power-of-2
  - Use NCollection_Array1 in Statistics() instead of raw array