### PR TITLE
Coding - Use throw instead of legacy Standard_Failure::Raise()

### DIFF
--- a/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_Geom.cxx
+++ b/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_Geom.cxx
@@ -94,7 +94,7 @@ Handle(ShapePersistent_Geom::Curve) ShapePersistent_Geom::Translate(
       }
       else
       {
-        Standard_NullObject::Raise("No mapping for the current Transient Curve");
+        throw Standard_NullObject("No mapping for the current Transient Curve");
       }
       theMap.Bind(theCurve, aPC);
     }
@@ -179,7 +179,7 @@ Handle(ShapePersistent_Geom::Surface) ShapePersistent_Geom::Translate(
       }
       else
       {
-        Standard_NullObject::Raise("No mapping for the current Transient Surface");
+        throw Standard_NullObject("No mapping for the current Transient Surface");
       }
       theMap.Bind(theSurf, aPS);
     }

--- a/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_Geom.hxx
+++ b/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_Geom.hxx
@@ -58,7 +58,7 @@ protected:
     //! Write persistent data to a file.
     void Write(StdObjMgt_WriteData&) const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::geometryBase::Write - not implemented");
+      throw Standard_NotImplemented("ShapePersistent_Geom::geometryBase::Write - not implemented");
     }
 
     //! Gets persistent child objects
@@ -67,8 +67,7 @@ protected:
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::geometryBase::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_Geom::geometryBase::PName - not implemented");
     }
   };
 
@@ -85,14 +84,13 @@ protected:
     //! Gets persistent child objects
     void PChildren(StdObjMgt_Persistent::SequenceOfPersistent&) const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::subBase::PChildren - not implemented");
+      throw Standard_NotImplemented("ShapePersistent_Geom::subBase::PChildren - not implemented");
     }
 
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::subBase::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_Geom::subBase::PName - not implemented");
     }
   };
 
@@ -112,8 +110,7 @@ protected:
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::subBase_gp::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_Geom::subBase_gp::PName - not implemented");
     }
   };
 
@@ -123,9 +120,7 @@ protected:
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise(
-        "ShapePersistent_Geom::subBase_empty::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_Geom::subBase_empty::PName - not implemented");
     }
   };
 
@@ -147,14 +142,13 @@ protected:
     //! Write persistent data to a file.
     void Write(StdObjMgt_WriteData&) const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::instance::Write - not implemented");
+      throw Standard_NotImplemented("ShapePersistent_Geom::instance::Write - not implemented");
     }
 
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_Geom::instance::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_Geom::instance::PName - not implemented");
     }
   };
 

--- a/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_Geom2d.cxx
+++ b/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_Geom2d.cxx
@@ -165,7 +165,7 @@ Handle(ShapePersistent_Geom2d::Curve) ShapePersistent_Geom2d::Translate(
       }
       else
       {
-        Standard_NullObject::Raise("No mapping for the current Transient Curve");
+        throw Standard_NullObject("No mapping for the current Transient Curve");
       }
       theMap.Bind(theCurve, aPC);
     }

--- a/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_HSequence.hxx
+++ b/src/ApplicationFramework/TKStd/ShapePersistent/ShapePersistent_HSequence.hxx
@@ -51,8 +51,7 @@ class ShapePersistent_HSequence
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise("ShapePersistent_HSequence::node::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_HSequence::node::PName - not implemented");
     }
 
     const Handle(node)& Previuos() const { return myPreviuos; }
