### PR TITLE
Foundation Classes - Optimize NCollection map containers

### DIFF
--- a/src/FoundationClasses/TKernel/NCollection/NCollection_DoubleMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_DoubleMap.hxx
@@ -589,10 +589,7 @@ public:
 
   //! Clear data. If doReleaseMemory is false then the table of
   //! buckets is not released and will be reused.
-  void Clear(const bool doReleaseMemory = false)
-  {
-    Destroy(DoubleMapNode::delNode, doReleaseMemory);
-  }
+  void Clear(const bool doReleaseMemory = false) { clearNodes<DoubleMapNode>(doReleaseMemory); }
 
   //! Clear data and reset allocator
   void Clear(const occ::handle<NCollection_BaseAllocator>& theAllocator)
@@ -603,7 +600,7 @@ public:
   }
 
   //! Destructor
-  ~NCollection_DoubleMap() override { Clear(true); }
+  ~NCollection_DoubleMap() { Clear(true); }
 
   //! Size
   int Size() const noexcept { return Extent(); }

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_IndexedMap.hxx
@@ -519,10 +519,7 @@ public:
 
   //! Clear data. If doReleaseMemory is false then the table of
   //! buckets is not released and will be reused.
-  void Clear(const bool doReleaseMemory = false)
-  {
-    Destroy(IndexedMapNode::delNode, doReleaseMemory);
-  }
+  void Clear(const bool doReleaseMemory = false) { clearNodes<IndexedMapNode>(doReleaseMemory); }
 
   //! Clear data and reset allocator
   void Clear(const occ::handle<NCollection_BaseAllocator>& theAllocator)
@@ -533,7 +530,7 @@ public:
   }
 
   //! Destructor
-  ~NCollection_IndexedMap() override { Clear(true); }
+  ~NCollection_IndexedMap() { Clear(true); }
 
   //! Size
   int Size() const noexcept { return Extent(); }

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Map.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Map.hxx
@@ -353,7 +353,7 @@ public:
 
   //! Clear data. If doReleaseMemory is false then the table of
   //! buckets is not released and will be reused.
-  void Clear(const bool doReleaseMemory = false) { Destroy(MapNode::delNode, doReleaseMemory); }
+  void Clear(const bool doReleaseMemory = false) { clearNodes<MapNode>(doReleaseMemory); }
 
   //! Clear data and reset allocator
   void Clear(const occ::handle<NCollection_BaseAllocator>& theAllocator)
@@ -364,7 +364,7 @@ public:
   }
 
   //! Destructor
-  ~NCollection_Map() override { Clear(true); }
+  ~NCollection_Map() { Clear(true); }
 
   //! Size
   int Size() const noexcept { return Extent(); }


### PR DESCRIPTION
Performance improvements to chaining-based map containers:

1. Reorder DataMapNode/IndexedDataMapNode fields: key is now placed before value in memory layout. Previously the node inherited from NCollection_TListNode<TheItemType>, storing value before key ([next][value][key]). Now inherits directly from NCollection_ListNode with key first ([next][key][value]), ensuring key comparisons during lookup hit the first cache line.

2. Remove virtual destructor from NCollection_BaseMap. No polymorphic deletion through BaseMap pointers exists in OCCT; the deletion mechanism uses function pointers. This saves 8 bytes (vtable pointer) per map instance and removes override from all derived destructors.

3. Add template clearNodes<NodeType>() to replace function-pointer-based Destroy() in derived map Clear() methods. Benefits:
   - Eliminates function pointer indirection per node (inlineable)
   - Skips unnecessary bucket zeroing on the release-memory path
   - Uses if constexpr to skip destructor for trivially destructible nodes The old Destroy() is kept for backward compatibility.

4. Deprecate NCollection_BaseMap::Statistics() which is unused in production code and has exception-unsafe allocation.