### PR TITLE
Visualization - Added visible flag to the layer settings.

### DIFF
--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_LayerList.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_LayerList.cxx
@@ -93,7 +93,8 @@ private:
     for (; myIter.More(); myIter.Next())
     {
       const occ::handle<Graphic3d_Layer>& aLayer = myIter.Value();
-      if (aLayer->IsImmediate() != myToDrawImmediate)
+      if (aLayer->IsImmediate() != myToDrawImmediate 
+          || !aLayer->LayerSettings().IsVisible())
       {
         continue;
       }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_LayerList.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_LayerList.cxx
@@ -93,8 +93,7 @@ private:
     for (; myIter.More(); myIter.Next())
     {
       const occ::handle<Graphic3d_Layer>& aLayer = myIter.Value();
-      if (aLayer->IsImmediate() != myToDrawImmediate 
-          || !aLayer->LayerSettings().IsVisible())
+      if (aLayer->IsImmediate() != myToDrawImmediate || !aLayer->LayerSettings().IsVisible())
       {
         continue;
       }

--- a/src/Visualization/TKService/GTests/FILES.cmake
+++ b/src/Visualization/TKService/GTests/FILES.cmake
@@ -7,5 +7,6 @@ set(OCCT_TKService_GTests_FILES
   Graphic3d_Aspects_Test.cxx
   Graphic3d_BndBox_Test.cxx
   Graphic3d_Flipper_Test.cxx
+  Graphic3d_ZLayerSettings_Test.cxx
   Image_VideoRecorder_Test.cxx
 )

--- a/src/Visualization/TKService/GTests/Graphic3d_ZLayerSettings_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_ZLayerSettings_Test.cxx
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <Graphic3d_ZLayerSettings.hxx>
+
+#include <sstream>
+
+//==================================================================================================
+// Default Constructor Tests
+//==================================================================================================
+
+TEST(Graphic3d_ZLayerSettingsTest, DefaultConstructor_IsVisibleTrue)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  EXPECT_TRUE(aSettings.IsVisible()) << "Default visibility should be TRUE";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, DefaultConstructor_IsImmediateFalse)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  EXPECT_FALSE(aSettings.IsImmediate()) << "Default IsImmediate should be FALSE";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, DefaultConstructor_IsRaytracableTrue)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  EXPECT_TRUE(aSettings.IsRaytracable()) << "Default IsRaytracable should be TRUE";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, DefaultConstructor_DepthTestEnabled)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  EXPECT_TRUE(aSettings.ToEnableDepthTest()) << "Default depth test should be enabled";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, DefaultConstructor_DepthWriteEnabled)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  EXPECT_TRUE(aSettings.ToEnableDepthWrite()) << "Default depth write should be enabled";
+}
+
+//==================================================================================================
+// Visibility Tests
+//==================================================================================================
+
+TEST(Graphic3d_ZLayerSettingsTest, SetVisible_False)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetVisible(Standard_False);
+  EXPECT_FALSE(aSettings.IsVisible()) << "Visibility should be FALSE after SetVisible(false)";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, SetVisible_True)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetVisible(Standard_False);
+  aSettings.SetVisible(Standard_True);
+  EXPECT_TRUE(aSettings.IsVisible()) << "Visibility should be TRUE after SetVisible(true)";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, SetVisible_Toggle)
+{
+  Graphic3d_ZLayerSettings aSettings;
+
+  // Initially visible
+  EXPECT_TRUE(aSettings.IsVisible());
+
+  // Hide
+  aSettings.SetVisible(Standard_False);
+  EXPECT_FALSE(aSettings.IsVisible());
+
+  // Show again
+  aSettings.SetVisible(Standard_True);
+  EXPECT_TRUE(aSettings.IsVisible());
+
+  // Hide again
+  aSettings.SetVisible(Standard_False);
+  EXPECT_FALSE(aSettings.IsVisible());
+}
+
+//==================================================================================================
+// Other Property Tests
+//==================================================================================================
+
+TEST(Graphic3d_ZLayerSettingsTest, SetName)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetName("TestLayer");
+  EXPECT_STREQ("TestLayer", aSettings.Name().ToCString()) << "Name should match set value";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, SetImmediate)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetImmediate(Standard_True);
+  EXPECT_TRUE(aSettings.IsImmediate()) << "IsImmediate should be TRUE after SetImmediate(true)";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, SetRaytracable)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetRaytracable(Standard_False);
+  EXPECT_FALSE(aSettings.IsRaytracable())
+    << "IsRaytracable should be FALSE after SetRaytracable(false)";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, SetEnableDepthTest)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetEnableDepthTest(Standard_False);
+  EXPECT_FALSE(aSettings.ToEnableDepthTest())
+    << "Depth test should be disabled after SetEnableDepthTest(false)";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, SetEnableDepthWrite)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetEnableDepthWrite(Standard_False);
+  EXPECT_FALSE(aSettings.ToEnableDepthWrite())
+    << "Depth write should be disabled after SetEnableDepthWrite(false)";
+}
+
+//==================================================================================================
+// DumpJson Tests
+//==================================================================================================
+
+TEST(Graphic3d_ZLayerSettingsTest, DumpJson_ContainsVisibility)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetVisible(Standard_True);
+
+  std::ostringstream aStream;
+  aSettings.DumpJson(aStream);
+
+  const std::string aJsonStr = aStream.str();
+  // Note: DumpFieldToName strips the "my" prefix, so "myVisible" becomes "Visible"
+  EXPECT_NE(std::string::npos, aJsonStr.find("Visible")) << "DumpJson should contain Visible field";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, DumpJson_VisibilityValueTrue)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetVisible(Standard_True);
+
+  std::ostringstream aStream;
+  aSettings.DumpJson(aStream);
+
+  const std::string aJsonStr = aStream.str();
+  // Check that Visible appears with value 1 (true)
+  // Note: DumpFieldToName strips the "my" prefix
+  EXPECT_NE(std::string::npos, aJsonStr.find("\"Visible\": 1"))
+    << "DumpJson should contain Visible: 1 when visible";
+}
+
+TEST(Graphic3d_ZLayerSettingsTest, DumpJson_VisibilityValueFalse)
+{
+  Graphic3d_ZLayerSettings aSettings;
+  aSettings.SetVisible(Standard_False);
+
+  std::ostringstream aStream;
+  aSettings.DumpJson(aStream);
+
+  const std::string aJsonStr = aStream.str();
+  // Note: DumpFieldToName strips the "my" prefix
+  EXPECT_NE(std::string::npos, aJsonStr.find("\"Visible\": 0"))
+    << "DumpJson should contain Visible: 0 when hidden";
+}

