### PR TITLE
Shape Healing - GlueEdgesWithPCurves is not valid

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -2338,7 +2338,6 @@ bool ShapeUpgrade_UnifySameDomain::MergeSubSeq(
       OutEdge = GlueEdgesWith3DCurves(theChain, VF, VL);
       return true;
     }
-    return false;
   }
   return false;
 }


### PR DESCRIPTION
GlueEdgesWithPCurves is reworked and no longer contains the dead code related to pcurves processing.
GlueEdgesWithPCurves is now renamed to GlueEdgesWith3DCurves.