### PR TITLE
Foundation classes - remove pragma lib comment in `OSD_Host.cxx`

### DIFF
--- a/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx
@@ -219,10 +219,6 @@ Standard_Integer OSD_Host::Error() const
 
   #include <OSD_Host.hxx>
 
-  #if defined(_MSC_VER)
-    #pragma comment(lib, "WSOCK32.LIB")
-  #endif
-
 void _osd_wnt_set_error(OSD_Error&, Standard_Integer, ...);
 
 static BOOL                    fInit = FALSE;


### PR DESCRIPTION
Hi! Working with 7.8.1 and linking it using cmake configs, I've stumbled upon missing `recv` symbol that comes in `WSOCK32.LIB`.

```
TKernel.lib(OSD_File.obj) : error LNK2019: unresolved external symbol recv referenced in function "public: void __cdecl OSD_File::ReadLine(class TCollection_AsciiString &,int,int &)" (?ReadLine@OSD_File@@QEAAXAEAVTCollection_AsciiString@@HAEAH@Z)
```

Investigating, I've found that `WSOCK32` is implicitly linked using `#pragma comment(lib, "WSOCK32.LIB")`, but only for `OSD_Host.cxx`, though `OSD_File.cxx` also needs it.

https://github.com/Open-Cascade-SAS/OCCT/blob/cb19690573aafc6ad436b69e31d55e2fc28130cb/src/FoundationClasses/TKernel/OSD/OSD_Host.cxx#L222-L224

Testing more recent version of OCCT (7.9.0), the linking issue was resolved by the commit https://github.com/Open-Cascade-SAS/OCCT/commit/2ab4e9e18045c3fd7d57ee6c5f060320eab2aa04 - the cause of the issue was that `WSOCK32` was mentioned in the corresponding `EXTERNLIB.cmake`, it's just wasn't linked for static libraries, so it end up not being in cmake configs, leading to the linking errors downstream.

https://github.com/Open-Cascade-SAS/OCCT/blob/cb19690573aafc6ad436b69e31d55e2fc28130cb/src/FoundationClasses/TKernel/EXTERNLIB.cmake#L9


So it seems this pragma statement `#pragma comment(lib, "WSOCK32.LIB")` is superseded as this point by cmake linking
and can be safely removed to avoid confusion why it's present in `OSD_Host.cxx` but missing in `OSD_File.cxx`.