--- a/src/Visualization/TKService/GTests/Graphic3d_ZLayerSettings_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_ZLayerSettings_Test.cxx
@@ -58,15 +58,15 @@ TEST(Graphic3d_ZLayerSettingsTest, DefaultConstructor_DepthWriteEnabled)
 TEST(Graphic3d_ZLayerSettingsTest, SetVisible_False)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetVisible(Standard_False);
+  aSettings.SetVisible(false);
   EXPECT_FALSE(aSettings.IsVisible()) << "Visibility should be FALSE after SetVisible(false)";
 }
 
 TEST(Graphic3d_ZLayerSettingsTest, SetVisible_True)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetVisible(Standard_False);
-  aSettings.SetVisible(Standard_True);
+  aSettings.SetVisible(false);
+  aSettings.SetVisible(true);
   EXPECT_TRUE(aSettings.IsVisible()) << "Visibility should be TRUE after SetVisible(true)";
 }
 
@@ -78,15 +78,15 @@ TEST(Graphic3d_ZLayerSettingsTest, SetVisible_Toggle)
   EXPECT_TRUE(aSettings.IsVisible());
 
   // Hide
-  aSettings.SetVisible(Standard_False);
+  aSettings.SetVisible(false);
   EXPECT_FALSE(aSettings.IsVisible());
 
   // Show again
