### PR TITLE
Fixed warnings that appear when building with MSVC

### DIFF
--- a/src/FoundationClasses/TKMath/MathInteg/MathInteg_Gauss.hxx
+++ b/src/FoundationClasses/TKMath/MathInteg/MathInteg_Gauss.hxx
@@ -202,7 +202,7 @@ IntegResult GaussComposite(Function& theFunc,
 
   const double aH           = (theUpper - theLower) / theNbIntervals;
   double       aSum         = 0.0;
-  int          aTotalPoints = 0;
+  size_t       aTotalPoints = 0;
 
   for (int i = 0; i < theNbIntervals; ++i)
   {

--- a/src/ModelingAlgorithms/TKBO/GTests/BOPAlgo_PaveFiller_Test.cxx
+++ b/src/ModelingAlgorithms/TKBO/GTests/BOPAlgo_PaveFiller_Test.cxx
@@ -277,7 +277,8 @@ TEST_F(BOPAlgo_PaveFillerTest, FuseConeWithRemovedPCurve_NullPCurveHandling)
     TopoDS_Wire aNewWire;
     aBuilder.MakeWire(aNewWire);
 
-    for (TopExp_Explorer aWireExp(aConicalFace, TopAbs_WIRE); aWireExp.More(); aWireExp.Next())
+    TopExp_Explorer aWireExp(aConicalFace, TopAbs_WIRE);
+    if (aWireExp.More()) // Only process first wire
     {
       const TopoDS_Wire& aWire = TopoDS::Wire(aWireExp.Current());
       for (TopExp_Explorer anEdgeExp(aWire, TopAbs_EDGE); anEdgeExp.More(); anEdgeExp.Next())
@@ -292,7 +293,6 @@ TEST_F(BOPAlgo_PaveFillerTest, FuseConeWithRemovedPCurve_NullPCurveHandling)
           aBuilder.Add(aNewWire, anEdge);
         }
       }
-      break; // Only process first wire
     }
 
     // Create new face with the modified wire


### PR DESCRIPTION
BOPAlgo_PaveFillerTest, FuseConeWithRemovedPCurve_NullPCurveHandling Warning for unreachable code since loop cannot be executed more then once.

GaussComposite
Warning about conversion from size_t to int.