### PR TITLE
Coding - Fix unnecessary loop iteration in BRepLib::BuildCurve3d

### DIFF
--- a/src/ModelingAlgorithms/TKTopAlgo/BRepLib/BRepLib.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepLib/BRepLib.cxx
@@ -371,7 +371,8 @@ Standard_Boolean BRepLib::BuildCurve3d(const TopoDS_Edge&     AnEdge,
     if (!BRep_Tool::Degenerated(AnEdge))
     {
       jj = 0;
-      for (ii = 0; ii < 3; ii++)
+      // BRep_Tool::CurveOnSurface expects Index >= 1, so start from 1.
+      for (ii = 1; ii < 3; ii++)
       {
         BRep_Tool::CurveOnSurface(TopoDS::Edge(AnEdge),
                                   Curve2dPtr,


### PR DESCRIPTION
BRep_Tool::CurveOnSurface expects Index >= 1, but the loop started
  from ii = 0, resulting in a wasted iteration that always returned
  a null pointer.

Fixes #0032371