-  aSettings.SetVisible(Standard_True);
+  aSettings.SetVisible(true);
   EXPECT_TRUE(aSettings.IsVisible());
 
   // Hide again
-  aSettings.SetVisible(Standard_False);
+  aSettings.SetVisible(false);
   EXPECT_FALSE(aSettings.IsVisible());
 }
 
@@ -104,14 +104,14 @@ TEST(Graphic3d_ZLayerSettingsTest, SetName)
 TEST(Graphic3d_ZLayerSettingsTest, SetImmediate)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetImmediate(Standard_True);
+  aSettings.SetImmediate(true);
   EXPECT_TRUE(aSettings.IsImmediate()) << "IsImmediate should be TRUE after SetImmediate(true)";
 }
 
 TEST(Graphic3d_ZLayerSettingsTest, SetRaytracable)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetRaytracable(Standard_False);
+  aSettings.SetRaytracable(false);
   EXPECT_FALSE(aSettings.IsRaytracable())
     << "IsRaytracable should be FALSE after SetRaytracable(false)";
 }
@@ -119,7 +119,7 @@ TEST(Graphic3d_ZLayerSettingsTest, SetRaytracable)
 TEST(Graphic3d_ZLayerSettingsTest, SetEnableDepthTest)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetEnableDepthTest(Standard_False);
+  aSettings.SetEnableDepthTest(false);
   EXPECT_FALSE(aSettings.ToEnableDepthTest())
     << "Depth test should be disabled after SetEnableDepthTest(false)";
 }
@@ -127,7 +127,7 @@ TEST(Graphic3d_ZLayerSettingsTest, SetEnableDepthTest)
 TEST(Graphic3d_ZLayerSettingsTest, SetEnableDepthWrite)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetEnableDepthWrite(Standard_False);
+  aSettings.SetEnableDepthWrite(false);
   EXPECT_FALSE(aSettings.ToEnableDepthWrite())
     << "Depth write should be disabled after SetEnableDepthWrite(false)";
 }
@@ -139,7 +139,7 @@ TEST(Graphic3d_ZLayerSettingsTest, SetEnableDepthWrite)
 TEST(Graphic3d_ZLayerSettingsTest, DumpJson_ContainsVisibility)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetVisible(Standard_True);
+  aSettings.SetVisible(true);
 
   std::ostringstream aStream;
   aSettings.DumpJson(aStream);
@@ -152,7 +152,7 @@ TEST(Graphic3d_ZLayerSettingsTest, DumpJson_ContainsVisibility)
 TEST(Graphic3d_ZLayerSettingsTest, DumpJson_VisibilityValueTrue)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetVisible(Standard_True);
+  aSettings.SetVisible(true);
 
   std::ostringstream aStream;
   aSettings.DumpJson(aStream);
@@ -167,7 +167,7 @@ TEST(Graphic3d_ZLayerSettingsTest, DumpJson_VisibilityValueTrue)
 TEST(Graphic3d_ZLayerSettingsTest, DumpJson_VisibilityValueFalse)
 {
   Graphic3d_ZLayerSettings aSettings;
-  aSettings.SetVisible(Standard_False);
+  aSettings.SetVisible(false);
 
   std::ostringstream aStream;
   aSettings.DumpJson(aStream);

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
@@ -36,7 +36,8 @@ struct Graphic3d_ZLayerSettings
         myToEnableDepthTest(true),
         myToEnableDepthWrite(true),
         myToClearDepth(true),
-        myToRenderInDepthPrepass(true)
+        myToRenderInDepthPrepass(true),
+        myVisible(Standard_True)
   {
   }
 
@@ -175,6 +176,17 @@ struct Graphic3d_ZLayerSettings
     myPolygonOffset.Units  = -1.0f;
   }
 
