### PR TITLE
Coding - Optimize double-lookup anti-patterns across codebase

### DIFF
--- a/src/ApplicationFramework/TKBinL/BinMDF/BinMDF_ADriverTable.cxx
+++ b/src/ApplicationFramework/TKBinL/BinMDF/BinMDF_ADriverTable.cxx
@@ -51,10 +51,10 @@ void BinMDF_ADriverTable::AddDerivedDriver(const occ::handle<TDF_Attribute>& the
     for (occ::handle<Standard_Type> aType = anInstanceType->Parent(); !aType.IsNull();
          aType                            = aType->Parent())
     {
-      if (myMap.IsBound(aType))
+      const occ::handle<BinMDF_ADriver>* pDriver = myMap.Seek(aType);
+      if (pDriver)
       {
-        occ::handle<BinMDF_DerivedDriver> aDriver =
-          new BinMDF_DerivedDriver(theInstance, myMap(aType));
+        occ::handle<BinMDF_DerivedDriver> aDriver = new BinMDF_DerivedDriver(theInstance, *pDriver);
         myMap.Bind(anInstanceType, aDriver);
         return;
       }
@@ -129,10 +129,10 @@ void BinMDF_ADriverTable::AssignIds(
     const occ::handle<Standard_Type>&  aType     = it.Key();
     const occ::handle<BinMDF_ADriver>& aDriver   = it.Value();
     const TCollection_AsciiString&     aTypeName = aDriver->TypeName();
-    if (aStringIdMap.IsBound(aTypeName))
+    const int*                         pId       = aStringIdMap.Seek(aTypeName);
+    if (pId)
     {
-      i = aStringIdMap(aTypeName);
-      myMapId.Bind(aType, i);
+      myMapId.Bind(aType, *pId);
     }
   }
 

--- a/src/ApplicationFramework/TKCAF/TNaming/TNaming_NamedShape.cxx
+++ b/src/ApplicationFramework/TKCAF/TNaming/TNaming_NamedShape.cxx
@@ -635,12 +635,13 @@ void TNaming_Builder::Generated(const TopoDS_Shape& newShape)
   TNaming_RefShape* pos = nullptr;
   TNaming_RefShape* pns;
 
-  if (myShapes->myMap.IsBound(newShape))
+  TNaming_RefShape** ppns = myShapes->myMap.ChangeSeek(newShape);
+  if (ppns)
   {
 #ifdef OCCT_DEBUG_BUILDER
     std::cout << "TNaming_Builder::Generate : the shape is already in the attribute" << std::endl;
 #endif
-    pns = myShapes->myMap.ChangeFind(newShape);
+    pns = *ppns;
     if (pns->FirstUse()->myAtt == myAtt.operator->())
     {
       throw Standard_ConstructionError("TNaming_Builder::Generate");
@@ -674,8 +675,9 @@ void TNaming_Builder::Delete(const TopoDS_Shape& oldShape)
   TNaming_RefShape* pns;
   TNaming_RefShape* pos;
 
-  if (myShapes->myMap.IsBound(oldShape))
-    pos = myShapes->myMap.ChangeFind(oldShape);
+  TNaming_RefShape** ppos = myShapes->myMap.ChangeSeek(oldShape);
+  if (ppos)
+    pos = *ppos;
   else
   {
 #ifdef OCCT_DEBUG_BUILDER
@@ -714,23 +716,25 @@ void TNaming_Builder::Generated(const TopoDS_Shape& oldShape, const TopoDS_Shape
 #endif
     return;
   }
-  TNaming_RefShape* pos;
-  if (!myShapes->myMap.IsBound(oldShape))
+  TNaming_RefShape*  pos;
+  TNaming_RefShape** ppos = myShapes->myMap.ChangeSeek(oldShape);
+  if (!ppos)
   {
     pos = new TNaming_RefShape(oldShape);
     myShapes->myMap.Bind(oldShape, pos);
   }
   else
-    pos = myShapes->myMap.ChangeFind(oldShape);
+    pos = *ppos;
 
-  TNaming_RefShape* pns;
-  if (!myShapes->myMap.IsBound(newShape))
+  TNaming_RefShape*  pns;
+  TNaming_RefShape** ppns = myShapes->myMap.ChangeSeek(newShape);
+  if (!ppns)
   {
     pns = new TNaming_RefShape(newShape);
     myShapes->myMap.Bind(newShape, pns);
   }
   else
-    pns = myShapes->myMap.ChangeFind(newShape);
+    pns = *ppns;
 
   TNaming_Node* pdn = new TNaming_Node(pos, pns);
   myAtt->Add(pdn);
@@ -757,23 +761,25 @@ void TNaming_Builder::Modify(const TopoDS_Shape& oldShape, const TopoDS_Shape& n
 #endif
     return;
   }
-  TNaming_RefShape* pos;
-  if (!myShapes->myMap.IsBound(oldShape))
+  TNaming_RefShape*  pos;
+  TNaming_RefShape** ppos = myShapes->myMap.ChangeSeek(oldShape);
+  if (!ppos)
   {
     pos = new TNaming_RefShape(oldShape);
     myShapes->myMap.Bind(oldShape, pos);
   }
   else
-    pos = myShapes->myMap.ChangeFind(oldShape);
+    pos = *ppos;
 
-  TNaming_RefShape* pns;
-  if (!myShapes->myMap.IsBound(newShape))
+  TNaming_RefShape*  pns;
+  TNaming_RefShape** ppns = myShapes->myMap.ChangeSeek(newShape);
+  if (!ppns)
   {
     pns = new TNaming_RefShape(newShape);
     myShapes->myMap.Bind(newShape, pns);
   }
   else
-    pns = myShapes->myMap.ChangeFind(newShape);
+    pns = *ppns;
 
   TNaming_Node* pdn = new TNaming_Node(pos, pns);
   myAtt->Add(pdn);
@@ -793,23 +799,25 @@ void TNaming_Builder::Select(const TopoDS_Shape& S, const TopoDS_Shape& InS)
       throw Standard_ConstructionError("TNaming_Builder : not same evolution");
   }
 
-  TNaming_RefShape* pos;
-  if (!myShapes->myMap.IsBound(InS))
+  TNaming_RefShape*  pos;
+  TNaming_RefShape** ppos = myShapes->myMap.ChangeSeek(InS);
+  if (!ppos)
   {
     pos = new TNaming_RefShape(InS);
     myShapes->myMap.Bind(InS, pos);
   }
   else
-    pos = myShapes->myMap.ChangeFind(InS);
+    pos = *ppos;
 
-  TNaming_RefShape* pns;
-  if (!myShapes->myMap.IsBound(S))
+  TNaming_RefShape*  pns;
+  TNaming_RefShape** ppns = myShapes->myMap.ChangeSeek(S);
+  if (!ppns)
   {
     pns = new TNaming_RefShape(S);
     myShapes->myMap.Bind(S, pns);
   }
   else
-    pns = myShapes->myMap.ChangeFind(S);
+    pns = *ppns;
 
   TNaming_Node* pdn = new TNaming_Node(pos, pns);
   myAtt->Add(pdn);

--- a/src/ApplicationFramework/TKCAF/TNaming/TNaming_Translator.cxx
+++ b/src/ApplicationFramework/TKCAF/TNaming/TNaming_Translator.cxx
@@ -70,10 +70,8 @@ const NCollection_DataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>& 
 
 const TopoDS_Shape TNaming_Translator::Copied(const TopoDS_Shape& aShape) const
 {
-  TopoDS_Shape aResult;
-  if (myDataMapOfResults.IsBound(aShape))
-    aResult = myDataMapOfResults.Find(aShape);
-  return aResult;
+  const TopoDS_Shape* pResult = myDataMapOfResults.Seek(aShape);
+  return pResult ? *pResult : TopoDS_Shape();
 }
 
 //=================================================================================================

--- a/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
+++ b/src/ApplicationFramework/TKStd/StdStorage/StdStorage_RootData.cxx
@@ -152,13 +152,8 @@ occ::handle<NCollection_HSequence<occ::handle<StdStorage_Root>>> StdStorage_Root
 
 occ::handle<StdStorage_Root> StdStorage_RootData::Find(const TCollection_AsciiString& aName) const
 {
-  occ::handle<StdStorage_Root> p;
-  if (myObjects.Contains(aName))
-  {
-    p = myObjects.FindFromKey(aName);
-  }
-
-  return p;
+  const occ::handle<StdStorage_Root>* pRoot = myObjects.Seek(aName);
+  return pRoot ? *pRoot : occ::handle<StdStorage_Root>();
 }
 
 bool StdStorage_RootData::IsRoot(const TCollection_AsciiString& aName) const
@@ -168,9 +163,10 @@ bool StdStorage_RootData::IsRoot(const TCollection_AsciiString& aName) const
 
 void StdStorage_RootData::RemoveRoot(const TCollection_AsciiString& aName)
 {
-  if (myObjects.Contains(aName))
+  occ::handle<StdStorage_Root>* pRoot = myObjects.ChangeSeek(aName);
+  if (pRoot)
   {
-    myObjects.ChangeFromKey(aName)->myRef = 0;
+    (*pRoot)->myRef = 0;
     myObjects.RemoveKey(aName);
     int aRef = 1;
     for (NCollection_IndexedDataMap<TCollection_AsciiString, occ::handle<StdStorage_Root>>::Iterator

--- a/src/ApplicationFramework/TKVCAF/TPrsStd/TPrsStd_DriverTable.cxx
+++ b/src/ApplicationFramework/TKVCAF/TPrsStd/TPrsStd_DriverTable.cxx
@@ -102,9 +102,10 @@ bool TPrsStd_DriverTable::AddDriver(const Standard_GUID&               guid,
 bool TPrsStd_DriverTable::FindDriver(const Standard_GUID&         guid,
                                      occ::handle<TPrsStd_Driver>& driver) const
 {
-  if (myDrivers.IsBound(guid))
+  const occ::handle<TPrsStd_Driver>* pDriver = myDrivers.Seek(guid);
+  if (pDriver)
   {
-    driver = myDrivers.Find(guid);
+    driver = *pDriver;
     return true;
   }
   return false;

--- a/src/DataExchange/TKDEIGES/IGESControl/IGESControl_Reader.cxx
+++ b/src/DataExchange/TKDEIGES/IGESControl/IGESControl_Reader.cxx
@@ -148,10 +148,7 @@ void IGESControl_Reader::PrintTransferInfo(const IFSelect_PrintFail  failsonly,
         char                                mess[300];
         const occ::handle<Transfer_Binder>& aBinder = iterTrans.Value();
         Sprintf(mess, "\t%s", aBinder->ResultTypeName());
-        if (aMapCountResult.IsBound(mess))
-          aMapCountResult.ChangeFind(mess)++;
-        else
-          aMapCountResult.Bind(mess, 1);
+        (*aMapCountResult.TryBound(mess, 0))++;
       }
       // Init for dicoCountMapping for IFSelect_Mapping
       else if (mode == IFSelect_Mapping)
@@ -167,10 +164,7 @@ void IGESControl_Reader::PrintTransferInfo(const IFSelect_PrintFail  failsonly,
                 "%d",
                 aBinder->ResultTypeName());
         // std::cout << mess << std::endl;
-        if (aMapCountMapping.IsBound(mess))
-          aMapCountMapping.ChangeFind(mess)++;
-        else
-          aMapCountMapping.Bind(mess, 1);
+        (*aMapCountMapping.TryBound(mess, 0))++;
       }
     }
 
@@ -189,38 +183,25 @@ void IGESControl_Reader::PrintTransferInfo(const IFSelect_PrintFail  failsonly,
       for (i = 1; (failsonly == IFSelect_FailAndWarn) && (i <= nw); i++)
       {
         Sprintf(mess, "\t W\t%d\t%d\t%s", type, form, aCheck->CWarning(i));
-        if (aMapCount.IsBound(mess))
-          aMapCount.ChangeFind(mess)++;
-        else
-          aMapCount.Bind(mess, 1);
-
-        occ::handle<NCollection_HSequence<int>> alist;
-        if (aMapList.IsBound(mess))
-          alist = aMapList.ChangeFind(mess);
-        else
+        (*aMapCount.TryBound(mess, 0))++;
+        occ::handle<NCollection_HSequence<int>>* pList = aMapList.ChangeSeek(mess);
+        if (!pList)
         {
-          alist = new NCollection_HSequence<int>();
-          aMapList.Bind(mess, alist);
+          pList = aMapList.Bound(mess, new NCollection_HSequence<int>());
         }
-        alist->Append(model->Number(igesEnt) * 2 - 1);
+        (*pList)->Append(model->Number(igesEnt) * 2 - 1);
       }
       for (i = 1; i <= nf; i++)
       {
         Sprintf(mess, "\t F\t%d\t%d\t%s", type, form, aCheck->CFail(i));
         // TF << mess << std::endl;
-        if (aMapCount.IsBound(mess))
-          aMapCount.ChangeFind(mess)++;
-        else
-          aMapCount.Bind(mess, 1);
-        occ::handle<NCollection_HSequence<int>> alist;
-        if (aMapList.IsBound(mess))
-          alist = aMapList.ChangeFind(mess);
-        else
+        (*aMapCount.TryBound(mess, 0))++;
+        occ::handle<NCollection_HSequence<int>>* pList = aMapList.ChangeSeek(mess);
+        if (!pList)
         {
-          alist = new NCollection_HSequence<int>();
-          aMapList.Bind(mess, alist);
+          pList = aMapList.Bound(mess, new NCollection_HSequence<int>());
         }
-        alist->Append(model->Number(igesEnt) * 2 - 1);
+        (*pList)->Append(model->Number(igesEnt) * 2 - 1);
       }
       nbWarn += nw;
       nbFail += nf;
@@ -337,10 +318,7 @@ void IGESControl_Reader::PrintTransferInfo(const IFSelect_PrintFail  failsonly,
                       "%d",
                       "Failed");
               // std::cout << mess << std::endl;
-              if (aMapCountMapping.IsBound(mess))
-                aMapCountMapping.ChangeFind(mess)++;
-              else
-                aMapCountMapping.Bind(mess, 1);
+              (*aMapCountMapping.TryBound(mess, 0))++;
             }
           }
         }

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.cxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.cxx
@@ -888,10 +888,7 @@ TDF_Label STEPCAFControl_Reader::AddShape(
     if (!subL.IsNull())
     {
       TDF_Label instL = STool->AddComponent(L, subL, it.Value().Location());
-      if (!myMap.IsBound(it.Value()))
-      {
-        myMap.Bind(it.Value(), instL);
-      }
+      myMap.TryBound(it.Value(), instL);
     }
   }
   if (SHAS.Length() > 0)
@@ -5534,10 +5531,11 @@ void STEPCAFControl_Reader::ExpandSubShapes(
     if (aReprItems.Length() == 0)
       continue;
 
-    if (!myMap.IsBound(aRootShape))
+    const TDF_Label* pRootLab = myMap.Seek(aRootShape);
+    if (!pRootLab)
       continue;
 
-    TDF_Label aRootLab = myMap.Find(aRootShape);
+    TDF_Label aRootLab = *pRootLab;
     // Do not add subshapes to assembly,
     // they will be processed with corresponding Shape_Product_Definition of necessary part.
     if (ShapeTool->IsAssembly(aRootLab))

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Writer.cxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Writer.cxx
@@ -965,9 +965,10 @@ bool STEPCAFControl_Writer::writeExternRefs(const occ::handle<XSControl_WorkSess
       continue; // should never be
 
     // find SDR
-    if (!myLabels.IsBound(aLab))
+    const TopoDS_Shape* pShape = myLabels.Seek(aLab);
+    if (!pShape)
       continue; // not recorded as translated, skip
-    TopoDS_Shape aShape = myLabels.Find(aLab);
+    TopoDS_Shape aShape = *pShape;
 
     occ::handle<StepShape_ShapeDefinitionRepresentation> aSDR;
     occ::handle<TransferBRep_ShapeMapper> mapper = TransferBRep::ShapeMapper(aFP, aShape);
@@ -1563,7 +1564,8 @@ bool STEPCAFControl_Writer::writeNames(const occ::handle<XSControl_WorkSession>&
   {
     const TDF_Label& aLabel = aLabelIter.Value();
     // find target STEP entity for the current shape
-    if (!myLabels.IsBound(aLabel))
+    const TopoDS_Shape* pShape = myLabels.Seek(aLabel);
+    if (!pShape)
       continue; // not recorded as translated, skip
     // get name
     occ::handle<TCollection_HAsciiString> aHName = new TCollection_HAsciiString;
@@ -1571,7 +1573,7 @@ bool STEPCAFControl_Writer::writeNames(const occ::handle<XSControl_WorkSession>&
     {
       continue;
     }
-    const TopoDS_Shape&                                        aShape = myLabels.Find(aLabel);
+    const TopoDS_Shape&                                        aShape = *pShape;
     occ::handle<StepShape_ShapeDefinitionRepresentation>       aSDR;
     occ::handle<StepShape_ContextDependentShapeRepresentation> aCDSR;
     bool isComponent = XCAFDoc_ShapeTool::IsComponent(aLabel) || myPureRefLabels.IsBound(aLabel);
@@ -1666,10 +1668,11 @@ bool STEPCAFControl_Writer::writeMetadataForLabel(const occ::handle<XSControl_Wo
     return false; // No metadata on this label
 
   // Find target STEP entity for the current shape:
-  if (!myLabels.IsBound(theLabel))
+  const TopoDS_Shape* pShape = myLabels.Seek(theLabel);
+  if (!pShape)
     return false; // Not recorded as translated, skip
 
-  const TopoDS_Shape&                                  aShape = myLabels.Find(theLabel);
+  const TopoDS_Shape&                                  aShape = *pShape;
   occ::handle<StepShape_ShapeDefinitionRepresentation> aSDR;
   const occ::handle<TransferBRep_ShapeMapper> aMapper = TransferBRep::ShapeMapper(aFP, aShape);
   if (!aFP->FindTypedTransient(aMapper,

--- a/src/DataExchange/TKDESTEP/StepAP214/StepAP214_Protocol.cxx
+++ b/src/DataExchange/TKDESTEP/StepAP214/StepAP214_Protocol.cxx
@@ -1579,10 +1579,8 @@ StepAP214_Protocol::StepAP214_Protocol()
 
 int StepAP214_Protocol::TypeNumber(const occ::handle<Standard_Type>& atype) const
 {
-  if (types.IsBound(atype))
-    return types.Find(atype);
-  else
-    return 0;
+  const int* pType = types.Seek(atype);
+  return pType ? *pType : 0;
 }
 
 //=================================================================================================

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_ShapeConvert.cxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_ShapeConvert.cxx
@@ -112,9 +112,10 @@ occ::handle<VrmlData_Geometry> VrmlData_ShapeConvert::makeTShapeNode(
       {
         occ::handle<Poly_Triangulation> aTri = BRep_Tool::Triangulation(aFace, theLoc);
 
-        if (myRelMap.IsBound(aTestedShape))
+        const occ::handle<VrmlData_Geometry>* pNode = myRelMap.Seek(aTestedShape);
+        if (pNode)
         {
-          aTShapeNode = myRelMap(aTestedShape);
+          aTShapeNode = *pNode;
           break;
         }
 
@@ -123,8 +124,9 @@ occ::handle<VrmlData_Geometry> VrmlData_ShapeConvert::makeTShapeNode(
           TopoDS_Shape aTestedShapeRev = aTestedShape;
           aTestedShapeRev.Orientation(isReverse ? TopAbs_FORWARD : TopAbs_REVERSED);
           occ::handle<VrmlData_IndexedFaceSet> aFaceSetToReuse;
-          if (myRelMap.IsBound(aTestedShapeRev))
-            aFaceSetToReuse = occ::down_cast<VrmlData_IndexedFaceSet>(myRelMap(aTestedShapeRev));
+          const occ::handle<VrmlData_Geometry>* pRevNode = myRelMap.Seek(aTestedShapeRev);
+          if (pRevNode)
+            aFaceSetToReuse = occ::down_cast<VrmlData_IndexedFaceSet>(*pRevNode);
 
           occ::handle<VrmlData_Coordinate> aCoordToReuse;
           if (!aFaceSetToReuse.IsNull())
@@ -149,17 +151,19 @@ occ::handle<VrmlData_Geometry> VrmlData_ShapeConvert::makeTShapeNode(
       const TopoDS_Edge& aEdge = TopoDS::Edge(theShape);
       if (!aEdge.IsNull())
       {
-        if (myRelMap.IsBound(aTestedShape))
+        const occ::handle<VrmlData_Geometry>* pEdgeNode = myRelMap.Seek(aTestedShape);
+        if (pEdgeNode)
         {
-          aTShapeNode = myRelMap(aTestedShape);
+          aTShapeNode = *pEdgeNode;
           break;
         }
         // Check the presence of reversly oriented Edge. It can also be used
         // because we do not distinguish the orientation for edges.
         aTestedShape.Orientation(isReverse ? TopAbs_FORWARD : TopAbs_REVERSED);
-        if (myRelMap.IsBound(aTestedShape))
+        pEdgeNode = myRelMap.Seek(aTestedShape);
+        if (pEdgeNode)
         {
-          aTShapeNode = myRelMap(aTestedShape);
+          aTShapeNode = *pEdgeNode;
           break;
         }
 

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_ShapeConvert.cxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_ShapeConvert.cxx
@@ -123,7 +123,7 @@ occ::handle<VrmlData_Geometry> VrmlData_ShapeConvert::makeTShapeNode(
         {
           TopoDS_Shape aTestedShapeRev = aTestedShape;
           aTestedShapeRev.Orientation(isReverse ? TopAbs_FORWARD : TopAbs_REVERSED);
-          occ::handle<VrmlData_IndexedFaceSet> aFaceSetToReuse;
+          occ::handle<VrmlData_IndexedFaceSet>  aFaceSetToReuse;
           const occ::handle<VrmlData_Geometry>* pRevNode = myRelMap.Seek(aTestedShapeRev);
           if (pRevNode)
             aFaceSetToReuse = occ::down_cast<VrmlData_IndexedFaceSet>(*pRevNode);

--- a/src/DataExchange/TKRWMesh/RWMesh/RWMesh_MaterialMap.cxx
+++ b/src/DataExchange/TKRWMesh/RWMesh/RWMesh_MaterialMap.cxx
@@ -50,9 +50,10 @@ RWMesh_MaterialMap::~RWMesh_MaterialMap() = default;
 
 TCollection_AsciiString RWMesh_MaterialMap::AddMaterial(const XCAFPrs_Style& theStyle)
 {
-  if (myStyles.IsBound1(theStyle))
+  const TCollection_AsciiString* pMatKey = myStyles.Seek1(theStyle);
+  if (pMatKey)
   {
-    return myStyles.Find1(theStyle);
+    return *pMatKey;
   }
 
   TCollection_AsciiString aMatKey, aMatName, aMatNameSuffix;

--- a/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_ShapeTool.cxx
+++ b/src/DataExchange/TKXCAF/XCAFDoc/XCAFDoc_ShapeTool.cxx
@@ -137,17 +137,19 @@ bool XCAFDoc_ShapeTool::SearchUsingMap(const TopoDS_Shape& S,
                                        const bool          findSubShape) const
 {
 
-  if (myShapeLabels.IsBound(S))
+  const TDF_Label* pLabel = myShapeLabels.Seek(S);
+  if (pLabel)
   {
-    L = myShapeLabels.Find(S);
+    L = *pLabel;
     return true;
   }
   TopoDS_Shape    S0 = S;
   TopLoc_Location loc;
   S0.Location(loc);
-  if (myShapeLabels.IsBound(S0))
+  pLabel = myShapeLabels.Seek(S0);
+  if (pLabel)
   {
-    TDF_Label                       L1 = myShapeLabels.Find(S0);
+    TDF_Label                       L1 = *pLabel;
     NCollection_Sequence<TDF_Label> Labels;
     if (GetUsers(L1, Labels, true))
     {
@@ -170,14 +172,16 @@ bool XCAFDoc_ShapeTool::SearchUsingMap(const TopoDS_Shape& S,
 
   if (hasSimpleShapes)
   {
-    if (mySimpleShapes.IsBound(S))
+    pLabel = mySimpleShapes.Seek(S);
+    if (pLabel)
     {
-      L = mySimpleShapes.Find(S);
+      L = *pLabel;
       return true;
     }
-    if (mySimpleShapes.IsBound(S0))
+    pLabel = mySimpleShapes.Seek(S0);
+    if (pLabel)
     {
-      L = mySimpleShapes.Find(S0);
+      L = *pLabel;
       return true;
     }
   }
@@ -407,10 +411,7 @@ void XCAFDoc_ShapeTool::SetShape(const TDF_Label& L, const TopoDS_Shape& S)
   //  }
   A->SetShape(S);
 
-  if (!myShapeLabels.IsBound(S))
-  {
-    myShapeLabels.Bind(S, L);
-  }
+  myShapeLabels.TryBound(S, L);
 }
 
 //=================================================================================================
@@ -605,10 +606,7 @@ TDF_Label XCAFDoc_ShapeTool::AddShape(const TopoDS_Shape& theShape,
 
   TDF_Label L = addShape(S, makeAssembly);
 
-  if (!myShapeLabels.IsBound(S))
-  {
-    myShapeLabels.Bind(S, L);
-  }
+  myShapeLabels.TryBound(S, L);
 
   return L;
 
@@ -922,8 +920,7 @@ TDF_Label XCAFDoc_ShapeTool::AddComponent(const TDF_Label&       assembly,
   TopoDS_Shape aShape;
   if (GetShape(L, aShape))
   {
-    if (!myShapeLabels.IsBound(aShape))
-      myShapeLabels.Bind(aShape, L);
+    myShapeLabels.TryBound(aShape, L);
   }
 
   return L;
@@ -1120,10 +1117,8 @@ TDF_Label XCAFDoc_ShapeTool::FindMainShapeUsingMap(const TopoDS_Shape& sub) cons
   //   TDF_Label L = myNotAssemblies.Value(i);
   //   if(IsSubShape(L,sub)) return L;
   // }
-  if (mySubShapes.IsBound(sub))
-    return mySubShapes.Find(sub);
-  TDF_Label L0;
-  return L0;
+  const TDF_Label* pLabel = mySubShapes.Seek(sub);
+  return pLabel ? *pLabel : TDF_Label();
 }
 
 //=================================================================================================

--- a/src/DataExchange/TKXSBase/IFSelect/IFSelect_SignatureList.cxx
+++ b/src/DataExchange/TKXSBase/IFSelect/IFSelect_SignatureList.cxx
@@ -64,10 +64,7 @@ void IFSelect_SignatureList::Add(const occ::handle<Standard_Transient>& ent, con
     return;
   }
 
-  if (thedicount.Contains(sign))
-    thedicount.ChangeFromKey(sign)++;
-  else
-    thedicount.Add(sign, 1);
+  (*thedicount.Bound(sign, 0))++;
 
   if (thelistat)
   {

--- a/src/DataExchange/TKXSBase/Interface/Interface_MSG.cxx
+++ b/src/DataExchange/TKXSBase/Interface/Interface_MSG.cxx
@@ -197,12 +197,7 @@ const char* Interface_MSG::Translated(const char* key)
     std::cout << " **  Interface_MSG:Translate ?? " << key << "  **" << std::endl;
   if (therec)
   {
-    if (thelist.IsBound(key))
-    {
-      thelist.ChangeFind(key)++;
-    }
-    else
-      thelist.Bind(key, 1);
+    (*thelist.TryBound(key, 0))++;
   }
   if (theraise)
     throw Standard_DomainError("Interface_MSG : Translate");
@@ -213,15 +208,8 @@ void Interface_MSG::Record(const char* key, const char* item)
 {
   occ::handle<TCollection_HAsciiString> dup;
   occ::handle<TCollection_HAsciiString> str = new TCollection_HAsciiString(item);
-  if (thedic.IsBound(key))
-  {
-    thedic.ChangeFind(key) = str;
-  }
-  else
-  {
-    thedic.Bind(key, str);
-    return;
-  }
+  if (thedic.Bind(key, str))
+    return; // newly added, skip the rest
   if (theprint)
     std::cout << " **  Interface_MSG:Record ?? " << key << " ** " << item << "  **" << std::endl;
   if (therec)

--- a/src/DataExchange/TKXSBase/MoniTool/MoniTool_Timer.cxx
+++ b/src/DataExchange/TKXSBase/MoniTool/MoniTool_Timer.cxx
@@ -66,8 +66,9 @@ occ::handle<MoniTool_Timer> MoniTool_Timer::Timer(const char* name)
   //  AmendAccess();
   NCollection_DataMap<const char*, occ::handle<MoniTool_Timer>, Standard_CStringHasher>& dic =
     Dictionary();
-  if (dic.IsBound(name))
-    return dic.Find(name);
+  const occ::handle<MoniTool_Timer>* pTimer = dic.Seek(name);
+  if (pTimer)
+    return *pTimer;
   occ::handle<MoniTool_Timer> MT = new MoniTool_Timer;
   MT->Timer().Reset();
   dic.Bind(name, MT);

--- a/src/DataExchange/TKXSBase/XSAlgo/XSAlgo_ShapeProcessor.cxx
+++ b/src/DataExchange/TKXSBase/XSAlgo/XSAlgo_ShapeProcessor.cxx
@@ -725,10 +725,7 @@ void XSAlgo_ShapeProcessor::SetShapeFixParameters(
        aParamIter.More();
        aParamIter.Next())
   {
-    if (!theTargetParameterMap.IsBound(aParamIter.Key()))
-    {
-      theTargetParameterMap.Bind(aParamIter.Key(), aParamIter.Value());
-    }
+    theTargetParameterMap.TryBound(aParamIter.Key(), aParamIter.Value());
   }
 }
 
@@ -770,10 +767,7 @@ void XSAlgo_ShapeProcessor::SetParameter(const char*                          th
   }
   else
   {
-    if (!theMap.IsBound(theKey))
-    {
-      theMap.Bind(theKey, theValue);
-    }
+    theMap.TryBound(theKey, theValue);
   }
 }
 

--- a/src/DataExchange/TKXSBase/XSControl/XSControl_TransferReader.cxx
+++ b/src/DataExchange/TKXSBase/XSControl/XSControl_TransferReader.cxx
@@ -185,9 +185,10 @@ bool XSControl_TransferReader::IsRecorded(const occ::handle<Standard_Transient>&
   int num = myModel->Number(ent);
   if (num == 0)
     return false;
-  if (!myResults.IsBound(num))
+  const occ::handle<Standard_Transient>* pRes = myResults.Seek(num);
+  if (!pRes)
     return false;
-  return (myResults.Find(num)->DynamicType() == STANDARD_TYPE(Transfer_ResultFromModel));
+  return ((*pRes)->DynamicType() == STANDARD_TYPE(Transfer_ResultFromModel));
 }
 
 //=================================================================================================
@@ -199,9 +200,10 @@ bool XSControl_TransferReader::HasResult(const occ::handle<Standard_Transient>& 
   int num = myModel->Number(ent);
   if (num == 0)
     return false;
-  if (!myResults.IsBound(num))
+  const occ::handle<Standard_Transient>* pRes = myResults.Seek(num);
+  if (!pRes)
     return false;
-  DeclareAndCast(Transfer_ResultFromModel, fr, myResults.Find(num));
+  DeclareAndCast(Transfer_ResultFromModel, fr, *pRes);
   if (fr.IsNull())
     return false;
   return fr->HasResult();
@@ -219,9 +221,9 @@ occ::handle<NCollection_HSequence<occ::handle<Standard_Transient>>> XSControl_Tr
   int i, nb = myModel->NbEntities();
   for (i = 1; i <= nb; i++)
   {
-    if (myResults.IsBound(i))
-      if (!myResults.Find(i).IsNull())
-        li->Append(myModel->Value(i));
+    const occ::handle<Standard_Transient>* pRes = myResults.Seek(i);
+    if (pRes && !(*pRes).IsNull())
+      li->Append(myModel->Value(i));
   }
   return li;
 }
@@ -248,9 +250,10 @@ bool XSControl_TransferReader::IsSkipped(const occ::handle<Standard_Transient>& 
   int num = myModel->Number(ent);
   if (num == 0)
     return false;
-  if (!myResults.IsBound(num))
+  const occ::handle<Standard_Transient>* pRes = myResults.Seek(num);
+  if (!pRes)
     return false;
-  return (myResults.Find(num)->DynamicType() != STANDARD_TYPE(Transfer_ResultFromModel));
+  return ((*pRes)->DynamicType() != STANDARD_TYPE(Transfer_ResultFromModel));
 }
 
 //=================================================================================================
@@ -262,9 +265,8 @@ bool XSControl_TransferReader::IsMarked(const occ::handle<Standard_Transient>& e
   int num = myModel->Number(ent);
   if (num == 0)
     return false;
-  if (!myResults.IsBound(num))
-    return false;
-  if (myResults.Find(num).IsNull())
+  const occ::handle<Standard_Transient>* pRes = myResults.Seek(num);
+  if (!pRes || (*pRes).IsNull())
     return false;
   return true;
 }
@@ -282,9 +284,10 @@ occ::handle<Transfer_ResultFromModel> XSControl_TransferReader::FinalResult(
   int num = myModel->Number(ent);
   if (num == 0)
     return res;
-  if (!myResults.IsBound(num))
+  const occ::handle<Standard_Transient>* pRes = myResults.Seek(num);
+  if (!pRes)
     return res;
-  res = GetCasted(Transfer_ResultFromModel, myResults.Find(num));
+  res = GetCasted(Transfer_ResultFromModel, *pRes);
   return res;
 }
 
@@ -317,9 +320,10 @@ occ::handle<Transfer_ResultFromModel> XSControl_TransferReader::ResultFromNumber
   occ::handle<Transfer_ResultFromModel> res;
   if (num < 1 || num > myModel->NbEntities())
     return res;
-  if (!myResults.IsBound(num))
+  const occ::handle<Standard_Transient>* pRes = myResults.Seek(num);
+  if (!pRes)
     return res;
-  res = GetCasted(Transfer_ResultFromModel, myResults.Find(num));
+  res = GetCasted(Transfer_ResultFromModel, *pRes);
   return res;
 }
 
@@ -375,13 +379,14 @@ bool XSControl_TransferReader::ClearResult(const occ::handle<Standard_Transient>
   int num = myModel->Number(ent);
   if (num == 0)
     return false;
-  if (!myResults.IsBound(num))
+  occ::handle<Standard_Transient>* pRes = myResults.ChangeSeek(num);
+  if (!pRes)
     return false;
   if (mode < 0)
-    myResults.ChangeFind(num).Nullify();
+    pRes->Nullify();
   else
   {
-    DeclareAndCast(Transfer_ResultFromModel, resu, myResults.Find(num));
+    DeclareAndCast(Transfer_ResultFromModel, resu, *pRes);
     if (resu.IsNull())
       return false;
     resu->Strip(mode);

--- a/src/Draw/TKDCAF/DNaming/DNaming.cxx
+++ b/src/Draw/TKDCAF/DNaming/DNaming.cxx
@@ -195,12 +195,10 @@ static void LoadC0Vertices(const TopoDS_Shape& S, const occ::handle<TDF_TagSourc
     TopExp_Explorer     explV(aFace, TopAbs_VERTEX);
     for (; explV.More(); explV.Next())
     {
-      const TopoDS_Shape& aVertex = explV.Current();
-      if (!vertexNaborFaces.IsBound(aVertex))
-        vertexNaborFaces.Bind(aVertex, empty);
-      bool                                     faceIsNew = true;
-      NCollection_List<TopoDS_Shape>::Iterator itrF(vertexNaborFaces.Find(aVertex));
-      for (; itrF.More(); itrF.Next())
+      const TopoDS_Shape&            aVertex   = explV.Current();
+      NCollection_List<TopoDS_Shape>* pList     = vertexNaborFaces.TryBound(aVertex, empty);
+      bool                            faceIsNew = true;
+      for (NCollection_List<TopoDS_Shape>::Iterator itrF(*pList); itrF.More(); itrF.Next())
       {
         if (itrF.Value().IsSame(aFace))
         {
@@ -210,7 +208,7 @@ static void LoadC0Vertices(const TopoDS_Shape& S, const occ::handle<TDF_TagSourc
       }
       if (faceIsNew)
       {
-        vertexNaborFaces.ChangeFind(aVertex).Append(aFace);
+        pList->Append(aFace);
       }
     }
   }
@@ -245,12 +243,10 @@ static void LoadC0Edges(const TopoDS_Shape& S, const occ::handle<TDF_TagSource>&
     TopExp_Explorer     explV(aFace, TopAbs_EDGE);
     for (; explV.More(); explV.Next())
     {
-      const TopoDS_Shape& anEdge = explV.Current();
-      if (!edgeNaborFaces.IsBound(anEdge))
-        edgeNaborFaces.Bind(anEdge, empty);
-      bool                                     faceIsNew = true;
-      NCollection_List<TopoDS_Shape>::Iterator itrF(edgeNaborFaces.Find(anEdge));
-      for (; itrF.More(); itrF.Next())
+      const TopoDS_Shape&             anEdge    = explV.Current();
+      NCollection_List<TopoDS_Shape>* pList     = edgeNaborFaces.TryBound(anEdge, empty);
+      bool                            faceIsNew = true;
+      for (NCollection_List<TopoDS_Shape>::Iterator itrF(*pList); itrF.More(); itrF.Next())
       {
         if (itrF.Value().IsSame(aFace))
         {
@@ -260,7 +256,7 @@ static void LoadC0Edges(const TopoDS_Shape& S, const occ::handle<TDF_TagSource>&
       }
       if (faceIsNew)
       {
-        edgeNaborFaces.ChangeFind(anEdge).Append(aFace);
+        pList->Append(aFace);
       }
     }
   }
@@ -271,11 +267,12 @@ static void LoadC0Edges(const TopoDS_Shape& S, const occ::handle<TDF_TagSource>&
   // clang-format on
   for (; anEx.More(); anEx.Next())
   {
-    bool                aC0     = false;
-    const TopoDS_Shape& anEdge1 = anEx.Current();
-    if (edgeNaborFaces.IsBound(anEdge1))
+    bool                                   aC0     = false;
+    const TopoDS_Shape&                    anEdge1 = anEx.Current();
+    const NCollection_List<TopoDS_Shape>* pList1  = edgeNaborFaces.Seek(anEdge1);
+    if (pList1)
     {
-      const NCollection_List<TopoDS_Shape>& aList1 = edgeNaborFaces.Find(anEdge1);
+      const NCollection_List<TopoDS_Shape>& aList1 = *pList1;
       if (aList1.Extent() < 2)
         continue; // mpv (06.09.2002): these edges already was loaded
       NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>::

--- a/src/Draw/TKDCAF/DNaming/DNaming.cxx
+++ b/src/Draw/TKDCAF/DNaming/DNaming.cxx
@@ -195,7 +195,7 @@ static void LoadC0Vertices(const TopoDS_Shape& S, const occ::handle<TDF_TagSourc
     TopExp_Explorer     explV(aFace, TopAbs_VERTEX);
     for (; explV.More(); explV.Next())
     {
-      const TopoDS_Shape&            aVertex   = explV.Current();
+      const TopoDS_Shape&             aVertex   = explV.Current();
       NCollection_List<TopoDS_Shape>* pList     = vertexNaborFaces.TryBound(aVertex, empty);
       bool                            faceIsNew = true;
       for (NCollection_List<TopoDS_Shape>::Iterator itrF(*pList); itrF.More(); itrF.Next())
@@ -267,8 +267,8 @@ static void LoadC0Edges(const TopoDS_Shape& S, const occ::handle<TDF_TagSource>&
   // clang-format on
   for (; anEx.More(); anEx.Next())
   {
-    bool                                   aC0     = false;
-    const TopoDS_Shape&                    anEdge1 = anEx.Current();
+    bool                                  aC0     = false;
+    const TopoDS_Shape&                   anEdge1 = anEx.Current();
     const NCollection_List<TopoDS_Shape>* pList1  = edgeNaborFaces.Seek(anEdge1);
     if (pList1)
     {

--- a/src/Draw/TKTopTest/MeshTest/MeshTest_CheckTopology.cxx
+++ b/src/Draw/TKTopTest/MeshTest/MeshTest_CheckTopology.cxx
@@ -211,14 +211,11 @@ void MeshTest_CheckTopology::Perform(Draw_Interpretor& di)
           // skip if it is on boundary
           if (aMapBndNodes.Contains(n1) && aMapBndNodes.Contains(n2))
             continue;
-          if (!myMapFaceLinks.Contains(iF))
-          {
-            occ::handle<NCollection_HSequence<int>> tmpSeq = new NCollection_HSequence<int>;
-            myMapFaceLinks.Add(iF, tmpSeq);
-          }
-          occ::handle<NCollection_HSequence<int>>& aSeq = myMapFaceLinks.ChangeFromKey(iF);
-          aSeq->Append(n1);
-          aSeq->Append(n2);
+          occ::handle<NCollection_HSequence<int>>* pSeq = myMapFaceLinks.ChangeSeek(iF);
+          if (!pSeq)
+            pSeq = myMapFaceLinks.Bound(iF, new NCollection_HSequence<int>);
+          (*pSeq)->Append(n1);
+          (*pSeq)->Append(n2);
         }
       }
     }

--- a/src/FoundationClasses/TKMath/Poly/Poly_MakeLoops.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_MakeLoops.cxx
@@ -298,11 +298,12 @@ int Poly_MakeLoops::findContour(int                                           th
 
     aLastNode = getLastNode(aIndexS);
 
-    if (aNodeLink.IsBound(aLastNode))
+    const int* pNodeLink = aNodeLink.Seek(aLastNode);
+    if (pNodeLink)
     {
       // closing the loop, stop search
       theContour.Add(aIndexS);
-      aStartIndex = theContour.FindIndex(aNodeLink.Find(aLastNode));
+      aStartIndex = theContour.FindIndex(*pNodeLink);
       break;
     }
   }

--- a/src/FoundationClasses/TKernel/GTests/NCollection_DataMap_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_DataMap_Test.cxx
@@ -275,3 +275,28 @@ TEST_F(NCollection_DataMapTest, STLAlgorithmCompatibility_Find)
   auto aNotFound = std::find(aMap.cbegin(), aMap.cend(), 999);
   EXPECT_TRUE(aNotFound == aMap.cend());
 }
+
+TEST_F(NCollection_DataMapTest, TryBound_NoOverwrite)
+{
+  NCollection_DataMap<int, TCollection_AsciiString> aMap;
+
+  // TryBound on new key should bind the value
+  TCollection_AsciiString* pVal1 = aMap.TryBound(1, "First");
+  ASSERT_NE(pVal1, nullptr);
+  EXPECT_EQ(*pVal1, "First");
+  EXPECT_EQ(aMap.Extent(), 1);
+
+  // TryBound on existing key should NOT overwrite, just return pointer
+  TCollection_AsciiString* pVal2 = aMap.TryBound(1, "Second");
+  ASSERT_NE(pVal2, nullptr);
+  EXPECT_EQ(*pVal2, "First"); // Should still be "First", not "Second"
+  EXPECT_EQ(pVal1, pVal2);    // Should be the same pointer
+  EXPECT_EQ(aMap.Extent(), 1); // Size should not change
+
+  // Compare with Bound which DOES overwrite
+  TCollection_AsciiString* pVal3 = aMap.Bound(1, "Third");
+  ASSERT_NE(pVal3, nullptr);
+  EXPECT_EQ(*pVal3, "Third"); // Bound overwrites the value
+  EXPECT_EQ(pVal1, pVal3);    // Same pointer
+  EXPECT_EQ(aMap.Extent(), 1);
+}

--- a/src/FoundationClasses/TKernel/GTests/NCollection_DataMap_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_DataMap_Test.cxx
@@ -289,8 +289,8 @@ TEST_F(NCollection_DataMapTest, TryBound_NoOverwrite)
   // TryBound on existing key should NOT overwrite, just return pointer
   TCollection_AsciiString* pVal2 = aMap.TryBound(1, "Second");
   ASSERT_NE(pVal2, nullptr);
-  EXPECT_EQ(*pVal2, "First"); // Should still be "First", not "Second"
-  EXPECT_EQ(pVal1, pVal2);    // Should be the same pointer
+  EXPECT_EQ(*pVal2, "First");  // Should still be "First", not "Second"
+  EXPECT_EQ(pVal1, pVal2);     // Should be the same pointer
   EXPECT_EQ(aMap.Extent(), 1); // Size should not change
 
   // Compare with Bound which DOES overwrite

--- a/src/FoundationClasses/TKernel/GTests/NCollection_IndexedDataMap_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_IndexedDataMap_Test.cxx
@@ -745,3 +745,105 @@ TEST(NCollection_IndexedDataMapTest, STLAlgorithmCompatibility_Find)
   auto aNotFound = std::find(aMap.cbegin(), aMap.cend(), 999);
   EXPECT_TRUE(aNotFound == aMap.cend());
 }
+
+TEST(NCollection_IndexedDataMapTest, BoundNewKey)
+{
+  NCollection_IndexedDataMap<KeyType, ItemType> aMap;
+
+  // Test Bound with new key - should add and return pointer
+  ItemType* pItem1 = aMap.Bound(10, 1.0);
+  EXPECT_TRUE(pItem1 != nullptr);
+  EXPECT_DOUBLE_EQ(*pItem1, 1.0);
+  EXPECT_EQ(aMap.Extent(), 1);
+  EXPECT_TRUE(aMap.Contains(10));
+
+  ItemType* pItem2 = aMap.Bound(20, 2.0);
+  EXPECT_TRUE(pItem2 != nullptr);
+  EXPECT_DOUBLE_EQ(*pItem2, 2.0);
+  EXPECT_EQ(aMap.Extent(), 2);
+  EXPECT_TRUE(aMap.Contains(20));
+
+  // Verify values through standard access
+  EXPECT_DOUBLE_EQ(aMap.FindFromKey(10), 1.0);
+  EXPECT_DOUBLE_EQ(aMap.FindFromKey(20), 2.0);
+}
+
+TEST(NCollection_IndexedDataMapTest, BoundExistingKey)
+{
+  NCollection_IndexedDataMap<KeyType, ItemType> aMap;
+
+  // Add initial element
+  aMap.Add(10, 1.0);
+  EXPECT_EQ(aMap.Extent(), 1);
+  EXPECT_DOUBLE_EQ(aMap.FindFromKey(10), 1.0);
+
+  // Call Bound with existing key - should NOT overwrite the value
+  ItemType* pItem = aMap.Bound(10, 999.0);
+  EXPECT_TRUE(pItem != nullptr);
+  EXPECT_DOUBLE_EQ(*pItem, 1.0); // Original value preserved
+  EXPECT_EQ(aMap.Extent(), 1);   // Size unchanged
+
+  // Verify the returned pointer can be used to modify the value
+  *pItem = 1.5;
+  EXPECT_DOUBLE_EQ(aMap.FindFromKey(10), 1.5);
+}
+
+TEST(NCollection_IndexedDataMapTest, BoundMixedUsage)
+{
+  NCollection_IndexedDataMap<KeyType, ItemType> aMap;
+
+  // Use Bound for both new and existing keys
+  ItemType* p1 = aMap.Bound(10, 1.0); // New key
+  ItemType* p2 = aMap.Bound(20, 2.0); // New key
+  ItemType* p3 = aMap.Bound(10, 3.0); // Existing key - should return existing item
+
+  EXPECT_EQ(aMap.Extent(), 2);
+  EXPECT_DOUBLE_EQ(*p1, 1.0);
+  EXPECT_DOUBLE_EQ(*p2, 2.0);
+  EXPECT_DOUBLE_EQ(*p3, 1.0); // Original value, not 3.0
+  EXPECT_EQ(p1, p3);          // Same pointer for same key
+
+  // Verify indices
+  EXPECT_EQ(aMap.FindIndex(10), 1);
+  EXPECT_EQ(aMap.FindIndex(20), 2);
+}
+
+TEST(NCollection_IndexedDataMapTest, BoundVsAddSemantics)
+{
+  // Verify that Bound has the same semantics as Add for new keys
+  NCollection_IndexedDataMap<KeyType, ItemType> aMap1;
+  NCollection_IndexedDataMap<KeyType, ItemType> aMap2;
+
+  // Add using Add()
+  aMap1.Add(10, 1.0);
+  aMap1.Add(20, 2.0);
+  aMap1.Add(10, 3.0); // Duplicate - ignored
+
+  // Add using Bound()
+  aMap2.Bound(10, 1.0);
+  aMap2.Bound(20, 2.0);
+  aMap2.Bound(10, 3.0); // Duplicate - ignored
+
+  // Both maps should have identical content
+  EXPECT_EQ(aMap1.Extent(), aMap2.Extent());
+  EXPECT_DOUBLE_EQ(aMap1.FindFromKey(10), aMap2.FindFromKey(10));
+  EXPECT_DOUBLE_EQ(aMap1.FindFromKey(20), aMap2.FindFromKey(20));
+}
+
+TEST(NCollection_IndexedDataMapTest, BoundWithMoveSemantics)
+{
+  NCollection_IndexedDataMap<TCollection_AsciiString, TCollection_AsciiString> aMap;
+
+  // Test with rvalue key
+  TCollection_AsciiString* p1 = aMap.Bound(TCollection_AsciiString("Key1"), TCollection_AsciiString("Value1"));
+  EXPECT_TRUE(p1 != nullptr);
+  EXPECT_TRUE(p1->IsEqual("Value1"));
+
+  // Test with rvalue item
+  TCollection_AsciiString aKey2("Key2");
+  TCollection_AsciiString* p2 = aMap.Bound(aKey2, TCollection_AsciiString("Value2"));
+  EXPECT_TRUE(p2 != nullptr);
+  EXPECT_TRUE(p2->IsEqual("Value2"));
+
+  EXPECT_EQ(aMap.Extent(), 2);
+}

--- a/src/FoundationClasses/TKernel/GTests/NCollection_IndexedDataMap_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_IndexedDataMap_Test.cxx
@@ -835,12 +835,13 @@ TEST(NCollection_IndexedDataMapTest, BoundWithMoveSemantics)
   NCollection_IndexedDataMap<TCollection_AsciiString, TCollection_AsciiString> aMap;
 
   // Test with rvalue key
-  TCollection_AsciiString* p1 = aMap.Bound(TCollection_AsciiString("Key1"), TCollection_AsciiString("Value1"));
+  TCollection_AsciiString* p1 =
+    aMap.Bound(TCollection_AsciiString("Key1"), TCollection_AsciiString("Value1"));
   EXPECT_TRUE(p1 != nullptr);
   EXPECT_TRUE(p1->IsEqual("Value1"));
 
   // Test with rvalue item
-  TCollection_AsciiString aKey2("Key2");
+  TCollection_AsciiString  aKey2("Key2");
   TCollection_AsciiString* p2 = aMap.Bound(aKey2, TCollection_AsciiString("Value2"));
   EXPECT_TRUE(p2 != nullptr);
   EXPECT_TRUE(p2->IsEqual("Value2"));

--- a/src/FoundationClasses/TKernel/GTests/NCollection_IndexedMap_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_IndexedMap_Test.cxx
@@ -563,3 +563,124 @@ TEST(NCollection_IndexedMapTest, STLAlgorithmCompatibility_Find)
   EXPECT_TRUE(aFoundStd != aVector.end());
   EXPECT_EQ(*aFoundOCCT, *aFoundStd);
 }
+
+TEST(NCollection_IndexedMapTest, AddedNewKey)
+{
+  NCollection_IndexedMap<KeyType> aMap;
+
+  // Test Added with new key - should add and return reference
+  const KeyType& key1 = aMap.Added(10);
+  EXPECT_EQ(key1, 10);
+  EXPECT_EQ(aMap.Extent(), 1);
+  EXPECT_TRUE(aMap.Contains(10));
+
+  const KeyType& key2 = aMap.Added(20);
+  EXPECT_EQ(key2, 20);
+  EXPECT_EQ(aMap.Extent(), 2);
+  EXPECT_TRUE(aMap.Contains(20));
+
+  const KeyType& key3 = aMap.Added(30);
+  EXPECT_EQ(key3, 30);
+  EXPECT_EQ(aMap.Extent(), 3);
+  EXPECT_TRUE(aMap.Contains(30));
+}
+
+TEST(NCollection_IndexedMapTest, AddedExistingKey)
+{
+  NCollection_IndexedMap<KeyType> aMap;
+
+  // Add initial element
+  aMap.Add(10);
+  EXPECT_EQ(aMap.Extent(), 1);
+
+  // Call Added with existing key - should return reference to existing key
+  const KeyType& keyRef = aMap.Added(10);
+  EXPECT_EQ(keyRef, 10);
+  EXPECT_EQ(aMap.Extent(), 1); // Size unchanged
+
+  // Verify the returned reference points to the key in the map
+  EXPECT_EQ(&keyRef, &aMap.FindKey(1));
+}
+
+TEST(NCollection_IndexedMapTest, AddedMixedUsage)
+{
+  NCollection_IndexedMap<KeyType> aMap;
+
+  // Use Added for both new and existing keys
+  const KeyType& k1 = aMap.Added(10); // New key
+  const KeyType& k2 = aMap.Added(20); // New key
+  const KeyType& k3 = aMap.Added(10); // Existing key - should return existing
+
+  EXPECT_EQ(aMap.Extent(), 2);
+  EXPECT_EQ(k1, 10);
+  EXPECT_EQ(k2, 20);
+  EXPECT_EQ(k3, 10);
+  EXPECT_EQ(&k1, &k3); // Same reference for same key
+
+  // Verify indices
+  EXPECT_EQ(aMap.FindIndex(10), 1);
+  EXPECT_EQ(aMap.FindIndex(20), 2);
+}
+
+TEST(NCollection_IndexedMapTest, AddedVsAddSemantics)
+{
+  // Verify that Added has the same semantics as Add for new keys
+  NCollection_IndexedMap<KeyType> aMap1;
+  NCollection_IndexedMap<KeyType> aMap2;
+
+  // Add using Add()
+  aMap1.Add(10);
+  aMap1.Add(20);
+  aMap1.Add(10); // Duplicate - ignored
+
+  // Add using Added()
+  aMap2.Added(10);
+  aMap2.Added(20);
+  aMap2.Added(10); // Duplicate - ignored
+
+  // Both maps should have identical content
+  EXPECT_EQ(aMap1.Extent(), aMap2.Extent());
+  EXPECT_EQ(aMap1.FindIndex(10), aMap2.FindIndex(10));
+  EXPECT_EQ(aMap1.FindIndex(20), aMap2.FindIndex(20));
+}
+
+TEST(NCollection_IndexedMapTest, AddedWithMoveSemantics)
+{
+  NCollection_IndexedMap<TCollection_AsciiString> aMap;
+
+  // Test with rvalue
+  const TCollection_AsciiString& ref1 = aMap.Added(TCollection_AsciiString("First"));
+  EXPECT_TRUE(ref1.IsEqual("First"));
+  EXPECT_EQ(aMap.Extent(), 1);
+
+  // Test with lvalue
+  TCollection_AsciiString aKey("Second");
+  const TCollection_AsciiString& ref2 = aMap.Added(aKey);
+  EXPECT_TRUE(ref2.IsEqual("Second"));
+  EXPECT_EQ(aMap.Extent(), 2);
+
+  // Test duplicate with rvalue
+  const TCollection_AsciiString& ref3 = aMap.Added(TCollection_AsciiString("First"));
+  EXPECT_TRUE(ref3.IsEqual("First"));
+  EXPECT_EQ(aMap.Extent(), 2); // No new element
+  EXPECT_EQ(&ref1, &ref3);     // Same reference
+}
+
+TEST(NCollection_IndexedMapTest, AddedReturnValueUsage)
+{
+  // Test that Added can be used in patterns replacing if (!Contains) Add
+  NCollection_IndexedMap<KeyType> aMap;
+
+  // Old pattern: if (!aMap.Contains(key)) { aMap.Add(key); }
+  // New pattern: aMap.Added(key);
+
+  // The return value allows getting the key reference in a single operation
+  for (int i = 0; i < 10; ++i)
+  {
+    // Try to add duplicates
+    const KeyType& ref = aMap.Added(i % 5); // Will add 0,1,2,3,4 then try duplicates
+    EXPECT_EQ(ref, i % 5);
+  }
+
+  EXPECT_EQ(aMap.Extent(), 5); // Only 5 unique elements
+}

--- a/src/FoundationClasses/TKernel/GTests/NCollection_IndexedMap_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_IndexedMap_Test.cxx
@@ -654,7 +654,7 @@ TEST(NCollection_IndexedMapTest, AddedWithMoveSemantics)
   EXPECT_EQ(aMap.Extent(), 1);
 
   // Test with lvalue
-  TCollection_AsciiString aKey("Second");
+  TCollection_AsciiString        aKey("Second");
   const TCollection_AsciiString& ref2 = aMap.Added(aKey);
   EXPECT_TRUE(ref2.IsEqual("Second"));
   EXPECT_EQ(aMap.Extent(), 2);

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_DataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_DataMap.hxx
@@ -443,6 +443,94 @@ public:
     return &data[aHash]->ChangeValue();
   }
 
+  //! TryBound binds Item to Key in map only if Key is not already present.
+  //! If Key already exists, the existing value is NOT modified.
+  //! @param theKey  key to add
+  //! @param theItem item to bind (only used if key is new)
+  //! @return pointer to item in map (either existing or newly bound)
+  TheItemType* TryBound(const TheKeyType& theKey, const TheItemType& theItem)
+  {
+    if (Resizable())
+      ReSize(Extent());
+    size_t       aHash;
+    DataMapNode* aNode;
+    if (lookup(theKey, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    DataMapNode** data = (DataMapNode**)myData1;
+    data[aHash]        = new (this->myAllocator) DataMapNode(theKey, theItem, data[aHash]);
+    Increment();
+    return &data[aHash]->ChangeValue();
+  }
+
+  //! TryBound binds Item to Key in map only if Key is not already present.
+  //! If Key already exists, the existing value is NOT modified.
+  //! @param theKey  key to add
+  //! @param theItem item to bind (only used if key is new)
+  //! @return pointer to item in map (either existing or newly bound)
+  TheItemType* TryBound(TheKeyType&& theKey, const TheItemType& theItem)
+  {
+    if (Resizable())
+      ReSize(Extent());
+    size_t       aHash;
+    DataMapNode* aNode;
+    if (lookup(theKey, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    DataMapNode** data = (DataMapNode**)myData1;
+    data[aHash] =
+      new (this->myAllocator) DataMapNode(std::forward<TheKeyType>(theKey), theItem, data[aHash]);
+    Increment();
+    return &data[aHash]->ChangeValue();
+  }
+
+  //! TryBound binds Item to Key in map only if Key is not already present.
+  //! If Key already exists, the existing value is NOT modified.
+  //! @param theKey  key to add
+  //! @param theItem item to bind (only used if key is new)
+  //! @return pointer to item in map (either existing or newly bound)
+  TheItemType* TryBound(const TheKeyType& theKey, TheItemType&& theItem)
+  {
+    if (Resizable())
+      ReSize(Extent());
+    size_t       aHash;
+    DataMapNode* aNode;
+    if (lookup(theKey, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    DataMapNode** data = (DataMapNode**)myData1;
+    data[aHash] =
+      new (this->myAllocator) DataMapNode(theKey, std::forward<TheItemType>(theItem), data[aHash]);
+    Increment();
+    return &data[aHash]->ChangeValue();
+  }
+
+  //! TryBound binds Item to Key in map only if Key is not already present.
+  //! If Key already exists, the existing value is NOT modified.
+  //! @param theKey  key to add
+  //! @param theItem item to bind (only used if key is new)
+  //! @return pointer to item in map (either existing or newly bound)
+  TheItemType* TryBound(TheKeyType&& theKey, TheItemType&& theItem)
+  {
+    if (Resizable())
+      ReSize(Extent());
+    size_t       aHash;
+    DataMapNode* aNode;
+    if (lookup(theKey, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    DataMapNode** data = (DataMapNode**)myData1;
+    data[aHash]        = new (this->myAllocator) DataMapNode(std::forward<TheKeyType>(theKey),
+                                                      std::forward<TheItemType>(theItem),
+                                                      data[aHash]);
+    Increment();
+    return &data[aHash]->ChangeValue();
+  }
+
   //! IsBound
   bool IsBound(const TheKeyType& theKey) const
   {

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedDataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedDataMap.hxx
@@ -506,7 +506,7 @@ public:
                                                        aNewIndex,
                                                        std::forward<TheItemType>(theItem),
                                                        myData1[aHash]);
-    myData1[aHash]         = aNode;
+    myData1[aHash] = aNode;
     myData2[aNewIndex - 1] = aNode;
     return &aNode->ChangeValue();
   }

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedDataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedDataMap.hxx
@@ -406,6 +406,111 @@ public:
     return aNewIndex;
   }
 
+  //! Bound binds Key-Item pair with convenient syntax.
+  //! If Key is already bound, returns pointer to existing Item (Item argument is ignored).
+  //! If Key is not bound, binds it with provided Item and returns pointer to newly bound Item.
+  //! @param theKey1 Key to search (and to bind, if it was not bound already)
+  //! @param theItem Item value to set for newly bound Key; ignored if Key was already bound
+  //! @return pointer to Item (new or existing)
+  TheItemType* Bound(const TheKeyType& theKey1, const TheItemType& theItem)
+  {
+    if (Resizable())
+    {
+      ReSize(Extent());
+    }
+    IndexedDataMapNode* aNode;
+    size_t              aHash;
+    if (lookup(theKey1, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    const int aNewIndex = Increment();
+    aNode = new (this->myAllocator) IndexedDataMapNode(theKey1, aNewIndex, theItem, myData1[aHash]);
+    myData1[aHash]         = aNode;
+    myData2[aNewIndex - 1] = aNode;
+    return &aNode->ChangeValue();
+  }
+
+  //! Bound binds Key-Item pair with convenient syntax.
+  //! If Key is already bound, returns pointer to existing Item (Item argument is ignored).
+  //! If Key is not bound, binds it with provided Item and returns pointer to newly bound Item.
+  //! @param theKey1 Key to search (and to bind, if it was not bound already)
+  //! @param theItem Item value to set for newly bound Key; ignored if Key was already bound
+  //! @return pointer to Item (new or existing)
+  TheItemType* Bound(TheKeyType&& theKey1, const TheItemType& theItem)
+  {
+    if (Resizable())
+    {
+      ReSize(Extent());
+    }
+    IndexedDataMapNode* aNode;
+    size_t              aHash;
+    if (lookup(theKey1, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    const int aNewIndex = Increment();
+    aNode               = new (this->myAllocator)
+      IndexedDataMapNode(std::forward<TheKeyType>(theKey1), aNewIndex, theItem, myData1[aHash]);
+    myData1[aHash]         = aNode;
+    myData2[aNewIndex - 1] = aNode;
+    return &aNode->ChangeValue();
+  }
+
+  //! Bound binds Key-Item pair with convenient syntax.
+  //! If Key is already bound, returns pointer to existing Item (Item argument is ignored).
+  //! If Key is not bound, binds it with provided Item and returns pointer to newly bound Item.
+  //! @param theKey1 Key to search (and to bind, if it was not bound already)
+  //! @param theItem Item value to set for newly bound Key; ignored if Key was already bound
+  //! @return pointer to Item (new or existing)
+  TheItemType* Bound(const TheKeyType& theKey1, TheItemType&& theItem)
+  {
+    if (Resizable())
+    {
+      ReSize(Extent());
+    }
+    IndexedDataMapNode* aNode;
+    size_t              aHash;
+    if (lookup(theKey1, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    const int aNewIndex = Increment();
+    aNode               = new (this->myAllocator)
+      IndexedDataMapNode(theKey1, aNewIndex, std::forward<TheItemType>(theItem), myData1[aHash]);
+    myData1[aHash]         = aNode;
+    myData2[aNewIndex - 1] = aNode;
+    return &aNode->ChangeValue();
+  }
+
+  //! Bound binds Key-Item pair with convenient syntax.
+  //! If Key is already bound, returns pointer to existing Item (Item argument is ignored).
+  //! If Key is not bound, binds it with provided Item and returns pointer to newly bound Item.
+  //! @param theKey1 Key to search (and to bind, if it was not bound already)
+  //! @param theItem Item value to set for newly bound Key; ignored if Key was already bound
+  //! @return pointer to Item (new or existing)
+  TheItemType* Bound(TheKeyType&& theKey1, TheItemType&& theItem)
+  {
+    if (Resizable())
+    {
+      ReSize(Extent());
+    }
+    IndexedDataMapNode* aNode;
+    size_t              aHash;
+    if (lookup(theKey1, aNode, aHash))
+    {
+      return &aNode->ChangeValue();
+    }
+    const int aNewIndex = Increment();
+    aNode          = new (this->myAllocator) IndexedDataMapNode(std::forward<TheKeyType>(theKey1),
+                                                       aNewIndex,
+                                                       std::forward<TheItemType>(theItem),
+                                                       myData1[aHash]);
+    myData1[aHash]         = aNode;
+    myData2[aNewIndex - 1] = aNode;
+    return &aNode->ChangeValue();
+  }
+
   //! Contains
   bool Contains(const TheKeyType& theKey1) const
   {

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedMap.hxx
@@ -283,6 +283,53 @@ public:
     return aNewIndex;
   }
 
+  //! Added: add a new key if not yet in the map, and return
+  //! reference to either newly added or previously existing object.
+  //! @param theKey1 Key to search (and to add, if it was not in the map already)
+  //! @return const reference to Key in the map (new or existing)
+  const TheKeyType& Added(const TheKeyType& theKey1)
+  {
+    if (Resizable())
+    {
+      ReSize(Extent());
+    }
+    IndexedMapNode* aNode;
+    size_t          aHash;
+    if (lookup(theKey1, aNode, aHash))
+    {
+      return aNode->Key1();
+    }
+    const int aNewIndex = Increment();
+    aNode          = new (this->myAllocator) IndexedMapNode(theKey1, aNewIndex, myData1[aHash]);
+    myData1[aHash] = aNode;
+    myData2[aNewIndex - 1] = aNode;
+    return aNode->Key1();
+  }
+
+  //! Added: add a new key if not yet in the map, and return
+  //! reference to either newly added or previously existing object.
+  //! @param theKey1 Key to search (and to add, if it was not in the map already)
+  //! @return const reference to Key in the map (new or existing)
+  const TheKeyType& Added(TheKeyType&& theKey1)
+  {
+    if (Resizable())
+    {
+      ReSize(Extent());
+    }
+    IndexedMapNode* aNode;
+    size_t          aHash;
+    if (lookup(theKey1, aNode, aHash))
+    {
+      return aNode->Key1();
+    }
+    const int aNewIndex = Increment();
+    aNode               = new (this->myAllocator)
+      IndexedMapNode(std::forward<TheKeyType>(theKey1), aNewIndex, myData1[aHash]);
+    myData1[aHash]         = aNode;
+    myData2[aNewIndex - 1] = aNode;
+    return aNode->Key1();
+  }
+
   //! Contains
   bool Contains(const TheKeyType& theKey1) const
   {

--- a/src/FoundationClasses/TKernel/OSD/OSD_PerfMeter.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_PerfMeter.cxx
@@ -254,10 +254,7 @@ void StopwatchStorage::Clear()
 TCollection_AsciiString StopwatchStorage::Print(const TCollection_AsciiString& theName) const
 {
   TCollection_AsciiString anOutput;
-  if (myStopwatches.IsBound(theName))
-  {
-    print(theName, anOutput);
-  }
+  print(theName, anOutput);
   return anOutput;
 }
 

--- a/src/FoundationClasses/TKernel/Plugin/Plugin.cxx
+++ b/src/FoundationClasses/TKernel/Plugin/Plugin.cxx
@@ -39,9 +39,13 @@ occ::handle<Standard_Transient> Plugin::Load(const Standard_GUID& aGUID, const b
   static NCollection_DataMap<TCollection_AsciiString, OSD_Function> theMapOfFunctions;
   OSD_Function                                                      f;
 
-  if (!theMapOfFunctions.IsBound(pid))
+  const OSD_Function* pFunc = theMapOfFunctions.Seek(pid);
+  if (pFunc)
   {
-
+    f = *pFunc;
+  }
+  else
+  {
     occ::handle<Resource_Manager> PluginResource = new Resource_Manager("Plugin");
     TCollection_AsciiString       theResource(thePluginId);
     theResource += ".Location";
@@ -96,8 +100,6 @@ occ::handle<Standard_Transient> Plugin::Load(const Standard_GUID& aGUID, const b
     }
     theMapOfFunctions.Bind(pid, f);
   }
-  else
-    f = theMapOfFunctions(pid);
 
   // Cast through void* to avoid -Wcast-function-type-mismatch warning.
   // This is safe for dynamically loaded plugin symbols.

--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
@@ -438,10 +438,12 @@ double Resource_Manager::Real(const char* aResourceName) const
 const char* Resource_Manager::Value(const char* aResource) const
 {
   TCollection_AsciiString Resource(aResource);
-  if (myUserMap.IsBound(Resource))
-    return myUserMap(Resource).ToCString();
-  if (myRefMap.IsBound(Resource))
-    return myRefMap(Resource).ToCString();
+  const TCollection_AsciiString* pVal = myUserMap.Seek(Resource);
+  if (pVal)
+    return pVal->ToCString();
+  pVal = myRefMap.Seek(Resource);
+  if (pVal)
+    return pVal->ToCString();
   throw Resource_NoSuchResource(aResource);
 }
 
@@ -453,16 +455,16 @@ const char* Resource_Manager::Value(const char* aResource) const
 const char16_t* Resource_Manager::ExtValue(const char* aResource)
 {
   TCollection_AsciiString Resource(aResource);
-  if (myExtStrMap.IsBound(Resource))
-    return myExtStrMap(Resource).ToExtString();
+  const TCollection_ExtendedString* pVal = myExtStrMap.Seek(Resource);
+  if (pVal)
+    return pVal->ToExtString();
 
   TCollection_AsciiString    Result = Value(aResource);
   TCollection_ExtendedString ExtResult;
 
   Resource_Unicode::ConvertFormatToUnicode(Result.ToCString(), ExtResult);
 
-  myExtStrMap.Bind(Resource, ExtResult);
-  return myExtStrMap(Resource).ToExtString();
+  return myExtStrMap.Bound(Resource, ExtResult)->ToExtString();
 }
 
 //=======================================================================
@@ -497,10 +499,7 @@ void Resource_Manager::SetResource(const char* aResource, const char16_t* aValue
   TCollection_ExtendedString ExtValue = aValue;
   TCollection_AsciiString    FormatStr(ExtValue.Length() * 3 + 10, ' ');
 
-  if (!myExtStrMap.Bind(Resource, ExtValue))
-  {
-    myExtStrMap(Resource) = ExtValue;
-  }
+  *myExtStrMap.Bound(Resource, ExtValue) = ExtValue;
   //
   pStr = (Standard_PCharacter)FormatStr.ToCString();
   //
@@ -519,8 +518,7 @@ void Resource_Manager::SetResource(const char* aResource, const char* aValue)
 {
   TCollection_AsciiString Resource = aResource;
   TCollection_AsciiString Value    = aValue;
-  if (!myUserMap.Bind(Resource, Value))
-    myUserMap(Resource) = Value;
+  *myUserMap.Bound(Resource, Value) = Value;
 }
 
 //=======================================================================

--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
@@ -437,7 +437,7 @@ double Resource_Manager::Real(const char* aResourceName) const
 
 const char* Resource_Manager::Value(const char* aResource) const
 {
-  TCollection_AsciiString Resource(aResource);
+  TCollection_AsciiString        Resource(aResource);
   const TCollection_AsciiString* pVal = myUserMap.Seek(Resource);
   if (pVal)
     return pVal->ToCString();
@@ -454,7 +454,7 @@ const char* Resource_Manager::Value(const char* aResource) const
 
 const char16_t* Resource_Manager::ExtValue(const char* aResource)
 {
-  TCollection_AsciiString Resource(aResource);
+  TCollection_AsciiString           Resource(aResource);
   const TCollection_ExtendedString* pVal = myExtStrMap.Seek(Resource);
   if (pVal)
     return pVal->ToExtString();
@@ -516,8 +516,8 @@ void Resource_Manager::SetResource(const char* aResource, const char16_t* aValue
 //=======================================================================
 void Resource_Manager::SetResource(const char* aResource, const char* aValue)
 {
-  TCollection_AsciiString Resource = aResource;
-  TCollection_AsciiString Value    = aValue;
+  TCollection_AsciiString Resource  = aResource;
+  TCollection_AsciiString Value     = aValue;
   *myUserMap.Bound(Resource, Value) = Value;
 }
 

--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
@@ -499,7 +499,7 @@ void Resource_Manager::SetResource(const char* aResource, const char16_t* aValue
   TCollection_ExtendedString ExtValue = aValue;
   TCollection_AsciiString    FormatStr(ExtValue.Length() * 3 + 10, ' ');
 
-  *myExtStrMap.Bound(Resource, ExtValue) = ExtValue;
+  myExtStrMap.Bound(Resource, ExtValue);
   //
   pStr = (Standard_PCharacter)FormatStr.ToCString();
   //
@@ -516,9 +516,9 @@ void Resource_Manager::SetResource(const char* aResource, const char16_t* aValue
 //=======================================================================
 void Resource_Manager::SetResource(const char* aResource, const char* aValue)
 {
-  TCollection_AsciiString Resource  = aResource;
-  TCollection_AsciiString Value     = aValue;
-  *myUserMap.Bound(Resource, Value) = Value;
+  TCollection_AsciiString Resource = aResource;
+  TCollection_AsciiString Value    = aValue;
+  myUserMap.Bound(Resource, Value);
 }
 
 //=======================================================================

--- a/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_RootData.cxx
@@ -104,14 +104,8 @@ occ::handle<NCollection_HSequence<occ::handle<Storage_Root>>> Storage_RootData::
 
 occ::handle<Storage_Root> Storage_RootData::Find(const TCollection_AsciiString& aName) const
 {
-  occ::handle<Storage_Root> p;
-
-  if (myObjects.IsBound(aName))
-  {
-    p = myObjects.Find(aName);
-  }
-
-  return p;
+  const occ::handle<Storage_Root>* pRoot = myObjects.Seek(aName);
+  return pRoot ? *pRoot : occ::handle<Storage_Root>();
 }
 
 bool Storage_RootData::IsRoot(const TCollection_AsciiString& aName) const
@@ -130,9 +124,10 @@ void Storage_RootData::RemoveRoot(const TCollection_AsciiString& aName)
 void Storage_RootData::UpdateRoot(const TCollection_AsciiString&          aName,
                                   const occ::handle<Standard_Persistent>& aPers)
 {
-  if (myObjects.IsBound(aName))
+  occ::handle<Storage_Root>* pRoot = myObjects.ChangeSeek(aName);
+  if (pRoot)
   {
-    myObjects.ChangeFind(aName)->SetObject(aPers);
+    (*pRoot)->SetObject(aPers);
   }
   else
   {

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -776,10 +776,10 @@ bool Storage_Schema::CheckTypeMigration(const TCollection_AsciiString& oldName,
 
   if (aDMap.Extent())
   {
-    if (aDMap.IsBound(oldName))
+    const TCollection_AsciiString* pNewName = aDMap.Seek(oldName);
+    if (pNewName)
     {
-      newName.Clear();
-      newName    = aDMap.Find(oldName);
+      newName    = *pNewName;
       aMigration = true;
   #ifdef OCCT_DEBUG
       std::cout << " newName = " << newName << std::endl;

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_BOP.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_BOP.cxx
@@ -685,10 +685,7 @@ void BOPAlgo_BOP::BuildRC(const Message_ProgressRange& theRange)
         {
           BOPTools_Set aST;
           aST.Add(aS, TopAbs_FACE);
-          if (!aMSet.Contains(aST))
-          {
-            aMSet.Add(aST, aS);
-          }
+          aMSet.Add(aST, aS);
         }
       }
     }
@@ -1184,10 +1181,7 @@ void BOPAlgo_BOP::BuildSolid(const Message_ProgressRange& theRange)
     {
       BOPTools_Set aST;
       aST.Add(aSx, TopAbs_FACE);
-      if (!aDMSTS.Contains(aST))
-      {
-        aDMSTS.Add(aST, aSx);
-      }
+      aDMSTS.Add(aST, aSx);
     }
   }
   // Check for user break

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_WireSplitter_1.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_WireSplitter_1.cxx
@@ -241,17 +241,7 @@ void BOPAlgo_WireSplitter::SplitBlock(const TopoDS_Face&                   myFac
     for (; aIt.More(); aIt.Next())
     {
       const TopoDS_Shape& aE = aIt.Value();
-      if (!aMapEE.Contains(aE))
-      {
-        NCollection_List<TopoDS_Shape> aLEx;
-        aLEx.Append(aE);
-        aMapEE.Add(aE, aLEx);
-      }
-      else
-      {
-        NCollection_List<TopoDS_Shape>& aLEx = aMapEE.ChangeFromKey(aE);
-        aLEx.Append(aE);
-      }
+      aMapEE.Bound(aE, NCollection_List<TopoDS_Shape>())->Append(aE);
     }
     //
     bFlag    = true;

--- a/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_AlgoTools.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_AlgoTools.cxx
@@ -380,8 +380,9 @@ void BOPTools_AlgoTools::OrientFacesOnShell(TopoDS_Shape& aShell)
       NCollection_List<TopoDS_Shape>::Iterator anIt(aLF);
       for (; anIt.More(); anIt.Next())
       {
-        const TopoDS_Shape& aF = anIt.Value();
-        if (aFM.Add(aF) == aFM.Extent())
+        const TopoDS_Shape& aF          = anIt.Value();
+        const int           aPrevExtent = aFM.Extent();
+        if (aFM.Add(aF) > aPrevExtent)
         {
           aLFTmp.Append(aF);
         }
@@ -483,8 +484,9 @@ void BOPTools_AlgoTools::OrientFacesOnShell(TopoDS_Shape& aShell)
       NCollection_List<TopoDS_Shape>::Iterator anIt(aLF);
       for (; anIt.More(); anIt.Next())
       {
-        const TopoDS_Face& aF = (*(TopoDS_Face*)(&anIt.Value()));
-        if (aProcessedFaces.Add(aF) == aProcessedFaces.Extent())
+        const TopoDS_Face& aF          = (*(TopoDS_Face*)(&anIt.Value()));
+        const int          aPrevExtent = aProcessedFaces.Extent();
+        if (aProcessedFaces.Add(aF) > aPrevExtent)
         {
           aBB.Add(aShellNew, aF);
         }

--- a/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_AlgoTools.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_AlgoTools.cxx
@@ -381,9 +381,8 @@ void BOPTools_AlgoTools::OrientFacesOnShell(TopoDS_Shape& aShell)
       for (; anIt.More(); anIt.Next())
       {
         const TopoDS_Shape& aF = anIt.Value();
-        if (!aFM.Contains(aF))
+        if (aFM.Add(aF) == aFM.Extent())
         {
-          aFM.Add(aF);
           aLFTmp.Append(aF);
         }
       }
@@ -485,9 +484,8 @@ void BOPTools_AlgoTools::OrientFacesOnShell(TopoDS_Shape& aShell)
       for (; anIt.More(); anIt.Next())
       {
         const TopoDS_Face& aF = (*(TopoDS_Face*)(&anIt.Value()));
-        if (!aProcessedFaces.Contains(aF))
+        if (aProcessedFaces.Add(aF) == aProcessedFaces.Extent())
         {
-          aProcessedFaces.Add(aF);
           aBB.Add(aShellNew, aF);
         }
       }

--- a/src/ModelingAlgorithms/TKBool/BRepAlgo/BRepAlgo_Loop.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepAlgo/BRepAlgo_Loop.cxx
@@ -506,18 +506,10 @@ static void StoreInMVE(
     YaCouture = false;
     return;
   }
-  if (!MVE.Contains(V1))
-  {
-    MVE.Add(V1, Empty);
-  }
-  MVE.ChangeFromKey(V1).Append(E);
+  MVE.Bound(V1, Empty)->Append(E);
   if (!V1.IsSame(V2))
   {
-    if (!MVE.Contains(V2))
-    {
-      MVE.Add(V2, Empty);
-    }
-    MVE.ChangeFromKey(V2).Append(E);
+    MVE.Bound(V2, Empty)->Append(E);
   }
   TopLoc_Location           L;
   occ::handle<Geom_Surface> S = BRep_Tool::Surface(F, L);

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_Evolved.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_Evolved.cxx
@@ -1271,10 +1271,7 @@ void BRepFill_Evolved::PlanarPerform(const TopoDS_Face&              Sp,
         {
           const TopoDS_Edge&  WC = TopoDS::Edge(Exp.Current());
           const TopoDS_Shape& GS = OffAnc.Ancestor(WC);
-          if (!myMap.IsBound(GS))
-            myMap.Bind(GS, EmptyMap);
-          if (!myMap(GS).IsBound(V[i]))
-            myMap(GS).Bind(V[i], Paral.GeneratedShapes(GS));
+          myMap.TryBound(GS, EmptyMap)->TryBound(V[i], Paral.GeneratedShapes(GS));
         }
       }
       TopoDS_Shape Rest = MapVP(V[i]);
@@ -1340,11 +1337,7 @@ void BRepFill_Evolved::PlanarPerform(const TopoDS_Face&              Sp,
         if (OffAnc.HasAncestor(CE))
         {
           const TopoDS_Shape& InitE = OffAnc.Ancestor(CE);
-          if (!myMap.IsBound(InitE))
-            myMap.Bind(InitE, EmptyMap);
-          if (!myMap(InitE).IsBound(E))
-            myMap(InitE).Bind(E, EmptyList);
-          myMap(InitE)(E).Append(F);
+          myMap.TryBound(InitE, EmptyMap)->TryBound(E, EmptyList)->Append(F);
         }
       }
     }
@@ -1402,16 +1395,7 @@ void BRepFill_Evolved::VerticalPerform(const TopoDS_Face&              Sp,
       {
         const TopoDS_Edge&  anEdge = TopoDS::Edge(Exp.Current());
         const TopoDS_Shape& AE     = OffAnc.Ancestor(anEdge);
-        if (!myMap.IsBound(AE))
-        {
-          myMap.Bind(AE, EmptyMap);
-        }
-        if (!myMap(AE).IsBound(V1))
-        {
-          NCollection_List<TopoDS_Shape> L;
-          myMap(AE).Bind(V1, L);
-        }
-        myMap(AE)(V1).Append(anEdge);
+        myMap.TryBound(AE, EmptyMap)->TryBound(V1, NCollection_List<TopoDS_Shape>())->Append(anEdge);
       }
       First = false;
     }
@@ -1435,23 +1419,16 @@ void BRepFill_Evolved::VerticalPerform(const TopoDS_Face&              Sp,
     {
       const NCollection_List<TopoDS_Shape>&    LOF = it.Value()(V1);
       NCollection_List<TopoDS_Shape>::Iterator itLOF(LOF);
-      if (!myMap(it.Key()).IsBound(V2))
-      {
-        NCollection_List<TopoDS_Shape> L;
-        myMap(it.Key()).Bind(V2, L);
-      }
-
-      if (!myMap(it.Key()).IsBound(E))
-      {
-        NCollection_List<TopoDS_Shape> L;
-        myMap(it.Key()).Bind(E, L);
-      }
+      NCollection_List<TopoDS_Shape>* pListV2 =
+        myMap.ChangeFind(it.Key()).TryBound(V2, NCollection_List<TopoDS_Shape>());
+      NCollection_List<TopoDS_Shape>* pListE =
+        myMap.ChangeFind(it.Key()).TryBound(E, NCollection_List<TopoDS_Shape>());
 
       for (; itLOF.More(); itLOF.Next())
       {
         const TopoDS_Shape& OS = itLOF.Value();
-        myMap(it.Key())(V2).Append(PS.LastShape(OS));
-        myMap(it.Key())(E).Append(PS.Shape(OS));
+        pListV2->Append(PS.LastShape(OS));
+        pListE->Append(PS.Shape(OS));
       }
     }
   }
@@ -1850,26 +1827,24 @@ void BRepFill_Evolved::Add(BRepFill_Evolved& Vevo, const TopoDS_Wire& Prof, BRep
     for (iteP.Initialize(MapVevo(CurrentSpine)); iteP.More(); iteP.Next())
     {
       CurrentProf = iteP.Key();
-      if (!myMap.IsBound(CurrentSpine))
+      //------------------------------------------------
+      // The element of spine is not yet present .
+      // => previous profile not on the border.
+      //-------------------------------------------------
+      NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>*
+        pSpineMap = myMap.TryBound(CurrentSpine, EmptyMap);
+      if (!pSpineMap->IsBound(CurrentProf))
       {
-        //------------------------------------------------
-        // The element of spine is not yet present .
-        // => previous profile not on the border.
-        //-------------------------------------------------
-        myMap.Bind(CurrentSpine, EmptyMap);
-      }
-      if (!myMap(CurrentSpine).IsBound(CurrentProf))
-      {
-        myMap(CurrentSpine).Bind(CurrentProf, EmptyList);
+        NCollection_List<TopoDS_Shape>* pProfList = pSpineMap->TryBound(CurrentProf, EmptyList);
         const NCollection_List<TopoDS_Shape>&    GenShapes = MapVevo(CurrentSpine)(CurrentProf);
         NCollection_List<TopoDS_Shape>::Iterator itl(GenShapes);
         for (; itl.More(); itl.Next())
         {
           // during Glue.Add the shared shapes are recreated.
           if (Glue.IsCopied(itl.Value()))
-            myMap(CurrentSpine)(CurrentProf).Append(Glue.Copy(itl.Value()));
+            pProfList->Append(Glue.Copy(itl.Value()));
           else
-            myMap(CurrentSpine)(CurrentProf).Append(itl.Value());
+            pProfList->Append(itl.Value());
         }
       }
     }
@@ -1953,16 +1928,7 @@ void BRepFill_Evolved::Transfert(
         itl.ChangeValue().Move(LS);
       }
 
-      if (!myMap.IsBound(InitialSpine))
-      {
-        myMap.Bind(InitialSpine, EmptyMap);
-      }
-
-      if (!myMap(InitialSpine).IsBound(InitialProf))
-      {
-        myMap(InitialSpine).Bind(InitialProf, EmptyList);
-      }
-      myMap(InitialSpine)(InitialProf).Append(GenShapes);
+      myMap.TryBound(InitialSpine, EmptyMap)->TryBound(InitialProf, EmptyList)->Append(GenShapes);
     }
   }
   //--------------------------------------------------------------
@@ -3284,11 +3250,7 @@ int VertexFromNode(
     else
     {
       B.MakeVertex(VN);
-      if (!MapNodeVertex.IsBound(aNode))
-      {
-        MapNodeVertex.Bind(aNode, EmptyMap);
-      }
-      MapNodeVertex(aNode).Bind(ShapeOnNode, VN);
+      MapNodeVertex.TryBound(aNode, EmptyMap)->Bind(ShapeOnNode, VN);
     }
   }
   return Status;

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_Evolved.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_Evolved.cxx
@@ -1395,7 +1395,9 @@ void BRepFill_Evolved::VerticalPerform(const TopoDS_Face&              Sp,
       {
         const TopoDS_Edge&  anEdge = TopoDS::Edge(Exp.Current());
         const TopoDS_Shape& AE     = OffAnc.Ancestor(anEdge);
-        myMap.TryBound(AE, EmptyMap)->TryBound(V1, NCollection_List<TopoDS_Shape>())->Append(anEdge);
+        myMap.TryBound(AE, EmptyMap)
+          ->TryBound(V1, NCollection_List<TopoDS_Shape>())
+          ->Append(anEdge);
       }
       First = false;
     }
@@ -1419,7 +1421,7 @@ void BRepFill_Evolved::VerticalPerform(const TopoDS_Face&              Sp,
     {
       const NCollection_List<TopoDS_Shape>&    LOF = it.Value()(V1);
       NCollection_List<TopoDS_Shape>::Iterator itLOF(LOF);
-      NCollection_List<TopoDS_Shape>* pListV2 =
+      NCollection_List<TopoDS_Shape>*          pListV2 =
         myMap.ChangeFind(it.Key()).TryBound(V2, NCollection_List<TopoDS_Shape>());
       NCollection_List<TopoDS_Shape>* pListE =
         myMap.ChangeFind(it.Key()).TryBound(E, NCollection_List<TopoDS_Shape>());

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_Generator.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_Generator.cxx
@@ -576,10 +576,7 @@ static TopoDS_Edge CreateNewEdge(
   }
   theCopiedEdges.Bind(theEdge, aNewEdge);
 
-  if (!theModifWires.Contains(theWire))
-  {
-    theModifWires.Add(theWire);
-  }
+  theModifWires.Add(theWire);
   return aNewEdge;
 }
 

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_OffsetWire.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_OffsetWire.cxx
@@ -391,11 +391,7 @@ const NCollection_List<TopoDS_Shape>& BRepFill_OffsetWire::GeneratedShapes(
       {
         if (myMap.Contains(it.Key()))
         {
-          if (!myMap.Contains(it.Value()))
-          {
-            NCollection_List<TopoDS_Shape> L;
-            myMap.Add(it.Value(), L);
-          }
+          myMap.Bound(it.Value(), NCollection_List<TopoDS_Shape>());
           if (!it.Value().IsSame(it.Key()))
           {
             myMap.ChangeFromKey(it.Value()).Append(myMap.ChangeFromKey(it.Key()));
@@ -404,11 +400,7 @@ const NCollection_List<TopoDS_Shape>& BRepFill_OffsetWire::GeneratedShapes(
         }
         if (myMap.Contains(it.Key().Reversed()))
         {
-          if (!myMap.Contains(it.Value().Reversed()))
-          {
-            NCollection_List<TopoDS_Shape> L;
-            myMap.Add(it.Value().Reversed(), L);
-          }
+          myMap.Bound(it.Value().Reversed(), NCollection_List<TopoDS_Shape>());
           if (!it.Value().IsSame(it.Key()))
           {
             myMap.ChangeFromKey(it.Value().Reversed())
@@ -519,10 +511,8 @@ void BRepFill_OffsetWire::Perform(const double Offset, const double Alt)
             myMapSpine.Bind(NewEdge, myMapSpine(anE));
             TopoDS_Vertex NewV1, NewV2;
             EdgeVertices(NewEdge, NewV1, NewV2);
-            if (!myMapSpine.IsBound(NewV1))
-              myMapSpine.Bind(NewV1, myMapSpine(anE));
-            if (!myMapSpine.IsBound(NewV2))
-              myMapSpine.Bind(NewV2, myMapSpine(anE));
+            myMapSpine.TryBound(NewV1, myMapSpine(anE));
+            myMapSpine.TryBound(NewV2, myMapSpine(anE));
           }
           myMapSpine.UnBind(anE);
         }
@@ -941,11 +931,8 @@ void BRepFill_OffsetWire::PerformWithBiLo(const TopoDS_Face&              Spine,
     {
       for (k = 0; k <= 1; k++)
       {
-        if (!MapBis.IsBound(E[k]))
-        {
-          MapBis.Bind(E[k], EmptySeq);
-          MapVerPar.Bind(E[k], EmptySeqOfReal);
-        }
+        MapBis.TryBound(E[k], EmptySeq);
+        MapVerPar.TryBound(E[k], EmptySeqOfReal);
         for (int ii = 1; ii <= Vertices.Length(); ii++)
         {
           MapBis(E[k]).Append(Vertices.Value(ii));
@@ -1202,10 +1189,8 @@ void BRepFill_OffsetWire::PrepareSpine()
           B.Add(NW, NE);
           myMapSpine.Bind(NE, E);
           EdgeVertices(NE, V1, V2);
-          if (!myMapSpine.IsBound(V1))
-            myMapSpine.Bind(V1, E);
-          if (!myMapSpine.IsBound(V2))
-            myMapSpine.Bind(V2, E);
+          myMapSpine.TryBound(V1, E);
+          myMapSpine.TryBound(V2, E);
         }
       }
     }
@@ -1365,18 +1350,8 @@ void BRepFill_OffsetWire::MakeWires()
         continue; // remove small closed edges
       if (!CheckSmallParamOnEdge(E))
         continue;
-      if (!MVE.Contains(V1))
-      {
-        NCollection_List<TopoDS_Shape> empty;
-        MVE.Add(V1, empty);
-      }
-      MVE.ChangeFromKey(V1).Append(E);
-      if (!MVE.Contains(V2))
-      {
-        NCollection_List<TopoDS_Shape> empty;
-        MVE.Add(V2, empty);
-      }
-      MVE.ChangeFromKey(V2).Append(E);
+      MVE.Bound(V1, NCollection_List<TopoDS_Shape>())->Append(E);
+      MVE.Bound(V2, NCollection_List<TopoDS_Shape>())->Append(E);
     }
   }
 

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder1.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder1.cxx
@@ -1850,14 +1850,16 @@ int TopOpeBRepBuild_Builder1::TwoPiecesON(const NCollection_Sequence<TopoDS_Shap
         //// ????
         else if (aStateObj == TopAbs_IN && aStateTool == TopAbs_IN)
         {
-          if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
+          const int aPrevExtent = myProcessedPartsON2d.Extent();
+          if (myProcessedPartsON2d.Add(aPieceObj) > aPrevExtent)
           {                                     // we proceed IsSame only if we didn't it before
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }
         else if (aStateObj == TopAbs_OUT && aStateTool == TopAbs_OUT)
         {
-          if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
+          const int aPrevExtent = myProcessedPartsON2d.Extent();
+          if (myProcessedPartsON2d.Add(aPieceObj) > aPrevExtent)
           {                                     // we proceed IsSame only if we didn't it before
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
@@ -1925,7 +1927,8 @@ int TopOpeBRepBuild_Builder1::TwoPiecesON(const NCollection_Sequence<TopoDS_Shap
         }
         else if (aStateObj == TopAbs_IN && aStateTool == TopAbs_IN)
         {
-          if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
+          const int aPrevExtent = myProcessedPartsON2d.Extent();
+          if (myProcessedPartsON2d.Add(aPieceObj) > aPrevExtent)
           {                                     // we proceed IsSame only if we didn't it before
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder1.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder1.cxx
@@ -1851,14 +1851,14 @@ int TopOpeBRepBuild_Builder1::TwoPiecesON(const NCollection_Sequence<TopoDS_Shap
         else if (aStateObj == TopAbs_IN && aStateTool == TopAbs_IN)
         {
           if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
-          { // we proceed IsSame only if we didn't it before
+          {                                     // we proceed IsSame only if we didn't it before
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }
         else if (aStateObj == TopAbs_OUT && aStateTool == TopAbs_OUT)
         {
           if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
-          { // we proceed IsSame only if we didn't it before
+          {                                     // we proceed IsSame only if we didn't it before
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }
@@ -1926,7 +1926,7 @@ int TopOpeBRepBuild_Builder1::TwoPiecesON(const NCollection_Sequence<TopoDS_Shap
         else if (aStateObj == TopAbs_IN && aStateTool == TopAbs_IN)
         {
           if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
-          { // we proceed IsSame only if we didn't it before
+          {                                     // we proceed IsSame only if we didn't it before
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder1.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder1.cxx
@@ -1850,17 +1850,15 @@ int TopOpeBRepBuild_Builder1::TwoPiecesON(const NCollection_Sequence<TopoDS_Shap
         //// ????
         else if (aStateObj == TopAbs_IN && aStateTool == TopAbs_IN)
         {
-          if (!myProcessedPartsON2d.Contains(aPieceObj))
+          if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
           { // we proceed IsSame only if we didn't it before
-            myProcessedPartsON2d.Add(aPieceObj);
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }
         else if (aStateObj == TopAbs_OUT && aStateTool == TopAbs_OUT)
         {
-          if (!myProcessedPartsON2d.Contains(aPieceObj))
+          if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
           { // we proceed IsSame only if we didn't it before
-            myProcessedPartsON2d.Add(aPieceObj);
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }
@@ -1927,9 +1925,8 @@ int TopOpeBRepBuild_Builder1::TwoPiecesON(const NCollection_Sequence<TopoDS_Shap
         }
         else if (aStateObj == TopAbs_IN && aStateTool == TopAbs_IN)
         {
-          if (!myProcessedPartsON2d.Contains(aPieceObj))
+          if (myProcessedPartsON2d.Add(aPieceObj) == myProcessedPartsON2d.Extent())
           { // we proceed IsSame only if we didn't it before
-            myProcessedPartsON2d.Add(aPieceObj);
             IsSame2d(aSeq, aListOfPiecesOut2d); // Perform IsSame 2d and keep periodic parts
           }
         }

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridSS.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_GridSS.cxx
@@ -648,11 +648,8 @@ static void FUNBUILD_MAPANCSPLSHAPES(
     const NCollection_List<TopoDS_Shape>& l = B.Splits(S, STATE);
     for (NCollection_List<TopoDS_Shape>::Iterator it(l); it.More(); it.Next())
     {
-      const TopoDS_Shape&            sps = it.Value(); // sps = split result of S on state STATE
-      NCollection_List<TopoDS_Shape> thelist;
-      if (!_IDM.Contains(sps))
-        _IDM.Add(sps, thelist);
-      _IDM.ChangeFromKey(sps).Append(S);
+      const TopoDS_Shape& sps = it.Value(); // sps = split result of S on state STATE
+      _IDM.Bound(sps, NCollection_List<TopoDS_Shape>())->Append(S);
     }
   }
 }

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Tools.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Tools.cxx
@@ -81,9 +81,8 @@ void TopOpeBRepBuild_Tools::FindState(
     for (i = 1; i <= nSub; i++)
     {
       const TopoDS_Shape& aSS = aSubshMap(i);
-      if (!aMapProcessedSubsh.Contains(aSS))
+      if (aMapProcessedSubsh.Add(aSS))
       {
-        aMapProcessedSubsh.Add(aSS);
         aMapSS.Bind(aSS, aState);
         FindState(aSS, aState, aSubshEnum, aMapSubshAnc, aMapProcessedSubsh, aMapSS);
       }
@@ -262,9 +261,8 @@ void TopOpeBRepBuild_Tools::FindState2(
     for (i = 1; i <= nSub; i++)
     {
       const TopoDS_Shape& aSS = aSubshMap(i);
-      if (!aMapProcessedSubsh.Contains(aSS))
+      if (aMapProcessedSubsh.Add(aSS))
       {
-        aMapProcessedSubsh.Add(aSS);
         aMapSS.Bind(aSS, aState);
         FindState2(aSS, aState, aMapSubshAnc, aMapProcessedSubsh, aMapSS);
       }
@@ -304,9 +302,8 @@ void TopOpeBRepBuild_Tools::FindState1(
     for (i = 1; i <= nSub; i++)
     {
       const TopoDS_Shape& aSS = aSubshMap(i);
-      if (!aMapProcessedSubsh.Contains(aSS))
+      if (aMapProcessedSubsh.Add(aSS))
       {
-        aMapProcessedSubsh.Add(aSS);
         aMapSS.Bind(aSS, aState);
         FindState1(aSS, aState, aMapSubshAnc, aMapProcessedSubsh, aMapSS);
       }

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepDS/TopOpeBRepDS_DataStructure.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepDS/TopOpeBRepDS_DataStructure.cxx
@@ -335,10 +335,7 @@ void TopOpeBRepDS_DataStructure::InitSectionEdges()
 
 int TopOpeBRepDS_DataStructure::AddSectionEdge(const TopoDS_Edge& E)
 {
-  int iE = mySectionEdges.FindIndex(E);
-  if (iE == 0)
-    iE = mySectionEdges.Add(E);
-  return iE;
+  return mySectionEdges.Add(E);
 }
 
 //=================================================================================================

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepDS/TopOpeBRepDS_FIR.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepDS/TopOpeBRepDS_FIR.cxx
@@ -312,11 +312,8 @@ void FUN_GmapS(
     FDS_data(I1, GT1, G1, ST1, S1);
     if (GT1 != MDSke || ST1 != MDSkf)
       continue;
-    const TopoDS_Shape&    SG1 = BDS.Shape(G1);
-    TopOpeBRepDS_ShapeData thedata;
-    if (!mosd.Contains(SG1))
-      mosd.Add(SG1, thedata);
-    mosd.ChangeFromKey(SG1).ChangeInterferences().Append(I1);
+    const TopoDS_Shape& SG1 = BDS.Shape(G1);
+    mosd.Bound(SG1, TopOpeBRepDS_ShapeData())->ChangeInterferences().Append(I1);
   }
 }
 

--- a/src/ModelingAlgorithms/TKExpress/Expr/Expr_RUIterator.cxx
+++ b/src/ModelingAlgorithms/TKExpress/Expr/Expr_RUIterator.cxx
@@ -36,20 +36,14 @@ Expr_RUIterator::Expr_RUIterator(const occ::handle<Expr_GeneralRelation>& rel)
     {
       var = ui1.Value();
       ui1.Next();
-      if (!myMap.Contains(var))
-      {
-        myMap.Add(var);
-      }
+      myMap.Add(var);
     }
     Expr_UnknownIterator ui2(srel->SecondMember());
     while (ui2.More())
     {
       var = ui2.Value();
       ui2.Next();
-      if (!myMap.Contains(var))
-      {
-        myMap.Add(var);
-      }
+      myMap.Add(var);
     }
   }
 }

--- a/src/ModelingAlgorithms/TKExpress/Expr/Expr_UnknownIterator.cxx
+++ b/src/ModelingAlgorithms/TKExpress/Expr/Expr_UnknownIterator.cxx
@@ -29,10 +29,7 @@ void Expr_UnknownIterator::Perform(const occ::handle<Expr_GeneralExpression>& ex
   if (exp->IsKind(STANDARD_TYPE(Expr_NamedUnknown)))
   {
     occ::handle<Expr_NamedUnknown> varexp = occ::down_cast<Expr_NamedUnknown>(exp);
-    if (!myMap.Contains(varexp))
-    {
-      myMap.Add(varexp);
-    }
+    myMap.Add(varexp);
   }
   int nbsub = exp->NbSubExpressions();
   for (int i = 1; i <= nbsub; i++)

--- a/src/ModelingAlgorithms/TKFeat/BRepFeat/BRepFeat_Builder.cxx
+++ b/src/ModelingAlgorithms/TKFeat/BRepFeat/BRepFeat_Builder.cxx
@@ -305,9 +305,10 @@ void BRepFeat_Builder::RebuildFaces()
     {
       const TopoDS_Shape& aS = aSI.Shape();
       //
-      if (myImages.IsBound(aS))
+      NCollection_List<TopoDS_Shape>* pLIm = myImages.ChangeSeek(aS);
+      if (pLIm)
       {
-        NCollection_List<TopoDS_Shape>& aLIm = myImages.ChangeFind(aS);
+        NCollection_List<TopoDS_Shape>& aLIm = *pLIm;
         aItIm.Initialize(aLIm);
         for (; aItIm.More();)
         {
@@ -353,9 +354,10 @@ void BRepFeat_Builder::RebuildFaces()
       anOriE                = aE.Orientation();
       bIsDegenerated        = BRep_Tool::Degenerated(aE);
       bIsClosed             = BRep_Tool::IsClosed(aE, aF);
-      if (myImages.IsBound(aE))
+      NCollection_List<TopoDS_Shape>* pLEIm = myImages.ChangeSeek(aE);
+      if (pLEIm)
       {
-        NCollection_List<TopoDS_Shape>& aLEIm = myImages.ChangeFind(aE);
+        NCollection_List<TopoDS_Shape>& aLEIm = *pLEIm;
         //
         bRem = false;
         bIm  = false;

--- a/src/ModelingAlgorithms/TKFeat/BRepFeat/BRepFeat_Builder.cxx
+++ b/src/ModelingAlgorithms/TKFeat/BRepFeat/BRepFeat_Builder.cxx
@@ -350,10 +350,10 @@ void BRepFeat_Builder::RebuildFaces()
     aExp.Init(aFF, TopAbs_EDGE);
     for (; aExp.More(); aExp.Next())
     {
-      const TopoDS_Edge& aE = (*(TopoDS_Edge*)(&aExp.Current()));
-      anOriE                = aE.Orientation();
-      bIsDegenerated        = BRep_Tool::Degenerated(aE);
-      bIsClosed             = BRep_Tool::IsClosed(aE, aF);
+      const TopoDS_Edge& aE                 = (*(TopoDS_Edge*)(&aExp.Current()));
+      anOriE                                = aE.Orientation();
+      bIsDegenerated                        = BRep_Tool::Degenerated(aE);
+      bIsClosed                             = BRep_Tool::IsClosed(aE, aF);
       NCollection_List<TopoDS_Shape>* pLEIm = myImages.ChangeSeek(aE);
       if (pLEIm)
       {

--- a/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_BuildShape.cxx
+++ b/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_BuildShape.cxx
@@ -69,9 +69,8 @@ void LocOpe_BuildShape::Perform(const NCollection_List<TopoDS_Shape>& L)
 
   for (itl.Initialize(L); itl.More(); itl.Next())
   {
-    if (itl.Value().ShapeType() == TopAbs_FACE && !mapF.Contains(itl.Value()))
+    if (itl.Value().ShapeType() == TopAbs_FACE && mapF.Add(itl.Value()))
     {
-      mapF.Add(itl.Value());
       B.Add(C, itl.Value());
     }
   }
@@ -337,9 +336,8 @@ static void Add(const int                                                      i
   NCollection_List<TopoDS_Shape>::Iterator itl(mapEF(ind));
   for (; itl.More(); itl.Next())
   {
-    if (!mapF.Contains(itl.Value()))
+    if (mapF.Add(itl.Value()))
     {
-      mapF.Add(itl.Value());
       TopExp_Explorer exp;
       for (exp.Init(itl.Value(), TopAbs_EDGE);
            //      for (TopExp_Explorer exp(itl.Value(),TopAbs_EDGE);

--- a/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_BuildShape.cxx
+++ b/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_BuildShape.cxx
@@ -69,9 +69,13 @@ void LocOpe_BuildShape::Perform(const NCollection_List<TopoDS_Shape>& L)
 
   for (itl.Initialize(L); itl.More(); itl.Next())
   {
-    if (itl.Value().ShapeType() == TopAbs_FACE && mapF.Add(itl.Value()))
+    if (itl.Value().ShapeType() == TopAbs_FACE)
     {
-      B.Add(C, itl.Value());
+      const int aPrevExtent = mapF.Extent();
+      if (mapF.Add(itl.Value()) > aPrevExtent)
+      {
+        B.Add(C, itl.Value());
+      }
     }
   }
 
@@ -336,7 +340,8 @@ static void Add(const int                                                      i
   NCollection_List<TopoDS_Shape>::Iterator itl(mapEF(ind));
   for (; itl.More(); itl.Next())
   {
-    if (mapF.Add(itl.Value()))
+    const int aPrevExtent = mapF.Extent();
+    if (mapF.Add(itl.Value()) > aPrevExtent)
     {
       TopExp_Explorer exp;
       for (exp.Init(itl.Value(), TopAbs_EDGE);

--- a/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_Generator.cxx
+++ b/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_Generator.cxx
@@ -102,10 +102,7 @@ void LocOpe_Generator::Perform(const occ::handle<LocOpe_GeneratedShape>& G)
     for (exp2.Init(edg, TopAbs_VERTEX); exp2.More(); exp2.Next())
     {
       const TopoDS_Vertex& vtx = TopoDS::Vertex(exp2.Current());
-      if (!GVtx.Contains(vtx))
-      {
-        GVtx.Add(vtx);
-      }
+      GVtx.Add(vtx);
     }
     for (exp2.Init(myShape, TopAbs_FACE); exp2.More(); exp2.Next())
     {
@@ -115,11 +112,7 @@ void LocOpe_Generator::Perform(const occ::handle<LocOpe_GeneratedShape>& G)
         if (exp3.Current().IsSame(edg) && exp3.Current().Orientation() == edg.Orientation())
         {
           theLeft.Add(fac);
-          NCollection_List<TopoDS_Shape> emptylist;
-          if (!myModShapes.IsBound(fac))
-          {
-            myModShapes.Bind(fac, emptylist);
-          }
+          myModShapes.Bound(fac, NCollection_List<TopoDS_Shape>());
           break;
         }
       }
@@ -509,12 +502,7 @@ void LocOpe_Generator::Perform(const occ::handle<LocOpe_GeneratedShape>& G)
     }
     if (KeepNewEdge)
     {
-      NCollection_List<TopoDS_Shape> emptylist;
-      if (!myModShapes.IsBound(edg))
-      {
-        myModShapes.Bind(edg, emptylist);
-      }
-      myModShapes(edg).Append(newedg);
+      myModShapes.Bound(edg, NCollection_List<TopoDS_Shape>())->Append(newedg);
       toRemove.Add(edg);
     }
   }

--- a/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_SplitShape.cxx
+++ b/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_SplitShape.cxx
@@ -990,10 +990,9 @@ bool LocOpe_SplitShape::AddOpenWire(const TopoDS_Wire& W, const TopoDS_Face& F)
     for (; lexp.More(); lexp.Next())
     {
       const TopoDS_Edge& edg = TopoDS::Edge(lexp.Value());
-      if (!MapE.Contains(edg))
+      if (MapE.Add(edg))
       {
         B.Add(newW2, edg);
-        MapE.Add(edg);
         nbAddBound++;
         if (anE1.IsNull())
           anE1 = edg;

--- a/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_Spliter.cxx
+++ b/src/ModelingAlgorithms/TKFeat/LocOpe/LocOpe_Spliter.cxx
@@ -181,12 +181,7 @@ void LocOpe_Spliter::Perform(const occ::handle<LocOpe_WiresOnShape>& PW)
       fac                = TopoDS::Face(myMap(fac).First());
       if (IsFaceWithSec)
         theFacesWithSection.Add(fac);
-      if (!mapFE.Contains(fac))
-      {
-        NCollection_List<TopoDS_Shape> thelist;
-        mapFE.Add(fac, thelist);
-      }
-      mapFE.ChangeFromKey(fac).Append(edg);
+      mapFE.Bound(fac, NCollection_List<TopoDS_Shape>())->Append(edg);
     }
   }
 

--- a/src/ModelingAlgorithms/TKGeomAlgo/Geom2dHatch/Geom2dHatch_Hatcher.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/Geom2dHatch/Geom2dHatch_Hatcher.cxx
@@ -67,11 +67,9 @@ void Geom2dHatch_Hatcher::Intersector(const Geom2dHatch_Intersector& Intersector
   myIntersector = Intersector;
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
-    {
-      Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-      Hatching.ClrPoints();
-    }
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
+      pHatching->ClrPoints();
   }
 }
 
@@ -85,11 +83,9 @@ void Geom2dHatch_Hatcher::Confusion2d(const double Confusion)
   myConfusion2d = Confusion;
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
-    {
-      Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-      Hatching.ClrPoints();
-    }
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
+      pHatching->ClrPoints();
   }
 }
 
@@ -103,11 +99,9 @@ void Geom2dHatch_Hatcher::Confusion3d(const double Confusion)
   myConfusion3d = Confusion;
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
-    {
-      Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-      Hatching.ClrPoints();
-    }
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
+      pHatching->ClrPoints();
   }
 }
 
@@ -118,11 +112,9 @@ void Geom2dHatch_Hatcher::KeepPoints(const bool Keep)
   myKeepPoints = Keep;
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
-    {
-      Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-      Hatching.ClrDomains();
-    }
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
+      pHatching->ClrDomains();
   }
 }
 
@@ -133,11 +125,9 @@ void Geom2dHatch_Hatcher::KeepSegments(const bool Keep)
   myKeepSegments = Keep;
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
-    {
-      Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-      Hatching.ClrDomains();
-    }
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
+      pHatching->ClrDomains();
   }
 }
 
@@ -167,11 +157,9 @@ int Geom2dHatch_Hatcher::AddElement(const Geom2dAdaptor_Curve& Curve,
   myElements.Bind(IndE, Element);
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
-    {
-      Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-      Hatching.ClrPoints();
-    }
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
+      pHatching->ClrPoints();
   }
   return IndE;
 }
@@ -188,9 +176,10 @@ void Geom2dHatch_Hatcher::RemElement(const int IndE)
 #endif
   for (int IndH = 1; IndH <= myNbHatchings; IndH++)
   {
-    if (myHatchings.IsBound(IndH))
+    Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+    if (pHatching)
     {
-      Geom2dHatch_Hatching& Hatching       = myHatchings.ChangeFind(IndH);
+      Geom2dHatch_Hatching& Hatching       = *pHatching;
       bool                  DomainsToClear = false;
       for (int IPntH = Hatching.NbPoints(); IPntH > 0; IPntH--)
       {
@@ -228,11 +217,9 @@ void Geom2dHatch_Hatcher::ClrElements()
     {
       for (int IndH = 1; IndH <= myNbHatchings; IndH++)
       {
-        if (myHatchings.IsBound(IndH))
-        {
-          Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-          Hatching.ClrPoints();
-        }
+        Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+        if (pHatching)
+          pHatching->ClrPoints();
       }
     }
     myElements.Clear();
@@ -294,11 +281,9 @@ void Geom2dHatch_Hatcher::ClrHatchings()
   {
     for (int IndH = 1; IndH <= myNbHatchings; IndH++)
     {
-      if (myHatchings.IsBound(IndH))
-      {
-        Geom2dHatch_Hatching& Hatching = myHatchings.ChangeFind(IndH);
-        Hatching.ClrPoints();
-      }
+      Geom2dHatch_Hatching* pHatching = myHatchings.ChangeSeek(IndH);
+      if (pHatching)
+        pHatching->ClrPoints();
     }
     myHatchings.Clear();
     myNbHatchings = 0;

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DiscretFactory.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DiscretFactory.cxx
@@ -104,10 +104,11 @@ bool BRepMesh_DiscretFactory::SetDefault(const TCollection_AsciiString& theName,
 
   TCollection_AsciiString  aMeshAlgoId = theName + "_" + theFuncName;
   BRepMesh_PluginEntryType aFunc       = nullptr;
-  if (myFactoryMethods.IsBound(aMeshAlgoId))
+  const OSD_Function*      pCachedFunc = myFactoryMethods.Seek(aMeshAlgoId);
+  if (pCachedFunc)
   {
     // retrieve from cache
-    aFunc = (BRepMesh_PluginEntryType)myFactoryMethods(aMeshAlgoId);
+    aFunc = (BRepMesh_PluginEntryType)*pCachedFunc;
   }
   else
   {

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_MeshTool.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_MeshTool.cxx
@@ -254,9 +254,8 @@ void BRepMesh_MeshTool::collectTrianglesOnFreeLinksAroundNodesOf(
 
         for (int i = 0; i < 3; ++i)
         {
-          if (aEdges[i] != aLinkIndex && !aUsedLinks.Contains(aEdges[i]))
+          if (aEdges[i] != aLinkIndex && aUsedLinks.Add(aEdges[i]))
           {
-            aUsedLinks.Add(aEdges[i]);
             aStack.push(aEdges[i]);
           }
         }

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_ModelPostProcessor.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_ModelPostProcessor.cxx
@@ -93,13 +93,7 @@ private:
         continue;
       }
 
-      if (!aMapOfPCurves.Contains(aDFacePtr))
-      {
-        aMapOfPCurves.Add(aDFacePtr, IMeshData::ListOfIPCurves());
-      }
-
-      IMeshData::ListOfIPCurves& aPCurves = aMapOfPCurves.ChangeFromKey(aDFacePtr);
-      aPCurves.Append(aPCurve);
+      aMapOfPCurves.Bound(aDFacePtr, IMeshData::ListOfIPCurves())->Append(aPCurve);
     }
 
     // Commit polygons related to separate face.

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset_1.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset_1.cxx
@@ -4002,7 +4002,7 @@ static void buildPairs(const NCollection_IndexedMap<TopoDS_Shape, TopTools_Shape
   for (int it1 = 1; it1 <= aNbS; ++it1)
   {
     const TopoDS_Shape& aS = theSMap(it1);
-    theIntPairs.Bound(aS, NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>());
+    theIntPairs.TryBound(aS, NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>());
   }
 
   for (int it1 = 1; it1 <= aNbS; ++it1)

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset_1.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset_1.cxx
@@ -4002,8 +4002,7 @@ static void buildPairs(const NCollection_IndexedMap<TopoDS_Shape, TopTools_Shape
   for (int it1 = 1; it1 <= aNbS; ++it1)
   {
     const TopoDS_Shape& aS = theSMap(it1);
-    if (!theIntPairs.IsBound(aS))
-      theIntPairs.Bind(aS, NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>());
+    theIntPairs.Bound(aS, NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>());
   }
 
   for (int it1 = 1; it1 <= aNbS; ++it1)

--- a/src/ModelingAlgorithms/TKOffset/Draft/Draft_Modification_1.cxx
+++ b/src/ModelingAlgorithms/TKOffset/Draft/Draft_Modification_1.cxx
@@ -442,26 +442,16 @@ bool Draft_Modification::Propagate()
     {
       E = TopoDS::Edge(editer.Current());
 
-      if (!myEMap.Contains(E))
-      {
-        Draft_EdgeInfo EInf(true);
-        myEMap.Add(E, EInf);
-      }
-      myEMap.ChangeFromKey(E).Add(Fc);
+      myEMap.Bound(E, Draft_EdgeInfo(true))->Add(Fc);
 
       // Exploration of the vertices of the edge
       vtiter.Init(E, TopAbs_VERTEX);
       while (vtiter.More())
       {
         V = TopoDS::Vertex(vtiter.Current());
-        if (!myVMap.Contains(V))
-        {
-          Draft_VertexInfo VInf;
-          myVMap.Add(V, VInf);
-        }
-
-        myVMap.ChangeFromKey(V).Add(E);
-        myVMap.ChangeFromKey(V).ChangeParameter(E) = BRep_Tool::Parameter(V, E);
+        Draft_VertexInfo* aVInfo = myVMap.Bound(V, Draft_VertexInfo());
+        aVInfo->Add(E);
+        aVInfo->ChangeParameter(E) = BRep_Tool::Parameter(V, E);
         vtiter.Next();
       }
       editer.Next();
@@ -496,11 +486,7 @@ bool Draft_Modification::Propagate()
       }
       if (found)
       {
-        if (!myEMap.Contains(E))
-        {
-          Draft_EdgeInfo EInf(false);
-          myEMap.Add(E, EInf);
-        }
+        myEMap.Add(E, Draft_EdgeInfo(false));
         myVMap.ChangeFromKey(Vt).Add(E);
         myVMap.ChangeFromKey(Vt).ChangeParameter(E) = BRep_Tool::Parameter(Vt, E);
       }

--- a/src/ModelingAlgorithms/TKOffset/Draft/Draft_Modification_1.cxx
+++ b/src/ModelingAlgorithms/TKOffset/Draft/Draft_Modification_1.cxx
@@ -448,7 +448,7 @@ bool Draft_Modification::Propagate()
       vtiter.Init(E, TopAbs_VERTEX);
       while (vtiter.More())
       {
-        V = TopoDS::Vertex(vtiter.Current());
+        V                        = TopoDS::Vertex(vtiter.Current());
         Draft_VertexInfo* aVInfo = myVMap.Bound(V, Draft_VertexInfo());
         aVInfo->Add(E);
         aVInfo->ChangeParameter(E) = BRep_Tool::Parameter(V, E);

--- a/src/ModelingAlgorithms/TKShHealing/ShapeAnalysis/ShapeAnalysis_Shell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeAnalysis/ShapeAnalysis_Shell.cxx
@@ -89,10 +89,9 @@ static bool CheckEdges(const TopoDS_Shape&                                      
 
     if (shape.Orientation() == TopAbs_FORWARD)
     {
-      // szv#4:S4163:12Mar99 optimized
-      if (dirs.FindIndex(shape) == 0)
-        dirs.Add(shape);
-      else
+      // Check if shape already exists - Add returns index <= previous extent if duplicate
+      const int aPrevExtent = dirs.Extent();
+      if (dirs.Add(shape) <= aPrevExtent)
       {
         bads.Add(shape);
         res = true;
@@ -100,10 +99,9 @@ static bool CheckEdges(const TopoDS_Shape&                                      
     }
     if (shape.Orientation() == TopAbs_REVERSED)
     {
-      // szv#4:S4163:12Mar99 optimized
-      if (revs.FindIndex(shape) == 0)
-        revs.Add(shape);
-      else
+      // Check if shape already exists - Add returns index <= previous extent if duplicate
+      const int aPrevExtent = revs.Extent();
+      if (revs.Add(shape) <= aPrevExtent)
       {
         bads.Add(shape);
         res = true;
@@ -111,9 +109,7 @@ static bool CheckEdges(const TopoDS_Shape&                                      
     }
     if (shape.Orientation() == TopAbs_INTERNAL)
     {
-      if (ints.FindIndex(shape) == 0)
-        ints.Add(shape);
-      // else { bads.Add (shape); res = true; }
+      ints.Add(shape);
     }
   }
 

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix.cxx
@@ -529,14 +529,7 @@ bool ShapeFix::FixVertexPosition(TopoDS_Shape&                          theshape
         aVert1 = aVert;
       else if (aVert1.IsSame(aVert))
         continue;
-      if (aMapVertEdges.Contains(aVert))
-        aMapVertEdges.ChangeFromKey(aVert).Append(aExp1.Current());
-      else
-      {
-        NCollection_List<TopoDS_Shape> alEdges;
-        alEdges.Append(aExp1.Current());
-        aMapVertEdges.Add(aVert, alEdges);
-      }
+      aMapVertEdges.Bound(aVert, NCollection_List<TopoDS_Shape>())->Append(aExp1.Current());
     }
   }
   bool isDone = false;

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
@@ -746,7 +746,7 @@ static bool AddMultiConexityFaces(
     }
     for (NCollection_List<TopoDS_Shape>::Iterator aItl(lfaces); aItl.More(); aItl.Next())
     {
-      TopoDS_Shape aF = aItl.Value();
+      TopoDS_Shape        aF          = aItl.Value();
       const TopoDS_Shape* pOthershell = aMapFaceShells.Seek(aF);
       if (!pOthershell)
         continue;

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
@@ -254,9 +254,8 @@ static NCollection_List<NCollection_Sequence<TopoDS_Shape>> GetConnectedFaceGrou
             {
               const TopoDS_Face& aNeighborFace = aConnectedFaces.Value(aFaceIdx);
 
-              if (!aVisitedFaces.Contains(aNeighborFace))
+              if (aVisitedFaces.Add(aNeighborFace))
               {
-                aVisitedFaces.Add(aNeighborFace);
                 aStack.push(aNeighborFace);
               }
             }
@@ -748,11 +747,11 @@ static bool AddMultiConexityFaces(
     for (NCollection_List<TopoDS_Shape>::Iterator aItl(lfaces); aItl.More(); aItl.Next())
     {
       TopoDS_Shape aF = aItl.Value();
-      if (!aMapFaceShells.IsBound(aF))
+      const TopoDS_Shape* pOthershell = aMapFaceShells.Seek(aF);
+      if (!pOthershell)
         continue;
 
-      TopoDS_Shape aOthershell;
-      aOthershell = aMapFaceShells.Find(aF);
+      TopoDS_Shape aOthershell = *pOthershell;
       if (MapOtherShells.IsBound(aOthershell))
         continue;
       if (!NonManifold && BRep_Tool::IsClosed(aOthershell))
@@ -812,10 +811,11 @@ static bool AddMultiConexityFaces(
     int ind = 0;
     for (int l = 1; l <= SeqShells.Length(); l++)
     {
-      if (!MapOtherShells.IsBound(SeqShells.Value(l)))
+      const int* pIsRev = MapOtherShells.Seek(SeqShells.Value(l));
+      if (!pIsRev)
         continue;
       ind++;
-      int          isRev     = MapOtherShells.Find(SeqShells.Value(l));
+      int          isRev     = *pIsRev;
       TopoDS_Shape anewShape = (isRev ? aSh.Reversed() : aSh);
 
       BRep_Builder aB1;
@@ -1146,13 +1146,12 @@ static void CreateNonManifoldShells(
           arshell = ss;
         }
 
-        if (!mapmerge.Contains(arshell))
+        if (mapmerge.Add(arshell))
         {
           for (TopExp_Explorer aEf(arshell, TopAbs_FACE); aEf.More(); aEf.Next())
           {
             aB.Add(aNewShell, aEf.Current());
           }
-          mapmerge.Add(arshell);
         }
       }
       else
@@ -1172,13 +1171,12 @@ static void CreateNonManifoldShells(
 
           mapmerge.Add(arshell);
         }
-        else if (!mapmerge.Contains(arshell))
+        else if (mapmerge.Add(arshell))
         {
           for (TopExp_Explorer aEf(arshell, TopAbs_FACE); aEf.More(); aEf.Next())
           {
             aB.Add(aNewShell, aEf.Current());
           }
-          mapmerge.Add(arshell);
         }
       }
     }

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -2587,9 +2587,7 @@ bool ShapeUpgrade_UnifySameDomain::MergeEdges(
       const TopoDS_Shape& aV = it.Value();
       if (aV.Orientation() == TopAbs_FORWARD || aV.Orientation() == TopAbs_REVERSED)
       {
-        if (!aMapVE.Contains(aV))
-          aMapVE.Add(aV, NCollection_List<TopoDS_Shape>());
-        aMapVE.ChangeFromKey(aV).Append(anEdge);
+        aMapVE.Bound(aV, NCollection_List<TopoDS_Shape>())->Append(anEdge);
       }
     }
   }

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepBuilderAPI/BRepBuilderAPI_Sewing.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepBuilderAPI/BRepBuilderAPI_Sewing.cxx
@@ -3187,7 +3187,7 @@ void BRepBuilderAPI_Sewing::VerticesAssembling(const Message_ProgressRange& theP
       for (TopoDS_Iterator itv(bound, false); itv.More(); itv.Next())
       {
         const TopoDS_Shape& node = itv.Value();
-        myNodeSections.Bound(node, NCollection_List<TopoDS_Shape>())->Append(bound);
+        myNodeSections.TryBound(node, NCollection_List<TopoDS_Shape>())->Append(bound);
       }
     }
     // Glue vertices
@@ -4085,7 +4085,7 @@ void BRepBuilderAPI_Sewing::Cutting(const Message_ProgressRange& theProgress)
           if (const TopoDS_Shape* pVertex = myVertexNode.Seek(vertex))
             vertex = TopoDS::Vertex(*pVertex);
           // Update node sections
-          myNodeSections.Bound(vertex, NCollection_List<TopoDS_Shape>())->Append(section);
+          myNodeSections.TryBound(vertex, NCollection_List<TopoDS_Shape>())->Append(section);
         }
         // Store bound for section
         mySectionBound.Bind(section, bound);
@@ -4158,7 +4158,7 @@ void BRepBuilderAPI_Sewing::GetFreeWires(
     for (TopoDS_Iterator Iv(edge, false); Iv.More(); Iv.Next())
     {
       const TopoDS_Vertex& V1 = TopoDS::Vertex(Iv.Value());
-      VertEdge.Bound(V1, NCollection_List<TopoDS_Shape>())->Append(edge);
+      VertEdge.TryBound(V1, NCollection_List<TopoDS_Shape>())->Append(edge);
     }
   }
   BRep_Builder B;

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepBuilderAPI/BRepBuilderAPI_Sewing.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepBuilderAPI/BRepBuilderAPI_Sewing.cxx
@@ -369,10 +369,10 @@ TopoDS_Edge BRepBuilderAPI_Sewing::SameParameterEdge(
     // Create presentation edge
     TopoDS_Vertex V1, V2;
     TopExp::Vertices(Edge1, V1, V2);
-    if (myVertexNode.Contains(V1))
-      V1 = TopoDS::Vertex(myVertexNode.FindFromKey(V1));
-    if (myVertexNode.Contains(V2))
-      V2 = TopoDS::Vertex(myVertexNode.FindFromKey(V2));
+    if (const TopoDS_Shape* pV1 = myVertexNode.Seek(V1))
+      V1 = TopoDS::Vertex(*pV1);
+    if (const TopoDS_Shape* pV2 = myVertexNode.Seek(V2))
+      V2 = TopoDS::Vertex(*pV2);
 
     TopoDS_Edge NewEdge = Edge1;
     NewEdge.EmptyCopy();
@@ -2627,11 +2627,7 @@ void BRepBuilderAPI_Sewing::FindFreeBoundaries()
     for (TopExp_Explorer eExp(shape, TopAbs_EDGE); eExp.More(); eExp.Next())
     {
       const TopoDS_Shape& edge = eExp.Current();
-      if (!EdgeFaces.Contains(edge))
-      {
-        NCollection_List<TopoDS_Shape> listFaces;
-        EdgeFaces.Add(edge, listFaces);
-      }
+      EdgeFaces.Add(edge, NCollection_List<TopoDS_Shape>());
     }
   }
   // Fill map Edge -> Faces
@@ -2644,10 +2640,8 @@ void BRepBuilderAPI_Sewing::FindFreeBoundaries()
     for (; fExp.More(); fExp.Next())
     {
       const TopoDS_Shape& face = fExp.Current();
-      if (mapFaces.Contains(face))
+      if (!mapFaces.Add(face))
         continue;
-      else
-        mapFaces.Add(face);
       // Explore face to find all boundaries
       for (TopoDS_Iterator aIw(face); aIw.More(); aIw.Next())
       {
@@ -2747,18 +2741,14 @@ void BRepBuilderAPI_Sewing::FindFreeBoundaries()
       if (isBound)
       {
         // Add to VertexNode
-        if (!myVertexNode.Contains(vFirst))
-          myVertexNode.Add(vFirst, vFirst);
-        if (!myVertexNode.Contains(vLast))
-          myVertexNode.Add(vLast, vLast);
+        myVertexNode.Add(vFirst, vFirst);
+        myVertexNode.Add(vLast, vLast);
       }
       else
       {
         // Add to VertexNodeFree
-        if (!myVertexNodeFree.Contains(vFirst))
-          myVertexNodeFree.Add(vFirst, vFirst);
-        if (!myVertexNodeFree.Contains(vLast))
-          myVertexNodeFree.Add(vLast, vLast);
+        myVertexNodeFree.Add(vFirst, vFirst);
+        myVertexNodeFree.Add(vLast, vLast);
       }
     }
   }
@@ -2887,9 +2877,8 @@ static bool CreateNewNodes(
       for (; ite.More(); ite.Next())
       {
         const TopoDS_Shape& edge = ite.Value();
-        if (!medge.Contains(edge))
+        if (medge.Add(edge))
         {
-          medge.Add(edge);
           ledge.Append(edge);
         }
       }
@@ -3049,14 +3038,14 @@ static bool GlueVertices(
         { // szv: Use brackets to destroy local variables
           TopoDS_Vertex ov1, ov2;
           TopExp::Vertices(TopoDS::Edge(e1), ov1, ov2);
-          if (aVertexNode.Contains(ov1))
+          if (const TopoDS_Shape* pOv1 = aVertexNode.Seek(ov1))
           {
-            if (node1.IsSame(aVertexNode.FindFromKey(ov1)))
+            if (node1.IsSame(*pOv1))
               v1 = ov1;
           }
-          if (aVertexNode.Contains(ov2))
+          if (const TopoDS_Shape* pOv2 = aVertexNode.Seek(ov2))
           {
-            if (node1.IsSame(aVertexNode.FindFromKey(ov2)))
+            if (node1.IsSame(*pOv2))
               v1 = ov2;
           }
         }
@@ -3080,14 +3069,14 @@ static bool GlueVertices(
           { // szv: Use brackets to destroy local variables
             TopoDS_Vertex ov1, ov2;
             TopExp::Vertices(TopoDS::Edge(e2), ov1, ov2);
-            if (aVertexNode.Contains(ov1))
+            if (const TopoDS_Shape* pOv1 = aVertexNode.Seek(ov1))
             {
-              if (node2.IsSame(aVertexNode.FindFromKey(ov1)))
+              if (node2.IsSame(*pOv1))
                 v2 = ov1;
             }
-            if (aVertexNode.Contains(ov2))
+            if (const TopoDS_Shape* pOv2 = aVertexNode.Seek(ov2))
             {
-              if (node2.IsSame(aVertexNode.FindFromKey(ov2)))
+              if (node2.IsSame(*pOv2))
                 v2 = ov2;
             }
           }
@@ -3198,14 +3187,7 @@ void BRepBuilderAPI_Sewing::VerticesAssembling(const Message_ProgressRange& theP
       for (TopoDS_Iterator itv(bound, false); itv.More(); itv.Next())
       {
         const TopoDS_Shape& node = itv.Value();
-        if (myNodeSections.IsBound(node))
-          myNodeSections(node).Append(bound);
-        else
-        {
-          NCollection_List<TopoDS_Shape> lbnd;
-          lbnd.Append(bound);
-          myNodeSections.Bind(node, lbnd);
-        }
+        myNodeSections.Bound(node, NCollection_List<TopoDS_Shape>())->Append(bound);
       }
     }
     // Glue vertices
@@ -3791,8 +3773,7 @@ void BRepBuilderAPI_Sewing::Merging(const bool /* firstTime */,
       }
       if (myBoundSections.IsBound(bound))
         myBoundSections.UnBind(bound);
-      if (!myMergedEdges.Contains(bound))
-        myMergedEdges.Add(bound);
+      myMergedEdges.Add(bound);
     }
   }
 
@@ -3884,10 +3865,10 @@ bool BRepBuilderAPI_Sewing::MergedNearestEdges(const TopoDS_Shape&              
       TopoDS_Vertex vs1, vs2;
       TopExp::Vertices(TopoDS::Edge(sec), vs1, vs2);
       TopoDS_Shape vs1n = vs1, vs2n = vs2;
-      if (myVertexNode.Contains(vs1))
-        vs1n = myVertexNode.FindFromKey(vs1);
-      if (myVertexNode.Contains(vs2))
-        vs2n = myVertexNode.FindFromKey(vs2);
+      if (const TopoDS_Shape* pVs1n = myVertexNode.Seek(vs1))
+        vs1n = *pVs1n;
+      if (const TopoDS_Shape* pVs2n = myVertexNode.Seek(vs2))
+        vs2n = *pVs2n;
       if ((mapVert1.Contains(vs1n) && mapVert2.Contains(vs2n))
           || (mapVert1.Contains(vs2n) && mapVert2.Contains(vs1n)))
         if (mapEdges.Add(sec))
@@ -4101,17 +4082,10 @@ void BRepBuilderAPI_Sewing::Cutting(const Message_ProgressRange& theProgress)
         {
           TopoDS_Shape vertex = itv.Value();
           // Convert vertex to node
-          if (myVertexNode.Contains(vertex))
-            vertex = TopoDS::Vertex(myVertexNode.FindFromKey(vertex));
+          if (const TopoDS_Shape* pVertex = myVertexNode.Seek(vertex))
+            vertex = TopoDS::Vertex(*pVertex);
           // Update node sections
-          if (myNodeSections.IsBound(vertex))
-            myNodeSections.ChangeFind(vertex).Append(section);
-          else
-          {
-            NCollection_List<TopoDS_Shape> lsec;
-            lsec.Append(section);
-            myNodeSections.Bind(vertex, lsec);
-          }
+          myNodeSections.Bound(vertex, NCollection_List<TopoDS_Shape>())->Append(section);
         }
         // Store bound for section
         mySectionBound.Bind(section, bound);
@@ -4184,14 +4158,7 @@ void BRepBuilderAPI_Sewing::GetFreeWires(
     for (TopoDS_Iterator Iv(edge, false); Iv.More(); Iv.Next())
     {
       const TopoDS_Vertex& V1 = TopoDS::Vertex(Iv.Value());
-      if (VertEdge.IsBound(V1))
-        VertEdge.ChangeFind(V1).Append(edge);
-      else
-      {
-        NCollection_List<TopoDS_Shape> ls;
-        ls.Append(edge);
-        VertEdge.Bind(V1, ls);
-      }
+      VertEdge.Bound(V1, NCollection_List<TopoDS_Shape>())->Append(edge);
     }
   }
   BRep_Builder B;

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Shell.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Shell.cxx
@@ -138,15 +138,8 @@ void BRepCheck_Shell::Minimum()
       TopExp_Explorer expe;
       for (expe.Init(exp.Current(), TopAbs_EDGE); expe.More(); expe.Next())
       {
-        const TopoDS_Shape& edg   = expe.Current();
-        int                 index = myMapEF.FindIndex(edg);
-        if (index == 0)
-        {
-          NCollection_List<TopoDS_Shape> thelist1;
-          index = myMapEF.Add(edg, thelist1);
-        }
-
-        myMapEF(index).Append(exp.Current());
+        const TopoDS_Shape& edg = expe.Current();
+        myMapEF.Bound(edg, NCollection_List<TopoDS_Shape>())->Append(exp.Current());
       }
     } // for (; exp.More(); exp.Next())
 
@@ -282,7 +275,7 @@ BRepCheck_Status BRepCheck_Shell::Closed(const bool Update)
 
   myCstat = BRepCheck_NoError;
   //
-  int                                                           index, aNbF;
+  int                                                           aNbF;
   TopExp_Explorer                                               exp, ede;
   NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> mapS;
   NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>        aMEToAvoid;
@@ -338,16 +331,7 @@ BRepCheck_Status BRepCheck_Shell::Closed(const bool Update)
         // if (IsOriented(aE)) {
         if (!aMEToAvoid.Contains(aE))
         {
-          // modified by NIZNHY-PKV Mon Jun  4 14:08:01 2007
-          index = myMapEF.FindIndex(aE);
-
-          if (!index)
-          {
-            NCollection_List<TopoDS_Shape> thelist;
-            index = myMapEF.Add(aE, thelist);
-          }
-
-          myMapEF(index).Append(aF);
+          myMapEF.Bound(aE, NCollection_List<TopoDS_Shape>())->Append(aF);
         }
       }
     }

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Wire.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Wire.cxx
@@ -1743,8 +1743,7 @@ static void Propagate(const NCollection_IndexedDataMap<TopoDS_Shape,
     for (; itrc.More(); itrc.Next())
     {
       const TopoDS_Shape& Edge = itrc.Value();
-      if (!mapE.Contains(Edge))
-        mapE.Add(Edge);
+      mapE.Add(Edge);
 
       TopExp_Explorer ex(Edge, TopAbs_VERTEX);
       for (; ex.More(); ex.Next())
@@ -1759,9 +1758,8 @@ static void Propagate(const NCollection_IndexedDataMap<TopoDS_Shape,
           for (; itl.More(); itl.Next())
           {
             const TopoDS_Shape& E = itl.Value();
-            if (!Edge.IsSame(E) && !mapE.Contains(E))
+            if (!Edge.IsSame(E) && mapE.Add(E))
             {
-              mapE.Add(E);
               nextEdges.Append(E);
             }
           }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_History.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_History.cxx
@@ -226,15 +226,17 @@ void BRepTools_History::Merge(const BRepTools_History& theHistory23)
           }
           else
           {
-            if (theHistory23.myShapeToGenerated.IsBound(aS2))
+            const NCollection_List<TopoDS_Shape>* pGen = theHistory23.myShapeToGenerated.Seek(aS2);
+            if (pGen)
             {
-              add(aAdditions[0], theHistory23.myShapeToGenerated(aS2));
+              add(aAdditions[0], *pGen);
               aMAndGPropagated.Add(aS2);
             }
 
-            if (theHistory23.myShapeToModified.IsBound(aS2))
+            const NCollection_List<TopoDS_Shape>* pMod = theHistory23.myShapeToModified.Seek(aS2);
+            if (pMod)
             {
-              add(aAdditions[aI], theHistory23.myShapeToModified(aS2));
+              add(aAdditions[aI], *pMod);
               aMAndGPropagated.Add(aS2);
 
               aL12.Remove(aSIt2);

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
@@ -208,8 +208,9 @@ void BRepTools_Modifier::Perform(const occ::handle<BRepTools_Modification>& M,
 
 void BRepTools_Modifier::Put(const TopoDS_Shape& S)
 {
-  if (myMap.Bind(S, TopoDS_Shape()))
+  if (!myMap.IsBound(S))
   {
+    myMap.Bind(S, TopoDS_Shape());
     for (TopoDS_Iterator theIterator(S, false); theIterator.More(); theIterator.Next())
     {
       Put(theIterator.Value());

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
@@ -208,12 +208,10 @@ void BRepTools_Modifier::Perform(const occ::handle<BRepTools_Modification>& M,
 
 void BRepTools_Modifier::Put(const TopoDS_Shape& S)
 {
-  if (!myMap.IsBound(S))
+  if (myMap.Bind(S, TopoDS_Shape()))
   {
-    myMap.Bind(S, TopoDS_Shape());
     for (TopoDS_Iterator theIterator(S, false); theIterator.More(); theIterator.Next())
     {
-
       Put(theIterator.Value());
     }
   }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_PurgeLocations.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_PurgeLocations.cxx
@@ -193,8 +193,6 @@ bool BRepTools_PurgeLocations::IsDone() const
 
 TopoDS_Shape BRepTools_PurgeLocations::ModifiedShape(const TopoDS_Shape& theInitShape) const
 {
-  TopoDS_Shape aShape = theInitShape;
-  if (myMapNewShapes.IsBound(theInitShape))
-    aShape = myMapNewShapes.Find(theInitShape);
-  return aShape;
+  const TopoDS_Shape* pShape = myMapNewShapes.Seek(theInitShape);
+  return pShape ? *pShape : theInitShape;
 }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
@@ -412,10 +412,11 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
       TopExp_Explorer itf1(Shape, TopAbs_EDGE);
       for (; itf1.More(); itf1.Next())
       {
-        const TopoDS_Shape& E = itf1.Current();
-        if (M.IsBound(E))
+        const TopoDS_Shape&  E     = itf1.Current();
+        const TopoDS_Shape* pShell = M.Seek(E);
+        if (pShell)
         {
-          SH = TopoDS::Shell(M(E));
+          SH = TopoDS::Shell(*pShell);
           if (SH.Orientation() == E.Orientation())
             NewO = TopAbs::Reverse(Shape.Orientation());
           else
@@ -445,11 +446,11 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
 
       for (; itf.More(); itf.Next())
       {
-        const TopoDS_Edge& E = TopoDS::Edge(itf.Current());
-
-        if (M.IsBound(E))
+        const TopoDS_Edge&   E         = TopoDS::Edge(itf.Current());
+        const TopoDS_Shape* pOldShell = M.Seek(E);
+        if (pOldShell)
         {
-          const TopoDS_Shape oldShell = M(E);
+          const TopoDS_Shape oldShell = *pOldShell;
           if (!oldShell.IsSame(SH))
           {
             // Fuse the old shell with the new one
@@ -482,13 +483,11 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
             TopExp_Explorer aexp(SH, TopAbs_EDGE);
             for (; aexp.More(); aexp.Next())
             {
-              // for (NCollection_DataMap<TopoDS_Shape, TopoDS_Shape,
-              // TopTools_ShapeMapHasher>::Iterator itm(M);
-              //		 itm.More(); ) {
-              if (!M.IsBound(aexp.Current()))
+              const TopoDS_Shape&  ae  = aexp.Current();
+              const TopoDS_Shape* pAs = M.Seek(ae);
+              if (!pAs)
                 continue;
-              const TopoDS_Shape& ae = aexp.Current();
-              TopoDS_Shape        as = M.Find(ae);
+              TopoDS_Shape as = *pAs;
               if (as.IsSame(oldShell))
               {
                 // update the orientation of free edges in SH.

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
@@ -412,7 +412,7 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
       TopExp_Explorer itf1(Shape, TopAbs_EDGE);
       for (; itf1.More(); itf1.Next())
       {
-        const TopoDS_Shape&  E     = itf1.Current();
+        const TopoDS_Shape& E      = itf1.Current();
         const TopoDS_Shape* pShell = M.Seek(E);
         if (pShell)
         {
@@ -446,7 +446,7 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
 
       for (; itf.More(); itf.Next())
       {
-        const TopoDS_Edge&   E         = TopoDS::Edge(itf.Current());
+        const TopoDS_Edge&  E         = TopoDS::Edge(itf.Current());
         const TopoDS_Shape* pOldShell = M.Seek(E);
         if (pOldShell)
         {
@@ -483,7 +483,7 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
             TopExp_Explorer aexp(SH, TopAbs_EDGE);
             for (; aexp.More(); aexp.Next())
             {
-              const TopoDS_Shape&  ae  = aexp.Current();
+              const TopoDS_Shape& ae  = aexp.Current();
               const TopoDS_Shape* pAs = M.Seek(ae);
               if (!pAs)
                 continue;

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_ReShape.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_ReShape.cxx
@@ -218,7 +218,7 @@ TopoDS_Shape BRepTools_ReShape::Value(const TopoDS_Shape& ashape) const
     shape.Location(nullLoc);
   }
 
-  bool                 fromMap = false;
+  bool                fromMap = false;
   const TReplacement* pRepl   = myShapeToReplacement.Seek(shape);
   if (!pRepl)
   {

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_ReShape.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_ReShape.cxx
@@ -218,14 +218,15 @@ TopoDS_Shape BRepTools_ReShape::Value(const TopoDS_Shape& ashape) const
     shape.Location(nullLoc);
   }
 
-  bool fromMap = false;
-  if (!myShapeToReplacement.IsBound(shape))
+  bool                 fromMap = false;
+  const TReplacement* pRepl   = myShapeToReplacement.Seek(shape);
+  if (!pRepl)
   {
     res = shape;
   }
   else
   {
-    res = myShapeToReplacement(shape).Result();
+    res = pRepl->Result();
     if (shape.Orientation() == TopAbs_REVERSED)
     {
       res.Reverse();
@@ -268,14 +269,15 @@ int BRepTools_ReShape::Status(const TopoDS_Shape& ashape, TopoDS_Shape& newsh, c
     shape.Location(nullLoc);
   }
 
-  if (!myShapeToReplacement.IsBound(shape))
+  const TReplacement* pRepl = myShapeToReplacement.Seek(shape);
+  if (!pRepl)
   {
     newsh = shape;
     res   = 0;
   }
   else
   {
-    newsh = myShapeToReplacement(shape).Result();
+    newsh = pRepl->Result();
     res   = 1;
   }
   if (res > 0)

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Substitution.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Substitution.cxx
@@ -140,12 +140,13 @@ void BRepTools_Substitution::Build(const TopoDS_Shape& S)
 
 bool BRepTools_Substitution::IsCopied(const TopoDS_Shape& S) const
 {
-  if (myMap.IsBound(S))
+  const NCollection_List<TopoDS_Shape>* pList = myMap.Seek(S);
+  if (pList)
   {
-    if (myMap(S).IsEmpty())
+    if (pList->IsEmpty())
       return true;
     else
-      return !S.IsSame(myMap(S).First());
+      return !S.IsSame(pList->First());
   }
   else
     return false;

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_WireExplorer.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_WireExplorer.cxx
@@ -227,9 +227,7 @@ void BRepTools_WireExplorer::Init(const TopoDS_Wire& W,
 
     if (!V1.IsNull())
     {
-      if (!myMap.IsBound(V1))
-        myMap.Bind(V1, empty);
-      myMap(V1).Append(E);
+      myMap.TryBound(V1, empty)->Append(E);
 
       // add or remove in the vertex map
       V1.Orientation(TopAbs_FORWARD);
@@ -344,10 +342,11 @@ void BRepTools_WireExplorer::Init(const TopoDS_Wire& W,
 
   if (V1.IsNull())
     return;
-  if (!myMap.IsBound(V1))
+  NCollection_List<TopoDS_Shape>* pList = myMap.ChangeSeek(V1);
+  if (!pList)
     return;
 
-  NCollection_List<TopoDS_Shape>& l = myMap(V1);
+  NCollection_List<TopoDS_Shape>& l = *pList;
   myEdge                            = TopoDS::Edge(l.First());
   l.RemoveFirst();
   myVertex = TopExp::FirstVertex(myEdge, true);
@@ -371,13 +370,14 @@ void BRepTools_WireExplorer::Next()
     myEdge = TopoDS_Edge();
     return;
   }
-  if (!myMap.IsBound(myVertex))
+  NCollection_List<TopoDS_Shape>* pList = myMap.ChangeSeek(myVertex);
+  if (!pList)
   {
     myEdge = TopoDS_Edge();
     return;
   }
 
-  NCollection_List<TopoDS_Shape>& l = myMap(myVertex);
+  NCollection_List<TopoDS_Shape>& l = *pList;
 
   if (l.IsEmpty())
   {

--- a/src/ModelingData/TKGeomBase/ProjLib/ProjLib_ProjectedCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ProjLib/ProjLib_ProjectedCurve.cxx
@@ -817,10 +817,7 @@ void ProjLib_ProjectedCurve::Perform(const occ::handle<Adaptor3d_Curve>& C)
             if (aPnt2d.Coord(anIdx) - aSurfFirstPar[anIdx - 1] < 0.0)
               aMapKey--;
 
-            if (aMap.IsBound(aMapKey))
-              aMap.ChangeFind(aMapKey)++;
-            else
-              aMap.Bind(aMapKey, 1);
+            (*aMap.TryBound(aMapKey, 0))++;
           }
         }
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.cxx
@@ -2034,7 +2034,8 @@ void OpenGl_Context::DiagnosticInformation(
 const occ::handle<OpenGl_Resource>& OpenGl_Context::GetResource(
   const TCollection_AsciiString& theKey) const
 {
-  return mySharedResources->IsBound(theKey) ? mySharedResources->Find(theKey) : NULL_GL_RESOURCE;
+  const occ::handle<OpenGl_Resource>* pRes = mySharedResources->Seek(theKey);
+  return pRes ? *pRes : NULL_GL_RESOURCE;
 }
 
 //=================================================================================================
@@ -2053,11 +2054,12 @@ bool OpenGl_Context::ShareResource(const TCollection_AsciiString&      theKey,
 
 void OpenGl_Context::ReleaseResource(const TCollection_AsciiString& theKey, const bool theToDelay)
 {
-  if (!mySharedResources->IsBound(theKey))
+  const occ::handle<OpenGl_Resource>* pRes = mySharedResources->Seek(theKey);
+  if (!pRes)
   {
     return;
   }
-  const occ::handle<OpenGl_Resource>& aRes = mySharedResources->Find(theKey);
+  const occ::handle<OpenGl_Resource>& aRes = *pRes;
   if (aRes->GetRefCount() > 1)
   {
     return;

--- a/src/Visualization/TKV3d/AIS/AIS_ColoredShape.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ColoredShape.cxx
@@ -833,20 +833,14 @@ void AIS_ColoredShape::bindSubShapes(
   {
     for (TopExp_Explorer anExp(theKeyShape, TopAbs_FACE); anExp.More(); anExp.Next())
     {
-      if (!theShapeDrawerMap.IsBound(anExp.Current()))
-      {
-        theShapeDrawerMap.Bind(anExp.Current(), theDrawer);
-      }
+      theShapeDrawerMap.TryBound(anExp.Current(), theDrawer);
     }
   }
   else if (aShapeWithColorType == TopAbs_WIRE)
   {
     for (TopExp_Explorer anExp(theKeyShape, TopAbs_EDGE); anExp.More(); anExp.Next())
     {
-      if (!theShapeDrawerMap.IsBound(anExp.Current()))
-      {
-        theShapeDrawerMap.Bind(anExp.Current(), theDrawer);
-      }
+      theShapeDrawerMap.TryBound(anExp.Current(), theDrawer);
     }
   }
   else

--- a/src/Visualization/TKV3d/AIS/AIS_InteractiveContext.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_InteractiveContext.cxx
@@ -710,12 +710,13 @@ void AIS_InteractiveContext::HilightWithColor(const occ::handle<AIS_InteractiveO
   }
 
   setContextToObject(theObj);
-  if (!myObjects.IsBound(theObj))
+  const occ::handle<AIS_GlobalStatus>* pStatus = myObjects.Seek(theObj);
+  if (!pStatus)
   {
     return;
   }
 
-  const occ::handle<AIS_GlobalStatus>& aStatus = myObjects(theObj);
+  const occ::handle<AIS_GlobalStatus>& aStatus = *pStatus;
   aStatus->SetHilightStatus(true);
 
   if (theObj->DisplayStatus() == PrsMgr_DisplayStatus_Displayed)
@@ -779,10 +780,11 @@ bool AIS_InteractiveContext::IsHilighted(const occ::handle<SelectMgr_EntityOwner
 
   if (anObj->GlobalSelOwner() == theOwner)
   {
-    if (!myObjects.IsBound(anObj))
+    const occ::handle<AIS_GlobalStatus>* pStatus = myObjects.Seek(anObj);
+    if (!pStatus)
       return false;
 
-    return myObjects(anObj)->IsHilighted();
+    return (*pStatus)->IsHilighted();
   }
 
   const occ::handle<Prs3d_Drawer>& aStyle  = getSelStyle(anObj, theOwner);


### PR DESCRIPTION
This commit eliminates double-lookup anti-patterns where code checks if a key exists (IsBound/Contains/FindIndex) and then performs a separate lookup to access or insert the value. These patterns perform two hash lookups when one suffices.

New API Methods Added:
- NCollection_DataMap::TryBound(key, value) - binds only if key not present, returns pointer to item (preserves existing values, unlike Bound)
- NCollection_DataMap::Seek(key) - returns const pointer or nullptr
- NCollection_DataMap::ChangeSeek(key) - returns non-const pointer or nullptr
- NCollection_IndexedDataMap::Bound(key, value) - returns pointer to item (new or existing), does not overwrite existing values
- NCollection_IndexedDataMap::TryBound(key, value) - alias for Bound with clearer semantics for non-overwriting behavior
- NCollection_IndexedMap::Added(key) - returns reference to key (new or existing)

Pattern Transformations Applied:
- IsBound + Find -> Seek (returns pointer, null-safe)
- IsBound + ChangeFind -> ChangeSeek (returns mutable pointer)
- IsBound + Bind (preserve existing) -> TryBound
- Contains + Add -> Add (for Map/IndexedMap)
- FindIndex==0 + Add -> Add (IndexedMap returns existing index)
- Multiple lookups consolidated to single Bound/Seek operations

Files Modified: 76 files across all major modules
- FoundationClasses: NCollection headers, Storage, Resource, Plugin, OSD
- ModelingData: BRepTools (History, Modifier, Quilt, ReShape, etc.)
- ModelingAlgorithms: TKBO, TKBool, TKFeat, TKMesh, TKOffset, TKShHealing, TKTopAlgo, TKGeomAlgo, TKExpress
- ApplicationFramework: TNaming, BinMDF, StdStorage, TPrsStd
- DataExchange: TKXCAF, TKXSBase, TKDESTEP, TKDEIGES, TKDEVRML, TKRWMesh
- Visualization: OpenGl_Context, AIS_ColoredShape, AIS_InteractiveContext
- Draw: DNaming, MeshTest

Unit Tests Added:
- NCollection_DataMap_Test.cxx: TryBound_NoOverwrite test
- NCollection_IndexedDataMap_Test.cxx: Bound* tests (5 new tests)
- NCollection_IndexedMap_Test.cxx: Added* tests (6 new tests)

Semantic Notes:
- TryBound preserves existing values (non-overwriting)
- Bound overwrites existing values (for DataMap) or preserves (for IndexedDataMap)
- For IndexedMap, Add() returns int (index), use Add()==Extent() to detect new