### PR TITLE
Build - Fix C++ standard options and NOMINMAX scope

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set (CMAKE_CONFIGURATION_TYPES Release Debug RelWithDebInfo CACHE INTERNAL "" FO
 
 # set using C++ standard
 set (BUILD_CPP_STANDARD "C++17" CACHE STRING "Select using c++ standard.")
-set_property(CACHE BUILD_CPP_STANDARD PROPERTY STRINGS "C++17" "C++20" "C++23 C++26")
+set_property(CACHE BUILD_CPP_STANDARD PROPERTY STRINGS "C++17" "C++20" "C++23" "C++26")
 
 # Set desired C++ standard
 if ("${BUILD_CPP_STANDARD}" STREQUAL "C++17")

--- a/adm/cmake/occt_defs_flags.cmake
+++ b/adm/cmake/occt_defs_flags.cmake
@@ -29,7 +29,7 @@ if (MSVC)
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /fp:precise /wd26812")
   # suppress warning on using portable non-secure functions in favor of non-portable secure ones
   # prevent min() and max() macros from Windows.h
-  add_definitions (-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE -DNOMINMAX)
+  add_definitions (-D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE)
 else()
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fexceptions")
   set (CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -fexceptions")
@@ -218,6 +218,11 @@ if (CMAKE_COMPILER_IS_GNUCXX AND NOT APPLE)
   # Optimize size of binaries
   set (CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
   set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
+endif()
+
+if (WIN32)
+  # prevent Windows.h from redefining std::min/std::max
+  add_definitions(-DNOMINMAX)
 endif()
 
 if (BUILD_RELEASE_DISABLE_EXCEPTIONS)


### PR DESCRIPTION
- Fix C++ standard dropdown: split "C++23 C++26" into separate options
- Move NOMINMAX define from MSVC-only to all WIN32 compilers