+  //! Return if layer should be visible; TRUE by default.
+  //! @return TRUE if layer is visible, FALSE if layer is hidden.
+  Standard_Boolean IsVisible() const { return myVisible; }
+
+  //! Set if the layer should be visible.
+  //! @param theVisible If TRUE, the layer will be rendered; if FALSE, the layer will be hidden.
+  void SetVisible(Standard_Boolean theVisible)
+  { 
+    myVisible = theVisible;
+  }
+
   //! Dumps the content of me into the stream
   void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const
   {
@@ -196,6 +208,7 @@ struct Graphic3d_ZLayerSettings
     OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToEnableDepthWrite)
     OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToClearDepth)
     OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToRenderInDepthPrepass)
+    OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myVisible)
   }
 
 protected:
@@ -214,6 +227,7 @@ protected:
   bool            myToEnableDepthWrite;    //!< option to enable write depth values
   bool            myToClearDepth;          //!< option to clear depth values before drawing the layer
   bool            myToRenderInDepthPrepass;//!< option to render layer within depth pre-pass
+  Standard_Boolean            myVisible;               //!< option to show or hide the layer
   // clang-format on
 };
 

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
@@ -182,7 +182,7 @@ struct Graphic3d_ZLayerSettings
 
   //! Set if the layer should be visible.
   //! @param theVisible If TRUE, the layer will be rendered; if FALSE, the layer will be hidden.
-  void SetVisible(Standard_Boolean theVisible) { myVisible = theVisible; }
+  void SetVisible(const Standard_Boolean theVisible) { myVisible = theVisible; }
 
   //! Dumps the content of me into the stream
   void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
@@ -182,10 +182,7 @@ struct Graphic3d_ZLayerSettings
 
   //! Set if the layer should be visible.
   //! @param theVisible If TRUE, the layer will be rendered; if FALSE, the layer will be hidden.
-  void SetVisible(Standard_Boolean theVisible)
-  { 
-    myVisible = theVisible;
-  }
+  void SetVisible(Standard_Boolean theVisible) { myVisible = theVisible; }
 
   //! Dumps the content of me into the stream
   void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ZLayerSettings.hxx
@@ -37,7 +37,7 @@ struct Graphic3d_ZLayerSettings
         myToEnableDepthWrite(true),
         myToClearDepth(true),
         myToRenderInDepthPrepass(true),
-        myVisible(Standard_True)
+        myVisible(true)
   {
   }
 
@@ -178,11 +178,11 @@ struct Graphic3d_ZLayerSettings
 
   //! Return if layer should be visible; TRUE by default.
   //! @return TRUE if layer is visible, FALSE if layer is hidden.
-  Standard_Boolean IsVisible() const { return myVisible; }
+  bool IsVisible() const { return myVisible; }
 
   //! Set if the layer should be visible.
   //! @param theVisible If TRUE, the layer will be rendered; if FALSE, the layer will be hidden.
-  void SetVisible(const Standard_Boolean theVisible) { myVisible = theVisible; }
+  void SetVisible(const bool theVisible) { myVisible = theVisible; }
 
   //! Dumps the content of me into the stream
   void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const
@@ -224,7 +224,7 @@ protected:
   bool            myToEnableDepthWrite;    //!< option to enable write depth values
   bool            myToClearDepth;          //!< option to clear depth values before drawing the layer
   bool            myToRenderInDepthPrepass;//!< option to render layer within depth pre-pass
-  Standard_Boolean            myVisible;               //!< option to show or hide the layer
+  bool            myVisible;               //!< option to show or hide the layer
   // clang-format on
 };
 


### PR DESCRIPTION
This new flag controls if a layer is rendered or skipped.

Being able to toggle the visibility of a layer is helpful for some use cases. In my specific case, the flag is needed to render a layer with highlightings in a separate FBO for use in a post-processing effect. This flag is used to turn off the layer in normal rendering and turn it on for single-layer rendering in a different FBO.

CLA-ID: 951