### PR TITLE
Coding - Optimize memory management in BOPAlgo classes

### DIFF
--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_PaveFiller_6.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_PaveFiller_6.cxx
@@ -740,10 +740,6 @@ void BOPAlgo_PaveFiller::MakeBlocks(const Message_ProgressRange& theRange)
     BOPDS_FaceInfo& aFI1 = myDS->ChangeFaceInfo(nF1);
     BOPDS_FaceInfo& aFI2 = myDS->ChangeFaceInfo(nF2);
     //
-    // Reset temporary allocator to reclaim memory from previous iteration.
-    // This prevents memory accumulation when processing many Face-Face pairs.
-    // All per-iteration collections must be cleared after Reset to invalidate old pointers.
-    aTmpAllocator->Reset(false);
     aMVOnIn.Clear();
     aMVCommon.Clear();
     aMPBOnIn.Clear();
@@ -755,6 +751,7 @@ void BOPAlgo_PaveFiller::MakeBlocks(const Message_ProgressRange& theRange)
     aMVStick.Clear();
     aMVEF.Clear();
     aMVBounds.Clear();
+    aTmpAllocator->Reset(false);
     //
     myDS->SubShapesOnIn(nF1, nF2, aMVOnIn, aMVCommon, aMPBOnIn, aMPBCommon);
     myDS->SharedEdges(nF1, nF2, aLSE, aTmpAllocator);

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_Delaun.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_Delaun.cxx
@@ -2379,7 +2379,6 @@ Standard_Boolean BRepMesh_Delaun::UseEdge(const Standard_Integer /*theIndex*/)
 Handle(IMeshData::MapOfInteger) BRepMesh_Delaun::getEdgesByType(
   const BRepMesh_DegreeOfFreedom theEdgeType) const
 {
-  Handle(NCollection_IncAllocator)  anAlloc = new NCollection_IncAllocator;
   Handle(IMeshData::MapOfInteger)   aResult = new IMeshData::MapOfInteger;
   IMeshData::IteratorOfMapOfInteger anEdgeIt(myMeshData->LinksOfDomain());
 


### PR DESCRIPTION
- Moved temporary allocator reset to the end of the iteration in BOPAlgo_PaveFiller to prevent memory accumulation.
- Introduced a separate temporary allocator for per-iteration data in BOPAlgo_FillIn3DParts, enhancing memory reclamation during processing.
- Cleared face map before resetting the allocator in BOPAlgo_Tools to ensure efficient memory usage.