### PR TITLE
Configuration - Update compiler flags and includes for macOS

### DIFF
--- a/adm/cmake/occt_defs_flags.cmake
+++ b/adm/cmake/occt_defs_flags.cmake
@@ -42,6 +42,10 @@ else()
   if (APPLE)
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
     set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -Wno-deprecated-declarations")
+    # Suppress elaborated-enum-base warnings from Apple system headers (CoreFoundation/CoreGraphics)
+    # when using newer Clang versions (LLVM 18+) that are stricter about this C++ standard violation
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-elaborated-enum-base")
+    set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -Wno-elaborated-enum-base")
   endif()
   add_definitions(-DOCC_CONVERT_SIGNALS)
 endif()
@@ -195,8 +199,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "[Cc][Ll][Aa][Nn][Gg]")
     # CLang can be used with both libstdc++ and libc++, however on OS X libstdc++ is outdated.
     set (CMAKE_CXX_FLAGS "-stdlib=libc++ ${CMAKE_CXX_FLAGS}")
   endif()
-  if (NOT WIN32)
-    # Optimize size of binaries
+  if (NOT WIN32 AND NOT APPLE)
+    # Optimize size of binaries (strip symbols)
+    # Note: -s is obsolete on macOS, so we only apply it on Linux
     set (CMAKE_SHARED_LINKER_FLAGS_RELEASE "-Wl,-s ${CMAKE_SHARED_LINKER_FLAGS_RELEASE}")
   endif()
 endif()

--- a/src/ApplicationFramework/TKLCAF/TDF/TDF_AttributeMap.hxx
+++ b/src/ApplicationFramework/TKLCAF/TDF/TDF_AttributeMap.hxx
@@ -16,6 +16,7 @@
 #ifndef TDF_AttributeMap_HeaderFile
 #define TDF_AttributeMap_HeaderFile
 
+#include <Standard_Handle.hxx>
 #include <TDF_Attribute.hxx>
 #include <NCollection_Map.hxx>
 

--- a/src/ApplicationFramework/TKLCAF/TDF/TDF_Label.lxx
+++ b/src/ApplicationFramework/TKLCAF/TDF/TDF_Label.lxx
@@ -23,14 +23,16 @@
 #include <TDF_TagSource.hxx>
 #include <TDF_Data.hxx>
 
+#include <cstdint>
+
 namespace std
 {
 template <>
 struct hash<TDF_Label>
 {
-  size_t operator()(const TDF_Label& theNode) const
+  size_t operator()(const TDF_Label& theLabel) const noexcept
   {
-    return std::hash<TDF_LabelNodePtr>{}(theNode.myLabelNode);
+    return static_cast<size_t>(reinterpret_cast<std::uintptr_t>(theLabel.myLabelNode));
   }
 };
 } // namespace std

--- a/src/ModelingData/TKG2d/Geom2dHash/Geom2dHash_CurveHasher.cxx
+++ b/src/ModelingData/TKG2d/Geom2dHash/Geom2dHash_CurveHasher.cxx
@@ -13,7 +13,7 @@
 
 #include <Geom2dHash_CurveHasher.hxx>
 
-#include <Standard_HashUtils.hxx>
+#include <Standard_CStringHasher.hxx>
 #include <Geom2d_Curve.hxx>
 #include <Geom2d_Line.hxx>
 #include <Geom2d_Circle.hxx>
@@ -83,7 +83,7 @@ std::size_t Geom2dHash_CurveHasher::operator()(const Handle(Geom2d_Curve)& theCu
   }
 
   // Unknown curve type - hash the type name
-  return std::hash<std::string>{}(theCurve->DynamicType()->Name());
+  return Standard_CStringHasher{}(theCurve->DynamicType()->Name());
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_CurveHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_CurveHasher.cxx
@@ -13,7 +13,7 @@
 
 #include <GeomHash_CurveHasher.hxx>
 
-#include <Standard_HashUtils.hxx>
+#include <Standard_CStringHasher.hxx>
 #include <Geom_Curve.hxx>
 #include <Geom_Line.hxx>
 #include <Geom_Circle.hxx>
@@ -83,7 +83,7 @@ std::size_t GeomHash_CurveHasher::operator()(const Handle(Geom_Curve)& theCurve)
   }
 
   // Unknown curve type - hash the type name
-  return std::hash<std::string>{}(theCurve->DynamicType()->Name());
+  return Standard_CStringHasher{}(theCurve->DynamicType()->Name());
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_SurfaceHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_SurfaceHasher.cxx
@@ -13,7 +13,7 @@
 
 #include <GeomHash_SurfaceHasher.hxx>
 
-#include <Standard_HashUtils.hxx>
+#include <Standard_CStringHasher.hxx>
 #include <Geom_Surface.hxx>
 #include <Geom_Plane.hxx>
 #include <Geom_CylindricalSurface.hxx>
@@ -100,7 +100,7 @@ std::size_t GeomHash_SurfaceHasher::operator()(
   }
 
   // Unknown surface type - hash the type name
-  return std::hash<std::string>{}(theSurface->DynamicType()->Name());
+  return Standard_CStringHasher{}(theSurface->DynamicType()->Name());
 }
 
 //=================================================================================================


### PR DESCRIPTION
- Added flags to suppress elaborated-enum-base warnings for newer Clang versions on macOS
- Updated includes in TDF_AttributeMap.hxx to include Standard_Handle.hxx
- Modified hash functions in GeomHash and Geom2dHash classes to use Standard_CStringHasher instead of Standard_HashUtils