### PR TITLE
Coding - Fix 0-based index in BRep_Tool::CurveOnSurface call

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -1557,7 +1557,7 @@ static TopoDS_Edge GlueEdgesWithPCurves(const TopTools_SequenceOfShape& aChain,
   TColGeom_SequenceOfSurface            SurfSeq;
   NCollection_Sequence<TopLoc_Location> LocSeq;
 
-  for (int aCurveIndex = 0;; aCurveIndex++)
+  for (int aCurveIndex = 1;; aCurveIndex++)
   {
     Handle(Geom2d_Curve) aCurve;
     Handle(Geom_Surface) aSurface;


### PR DESCRIPTION
Fixed incorrect loop index initialization in GlueEdgesWithPCurves function. The loop for iterating PCurves started from index 0, but BRep_Tool::CurveOnSurface requires 1-based indexing (returns immediately when Index < 1).

This bug caused the first PCurve to be skipped, potentially leading to incorrect edge gluing results in ShapeUpgrade_UnifySameDomain.

Changed: for (int aCurveIndex = 0;; ...) -> for (int aCurveIndex = 1;; ...)