@@ -96,9 +95,7 @@ class ShapePersistent_HSequence
     //! Returns persistent type name
     const char* PName() const override
     {
-      Standard_NotImplemented::Raise(
-        "ShapePersistent_HSequence::instance::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("ShapePersistent_HSequence::instance::PName - not implemented");
     }
 
     //! Import transient object from the persistent data.

--- a/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_HArray1.hxx
+++ b/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_HArray1.hxx
@@ -88,8 +88,7 @@ protected:
 
     const char* PNameT() const
     {
-      Standard_NotImplemented::Raise("StdLPersistent_HArray1::instance::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("StdLPersistent_HArray1::instance::PName - not implemented");
     }
 
     void PChildrenT(StdObjMgt_Persistent::SequenceOfPersistent&) const {}

--- a/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_HArray2.hxx
+++ b/src/ApplicationFramework/TKStdL/StdLPersistent/StdLPersistent_HArray2.hxx
@@ -105,8 +105,7 @@ protected:
 
     const char* PNameT() const
     {
-      Standard_NotImplemented::Raise("StdLPersistent_HArray2::instance::PName - not implemented");
-      return "";
+      throw Standard_NotImplemented("StdLPersistent_HArray2::instance::PName - not implemented");
     }
 
     void PChildrenT(StdObjMgt_Persistent::SequenceOfPersistent&) const {}

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfMaterialMap.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_GltfMaterialMap.cxx
@@ -360,9 +360,8 @@ void RWGltf_GltfMaterialMap::DefineMaterial(const XCAFPrs_Style& theStyle,
 #ifdef HAVE_RAPIDJSON
   if (myWriter == nullptr)
   {
-    Standard_ProgramError::Raise(
+    throw Standard_ProgramError(
       "RWGltf_GltfMaterialMap::DefineMaterial() should be called with JSON Writer");
-    return;
   }
 
   XCAFDoc_VisMaterialPBR aPbrMat;

--- a/src/DataExchange/TKDESTEP/StepFile/lex.step.cxx
+++ b/src/DataExchange/TKDESTEP/StepFile/lex.step.cxx
@@ -539,7 +539,7 @@ typedef step::parser::token token;
 /* skl 31.01.2002 for OCC133(OCC96,97) - incorrect
 long string in files Henri.stp and 401.stp*/
 #include <Standard_Failure.hxx>
-#define YY_FATAL_ERROR(msg) Standard_Failure::Raise(msg);
+#define YY_FATAL_ERROR(msg) throw Standard_Failure(msg);
 
 /* abv 07.06.02: force inclusion of stdlib.h on WNT to avoid warnings */
 #ifdef _MSC_VER

--- a/src/DataExchange/TKDESTEP/StepFile/step.lex
+++ b/src/DataExchange/TKDESTEP/StepFile/step.lex
@@ -64,7 +64,7 @@ typedef step::parser::token token;
 /* skl 31.01.2002 for OCC133(OCC96,97) - incorrect
 long string in files Henri.stp and 401.stp*/
 #include <Standard_Failure.hxx>
-#define YY_FATAL_ERROR(msg) Standard_Failure::Raise(msg);
+#define YY_FATAL_ERROR(msg) throw Standard_Failure(msg);
 
 /* abv 07.06.02: force inclusion of stdlib.h on WNT to avoid warnings */
 #ifdef _MSC_VER

--- a/src/DataExchange/TKXCAF/XCAFPrs/XCAFPrs_DocumentExplorer.cxx
+++ b/src/DataExchange/TKXCAF/XCAFPrs/XCAFPrs_DocumentExplorer.cxx
@@ -256,7 +256,7 @@ void XCAFPrs_DocumentExplorer::initRoot()
     if (aRootLab.IsNull())
     {
       // assert - invalid input
-      // Standard_ProgramError::Raise ("XCAFPrs_DocumentExplorer - NULL label in the input");
+      // throw Standard_ProgramError("XCAFPrs_DocumentExplorer - NULL label in the input");
       myRootIter.Next();
       continue;
     }
@@ -285,7 +285,7 @@ void XCAFPrs_DocumentExplorer::initCurrent(bool theIsAssembly)
   {
     if (myTop < 0)
     {
-      Standard_ProgramError::Raise("XCAFPrs_DocumentExplorer - internal error");
+      throw Standard_ProgramError("XCAFPrs_DocumentExplorer - internal error");
     }
     myCurrent = myNodeStack.Value(myTop);
   }
@@ -328,8 +328,7 @@ void XCAFPrs_DocumentExplorer::Next()
 {
   if (!myHasMore)
   {
-    Standard_ProgramError::Raise("XCAFPrs_DocumentExplorer::Next() - out of range");
-    return; // assert
+    throw Standard_ProgramError("XCAFPrs_DocumentExplorer::Next() - out of range");
   }
 
   if (myTop < 0)

--- a/src/FoundationClasses/TKernel/Standard/Standard_ReadBuffer.hxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_ReadBuffer.hxx
@@ -64,7 +64,7 @@ public:
 
     if (theChunkLen > sizeof(myBuffer))
     {
-      Standard_ProgramError::Raise(
+      throw Standard_ProgramError(
         "Internal error - chunk size is greater then preallocated buffer");
     }
   }

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill.cxx
@@ -863,7 +863,7 @@ void BRepFill::Axe(const TopoDS_Shape& Spine,
 void BRepFill::SearchOrigin(TopoDS_Wire& W, const gp_Pnt& P, const gp_Vec& Dir, const double Tol)
 {
   if (!W.Closed())
-    Standard_NoSuchObject::Raise("BRepFill::SearchOrigin : the wire must be closed");
+    throw Standard_NoSuchObject("BRepFill::SearchOrigin : the wire must be closed");
 
   bool          NewVertex = false;
   double        theparam  = 1.e101, angle;

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_CurveTessellator.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_CurveTessellator.cxx
@@ -65,7 +65,7 @@ void BRepMesh_CurveTessellator::init()
 {
   if (myParameters.MinSize <= 0.0)
   {
-    Standard_Failure::Raise("The structure \"myParameters\" is not initialized");
+    throw Standard_Failure("The structure \"myParameters\" is not initialized");
   }
 
   TopExp::Vertices(myEdge, myFirstVertex, myLastVertex);

--- a/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_MakeEvolved.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_MakeEvolved.cxx
@@ -43,7 +43,7 @@ BRepOffsetAPI_MakeEvolved::BRepOffsetAPI_MakeEvolved(const TopoDS_Shape&    Spin
 {
   if (Spine.ShapeType() != TopAbs_WIRE && Spine.ShapeType() != TopAbs_FACE)
   {
-    Standard_TypeMismatch::Raise("BRepOffsetAPI_MakeEvolved: face or wire is expected as a spine");
+    throw Standard_TypeMismatch("BRepOffsetAPI_MakeEvolved: face or wire is expected as a spine");
   }
   if (theIsVolume)
   {
@@ -96,7 +96,7 @@ const BRepFill_Evolved& BRepOffsetAPI_MakeEvolved::Evolved() const
 {
   if (myIsVolume)
   {
-    Standard_TypeMismatch::Raise(
+    throw Standard_TypeMismatch(
       "BRepOffsetAPI_MakeEvolved: myEvolved is accessed while in volume mode");
   }
   return myEvolved;

--- a/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor.cxx
+++ b/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor.cxx
@@ -84,7 +84,7 @@ occ::handle<Geom2d_Curve> Geom2dAdaptor::MakeCurve(const Adaptor2d_Curve2d& HC)
       }
       else
       {
-        Standard_DomainError::Raise("Geom2dAdaptor::MakeCurve, Not Geom2dAdaptor_Curve");
+        throw Standard_DomainError("Geom2dAdaptor::MakeCurve, Not Geom2dAdaptor_Curve");
       }
     }
     break;

--- a/src/ModelingData/TKGeomBase/ProjLib/ProjLib.cxx
+++ b/src/ModelingData/TKGeomBase/ProjLib/ProjLib.cxx
@@ -207,7 +207,7 @@ void ProjLib::MakePCurveOfType(const ProjLib_ProjectedCurve& PC, occ::handle<Geo
     case GeomAbs_BezierCurve:
     case GeomAbs_OtherCurve:
     default:
-      Standard_NotImplemented::Raise("ProjLib::MakePCurveOfType");
+      throw Standard_NotImplemented("ProjLib::MakePCurveOfType");
       break;
   }
 }


### PR DESCRIPTION
Replace Standard_*::Raise calls with throw statements for better exception handling