### PR TITLE
Modelling - Fixed crash in ComputePolesIndexes()

### DIFF
--- a/src/ModelingData/TKGeomBase/BndLib/BndLib_AddSurface.cxx
+++ b/src/ModelingData/TKGeomBase/BndLib/BndLib_AddSurface.cxx
@@ -226,7 +226,7 @@ void ComputePolesIndexes(const NCollection_Array1<double>& theKnots,
 
   BSplCLib::Hunt(theKnots, theMax, theOutMaxIdx);
   theOutMaxIdx++;
-  theOutMaxIdx   = std::clamp(theOutMaxIdx, theKnots.Lower(), theKnots.Upper());
+  theOutMaxIdx          = std::clamp(theOutMaxIdx, theKnots.Lower(), theKnots.Upper());
   const int aMultiplier = theMults(theOutMaxIdx);
 
   theOutMinIdx = BSplCLib::PoleIndex(theDegree, theOutMinIdx, theIsPeriodic, theMults) + 1;


### PR DESCRIPTION
When initially computing theOutMinIdx and theOutMaxIdx only one bound was checked for each index - lower bound for theOutMinIdx and upper bound for theOutMaxIdx. THis is not enough, theOutMinIdx still can be greater then upper bound and theOutMaxIdx still can be less then lower bound.

Fixed the problem by adding std::clamp that checks both bounds for both values.