### PR TITLE
Modeling Data - Optimize BRep hot paths with enum discriminants and caching

### DIFF
--- a/src/FoundationClasses/TKMath/TopLoc/TopLoc_Location.cxx
+++ b/src/FoundationClasses/TKMath/TopLoc/TopLoc_Location.cxx
@@ -115,6 +115,8 @@ TopLoc_Location TopLoc_Location::Multiplied(const TopLoc_Location& Other) const
 
 TopLoc_Location TopLoc_Location::Divided(const TopLoc_Location& Other) const
 {
+  if (Other.IsIdentity())
+    return *this;
   return Multiplied(Other.Inverted());
 }
 
@@ -125,6 +127,10 @@ TopLoc_Location TopLoc_Location::Divided(const TopLoc_Location& Other) const
 
 TopLoc_Location TopLoc_Location::Predivided(const TopLoc_Location& Other) const
 {
+  if (Other.IsIdentity())
+    return *this;
+  if (IsIdentity())
+    return Other.Inverted();
   return Other.Inverted().Multiplied(*this);
 }
 

--- a/src/FoundationClasses/TKMath/TopLoc/TopLoc_SListOfItemLocation.hxx
+++ b/src/FoundationClasses/TKMath/TopLoc/TopLoc_SListOfItemLocation.hxx
@@ -99,7 +99,6 @@ public:
   //! and the list <me> as tail.
   void Construct(const TopLoc_ItemLocation& anItem)
   {
-    // Use move assignment to avoid atomic refcount increment in Assign().
     *this = TopLoc_SListOfItemLocation(anItem, *this);
   }
 

--- a/src/FoundationClasses/TKMath/TopLoc/TopLoc_SListOfItemLocation.hxx
+++ b/src/FoundationClasses/TKMath/TopLoc/TopLoc_SListOfItemLocation.hxx
@@ -99,7 +99,8 @@ public:
   //! and the list <me> as tail.
   void Construct(const TopLoc_ItemLocation& anItem)
   {
-    Assign(TopLoc_SListOfItemLocation(anItem, *this));
+    // Use move assignment to avoid atomic refcount increment in Assign().
+    *this = TopLoc_SListOfItemLocation(anItem, *this);
   }
 
   //! Replaces the list <me> by its tail.

--- a/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
@@ -400,7 +400,7 @@ static void UpdatePoints(NCollection_List<occ::handle<BRep_PointRepresentation>>
   while (itpr.More())
   {
     const occ::handle<BRep_PointRepresentation>& pr     = itpr.Value();
-    bool                                         isponc = pr->IsPointOnCurve(C, L);
+    bool                                         isponc = pr->IsPointOnCurve() && pr->IsPointOnCurve(C, L);
     if (isponc)
       break;
     itpr.Next();
@@ -428,7 +428,7 @@ static void UpdatePoints(NCollection_List<occ::handle<BRep_PointRepresentation>>
   while (itpr.More())
   {
     const occ::handle<BRep_PointRepresentation>& pr        = itpr.Value();
-    bool                                         isponcons = pr->IsPointOnCurveOnSurface(PC, S, L);
+    bool                                         isponcons = pr->IsPointOnCurveOnSurface() && pr->IsPointOnCurveOnSurface(PC, S, L);
     if (isponcons)
       break;
     itpr.Next();
@@ -456,7 +456,7 @@ static void UpdatePoints(NCollection_List<occ::handle<BRep_PointRepresentation>>
   while (itpr.More())
   {
     const occ::handle<BRep_PointRepresentation>& pr     = itpr.Value();
-    bool                                         ispons = pr->IsPointOnSurface(S, L);
+    bool                                         ispons = pr->IsPointOnSurface() && pr->IsPointOnSurface(S, L);
     if (ispons)
       break;
     itpr.Next();

--- a/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
@@ -373,7 +373,7 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr     = itcr.Value();
-    bool                                         isregu = cr->IsRegularity(S1, S2, L1, L2);
+    bool                                         isregu = cr->IsRegularity() && cr->IsRegularity(S1, S2, L1, L2);
     if (isregu)
       break;
     itcr.Next();
@@ -1149,12 +1149,7 @@ void BRep_Builder::Transfert(const TopoDS_Edge& Ein, const TopoDS_Edge& Eout) co
 
     const occ::handle<BRep_CurveRepresentation>& CR = itcr.Value();
 
-    if (CR->IsCurveOnSurface())
-    {
-      UpdateEdge(Eout, CR->PCurve(), CR->Surface(), Ein.Location() * CR->Location(), tol);
-    }
-
-    else if (CR->IsCurveOnClosedSurface())
+    if (CR->IsCurveOnClosedSurface())
     {
       UpdateEdge(Eout,
                  CR->PCurve(),
@@ -1162,6 +1157,10 @@ void BRep_Builder::Transfert(const TopoDS_Edge& Ein, const TopoDS_Edge& Eout) co
                  CR->Surface(),
                  Ein.Location() * CR->Location(),
                  tol);
+    }
+    else if (CR->IsCurveOnSurface())
+    {
+      UpdateEdge(Eout, CR->PCurve(), CR->Surface(), Ein.Location() * CR->Location(), tol);
     }
 
     if (CR->IsRegularity())

--- a/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
@@ -61,18 +61,18 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
                          occ::handle<BRep_Curve3D>& theCached3D)
 {
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
-  bool                                                              hasRange = false;
+  bool                                                              aHasRange = false;
   double                                                            f = 0., l = 0.;
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
-        || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D || aKind == BRep_CurveRepKind::CurveOnSurface
+        || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
       static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
-      hasRange = true;
-      if (kind == BRep_CurveRepKind::Curve3D)
+      aHasRange = true;
+      if (aKind == BRep_CurveRepKind::Curve3D)
         break;
     }
     itcr.Next();
@@ -88,7 +88,7 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
   {
     occ::handle<BRep_Curve3D> C3d = new BRep_Curve3D(C, L);
     // test if there is already a range
-    if (hasRange)
+    if (aHasRange)
     {
       C3d->SetRange(f, l);
     }
@@ -117,14 +117,14 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D)
     {
       static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
       itcr.Next();
     }
-    else if (kind == BRep_CurveRepKind::CurveOnSurface
-             || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    else if (aKind == BRep_CurveRepKind::CurveOnSurface
+             || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
       if (itcr.Value()->IsCurveOnSurface(S, L))
       {
@@ -187,14 +187,14 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D)
     {
       static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
       itcr.Next();
     }
-    else if (kind == BRep_CurveRepKind::CurveOnSurface
-             || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    else if (aKind == BRep_CurveRepKind::CurveOnSurface
+             || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
       if (itcr.Value()->IsCurveOnSurface(S, L))
       {
@@ -255,13 +255,13 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D)
     {
       static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
     }
-    else if ((kind == BRep_CurveRepKind::CurveOnSurface
-              || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    else if ((aKind == BRep_CurveRepKind::CurveOnSurface
+              || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
              && itcr.Value()->IsCurveOnSurface(S, L))
     {
       break;
@@ -318,13 +318,13 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D)
     {
       static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
     }
-    else if ((kind == BRep_CurveRepKind::CurveOnSurface
-              || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    else if ((aKind == BRep_CurveRepKind::CurveOnSurface
+              || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
              && itcr.Value()->IsCurveOnSurface(S, L))
     {
       break;
@@ -1084,11 +1084,11 @@ void BRep_Builder::Range(const TopoDS_Edge& E,
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
-        || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D || aKind == BRep_CurveRepKind::CurveOnSurface
+        || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
-      if (!Only3d || kind == BRep_CurveRepKind::Curve3D)
+      if (!Only3d || aKind == BRep_CurveRepKind::Curve3D)
         static_cast<BRep_GCurve*>(itcr.Value().get())->SetRange(First, Last);
     }
     itcr.Next();
@@ -1117,9 +1117,9 @@ void BRep_Builder::Range(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if ((kind == BRep_CurveRepKind::CurveOnSurface
-         || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if ((aKind == BRep_CurveRepKind::CurveOnSurface
+         || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
         && itcr.Value()->IsCurveOnSurface(S, l))
     {
       static_cast<BRep_GCurve*>(itcr.Value().get())->SetRange(First, Last);
@@ -1246,9 +1246,9 @@ void BRep_Builder::UpdateVertex(const TopoDS_Vertex& V,
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
-        || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D || aKind == BRep_CurveRepKind::CurveOnSurface
+        || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
       BRep_GCurve* GC = static_cast<BRep_GCurve*>(itcr.Value().get());
       if (ori == TopAbs_FORWARD)
@@ -1260,7 +1260,7 @@ void BRep_Builder::UpdateVertex(const TopoDS_Vertex& V,
         NCollection_List<occ::handle<BRep_PointRepresentation>>& lpr    = TV->ChangePoints();
         const TopLoc_Location&                                   GCloc  = GC->Location();
         TopLoc_Location                                          LGCloc = L * GCloc;
-        if (kind == BRep_CurveRepKind::Curve3D)
+        if (aKind == BRep_CurveRepKind::Curve3D)
         {
           const occ::handle<Geom_Curve>& GC3d = GC->Curve3D();
           UpdatePoints(lpr, Par, GC3d, LGCloc);
@@ -1337,9 +1337,9 @@ void BRep_Builder::UpdateVertex(const TopoDS_Vertex&             V,
 
   while (itcr.More())
   {
-    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
-    if ((kind == BRep_CurveRepKind::CurveOnSurface
-         || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    const BRep_CurveRepKind aKind = itcr.Value()->RepresentationKind();
+    if ((aKind == BRep_CurveRepKind::CurveOnSurface
+         || aKind == BRep_CurveRepKind::CurveOnClosedSurface)
         && itcr.Value()->IsCurveOnSurface(S, L))
     { // xpu020198 : BUC60407
       BRep_GCurve* GC = static_cast<BRep_GCurve*>(itcr.Value().get());

--- a/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
@@ -61,16 +61,18 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
                          occ::handle<BRep_Curve3D>& theCached3D)
 {
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
-  occ::handle<BRep_GCurve>                                          GC;
+  bool                                                              hasRange = false;
   double                                                            f = 0., l = 0.;
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
+        || kind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
-      GC->Range(f, l);
-      if (GC->IsCurve3D())
+      static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
+      hasRange = true;
+      if (kind == BRep_CurveRepKind::Curve3D)
         break;
     }
     itcr.Next();
@@ -86,7 +88,7 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
   {
     occ::handle<BRep_Curve3D> C3d = new BRep_Curve3D(C, L);
     // test if there is already a range
-    if (!GC.IsNull())
+    if (hasRange)
     {
       C3d->SetRange(f, l);
     }
@@ -109,26 +111,22 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 {
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
   occ::handle<BRep_CurveRepresentation>                             cr;
-  occ::handle<BRep_GCurve>                                          GC;
   double f = -Precision::Infinite(), l = Precision::Infinite();
   // search the range of the 3d curve
   // and remove any existing representation
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D)
     {
-      if (GC->IsCurve3D())
-      {
-        //      if (!C.IsNull()) { //xpu031198, edge degeneree
-
-        // xpu151298 : parameters can be set for null curves
-        //             see lbo & flo, to determine whether range is defined
-        //             compare first and last parameters with default values.
-        GC->Range(f, l);
-      }
-      if (GC->IsCurveOnSurface(S, L))
+      static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
+      itcr.Next();
+    }
+    else if (kind == BRep_CurveRepKind::CurveOnSurface
+             || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    {
+      if (itcr.Value()->IsCurveOnSurface(S, L))
       {
         // remove existing curve on surface
         // cr is used to keep a reference on the curve representation
@@ -182,7 +180,6 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 {
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
   occ::handle<BRep_CurveRepresentation>                             cr;
-  occ::handle<BRep_GCurve>                                          GC;
   double f = -Precision::Infinite(), l = Precision::Infinite();
 
   // search the range of the 3d curve
@@ -190,19 +187,16 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D)
     {
-      if (GC->IsCurve3D())
-      {
-        //      if (!C.IsNull()) { //xpu031198, edge degeneree
-
-        // xpu151298 : parameters can be set for null curves
-        //             see lbo & flo, to determine whether range is defined
-        //             compare first and last parameters with default values.
-        GC->Range(f, l);
-      }
-      if (GC->IsCurveOnSurface(S, L))
+      static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
+      itcr.Next();
+    }
+    else if (kind == BRep_CurveRepKind::CurveOnSurface
+             || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    {
+      if (itcr.Value()->IsCurveOnSurface(S, L))
       {
         // remove existing curve on surface
         // cr is used to keep a reference on the curve representation
@@ -257,21 +251,20 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 {
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
   occ::handle<BRep_CurveRepresentation>                             cr;
-  occ::handle<BRep_GCurve>                                          GC;
   double f = -Precision::Infinite(), l = Precision::Infinite();
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D)
     {
-      if (GC->IsCurve3D())
-      {
-        GC->Range(f, l);
-      }
-      bool iscos = GC->IsCurveOnSurface(S, L);
-      if (iscos)
-        break;
+      static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
+    }
+    else if ((kind == BRep_CurveRepKind::CurveOnSurface
+              || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+             && itcr.Value()->IsCurveOnSurface(S, L))
+    {
+      break;
     }
     itcr.Next();
   }
@@ -321,21 +314,20 @@ static void UpdateCurves(NCollection_List<occ::handle<BRep_CurveRepresentation>>
 {
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
   occ::handle<BRep_CurveRepresentation>                             cr;
-  occ::handle<BRep_GCurve>                                          GC;
   double f = -Precision::Infinite(), l = Precision::Infinite();
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D)
     {
-      if (GC->IsCurve3D())
-      {
-        GC->Range(f, l);
-      }
-      bool iscos = GC->IsCurveOnSurface(S, L);
-      if (iscos)
-        break;
+      static_cast<const BRep_GCurve*>(itcr.Value().get())->Range(f, l);
+    }
+    else if ((kind == BRep_CurveRepKind::CurveOnSurface
+              || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+             && itcr.Value()->IsCurveOnSurface(S, L))
+    {
+      break;
     }
     itcr.Next();
   }
@@ -1089,13 +1081,16 @@ void BRep_Builder::Range(const TopoDS_Edge& E,
   }
   NCollection_List<occ::handle<BRep_CurveRepresentation>>&          lcr = TE->ChangeCurves();
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
-  occ::handle<BRep_GCurve>                                          GC;
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull() && (!Only3d || GC->IsCurve3D()))
-      GC->SetRange(First, Last);
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
+        || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+    {
+      if (!Only3d || kind == BRep_CurveRepKind::Curve3D)
+        static_cast<BRep_GCurve*>(itcr.Value().get())->SetRange(First, Last);
+    }
     itcr.Next();
   }
 
@@ -1119,14 +1114,15 @@ void BRep_Builder::Range(const TopoDS_Edge&               E,
 
   NCollection_List<occ::handle<BRep_CurveRepresentation>>&          lcr = TE->ChangeCurves();
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
-  occ::handle<BRep_GCurve>                                          GC;
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull() && GC->IsCurveOnSurface(S, l))
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if ((kind == BRep_CurveRepKind::CurveOnSurface
+         || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+        && itcr.Value()->IsCurveOnSurface(S, l))
     {
-      GC->SetRange(First, Last);
+      static_cast<BRep_GCurve*>(itcr.Value().get())->SetRange(First, Last);
       break;
     }
     itcr.Next();
@@ -1248,13 +1244,14 @@ void BRep_Builder::UpdateVertex(const TopoDS_Vertex& V,
 
   NCollection_List<occ::handle<BRep_CurveRepresentation>>&          lcr = TE->ChangeCurves();
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
-  occ::handle<BRep_GCurve>                                          GC;
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
+        || kind == BRep_CurveRepKind::CurveOnClosedSurface)
     {
+      BRep_GCurve* GC = static_cast<BRep_GCurve*>(itcr.Value().get());
       if (ori == TopAbs_FORWARD)
         GC->First(Par);
       else if (ori == TopAbs_REVERSED)
@@ -1264,12 +1261,12 @@ void BRep_Builder::UpdateVertex(const TopoDS_Vertex& V,
         NCollection_List<occ::handle<BRep_PointRepresentation>>& lpr    = TV->ChangePoints();
         const TopLoc_Location&                                   GCloc  = GC->Location();
         TopLoc_Location                                          LGCloc = L * GCloc;
-        if (GC->IsCurve3D())
+        if (kind == BRep_CurveRepKind::Curve3D)
         {
           const occ::handle<Geom_Curve>& GC3d = GC->Curve3D();
           UpdatePoints(lpr, Par, GC3d, LGCloc);
         }
-        else if (GC->IsCurveOnSurface())
+        else // CurveOnSurface or CurveOnClosedSurface
         {
           const occ::handle<Geom2d_Curve>& GCpc = GC->PCurve();
           const occ::handle<Geom_Surface>& GCsu = GC->Surface();
@@ -1338,29 +1335,27 @@ void BRep_Builder::UpdateVertex(const TopoDS_Vertex&             V,
 
   NCollection_List<occ::handle<BRep_CurveRepresentation>>&          lcr = TE->ChangeCurves();
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(lcr);
-  occ::handle<BRep_GCurve>                                          GC;
 
   while (itcr.More())
   {
-    GC = occ::down_cast<BRep_GCurve>(itcr.Value());
-    if (!GC.IsNull())
-    {
-      //      if (GC->IsCurveOnSurface(S,l)) {
-      if (GC->IsCurveOnSurface(S, L))
-      { // xpu020198 : BUC60407
-        if (ori == TopAbs_FORWARD)
-          GC->First(Par);
-        else if (ori == TopAbs_REVERSED)
-          GC->Last(Par);
-        else
-        {
-          NCollection_List<occ::handle<BRep_PointRepresentation>>& lpr  = TV->ChangePoints();
-          const occ::handle<Geom2d_Curve>&                         GCpc = GC->PCurve();
-          UpdatePoints(lpr, Par, GCpc, S, l);
-          TV->Modified(true);
-        }
-        break;
+    const BRep_CurveRepKind kind = itcr.Value()->RepresentationKind();
+    if ((kind == BRep_CurveRepKind::CurveOnSurface
+         || kind == BRep_CurveRepKind::CurveOnClosedSurface)
+        && itcr.Value()->IsCurveOnSurface(S, L))
+    { // xpu020198 : BUC60407
+      BRep_GCurve* GC = static_cast<BRep_GCurve*>(itcr.Value().get());
+      if (ori == TopAbs_FORWARD)
+        GC->First(Par);
+      else if (ori == TopAbs_REVERSED)
+        GC->Last(Par);
+      else
+      {
+        NCollection_List<occ::handle<BRep_PointRepresentation>>& lpr  = TV->ChangePoints();
+        const occ::handle<Geom2d_Curve>&                         GCpc = GC->PCurve();
+        UpdatePoints(lpr, Par, GCpc, S, l);
+        TV->Modified(true);
       }
+      break;
     }
     itcr.Next();
   }

--- a/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Builder.cxx
@@ -1149,6 +1149,7 @@ void BRep_Builder::Transfert(const TopoDS_Edge& Ein, const TopoDS_Edge& Eout) co
 
     const occ::handle<BRep_CurveRepresentation>& CR = itcr.Value();
 
+    // Check closed surface first: IsCurveOnClosedSurface() implies IsCurveOnSurface().
     if (CR->IsCurveOnClosedSurface())
     {
       UpdateEdge(Eout,

--- a/src/ModelingData/TKBRep/BRep/BRep_Curve3D.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Curve3D.cxx
@@ -28,7 +28,8 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_Curve3D, BRep_GCurve)
 BRep_Curve3D::BRep_Curve3D(const occ::handle<Geom_Curve>& C, const TopLoc_Location& L)
     : BRep_GCurve(L,
                   C.IsNull() ? RealFirst() : C->FirstParameter(),
-                  C.IsNull() ? RealLast() : C->LastParameter()),
+                  C.IsNull() ? RealLast() : C->LastParameter(),
+                  BRep_CurveRepKind::Curve3D),
       myCurve(C)
 {
 }
@@ -39,13 +40,6 @@ void BRep_Curve3D::D0(const double U, gp_Pnt& P) const
 {
   // should be D0 NYI
   P = myCurve->Value(U);
-}
-
-//=================================================================================================
-
-bool BRep_Curve3D::IsCurve3D() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_Curve3D.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Curve3D.hxx
@@ -36,9 +36,6 @@ public:
   //! Computes the point at parameter U.
   Standard_EXPORT void D0(const double U, gp_Pnt& P) const override;
 
-  //! Returns True.
-  Standard_EXPORT bool IsCurve3D() const override;
-
   Standard_EXPORT const occ::handle<Geom_Curve>& Curve3D() const override;
 
   Standard_EXPORT void Curve3D(const occ::handle<Geom_Curve>& C) override;

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.cxx
@@ -31,7 +31,7 @@ BRep_CurveOn2Surfaces::BRep_CurveOn2Surfaces(const occ::handle<Geom_Surface>& S1
                                              const TopLoc_Location&           L1,
                                              const TopLoc_Location&           L2,
                                              const GeomAbs_Shape              C)
-    : BRep_CurveRepresentation(L1),
+    : BRep_CurveRepresentation(L1, BRep_CurveRepKind::CurveOn2Surfaces),
       mySurface(S1),
       mySurface2(S2),
       myLocation2(L2),
@@ -44,13 +44,6 @@ BRep_CurveOn2Surfaces::BRep_CurveOn2Surfaces(const occ::handle<Geom_Surface>& S1
 void BRep_CurveOn2Surfaces::D0(const double, gp_Pnt&) const
 {
   throw Standard_NullObject("BRep_CurveOn2Surfaces::D0");
-}
-
-//=================================================================================================
-
-bool BRep_CurveOn2Surfaces::IsRegularity() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.hxx
@@ -35,9 +35,6 @@ public:
                                         const TopLoc_Location&           L2,
                                         const GeomAbs_Shape              C);
 
-  //! Returns True.
-  Standard_EXPORT bool IsRegularity() const override;
-
   //! A curve on two surfaces (continuity).
   Standard_EXPORT bool IsRegularity(const occ::handle<Geom_Surface>& S1,
                                     const occ::handle<Geom_Surface>& S2,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
@@ -36,20 +36,7 @@ BRep_CurveOnClosedSurface::BRep_CurveOnClosedSurface(const occ::handle<Geom2d_Cu
       myPCurve2(PC2),
       myContinuity(C)
 {
-}
-
-//=================================================================================================
-
-bool BRep_CurveOnClosedSurface::IsCurveOnClosedSurface() const
-{
-  return true;
-}
-
-//=================================================================================================
-
-bool BRep_CurveOnClosedSurface::IsRegularity() const
-{
-  return true;
+  myKind = BRep_CurveRepKind::CurveOnClosedSurface;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
@@ -32,11 +32,10 @@ BRep_CurveOnClosedSurface::BRep_CurveOnClosedSurface(const occ::handle<Geom2d_Cu
                                                      const occ::handle<Geom_Surface>& S,
                                                      const TopLoc_Location&           L,
                                                      const GeomAbs_Shape              C)
-    : BRep_CurveOnSurface(PC1, S, L),
+    : BRep_CurveOnSurface(PC1, S, L, BRep_CurveRepKind::CurveOnClosedSurface),
       myPCurve2(PC2),
       myContinuity(C)
 {
-  myKind = BRep_CurveRepKind::CurveOnClosedSurface;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
@@ -32,10 +32,11 @@ BRep_CurveOnClosedSurface::BRep_CurveOnClosedSurface(const occ::handle<Geom2d_Cu
                                                      const occ::handle<Geom_Surface>& S,
                                                      const TopLoc_Location&           L,
                                                      const GeomAbs_Shape              C)
-    : BRep_CurveOnSurface(PC1, S, L, BRep_CurveRepKind::CurveOnClosedSurface),
+    : BRep_CurveOnSurface(PC1, S, L),
       myPCurve2(PC2),
       myContinuity(C)
 {
+  myKind = BRep_CurveRepKind::CurveOnClosedSurface;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.hxx
@@ -41,12 +41,6 @@ public:
 
   void UVPoints2(gp_Pnt2d& P1, gp_Pnt2d& P2) const;
 
-  //! Returns True.
-  Standard_EXPORT bool IsCurveOnClosedSurface() const override;
-
-  //! Returns True
-  Standard_EXPORT bool IsRegularity() const override;
-
   //! A curve on two surfaces (continuity).
   Standard_EXPORT bool IsRegularity(const occ::handle<Geom_Surface>& S1,
                                     const occ::handle<Geom_Surface>& S2,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
@@ -30,8 +30,9 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveOnSurface, BRep_GCurve)
 
 BRep_CurveOnSurface::BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
                                          const occ::handle<Geom_Surface>& S,
-                                         const TopLoc_Location&           L)
-    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter(), BRep_CurveRepKind::CurveOnSurface),
+                                         const TopLoc_Location&           L,
+                                         const BRep_CurveRepKind          theKind)
+    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter(), theKind),
       myPCurve(PC),
       mySurface(S)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
@@ -31,7 +31,7 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveOnSurface, BRep_GCurve)
 BRep_CurveOnSurface::BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
                                          const occ::handle<Geom_Surface>& S,
                                          const TopLoc_Location&           L)
-    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter()),
+    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter(), BRep_CurveRepKind::CurveOnSurface),
       myPCurve(PC),
       mySurface(S)
 {
@@ -45,13 +45,6 @@ void BRep_CurveOnSurface::D0(const double U, gp_Pnt& P) const
   gp_Pnt2d P2d = myPCurve->Value(U);
   P            = mySurface->Value(P2d.X(), P2d.Y());
   P.Transform(myLocation.Transformation());
-}
-
-//=================================================================================================
-
-bool BRep_CurveOnSurface::IsCurveOnSurface() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
@@ -30,9 +30,8 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveOnSurface, BRep_GCurve)
 
 BRep_CurveOnSurface::BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
                                          const occ::handle<Geom_Surface>& S,
-                                         const TopLoc_Location&           L,
-                                         const BRep_CurveRepKind          theKind)
-    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter(), theKind),
+                                         const TopLoc_Location&           L)
+    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter(), BRep_CurveRepKind::CurveOnSurface),
       myPCurve(PC),
       mySurface(S)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
@@ -34,11 +34,9 @@ class BRep_CurveOnSurface : public BRep_GCurve
 {
 
 public:
-  Standard_EXPORT BRep_CurveOnSurface(
-    const occ::handle<Geom2d_Curve>& PC,
-    const occ::handle<Geom_Surface>& S,
-    const TopLoc_Location&           L,
-    const BRep_CurveRepKind          theKind = BRep_CurveRepKind::CurveOnSurface);
+  Standard_EXPORT BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
+                                      const occ::handle<Geom_Surface>& S,
+                                      const TopLoc_Location&           L);
 
   void SetUVPoints(const gp_Pnt2d& P1, const gp_Pnt2d& P2);
 

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
@@ -45,9 +45,6 @@ public:
   //! Computes the point at parameter U.
   Standard_EXPORT void D0(const double U, gp_Pnt& P) const override;
 
-  //! Returns True.
-  Standard_EXPORT bool IsCurveOnSurface() const override;
-
   //! A curve in the parametric space of a surface.
   Standard_EXPORT bool IsCurveOnSurface(const occ::handle<Geom_Surface>& S,
                                         const TopLoc_Location&           L) const override;

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
@@ -34,9 +34,11 @@ class BRep_CurveOnSurface : public BRep_GCurve
 {
 
 public:
-  Standard_EXPORT BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
-                                      const occ::handle<Geom_Surface>& S,
-                                      const TopLoc_Location&           L);
+  Standard_EXPORT BRep_CurveOnSurface(
+    const occ::handle<Geom2d_Curve>& PC,
+    const occ::handle<Geom_Surface>& S,
+    const TopLoc_Location&           L,
+    const BRep_CurveRepKind          theKind = BRep_CurveRepKind::CurveOnSurface);
 
   void SetUVPoints(const gp_Pnt2d& P1, const gp_Pnt2d& P2);
 

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
@@ -29,41 +29,6 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveRepresentation, Standard_Transient)
 
 //=================================================================================================
 
-BRep_CurveRepresentation::BRep_CurveRepresentation(const TopLoc_Location& L)
-    : myLocation(L)
-{
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsCurve3D() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsCurveOnSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsCurveOnClosedSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsRegularity() const
-{
-  return false;
-}
-
-//=================================================================================================
-
 bool BRep_CurveRepresentation::IsCurveOnSurface(const occ::handle<Geom_Surface>&,
                                                 const TopLoc_Location&) const
 {
@@ -82,43 +47,8 @@ bool BRep_CurveRepresentation::IsRegularity(const occ::handle<Geom_Surface>&,
 
 //=================================================================================================
 
-bool BRep_CurveRepresentation::IsPolygon3D() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnTriangulation() const
-{
-  return false;
-}
-
-//=================================================================================================
-
 bool BRep_CurveRepresentation::IsPolygonOnTriangulation(const occ::handle<Poly_Triangulation>&,
                                                         const TopLoc_Location&) const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnClosedTriangulation() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnClosedSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnSurface() const
 {
   return false;
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
@@ -31,7 +31,6 @@ class Poly_Polygon2D;
 class Poly_PolygonOnTriangulation;
 
 //! Discriminant tag identifying the concrete type of a curve representation.
-//! Used for O(1) type checks instead of virtual dispatch.
 enum class BRep_CurveRepKind : uint8_t
 {
   Curve3D,
@@ -51,7 +50,7 @@ class BRep_CurveRepresentation : public Standard_Transient
 {
 
 public:
-  //! Returns the concrete representation kind tag for O(1) type discrimination.
+  //! Returns the concrete representation kind tag.
   BRep_CurveRepKind RepresentationKind() const { return myKind; }
 
   //! A 3D curve representation.

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
@@ -30,64 +30,96 @@ class Poly_Polygon3D;
 class Poly_Polygon2D;
 class Poly_PolygonOnTriangulation;
 
+//! Discriminant tag identifying the concrete type of a curve representation.
+//! Used for O(1) type checks instead of virtual dispatch.
+enum class BRep_CurveRepKind : uint8_t
+{
+  Curve3D,
+  CurveOnSurface,
+  CurveOnClosedSurface,
+  CurveOn2Surfaces,
+  Polygon3D,
+  PolygonOnSurface,
+  PolygonOnClosedSurface,
+  PolygonOnTriangulation,
+  PolygonOnClosedTriangulation
+};
+
 //! Root class for the curve representations. Contains
 //! a location.
 class BRep_CurveRepresentation : public Standard_Transient
 {
 
 public:
+  //! Returns the concrete representation kind tag for O(1) type discrimination.
+  BRep_CurveRepKind RepresentationKind() const { return myKind; }
+
   //! A 3D curve representation.
-  Standard_EXPORT virtual bool IsCurve3D() const;
+  bool IsCurve3D() const { return myKind == BRep_CurveRepKind::Curve3D; }
 
   //! A curve in the parametric space of a surface.
-  Standard_EXPORT virtual bool IsCurveOnSurface() const;
+  bool IsCurveOnSurface() const
+  {
+    return myKind == BRep_CurveRepKind::CurveOnSurface
+           || myKind == BRep_CurveRepKind::CurveOnClosedSurface;
+  }
 
   //! A continuity between two surfaces.
-  Standard_EXPORT virtual bool IsRegularity() const;
+  bool IsRegularity() const
+  {
+    return myKind == BRep_CurveRepKind::CurveOnClosedSurface
+           || myKind == BRep_CurveRepKind::CurveOn2Surfaces;
+  }
 
-  //! A curve with two parametric curves on the same
-  //! surface.
-  Standard_EXPORT virtual bool IsCurveOnClosedSurface() const;
+  //! A curve with two parametric curves on the same surface.
+  bool IsCurveOnClosedSurface() const { return myKind == BRep_CurveRepKind::CurveOnClosedSurface; }
 
-  //! Is it a curve in the parametric space of <S> with
-  //! location <L>.
+  //! Is it a curve in the parametric space of <S> with location <L>.
   Standard_EXPORT virtual bool IsCurveOnSurface(const occ::handle<Geom_Surface>& S,
                                                 const TopLoc_Location&           L) const;
 
-  //! Is it a regularity between <S1> and <S2> with
-  //! location <L1> and <L2>.
+  //! Is it a regularity between <S1> and <S2> with location <L1> and <L2>.
   Standard_EXPORT virtual bool IsRegularity(const occ::handle<Geom_Surface>& S1,
                                             const occ::handle<Geom_Surface>& S2,
                                             const TopLoc_Location&           L1,
                                             const TopLoc_Location&           L2) const;
 
   //! A 3D polygon representation.
-  Standard_EXPORT virtual bool IsPolygon3D() const;
+  bool IsPolygon3D() const { return myKind == BRep_CurveRepKind::Polygon3D; }
 
-  //! A representation by an array of nodes on a
-  //! triangulation.
-  Standard_EXPORT virtual bool IsPolygonOnTriangulation() const;
+  //! A representation by an array of nodes on a triangulation.
+  bool IsPolygonOnTriangulation() const
+  {
+    return myKind == BRep_CurveRepKind::PolygonOnTriangulation
+           || myKind == BRep_CurveRepKind::PolygonOnClosedTriangulation;
+  }
 
-  //! Is it a polygon in the definition of <T> with
-  //! location <L>.
+  //! Is it a polygon in the definition of <T> with location <L>.
   Standard_EXPORT virtual bool IsPolygonOnTriangulation(const occ::handle<Poly_Triangulation>& T,
                                                         const TopLoc_Location& L) const;
 
-  //! A representation by two arrays of nodes on a
-  //! triangulation.
-  Standard_EXPORT virtual bool IsPolygonOnClosedTriangulation() const;
+  //! A representation by two arrays of nodes on a triangulation.
+  bool IsPolygonOnClosedTriangulation() const
+  {
+    return myKind == BRep_CurveRepKind::PolygonOnClosedTriangulation;
+  }
 
   //! A polygon in the parametric space of a surface.
-  Standard_EXPORT virtual bool IsPolygonOnSurface() const;
+  bool IsPolygonOnSurface() const
+  {
+    return myKind == BRep_CurveRepKind::PolygonOnSurface
+           || myKind == BRep_CurveRepKind::PolygonOnClosedSurface;
+  }
 
-  //! Is it a polygon in the parametric space of <S> with
-  //! location <L>.
+  //! Is it a polygon in the parametric space of <S> with location <L>.
   Standard_EXPORT virtual bool IsPolygonOnSurface(const occ::handle<Geom_Surface>& S,
                                                   const TopLoc_Location&           L) const;
 
-  //! Two 2D polygon representations in the parametric
-  //! space of a surface.
-  Standard_EXPORT virtual bool IsPolygonOnClosedSurface() const;
+  //! Two 2D polygon representations in the parametric space of a surface.
+  bool IsPolygonOnClosedSurface() const
+  {
+    return myKind == BRep_CurveRepKind::PolygonOnClosedSurface;
+  }
 
   const TopLoc_Location& Location() const;
 
@@ -150,9 +182,14 @@ public:
   DEFINE_STANDARD_RTTIEXT(BRep_CurveRepresentation, Standard_Transient)
 
 protected:
-  Standard_EXPORT BRep_CurveRepresentation(const TopLoc_Location& L);
+  BRep_CurveRepresentation(const TopLoc_Location& L, const BRep_CurveRepKind theKind)
+      : myLocation(L),
+        myKind(theKind)
+  {
+  }
 
-  TopLoc_Location myLocation;
+  TopLoc_Location      myLocation;
+  BRep_CurveRepKind    myKind;
 };
 
 #include <BRep_CurveRepresentation.lxx>

--- a/src/ModelingData/TKBRep/BRep/BRep_GCurve.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_GCurve.cxx
@@ -22,11 +22,13 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_GCurve, BRep_CurveRepresentation)
 
 //=================================================================================================
 
-BRep_GCurve::BRep_GCurve(const TopLoc_Location& L, const double First, const double Last)
-    : BRep_CurveRepresentation(L),
+BRep_GCurve::BRep_GCurve(const TopLoc_Location&  L,
+                         const double            First,
+                         const double            Last,
+                         const BRep_CurveRepKind theKind)
+    : BRep_CurveRepresentation(L, theKind),
       myFirst(First),
       myLast(Last)
-
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_GCurve.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_GCurve.hxx
@@ -56,7 +56,10 @@ public:
   DEFINE_STANDARD_RTTIEXT(BRep_GCurve, BRep_CurveRepresentation)
 
 protected:
-  Standard_EXPORT BRep_GCurve(const TopLoc_Location& L, const double First, const double Last);
+  Standard_EXPORT BRep_GCurve(const TopLoc_Location&  L,
+                              const double            First,
+                              const double            Last,
+                              const BRep_CurveRepKind theKind);
 
 private:
   double myFirst;

--- a/src/ModelingData/TKBRep/BRep/BRep_PointOnCurve.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointOnCurve.cxx
@@ -26,16 +26,9 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PointOnCurve, BRep_PointRepresentation)
 BRep_PointOnCurve::BRep_PointOnCurve(const double                   P,
                                      const occ::handle<Geom_Curve>& C,
                                      const TopLoc_Location&         L)
-    : BRep_PointRepresentation(P, L),
+    : BRep_PointRepresentation(P, L, BRep_PointRepKind::PointOnCurve),
       myCurve(C)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PointOnCurve::IsPointOnCurve() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PointOnCurve.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointOnCurve.hxx
@@ -33,9 +33,6 @@ public:
                                     const occ::handle<Geom_Curve>& C,
                                     const TopLoc_Location&         L);
 
-  //! Returns True
-  Standard_EXPORT bool IsPointOnCurve() const override;
-
   Standard_EXPORT bool IsPointOnCurve(const occ::handle<Geom_Curve>& C,
                                       const TopLoc_Location&         L) const override;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PointOnCurveOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointOnCurveOnSurface.cxx
@@ -28,16 +28,9 @@ BRep_PointOnCurveOnSurface::BRep_PointOnCurveOnSurface(const double             
                                                        const occ::handle<Geom2d_Curve>& C,
                                                        const occ::handle<Geom_Surface>& S,
                                                        const TopLoc_Location&           L)
-    : BRep_PointsOnSurface(P, S, L),
+    : BRep_PointsOnSurface(P, S, L, BRep_PointRepKind::PointOnCurveOnSurface),
       myPCurve(C)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PointOnCurveOnSurface::IsPointOnCurveOnSurface() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PointOnCurveOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointOnCurveOnSurface.hxx
@@ -36,9 +36,6 @@ public:
                                              const occ::handle<Geom_Surface>& S,
                                              const TopLoc_Location&           L);
 
-  //! Returns True
-  Standard_EXPORT bool IsPointOnCurveOnSurface() const override;
-
   Standard_EXPORT bool IsPointOnCurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
                                                const occ::handle<Geom_Surface>& S,
                                                const TopLoc_Location&           L) const override;

--- a/src/ModelingData/TKBRep/BRep/BRep_PointOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointOnSurface.cxx
@@ -27,16 +27,9 @@ BRep_PointOnSurface::BRep_PointOnSurface(const double                     P1,
                                          const double                     P2,
                                          const occ::handle<Geom_Surface>& S,
                                          const TopLoc_Location&           L)
-    : BRep_PointsOnSurface(P1, S, L),
+    : BRep_PointsOnSurface(P1, S, L, BRep_PointRepKind::PointOnSurface),
       myParameter2(P2)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PointOnSurface::IsPointOnSurface() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PointOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointOnSurface.hxx
@@ -34,8 +34,6 @@ public:
                                       const occ::handle<Geom_Surface>& S,
                                       const TopLoc_Location&           L);
 
-  Standard_EXPORT bool IsPointOnSurface() const override;
-
   Standard_EXPORT bool IsPointOnSurface(const occ::handle<Geom_Surface>& S,
                                         const TopLoc_Location&           L) const override;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.cxx
@@ -25,35 +25,6 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PointRepresentation, Standard_Transient)
 
 //=================================================================================================
 
-BRep_PointRepresentation::BRep_PointRepresentation(const double P, const TopLoc_Location& L)
-    : myLocation(L),
-      myParameter(P)
-{
-}
-
-//=================================================================================================
-
-bool BRep_PointRepresentation::IsPointOnCurve() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_PointRepresentation::IsPointOnCurveOnSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_PointRepresentation::IsPointOnSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
 bool BRep_PointRepresentation::IsPointOnCurve(const occ::handle<Geom_Curve>&,
                                               const TopLoc_Location&) const
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.hxx
@@ -26,20 +26,35 @@ class Geom_Curve;
 class Geom2d_Curve;
 class Geom_Surface;
 
+//! Discriminant tag identifying the concrete type of a point representation.
+//! Used for O(1) type checks instead of virtual dispatch.
+enum class BRep_PointRepKind : uint8_t
+{
+  PointOnCurve,
+  PointOnSurface,
+  PointOnCurveOnSurface
+};
+
 //! Root class for the points representations.
 //! Contains a location and a parameter.
 class BRep_PointRepresentation : public Standard_Transient
 {
 
 public:
+  //! Returns the concrete representation kind tag for O(1) type discrimination.
+  BRep_PointRepKind PointRepresentationKind() const { return myPointKind; }
+
   //! A point on a 3d curve.
-  Standard_EXPORT virtual bool IsPointOnCurve() const;
+  bool IsPointOnCurve() const { return myPointKind == BRep_PointRepKind::PointOnCurve; }
 
   //! A point on a 2d curve on a surface.
-  Standard_EXPORT virtual bool IsPointOnCurveOnSurface() const;
+  bool IsPointOnCurveOnSurface() const
+  {
+    return myPointKind == BRep_PointRepKind::PointOnCurveOnSurface;
+  }
 
   //! A point on a surface.
-  Standard_EXPORT virtual bool IsPointOnSurface() const;
+  bool IsPointOnSurface() const { return myPointKind == BRep_PointRepKind::PointOnSurface; }
 
   //! A point on the curve <C>.
   Standard_EXPORT virtual bool IsPointOnCurve(const occ::handle<Geom_Curve>& C,
@@ -84,7 +99,14 @@ public:
   DEFINE_STANDARD_RTTIEXT(BRep_PointRepresentation, Standard_Transient)
 
 protected:
-  Standard_EXPORT BRep_PointRepresentation(const double P, const TopLoc_Location& L);
+  BRep_PointRepresentation(const double P, const TopLoc_Location& L, const BRep_PointRepKind theKind)
+      : myLocation(L),
+        myParameter(P),
+        myPointKind(theKind)
+  {
+  }
+
+  BRep_PointRepKind myPointKind;
 
 private:
   TopLoc_Location myLocation;

--- a/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.hxx
@@ -27,7 +27,6 @@ class Geom2d_Curve;
 class Geom_Surface;
 
 //! Discriminant tag identifying the concrete type of a point representation.
-//! Used for O(1) type checks instead of virtual dispatch.
 enum class BRep_PointRepKind : uint8_t
 {
   PointOnCurve,
@@ -41,7 +40,7 @@ class BRep_PointRepresentation : public Standard_Transient
 {
 
 public:
-  //! Returns the concrete representation kind tag for O(1) type discrimination.
+  //! Returns the concrete representation kind tag.
   BRep_PointRepKind PointRepresentationKind() const { return myPointKind; }
 
   //! A point on a 3d curve.

--- a/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointRepresentation.hxx
@@ -100,9 +100,9 @@ public:
 
 protected:
   BRep_PointRepresentation(const double P, const TopLoc_Location& L, const BRep_PointRepKind theKind)
-      : myLocation(L),
-        myParameter(P),
-        myPointKind(theKind)
+      : myPointKind(theKind),
+        myLocation(L),
+        myParameter(P)
   {
   }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PointsOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointsOnSurface.cxx
@@ -25,8 +25,9 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PointsOnSurface, BRep_PointRepresentation)
 
 BRep_PointsOnSurface::BRep_PointsOnSurface(const double                     P,
                                            const occ::handle<Geom_Surface>& S,
-                                           const TopLoc_Location&           L)
-    : BRep_PointRepresentation(P, L),
+                                           const TopLoc_Location&           L,
+                                           const BRep_PointRepKind          theKind)
+    : BRep_PointRepresentation(P, L, theKind),
       mySurface(S)
 {
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_PointsOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PointsOnSurface.hxx
@@ -41,7 +41,8 @@ public:
 protected:
   Standard_EXPORT BRep_PointsOnSurface(const double                     P,
                                        const occ::handle<Geom_Surface>& S,
-                                       const TopLoc_Location&           L);
+                                       const TopLoc_Location&           L,
+                                       const BRep_PointRepKind          theKind);
 
 private:
   occ::handle<Geom_Surface> mySurface;

--- a/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.cxx
@@ -26,16 +26,9 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_Polygon3D, BRep_CurveRepresentation)
 //=================================================================================================
 
 BRep_Polygon3D::BRep_Polygon3D(const occ::handle<Poly_Polygon3D>& P, const TopLoc_Location& L)
-    : BRep_CurveRepresentation(L),
+    : BRep_CurveRepresentation(L, BRep_CurveRepKind::Polygon3D),
       myPolygon3D(P)
 {
-}
-
-//=================================================================================================
-
-bool BRep_Polygon3D::IsPolygon3D() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.hxx
@@ -31,9 +31,6 @@ class BRep_Polygon3D : public BRep_CurveRepresentation
 public:
   Standard_EXPORT BRep_Polygon3D(const occ::handle<Poly_Polygon3D>& P, const TopLoc_Location& L);
 
-  //! Returns True.
-  Standard_EXPORT bool IsPolygon3D() const override;
-
   Standard_EXPORT const occ::handle<Poly_Polygon3D>& Polygon3D() const override;
 
   Standard_EXPORT void Polygon3D(const occ::handle<Poly_Polygon3D>& P) override;

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
@@ -32,13 +32,7 @@ BRep_PolygonOnClosedSurface::BRep_PolygonOnClosedSurface(const occ::handle<Poly_
     : BRep_PolygonOnSurface(P1, S, L),
       myPolygon2(P2)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PolygonOnClosedSurface::IsPolygonOnClosedSurface() const
-{
-  return true;
+  myKind = BRep_CurveRepKind::PolygonOnClosedSurface;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
@@ -29,9 +29,10 @@ BRep_PolygonOnClosedSurface::BRep_PolygonOnClosedSurface(const occ::handle<Poly_
                                                          const occ::handle<Poly_Polygon2D>& P2,
                                                          const occ::handle<Geom_Surface>&   S,
                                                          const TopLoc_Location&             L)
-    : BRep_PolygonOnSurface(P1, S, L, BRep_CurveRepKind::PolygonOnClosedSurface),
+    : BRep_PolygonOnSurface(P1, S, L),
       myPolygon2(P2)
 {
+  myKind = BRep_CurveRepKind::PolygonOnClosedSurface;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
@@ -29,10 +29,9 @@ BRep_PolygonOnClosedSurface::BRep_PolygonOnClosedSurface(const occ::handle<Poly_
                                                          const occ::handle<Poly_Polygon2D>& P2,
                                                          const occ::handle<Geom_Surface>&   S,
                                                          const TopLoc_Location&             L)
-    : BRep_PolygonOnSurface(P1, S, L),
+    : BRep_PolygonOnSurface(P1, S, L, BRep_CurveRepKind::PolygonOnClosedSurface),
       myPolygon2(P2)
 {
-  myKind = BRep_CurveRepKind::PolygonOnClosedSurface;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.hxx
@@ -37,9 +37,6 @@ public:
                                               const occ::handle<Geom_Surface>&   S,
                                               const TopLoc_Location&             L);
 
-  //! returns True.
-  Standard_EXPORT bool IsPolygonOnClosedSurface() const override;
-
   Standard_EXPORT const occ::handle<Poly_Polygon2D>& Polygon2() const override;
 
   Standard_EXPORT void Polygon2(const occ::handle<Poly_Polygon2D>& P) override;

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
@@ -33,13 +33,7 @@ BRep_PolygonOnClosedTriangulation::BRep_PolygonOnClosedTriangulation(
     : BRep_PolygonOnTriangulation(P1, T, L),
       myPolygon2(P2)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PolygonOnClosedTriangulation::IsPolygonOnClosedTriangulation() const
-{
-  return true;
+  myKind = BRep_CurveRepKind::PolygonOnClosedTriangulation;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
@@ -30,9 +30,10 @@ BRep_PolygonOnClosedTriangulation::BRep_PolygonOnClosedTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P2,
   const occ::handle<Poly_Triangulation>&          T,
   const TopLoc_Location&                          L)
-    : BRep_PolygonOnTriangulation(P1, T, L, BRep_CurveRepKind::PolygonOnClosedTriangulation),
+    : BRep_PolygonOnTriangulation(P1, T, L),
       myPolygon2(P2)
 {
+  myKind = BRep_CurveRepKind::PolygonOnClosedTriangulation;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
@@ -30,10 +30,9 @@ BRep_PolygonOnClosedTriangulation::BRep_PolygonOnClosedTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P2,
   const occ::handle<Poly_Triangulation>&          T,
   const TopLoc_Location&                          L)
-    : BRep_PolygonOnTriangulation(P1, T, L),
+    : BRep_PolygonOnTriangulation(P1, T, L, BRep_CurveRepKind::PolygonOnClosedTriangulation),
       myPolygon2(P2)
 {
-  myKind = BRep_CurveRepKind::PolygonOnClosedTriangulation;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.hxx
@@ -38,9 +38,6 @@ public:
     const occ::handle<Poly_Triangulation>&          Tr,
     const TopLoc_Location&                          L);
 
-  //! Returns True.
-  Standard_EXPORT bool IsPolygonOnClosedTriangulation() const override;
-
   Standard_EXPORT void PolygonOnTriangulation2(
     const occ::handle<Poly_PolygonOnTriangulation>& P2) override;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
@@ -28,9 +28,8 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PolygonOnSurface, BRep_CurveRepresentation)
 
 BRep_PolygonOnSurface::BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
                                              const occ::handle<Geom_Surface>&   S,
-                                             const TopLoc_Location&             L,
-                                             const BRep_CurveRepKind            theKind)
-    : BRep_CurveRepresentation(L, theKind),
+                                             const TopLoc_Location&             L)
+    : BRep_CurveRepresentation(L, BRep_CurveRepKind::PolygonOnSurface),
       myPolygon2D(P),
       mySurface(S)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
@@ -29,17 +29,10 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PolygonOnSurface, BRep_CurveRepresentation)
 BRep_PolygonOnSurface::BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
                                              const occ::handle<Geom_Surface>&   S,
                                              const TopLoc_Location&             L)
-    : BRep_CurveRepresentation(L),
+    : BRep_CurveRepresentation(L, BRep_CurveRepKind::PolygonOnSurface),
       myPolygon2D(P),
       mySurface(S)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PolygonOnSurface::IsPolygonOnSurface() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
@@ -28,8 +28,9 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PolygonOnSurface, BRep_CurveRepresentation)
 
 BRep_PolygonOnSurface::BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
                                              const occ::handle<Geom_Surface>&   S,
-                                             const TopLoc_Location&             L)
-    : BRep_CurveRepresentation(L, BRep_CurveRepKind::PolygonOnSurface),
+                                             const TopLoc_Location&             L,
+                                             const BRep_CurveRepKind            theKind)
+    : BRep_CurveRepresentation(L, theKind),
       myPolygon2D(P),
       mySurface(S)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
@@ -37,10 +37,6 @@ public:
 
   //! A 2D polygon representation in the parametric
   //! space of a surface.
-  Standard_EXPORT bool IsPolygonOnSurface() const override;
-
-  //! A 2D polygon representation in the parametric
-  //! space of a surface.
   Standard_EXPORT bool IsPolygonOnSurface(const occ::handle<Geom_Surface>& S,
                                           const TopLoc_Location&           L) const override;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
@@ -31,9 +31,11 @@ class BRep_PolygonOnSurface : public BRep_CurveRepresentation
 {
 
 public:
-  Standard_EXPORT BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
-                                        const occ::handle<Geom_Surface>&   S,
-                                        const TopLoc_Location&             L);
+  Standard_EXPORT BRep_PolygonOnSurface(
+    const occ::handle<Poly_Polygon2D>& P,
+    const occ::handle<Geom_Surface>&   S,
+    const TopLoc_Location&             L,
+    const BRep_CurveRepKind            theKind = BRep_CurveRepKind::PolygonOnSurface);
 
   //! A 2D polygon representation in the parametric
   //! space of a surface.

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
@@ -31,11 +31,9 @@ class BRep_PolygonOnSurface : public BRep_CurveRepresentation
 {
 
 public:
-  Standard_EXPORT BRep_PolygonOnSurface(
-    const occ::handle<Poly_Polygon2D>& P,
-    const occ::handle<Geom_Surface>&   S,
-    const TopLoc_Location&             L,
-    const BRep_CurveRepKind            theKind = BRep_CurveRepKind::PolygonOnSurface);
+  Standard_EXPORT BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
+                                        const occ::handle<Geom_Surface>&   S,
+                                        const TopLoc_Location&             L);
 
   //! A 2D polygon representation in the parametric
   //! space of a surface.

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
@@ -28,9 +28,8 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PolygonOnTriangulation, BRep_CurveRepresentation
 BRep_PolygonOnTriangulation::BRep_PolygonOnTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P,
   const occ::handle<Poly_Triangulation>&          T,
-  const TopLoc_Location&                          L,
-  const BRep_CurveRepKind                         theKind)
-    : BRep_CurveRepresentation(L, theKind),
+  const TopLoc_Location&                          L)
+    : BRep_CurveRepresentation(L, BRep_CurveRepKind::PolygonOnTriangulation),
       myPolygon(P),
       myTriangulation(T)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
@@ -28,8 +28,9 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PolygonOnTriangulation, BRep_CurveRepresentation
 BRep_PolygonOnTriangulation::BRep_PolygonOnTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P,
   const occ::handle<Poly_Triangulation>&          T,
-  const TopLoc_Location&                          L)
-    : BRep_CurveRepresentation(L, BRep_CurveRepKind::PolygonOnTriangulation),
+  const TopLoc_Location&                          L,
+  const BRep_CurveRepKind                         theKind)
+    : BRep_CurveRepresentation(L, theKind),
       myPolygon(P),
       myTriangulation(T)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
@@ -29,17 +29,10 @@ BRep_PolygonOnTriangulation::BRep_PolygonOnTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P,
   const occ::handle<Poly_Triangulation>&          T,
   const TopLoc_Location&                          L)
-    : BRep_CurveRepresentation(L),
+    : BRep_CurveRepresentation(L, BRep_CurveRepKind::PolygonOnTriangulation),
       myPolygon(P),
       myTriangulation(T)
 {
-}
-
-//=================================================================================================
-
-bool BRep_PolygonOnTriangulation::IsPolygonOnTriangulation() const
-{
-  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
@@ -31,11 +31,9 @@ class BRep_PolygonOnTriangulation : public BRep_CurveRepresentation
 {
 
 public:
-  Standard_EXPORT BRep_PolygonOnTriangulation(
-    const occ::handle<Poly_PolygonOnTriangulation>& P,
-    const occ::handle<Poly_Triangulation>&          T,
-    const TopLoc_Location&                          L,
-    const BRep_CurveRepKind theKind = BRep_CurveRepKind::PolygonOnTriangulation);
+  Standard_EXPORT BRep_PolygonOnTriangulation(const occ::handle<Poly_PolygonOnTriangulation>& P,
+                                              const occ::handle<Poly_Triangulation>&          T,
+                                              const TopLoc_Location&                          L);
 
   //! Is it a polygon in the definition of <T> with
   //! location <L>.

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
@@ -31,9 +31,11 @@ class BRep_PolygonOnTriangulation : public BRep_CurveRepresentation
 {
 
 public:
-  Standard_EXPORT BRep_PolygonOnTriangulation(const occ::handle<Poly_PolygonOnTriangulation>& P,
-                                              const occ::handle<Poly_Triangulation>&          T,
-                                              const TopLoc_Location&                          L);
+  Standard_EXPORT BRep_PolygonOnTriangulation(
+    const occ::handle<Poly_PolygonOnTriangulation>& P,
+    const occ::handle<Poly_Triangulation>&          T,
+    const TopLoc_Location&                          L,
+    const BRep_CurveRepKind theKind = BRep_CurveRepKind::PolygonOnTriangulation);
 
   //! Is it a polygon in the definition of <T> with
   //! location <L>.

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
@@ -35,9 +35,6 @@ public:
                                               const occ::handle<Poly_Triangulation>&          T,
                                               const TopLoc_Location&                          L);
 
-  //! returns True.
-  Standard_EXPORT bool IsPolygonOnTriangulation() const override;
-
   //! Is it a polygon in the definition of <T> with
   //! location <L>.
   Standard_EXPORT bool IsPolygonOnTriangulation(const occ::handle<Poly_Triangulation>& T,

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.cxx
@@ -97,7 +97,6 @@ occ::handle<TopoDS_TShape> BRep_TEdge::EmptyCopy() const
 {
   occ::handle<BRep_TEdge> TE = new BRep_TEdge();
   TE->Tolerance(myTolerance);
-  // Copy the curves representations (polygons are NOT copied).
   NCollection_List<occ::handle<BRep_CurveRepresentation>>&          l = TE->ChangeCurves();
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itr(myCurves);
 
@@ -109,7 +108,6 @@ occ::handle<TopoDS_TShape> BRep_TEdge::EmptyCopy() const
         || aKind == BRep_CurveRepKind::CurveOn2Surfaces)
     {
       occ::handle<BRep_CurveRepresentation> aCopy = itr.Value()->Copy();
-      // Maintain 3D curve cache for the new edge.
       if (aKind == BRep_CurveRepKind::Curve3D)
       {
         TE->Curve3D(occ::down_cast<BRep_Curve3D>(aCopy));

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.cxx
@@ -103,14 +103,14 @@ occ::handle<TopoDS_TShape> BRep_TEdge::EmptyCopy() const
 
   while (itr.More())
   {
-    const BRep_CurveRepKind kind = itr.Value()->RepresentationKind();
-    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
-        || kind == BRep_CurveRepKind::CurveOnClosedSurface
-        || kind == BRep_CurveRepKind::CurveOn2Surfaces)
+    const BRep_CurveRepKind aKind = itr.Value()->RepresentationKind();
+    if (aKind == BRep_CurveRepKind::Curve3D || aKind == BRep_CurveRepKind::CurveOnSurface
+        || aKind == BRep_CurveRepKind::CurveOnClosedSurface
+        || aKind == BRep_CurveRepKind::CurveOn2Surfaces)
     {
       occ::handle<BRep_CurveRepresentation> aCopy = itr.Value()->Copy();
       // Maintain 3D curve cache for the new edge.
-      if (kind == BRep_CurveRepKind::Curve3D)
+      if (aKind == BRep_CurveRepKind::Curve3D)
       {
         TE->Curve3D(occ::down_cast<BRep_Curve3D>(aCopy));
       }

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.cxx
@@ -103,12 +103,14 @@ occ::handle<TopoDS_TShape> BRep_TEdge::EmptyCopy() const
 
   while (itr.More())
   {
-    if (itr.Value()->IsKind(STANDARD_TYPE(BRep_GCurve))
-        || itr.Value()->IsKind(STANDARD_TYPE(BRep_CurveOn2Surfaces)))
+    const BRep_CurveRepKind kind = itr.Value()->RepresentationKind();
+    if (kind == BRep_CurveRepKind::Curve3D || kind == BRep_CurveRepKind::CurveOnSurface
+        || kind == BRep_CurveRepKind::CurveOnClosedSurface
+        || kind == BRep_CurveRepKind::CurveOn2Surfaces)
     {
       occ::handle<BRep_CurveRepresentation> aCopy = itr.Value()->Copy();
       // Maintain 3D curve cache for the new edge.
-      if (aCopy->IsCurve3D())
+      if (kind == BRep_CurveRepKind::Curve3D)
       {
         TE->Curve3D(occ::down_cast<BRep_Curve3D>(aCopy));
       }

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.hxx
@@ -24,6 +24,8 @@
 #include <BRep_CurveRepresentation.hxx>
 #include <NCollection_List.hxx>
 #include <TopoDS_TEdge.hxx>
+class BRep_Curve3D;
+class BRep_Polygon3D;
 class TopoDS_TShape;
 
 //! The TEdge from BRep is inherited from the TEdge
@@ -67,6 +69,18 @@ public:
 
   NCollection_List<occ::handle<BRep_CurveRepresentation>>& ChangeCurves();
 
+  //! Returns the cached 3D curve representation, or null handle if none.
+  const occ::handle<BRep_Curve3D>& Curve3D() const;
+
+  //! Sets the cached 3D curve representation.
+  void Curve3D(const occ::handle<BRep_Curve3D>& theCurve);
+
+  //! Returns the cached 3D polygon representation, or null handle if none.
+  const occ::handle<BRep_Polygon3D>& Polygon3D() const;
+
+  //! Sets the cached 3D polygon representation.
+  void Polygon3D(const occ::handle<BRep_Polygon3D>& thePolygon);
+
   //! Returns a copy of the TShape with no sub-shapes.
   Standard_EXPORT occ::handle<TopoDS_TShape> EmptyCopy() const override;
 
@@ -79,6 +93,8 @@ private:
   double                                                  myTolerance;
   int                                                     myFlags;
   NCollection_List<occ::handle<BRep_CurveRepresentation>> myCurves;
+  occ::handle<BRep_Curve3D>                               myCurve3D;
+  occ::handle<BRep_Polygon3D>                             myPolygon3D;
 };
 
 #include <BRep_TEdge.lxx>

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.hxx
@@ -69,16 +69,12 @@ public:
 
   NCollection_List<occ::handle<BRep_CurveRepresentation>>& ChangeCurves();
 
-  //! Returns the cached 3D curve representation, or null handle if none.
   const occ::handle<BRep_Curve3D>& Curve3D() const;
 
-  //! Sets the cached 3D curve representation.
   void Curve3D(const occ::handle<BRep_Curve3D>& theCurve);
 
-  //! Returns the cached 3D polygon representation, or null handle if none.
   const occ::handle<BRep_Polygon3D>& Polygon3D() const;
 
-  //! Sets the cached 3D polygon representation.
   void Polygon3D(const occ::handle<BRep_Polygon3D>& thePolygon);
 
   //! Returns a copy of the TShape with no sub-shapes.

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.lxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.lxx
@@ -14,6 +14,8 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <Precision.hxx>
+
 //=================================================================================================
 
 inline double BRep_TEdge::Tolerance() const
@@ -25,7 +27,7 @@ inline double BRep_TEdge::Tolerance() const
 
 inline void BRep_TEdge::Tolerance(const double T)
 {
-  myTolerance = T;
+  myTolerance = std::max(T, Precision::Confusion());
 }
 
 //=================================================================================================
@@ -33,7 +35,7 @@ inline void BRep_TEdge::Tolerance(const double T)
 inline void BRep_TEdge::UpdateTolerance(const double T)
 {
   if (T > myTolerance)
-    myTolerance = T;
+    myTolerance = std::max(T, Precision::Confusion());
 }
 
 //=================================================================================================
@@ -48,4 +50,32 @@ inline const NCollection_List<occ::handle<BRep_CurveRepresentation>>& BRep_TEdge
 inline NCollection_List<occ::handle<BRep_CurveRepresentation>>& BRep_TEdge::ChangeCurves()
 {
   return myCurves;
+}
+
+//=================================================================================================
+
+inline const occ::handle<BRep_Curve3D>& BRep_TEdge::Curve3D() const
+{
+  return myCurve3D;
+}
+
+//=================================================================================================
+
+inline void BRep_TEdge::Curve3D(const occ::handle<BRep_Curve3D>& theCurve)
+{
+  myCurve3D = theCurve;
+}
+
+//=================================================================================================
+
+inline const occ::handle<BRep_Polygon3D>& BRep_TEdge::Polygon3D() const
+{
+  return myPolygon3D;
+}
+
+//=================================================================================================
+
+inline void BRep_TEdge::Polygon3D(const occ::handle<BRep_Polygon3D>& thePolygon)
+{
+  myPolygon3D = thePolygon;
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.lxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.lxx
@@ -49,6 +49,11 @@ inline const NCollection_List<occ::handle<BRep_CurveRepresentation>>& BRep_TEdge
 
 inline NCollection_List<occ::handle<BRep_CurveRepresentation>>& BRep_TEdge::ChangeCurves()
 {
+  // Invalidate cached representations since the caller may modify the list
+  // (e.g. remove or replace entries). The cache will be lazily repopulated
+  // on the next BRep_Tool query, or explicitly set by BRep_Builder methods.
+  myCurve3D.Nullify();
+  myPolygon3D.Nullify();
   return myCurves;
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_TEdge.lxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TEdge.lxx
@@ -49,9 +49,6 @@ inline const NCollection_List<occ::handle<BRep_CurveRepresentation>>& BRep_TEdge
 
 inline NCollection_List<occ::handle<BRep_CurveRepresentation>>& BRep_TEdge::ChangeCurves()
 {
-  // Invalidate cached representations since the caller may modify the list
-  // (e.g. remove or replace entries). The cache will be lazily repopulated
-  // on the next BRep_Tool query, or explicitly set by BRep_Builder methods.
   myCurve3D.Nullify();
   myPolygon3D.Nullify();
   return myCurves;

--- a/src/ModelingData/TKBRep/BRep/BRep_TFace.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TFace.cxx
@@ -38,7 +38,6 @@ BRep_TFace::BRep_TFace()
 
 //=================================================================================================
 
-//! Checks if the given surface is a plane (directly, or through trimming/offset).
 static bool computeIsPlane(const occ::handle<Geom_Surface>& theSurface)
 {
   if (theSurface.IsNull())
@@ -84,8 +83,6 @@ void BRep_TFace::Tolerance(const double theTolerance)
 occ::handle<TopoDS_TShape> BRep_TFace::EmptyCopy() const
 {
   occ::handle<BRep_TFace> TF = new BRep_TFace();
-  // Assign surface and cached plane flag directly to avoid
-  // redundant RTTI downcasts in computeIsPlane().
   TF->mySurface = mySurface;
   TF->myIsPlane = myIsPlane;
   TF->myLocation = myLocation;

--- a/src/ModelingData/TKBRep/BRep/BRep_TFace.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TFace.cxx
@@ -84,10 +84,12 @@ void BRep_TFace::Tolerance(const double theTolerance)
 occ::handle<TopoDS_TShape> BRep_TFace::EmptyCopy() const
 {
   occ::handle<BRep_TFace> TF = new BRep_TFace();
-  TF->Surface(mySurface);
-  TF->Location(myLocation);
+  // Assign surface and cached plane flag directly to avoid
+  // redundant RTTI downcasts in computeIsPlane().
+  TF->mySurface = mySurface;
+  TF->myIsPlane = myIsPlane;
+  TF->myLocation = myLocation;
   TF->Tolerance(myTolerance);
-  // myIsPlane is already set by Surface() setter above.
   return TF;
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_TFace.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TFace.hxx
@@ -71,7 +71,7 @@ public:
   double Tolerance() const { return myTolerance; }
 
   //! Sets the tolerance for this face.
-  void Tolerance(const double theTolerance);
+  Standard_EXPORT void Tolerance(const double theTolerance);
 
   //! Returns TRUE if the face surface is a plane.
   bool IsPlane() const { return myIsPlane; }

--- a/src/ModelingData/TKBRep/BRep/BRep_TFace.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TFace.hxx
@@ -59,7 +59,6 @@ public:
   const occ::handle<Geom_Surface>& Surface() const { return mySurface; }
 
   //! Sets surface for this face.
-  //! Updates the cached IsPlane flag.
   Standard_EXPORT void Surface(const occ::handle<Geom_Surface>& theSurface);
 
   //! Returns the face location.
@@ -72,10 +71,9 @@ public:
   double Tolerance() const { return myTolerance; }
 
   //! Sets the tolerance for this face.
-  //! The value is clamped to at least Precision::Confusion().
   void Tolerance(const double theTolerance);
 
-  //! Returns TRUE if the face surface is a plane (or trimmed/offset plane).
+  //! Returns TRUE if the face surface is a plane.
   bool IsPlane() const { return myIsPlane; }
 
   //! Returns TRUE if the boundary of this face is known to be the parametric space (Umin, UMax,

--- a/src/ModelingData/TKBRep/BRep/BRep_TFace.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TFace.hxx
@@ -59,7 +59,8 @@ public:
   const occ::handle<Geom_Surface>& Surface() const { return mySurface; }
 
   //! Sets surface for this face.
-  void Surface(const occ::handle<Geom_Surface>& theSurface) { mySurface = theSurface; }
+  //! Updates the cached IsPlane flag.
+  Standard_EXPORT void Surface(const occ::handle<Geom_Surface>& theSurface);
 
   //! Returns the face location.
   const TopLoc_Location& Location() const { return myLocation; }
@@ -71,7 +72,11 @@ public:
   double Tolerance() const { return myTolerance; }
 
   //! Sets the tolerance for this face.
-  void Tolerance(const double theTolerance) { myTolerance = theTolerance; }
+  //! The value is clamped to at least Precision::Confusion().
+  void Tolerance(const double theTolerance);
+
+  //! Returns TRUE if the face surface is a plane (or trimmed/offset plane).
+  bool IsPlane() const { return myIsPlane; }
 
   //! Returns TRUE if the boundary of this face is known to be the parametric space (Umin, UMax,
   //! VMin, VMax).
@@ -142,6 +147,7 @@ private:
   TopLoc_Location                                   myLocation;
   double                                            myTolerance;
   bool                                              myNaturalRestriction;
+  bool                                              myIsPlane;
 };
 
 #endif // _BRep_TFace_HeaderFile

--- a/src/ModelingData/TKBRep/BRep/BRep_TVertex.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TVertex.cxx
@@ -16,6 +16,7 @@
 
 #include <BRep_TVertex.hxx>
 #include <gp_Pnt.hxx>
+#include <Precision.hxx>
 #include <Standard_Type.hxx>
 #include <TopoDS_Shape.hxx>
 
@@ -24,7 +25,7 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_TVertex, TopoDS_TVertex)
 //=================================================================================================
 
 BRep_TVertex::BRep_TVertex()
-    : myTolerance(RealEpsilon())
+    : myTolerance(Precision::Confusion())
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_TVertex.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TVertex.cxx
@@ -34,8 +34,8 @@ BRep_TVertex::BRep_TVertex()
 occ::handle<TopoDS_TShape> BRep_TVertex::EmptyCopy() const
 {
   occ::handle<BRep_TVertex> TV = new BRep_TVertex();
-  TV->Pnt(myPnt);
-  TV->Tolerance(myTolerance);
+  TV->myPnt       = myPnt;
+  TV->myTolerance = myTolerance;
   return TV;
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_TVertex.lxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_TVertex.lxx
@@ -14,6 +14,8 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <Precision.hxx>
+
 //=================================================================================================
 
 inline double BRep_TVertex::Tolerance() const
@@ -25,7 +27,7 @@ inline double BRep_TVertex::Tolerance() const
 
 inline void BRep_TVertex::Tolerance(const double T)
 {
-  myTolerance = T;
+  myTolerance = std::max(T, Precision::Confusion());
 }
 
 //=================================================================================================
@@ -33,7 +35,7 @@ inline void BRep_TVertex::Tolerance(const double T)
 inline void BRep_TVertex::UpdateTolerance(const double T)
 {
   if (T > myTolerance)
-    myTolerance = T;
+    myTolerance = std::max(T, Precision::Confusion());
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -1040,7 +1040,7 @@ void BRep_Tool::SetUVPoints(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    occ::handle<BRep_CurveRepresentation> cr = itcr.Value();
+    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
     if (cr->IsCurveOnSurface(S, l))
     {
       if (cr->IsCurveOnClosedSurface() && Eisreversed)
@@ -1053,6 +1053,7 @@ void BRep_Tool::SetUVPoints(const TopoDS_Edge&               E,
         BRep_CurveOnSurface* CS = static_cast<BRep_CurveOnSurface*>(cr.get());
         CS->SetUVPoints(PFirst, PLast);
       }
+      return;
     }
     itcr.Next();
   }

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -894,18 +894,18 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
     return;
   }
 
-  bool aHasRange = false;
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
     if (cr->IsCurve3D())
     {
-      const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
-      GC->Range(First, Last);
-      aHasRange = true;
       if (!cr->Curve3D().IsNull())
+      {
+        const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
+        GC->Range(First, Last);
         return;
+      }
     }
     else if (cr->IsCurveOnSurface())
     {
@@ -915,8 +915,7 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
     }
     itcr.Next();
   }
-  if (!aHasRange)
-    First = Last = 0.;
+  First = Last = 0.;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -1151,8 +1151,8 @@ GeomAbs_Shape BRep_Tool::Continuity(const TopoDS_Edge&               E,
   TopLoc_Location l2 = L2.Predivided(E.Location());
 
   // find the representation
-  NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(
-    (*((occ::handle<BRep_TEdge>*)&E.TShape()))->ChangeCurves());
+  const BRep_TEdge* TE = static_cast<const BRep_TEdge*>(E.TShape().get());
+  NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
 
   while (itcr.More())
   {
@@ -1187,9 +1187,9 @@ bool BRep_Tool::HasContinuity(const TopoDS_Edge& E)
 
 GeomAbs_Shape BRep_Tool::MaxContinuity(const TopoDS_Edge& theEdge)
 {
-  GeomAbs_Shape aMaxCont = GeomAbs_C0;
-  for (NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator aReprIter(
-         (*((occ::handle<BRep_TEdge>*)&theEdge.TShape()))->ChangeCurves());
+  const BRep_TEdge* TE       = static_cast<const BRep_TEdge*>(theEdge.TShape().get());
+  GeomAbs_Shape     aMaxCont = GeomAbs_C0;
+  for (NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator aReprIter(TE->Curves());
        aReprIter.More();
        aReprIter.Next())
   {

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -314,7 +314,7 @@ occ::handle<Geom2d_Curve> BRep_Tool::CurveOnSurface(const TopoDS_Edge&          
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, loc))
+    if (cr->IsCurveOnSurface() && cr->IsCurveOnSurface(S, loc))
     {
       const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
       GC->Range(First, Last);
@@ -527,7 +527,7 @@ occ::handle<Poly_Polygon2D> BRep_Tool::PolygonOnSurface(const TopoDS_Edge&      
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnSurface(S, l))
+    if (cr->IsPolygonOnSurface() && cr->IsPolygonOnSurface(S, l))
     {
       if (cr->IsPolygonOnClosedSurface() && Eisreversed)
         return cr->Polygon2();
@@ -633,7 +633,7 @@ const occ::handle<Poly_PolygonOnTriangulation>& BRep_Tool::PolygonOnTriangulatio
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnTriangulation(T, l))
+    if (cr->IsPolygonOnTriangulation() && cr->IsPolygonOnTriangulation(T, l))
     {
       if (cr->IsPolygonOnClosedTriangulation() && Eisreversed)
         return cr->PolygonOnTriangulation2();
@@ -767,7 +767,7 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l) && cr->IsCurveOnClosedSurface())
+    if (cr->IsCurveOnClosedSurface() && cr->IsCurveOnSurface(S, l))
       return true;
     itcr.Next();
   }
@@ -798,7 +798,7 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&                     E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnTriangulation(T, l) && cr->IsPolygonOnClosedTriangulation())
+    if (cr->IsPolygonOnClosedTriangulation() && cr->IsPolygonOnTriangulation(T, l))
       return true;
     itcr.Next();
   }
@@ -897,7 +897,7 @@ void BRep_Tool::Range(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l))
+    if (cr->IsCurveOnSurface() && cr->IsCurveOnSurface(S, l))
     {
       const BRep_CurveOnSurface* CR = static_cast<const BRep_CurveOnSurface*>(cr.get());
       CR->Range(First, Last);
@@ -939,7 +939,7 @@ void BRep_Tool::UVPoints(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l))
+    if (cr->IsCurveOnSurface() && cr->IsCurveOnSurface(S, l))
     {
       if (cr->IsCurveOnClosedSurface() && Eisreversed)
       {
@@ -1041,7 +1041,7 @@ void BRep_Tool::SetUVPoints(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l))
+    if (cr->IsCurveOnSurface() && cr->IsCurveOnSurface(S, l))
     {
       if (cr->IsCurveOnClosedSurface() && Eisreversed)
       {
@@ -1130,7 +1130,7 @@ bool BRep_Tool::HasContinuity(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsRegularity(S1, S2, l1, l2))
+    if (cr->IsRegularity() && cr->IsRegularity(S1, S2, l1, l2))
       return true;
     itcr.Next();
   }
@@ -1158,7 +1158,7 @@ GeomAbs_Shape BRep_Tool::Continuity(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsRegularity(S1, S2, l1, l2))
+    if (cr->IsRegularity() && cr->IsRegularity(S1, S2, l1, l2))
       return cr->Continuity();
     itcr.Next();
   }
@@ -1321,7 +1321,7 @@ bool BRep_Tool::Parameter(const TopoDS_Vertex& theV, const TopoDS_Edge& theE, do
       while (itpr.More())
       {
         const occ::handle<BRep_PointRepresentation>& pr = itpr.Value();
-        if (pr->IsPointOnCurve(C, L))
+        if (pr->IsPointOnCurve() && pr->IsPointOnCurve(C, L))
         {
           double p   = pr->Parameter();
           double res = p; // SVV 4 nov 99 - to avoid warnings on Linux
@@ -1372,7 +1372,7 @@ bool BRep_Tool::Parameter(const TopoDS_Vertex& theV, const TopoDS_Edge& theE, do
       while (itpr.More())
       {
         const occ::handle<BRep_PointRepresentation>& pr = itpr.Value();
-        if (pr->IsPointOnCurveOnSurface(PC, S, L))
+        if (pr->IsPointOnCurveOnSurface() && pr->IsPointOnCurveOnSurface(PC, S, L))
         {
           double p = pr->Parameter();
           // Closed curves RLE 16 june 94
@@ -1482,7 +1482,7 @@ double BRep_Tool::Parameter(const TopoDS_Vertex&             V,
 
     while (itpr.More())
     {
-      if (itpr.Value()->IsPointOnCurveOnSurface(PC, S, L))
+      if (itpr.Value()->IsPointOnCurveOnSurface() && itpr.Value()->IsPointOnCurveOnSurface(PC, S, L))
         return itpr.Value()->Parameter();
       itpr.Next();
     }
@@ -1501,7 +1501,7 @@ double BRep_Tool::Parameter(const TopoDS_Vertex&             V,
     while (itpr.More())
     {
       const occ::handle<BRep_PointRepresentation>& pr = itpr.Value();
-      if (pr->IsPointOnCurve(C, L1))
+      if (pr->IsPointOnCurve() && pr->IsPointOnCurve(C, L1))
       {
         double p   = pr->Parameter();
         double res = p;
@@ -1553,7 +1553,7 @@ gp_Pnt2d BRep_Tool::Parameters(const TopoDS_Vertex& V, const TopoDS_Face& F)
   // It is checked if there is PointRepresentation (case non Manifold)
   while (itpr.More())
   {
-    if (itpr.Value()->IsPointOnSurface(S, L))
+    if (itpr.Value()->IsPointOnSurface() && itpr.Value()->IsPointOnSurface(S, L))
     {
       return gp_Pnt2d(itpr.Value()->Parameter(), itpr.Value()->Parameter2());
     }

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -769,15 +769,14 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
 bool BRep_Tool::IsClosed(const TopoDS_Edge& E, const TopoDS_Face& F)
 {
   const BRep_TFace* TF = static_cast<const BRep_TFace*>(F.TShape().get());
+  TopLoc_Location   l;
   // An edge on a plane can never be closed in parametric space.
   if (!TF->IsPlane())
   {
-    TopLoc_Location                  l;
     const occ::handle<Geom_Surface>& S = BRep_Tool::Surface(F, l);
     if (IsClosed(E, S, l))
       return true;
   }
-  TopLoc_Location                        l;
   const occ::handle<Poly_Triangulation>& T = BRep_Tool::Triangulation(F, l);
   return IsClosed(E, T, l);
 }
@@ -906,7 +905,7 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
   }
 
   // Fall back to searching for Curve3D or CurveOnSurface representations.
-  bool hasRange = false;
+  bool aHasRange = false;
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   while (itcr.More())
   {
@@ -915,7 +914,7 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
     {
       const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
       GC->Range(First, Last);
-      hasRange = true;
+      aHasRange = true;
       if (!cr->Curve3D().IsNull())
         return;
     }
@@ -927,7 +926,7 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
     }
     itcr.Next();
   }
-  if (!hasRange)
+  if (!aHasRange)
     First = Last = 0.;
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -164,7 +164,6 @@ const occ::handle<Geom_Curve>& BRep_Tool::Curve(const TopoDS_Edge& E,
                                                 double&            First,
                                                 double&            Last)
 {
-  // Use the cached 3D curve representation for O(1) access.
   const BRep_TEdge*                TE      = static_cast<const BRep_TEdge*>(E.TShape().get());
   const occ::handle<BRep_Curve3D>& aCached = TE->Curve3D();
   if (!aCached.IsNull())
@@ -175,8 +174,6 @@ const occ::handle<Geom_Curve>& BRep_Tool::Curve(const TopoDS_Edge& E,
     return aCached->Curve3D();
   }
 
-  // Fallback: cache was invalidated (e.g. by external ChangeCurves() callers).
-  // Scan the list to find Curve3D representation.
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   while (itcr.More())
   {
@@ -239,7 +236,6 @@ bool BRep_Tool::IsGeometric(const TopoDS_Face& F)
 
 bool BRep_Tool::IsGeometric(const TopoDS_Edge& E)
 {
-  // Check cached 3D curve first for O(1) access.
   const BRep_TEdge*                TE      = static_cast<const BRep_TEdge*>(E.TShape().get());
   const occ::handle<BRep_Curve3D>& aCached = TE->Curve3D();
   if (!aCached.IsNull() && !aCached->Curve3D().IsNull())
@@ -247,7 +243,6 @@ bool BRep_Tool::IsGeometric(const TopoDS_Edge& E)
     return true;
   }
 
-  // Fall back to searching for Curve3D or CurveOnSurface representations.
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   while (itcr.More())
   {
@@ -274,7 +269,6 @@ static const occ::handle<Poly_Polygon3D> nullPolygon3D;
 
 const occ::handle<Poly_Polygon3D>& BRep_Tool::Polygon3D(const TopoDS_Edge& E, TopLoc_Location& L)
 {
-  // Use the cached Polygon3D representation for O(1) access.
   const BRep_TEdge*                  TE      = static_cast<const BRep_TEdge*>(E.TShape().get());
   const occ::handle<BRep_Polygon3D>& aCached = TE->Polygon3D();
   if (!aCached.IsNull())
@@ -284,8 +278,6 @@ const occ::handle<Poly_Polygon3D>& BRep_Tool::Polygon3D(const TopoDS_Edge& E, To
     return aCached->Polygon3D();
   }
 
-  // Fallback: cache was invalidated (e.g. by external ChangeCurves() callers).
-  // Scan the list to find Polygon3D representation.
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   while (itcr.More())
   {
@@ -770,7 +762,6 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge& E, const TopoDS_Face& F)
 {
   const BRep_TFace* TF = static_cast<const BRep_TFace*>(F.TShape().get());
   TopLoc_Location   l;
-  // An edge on a plane can never be closed in parametric space.
   if (!TF->IsPlane())
   {
     const occ::handle<Geom_Surface>& S = BRep_Tool::Surface(F, l);
@@ -894,7 +885,6 @@ bool BRep_Tool::Degenerated(const TopoDS_Edge& E)
 
 void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
 {
-  // Check cached 3D curve first for O(1) access.
   const BRep_TEdge*                TE      = static_cast<const BRep_TEdge*>(E.TShape().get());
   const occ::handle<BRep_Curve3D>& aCached = TE->Curve3D();
   if (!aCached.IsNull() && !aCached->Curve3D().IsNull())
@@ -904,7 +894,6 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
     return;
   }
 
-  // Fall back to searching for Curve3D or CurveOnSurface representations.
   bool aHasRange = false;
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   while (itcr.More())

--- a/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
@@ -1,0 +1,207 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRep_Curve3D.hxx>
+#include <BRep_CurveOn2Surfaces.hxx>
+#include <BRep_CurveOnClosedSurface.hxx>
+#include <BRep_CurveOnSurface.hxx>
+#include <BRep_CurveRepresentation.hxx>
+#include <BRep_Polygon3D.hxx>
+#include <BRep_PolygonOnClosedSurface.hxx>
+#include <BRep_PolygonOnClosedTriangulation.hxx>
+#include <BRep_PolygonOnSurface.hxx>
+#include <BRep_PolygonOnTriangulation.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <GeomAbs_Shape.hxx>
+#include <NCollection_Array1.hxx>
+#include <Poly_Polygon2D.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopLoc_Location.hxx>
+#include <gp_Pln.hxx>
+
+// Helper objects for constructing test representations.
+// All Is*() queries are called through the base class handle to avoid
+// C++ name hiding by virtual overloads with parameters in derived classes.
+namespace
+{
+Handle(Geom_Line)   TheLine3D() { return new Geom_Line(gp_Pnt(0., 0., 0.), gp_Dir(1., 0., 0.)); }
+Handle(Geom2d_Line) TheLine2D() { return new Geom2d_Line(gp_Pnt2d(0., 0.), gp_Dir2d(1., 0.)); }
+Handle(Geom_Plane)  ThePlane()  { return new Geom_Plane(gp_Pln()); }
+TopLoc_Location     TheLoc()    { return TopLoc_Location(); }
+
+Handle(Poly_Polygon3D) ThePoly3D()
+{
+  NCollection_Array1<gp_Pnt> aNodes(1, 2);
+  aNodes.SetValue(1, gp_Pnt(0., 0., 0.));
+  aNodes.SetValue(2, gp_Pnt(1., 0., 0.));
+  return new Poly_Polygon3D(aNodes);
+}
+
+Handle(Poly_Polygon2D) ThePoly2D()
+{
+  NCollection_Array1<gp_Pnt2d> aNodes(1, 2);
+  aNodes.SetValue(1, gp_Pnt2d(0., 0.));
+  aNodes.SetValue(2, gp_Pnt2d(1., 0.));
+  return new Poly_Polygon2D(aNodes);
+}
+
+Handle(Poly_Triangulation) TheTriangulation()
+{
+  return new Poly_Triangulation(1, 0, false);
+}
+
+Handle(Poly_PolygonOnTriangulation) ThePolyOnTri()
+{
+  NCollection_Array1<int> aNodes(1, 1);
+  aNodes.SetValue(1, 1);
+  return new Poly_PolygonOnTriangulation(aNodes);
+}
+} // namespace
+
+TEST(BRep_CurveRepresentation_Test, Curve3D_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep = new BRep_Curve3D(TheLine3D(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::Curve3D)
+    << "RepresentationKind should be Curve3D";
+  EXPECT_TRUE(aRep->IsCurve3D()) << "IsCurve3D should be true";
+  EXPECT_FALSE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be false";
+  EXPECT_FALSE(aRep->IsRegularity()) << "IsRegularity should be false";
+  EXPECT_FALSE(aRep->IsCurveOnClosedSurface()) << "IsCurveOnClosedSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnClosedSurface()) << "IsPolygonOnClosedSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnClosedTriangulation())
+    << "IsPolygonOnClosedTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, CurveOnSurface_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_CurveOnSurface(TheLine2D(), ThePlane(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::CurveOnSurface)
+    << "RepresentationKind should be CurveOnSurface";
+  EXPECT_TRUE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be true";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsRegularity()) << "IsRegularity should be false";
+  EXPECT_FALSE(aRep->IsCurveOnClosedSurface()) << "IsCurveOnClosedSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, CurveOnClosedSurface_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_CurveOnClosedSurface(TheLine2D(), TheLine2D(), ThePlane(), TheLoc(), GeomAbs_C0);
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::CurveOnClosedSurface)
+    << "RepresentationKind should be CurveOnClosedSurface";
+  EXPECT_TRUE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be true (parent check)";
+  EXPECT_TRUE(aRep->IsCurveOnClosedSurface()) << "IsCurveOnClosedSurface should be true";
+  EXPECT_TRUE(aRep->IsRegularity()) << "IsRegularity should be true";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, CurveOn2Surfaces_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_CurveOn2Surfaces(ThePlane(), ThePlane(), TheLoc(), TheLoc(), GeomAbs_C0);
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::CurveOn2Surfaces)
+    << "RepresentationKind should be CurveOn2Surfaces";
+  EXPECT_TRUE(aRep->IsRegularity()) << "IsRegularity should be true";
+  EXPECT_FALSE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be false";
+  EXPECT_FALSE(aRep->IsCurveOnClosedSurface()) << "IsCurveOnClosedSurface should be false";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, Polygon3D_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep = new BRep_Polygon3D(ThePoly3D(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::Polygon3D)
+    << "RepresentationKind should be Polygon3D";
+  EXPECT_TRUE(aRep->IsPolygon3D()) << "IsPolygon3D should be true";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be false";
+  EXPECT_FALSE(aRep->IsRegularity()) << "IsRegularity should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, PolygonOnSurface_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_PolygonOnSurface(ThePoly2D(), ThePlane(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::PolygonOnSurface)
+    << "RepresentationKind should be PolygonOnSurface";
+  EXPECT_TRUE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be true";
+  EXPECT_FALSE(aRep->IsPolygonOnClosedSurface()) << "IsPolygonOnClosedSurface should be false";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, PolygonOnClosedSurface_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_PolygonOnClosedSurface(ThePoly2D(), ThePoly2D(), ThePlane(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::PolygonOnClosedSurface)
+    << "RepresentationKind should be PolygonOnClosedSurface";
+  EXPECT_TRUE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be true (parent check)";
+  EXPECT_TRUE(aRep->IsPolygonOnClosedSurface()) << "IsPolygonOnClosedSurface should be true";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, PolygonOnTriangulation_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_PolygonOnTriangulation(ThePolyOnTri(), TheTriangulation(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::PolygonOnTriangulation)
+    << "RepresentationKind should be PolygonOnTriangulation";
+  EXPECT_TRUE(aRep->IsPolygonOnTriangulation()) << "IsPolygonOnTriangulation should be true";
+  EXPECT_FALSE(aRep->IsPolygonOnClosedTriangulation())
+    << "IsPolygonOnClosedTriangulation should be false";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be false";
+}
+
+TEST(BRep_CurveRepresentation_Test, PolygonOnClosedTriangulation_EnumChecks)
+{
+  Handle(BRep_CurveRepresentation) aRep =
+    new BRep_PolygonOnClosedTriangulation(ThePolyOnTri(), ThePolyOnTri(), TheTriangulation(), TheLoc());
+  EXPECT_EQ(aRep->RepresentationKind(), BRep_CurveRepKind::PolygonOnClosedTriangulation)
+    << "RepresentationKind should be PolygonOnClosedTriangulation";
+  EXPECT_TRUE(aRep->IsPolygonOnTriangulation())
+    << "IsPolygonOnTriangulation should be true (parent check)";
+  EXPECT_TRUE(aRep->IsPolygonOnClosedTriangulation())
+    << "IsPolygonOnClosedTriangulation should be true";
+  EXPECT_FALSE(aRep->IsCurve3D()) << "IsCurve3D should be false";
+  EXPECT_FALSE(aRep->IsPolygon3D()) << "IsPolygon3D should be false";
+  EXPECT_FALSE(aRep->IsPolygonOnSurface()) << "IsPolygonOnSurface should be false";
+  EXPECT_FALSE(aRep->IsCurveOnSurface()) << "IsCurveOnSurface should be false";
+}

--- a/src/ModelingData/TKBRep/GTests/BRep_PointRepresentation_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_PointRepresentation_Test.cxx
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRep_PointOnCurve.hxx>
+#include <BRep_PointOnCurveOnSurface.hxx>
+#include <BRep_PointOnSurface.hxx>
+#include <BRep_PointRepresentation.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <TopLoc_Location.hxx>
+#include <gp_Pln.hxx>
+
+// All Is*() queries are called through the base class handle to avoid
+// C++ name hiding by virtual overloads with parameters in derived classes.
+
+TEST(BRep_PointRepresentation_Test, PointOnCurve_EnumChecks)
+{
+  Handle(Geom_Line) aLine = new Geom_Line(gp_Pnt(0., 0., 0.), gp_Dir(1., 0., 0.));
+  Handle(BRep_PointRepresentation) aRep = new BRep_PointOnCurve(0.5, aLine, TopLoc_Location());
+  EXPECT_EQ(aRep->PointRepresentationKind(), BRep_PointRepKind::PointOnCurve)
+    << "PointRepresentationKind should be PointOnCurve";
+  EXPECT_TRUE(aRep->IsPointOnCurve()) << "IsPointOnCurve should be true";
+  EXPECT_FALSE(aRep->IsPointOnSurface()) << "IsPointOnSurface should be false";
+  EXPECT_FALSE(aRep->IsPointOnCurveOnSurface()) << "IsPointOnCurveOnSurface should be false";
+}
+
+TEST(BRep_PointRepresentation_Test, PointOnSurface_EnumChecks)
+{
+  Handle(Geom_Plane) aPlane = new Geom_Plane(gp_Pln());
+  Handle(BRep_PointRepresentation) aRep =
+    new BRep_PointOnSurface(0.5, 0.5, aPlane, TopLoc_Location());
+  EXPECT_EQ(aRep->PointRepresentationKind(), BRep_PointRepKind::PointOnSurface)
+    << "PointRepresentationKind should be PointOnSurface";
+  EXPECT_TRUE(aRep->IsPointOnSurface()) << "IsPointOnSurface should be true";
+  EXPECT_FALSE(aRep->IsPointOnCurve()) << "IsPointOnCurve should be false";
+  EXPECT_FALSE(aRep->IsPointOnCurveOnSurface()) << "IsPointOnCurveOnSurface should be false";
+}
+
+TEST(BRep_PointRepresentation_Test, PointOnCurveOnSurface_EnumChecks)
+{
+  Handle(Geom2d_Line) aLine2d = new Geom2d_Line(gp_Pnt2d(0., 0.), gp_Dir2d(1., 0.));
+  Handle(Geom_Plane)  aPlane  = new Geom_Plane(gp_Pln());
+  Handle(BRep_PointRepresentation) aRep =
+    new BRep_PointOnCurveOnSurface(0.5, aLine2d, aPlane, TopLoc_Location());
+  EXPECT_EQ(aRep->PointRepresentationKind(), BRep_PointRepKind::PointOnCurveOnSurface)
+    << "PointRepresentationKind should be PointOnCurveOnSurface";
+  EXPECT_TRUE(aRep->IsPointOnCurveOnSurface()) << "IsPointOnCurveOnSurface should be true";
+  EXPECT_FALSE(aRep->IsPointOnCurve()) << "IsPointOnCurve should be false";
+  EXPECT_FALSE(aRep->IsPointOnSurface()) << "IsPointOnSurface should be false";
+}

--- a/src/ModelingData/TKBRep/GTests/BRep_TEdge_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_TEdge_Test.cxx
@@ -1,0 +1,149 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRep_Builder.hxx>
+#include <BRep_Curve3D.hxx>
+#include <BRep_Polygon3D.hxx>
+#include <BRep_TEdge.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <Geom_Line.hxx>
+#include <NCollection_Array1.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Precision.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+
+TEST(BRep_TEdge_Test, DefaultConstruction_CacheIsNull)
+{
+  Handle(BRep_TEdge) aTEdge = new BRep_TEdge();
+  EXPECT_TRUE(aTEdge->Curve3D().IsNull()) << "New TEdge should have null Curve3D cache";
+  EXPECT_TRUE(aTEdge->Polygon3D().IsNull()) << "New TEdge should have null Polygon3D cache";
+}
+
+TEST(BRep_TEdge_Test, Curve3D_SetAndGet)
+{
+  Handle(BRep_TEdge)  aTEdge = new BRep_TEdge();
+  Handle(Geom_Line)   aLine  = new Geom_Line(gp_Pnt(0., 0., 0.), gp_Dir(1., 0., 0.));
+  Handle(BRep_Curve3D) aCurve3D = new BRep_Curve3D(aLine, TopLoc_Location());
+  aTEdge->Curve3D(aCurve3D);
+  EXPECT_FALSE(aTEdge->Curve3D().IsNull()) << "Curve3D cache should be set";
+  EXPECT_TRUE(aTEdge->Curve3D() == aCurve3D) << "Curve3D cache should match what was set";
+}
+
+TEST(BRep_TEdge_Test, Polygon3D_SetAndGet)
+{
+  Handle(BRep_TEdge) aTEdge = new BRep_TEdge();
+  NCollection_Array1<gp_Pnt> aNodes(1, 2);
+  aNodes.SetValue(1, gp_Pnt(0., 0., 0.));
+  aNodes.SetValue(2, gp_Pnt(1., 0., 0.));
+  Handle(Poly_Polygon3D) aPoly = new Poly_Polygon3D(aNodes);
+  Handle(BRep_Polygon3D) aPolyRep = new BRep_Polygon3D(aPoly, TopLoc_Location());
+  aTEdge->Polygon3D(aPolyRep);
+  EXPECT_FALSE(aTEdge->Polygon3D().IsNull()) << "Polygon3D cache should be set";
+  EXPECT_TRUE(aTEdge->Polygon3D() == aPolyRep) << "Polygon3D cache should match what was set";
+}
+
+TEST(BRep_TEdge_Test, ChangeCurves_InvalidatesCache)
+{
+  Handle(BRep_TEdge)   aTEdge   = new BRep_TEdge();
+  Handle(Geom_Line)    aLine    = new Geom_Line(gp_Pnt(0., 0., 0.), gp_Dir(1., 0., 0.));
+  Handle(BRep_Curve3D) aCurve3D = new BRep_Curve3D(aLine, TopLoc_Location());
+  aTEdge->Curve3D(aCurve3D);
+
+  NCollection_Array1<gp_Pnt> aNodes(1, 2);
+  aNodes.SetValue(1, gp_Pnt(0., 0., 0.));
+  aNodes.SetValue(2, gp_Pnt(1., 0., 0.));
+  Handle(Poly_Polygon3D) aPoly    = new Poly_Polygon3D(aNodes);
+  Handle(BRep_Polygon3D) aPolyRep = new BRep_Polygon3D(aPoly, TopLoc_Location());
+  aTEdge->Polygon3D(aPolyRep);
+
+  EXPECT_FALSE(aTEdge->Curve3D().IsNull()) << "Curve3D cache should be set before ChangeCurves";
+  EXPECT_FALSE(aTEdge->Polygon3D().IsNull()) << "Polygon3D cache should be set before ChangeCurves";
+
+  // ChangeCurves() should invalidate both caches
+  aTEdge->ChangeCurves();
+  EXPECT_TRUE(aTEdge->Curve3D().IsNull()) << "Curve3D cache should be null after ChangeCurves";
+  EXPECT_TRUE(aTEdge->Polygon3D().IsNull()) << "Polygon3D cache should be null after ChangeCurves";
+}
+
+TEST(BRep_TEdge_Test, EmptyCopy_PreservesCurve3DCache)
+{
+  // Build a TEdge with a Curve3D cache set explicitly
+  Handle(BRep_TEdge)   aTEdge   = new BRep_TEdge();
+  Handle(Geom_Line)    aLine    = new Geom_Line(gp_Pnt(0., 0., 0.), gp_Dir(1., 0., 0.));
+  Handle(BRep_Curve3D) aCurve3D = new BRep_Curve3D(aLine, TopLoc_Location());
+  aTEdge->Curve3D(aCurve3D);
+  aTEdge->ChangeCurves().Append(aCurve3D);
+  // Re-set cache after ChangeCurves invalidated it
+  aTEdge->Curve3D(aCurve3D);
+  ASSERT_FALSE(aTEdge->Curve3D().IsNull()) << "Original should have a Curve3D cache";
+
+  Handle(TopoDS_TShape) aCopy = aTEdge->EmptyCopy();
+  const Handle(BRep_TEdge)& aCopyEdge = Handle(BRep_TEdge)::DownCast(aCopy);
+  ASSERT_FALSE(aCopyEdge.IsNull()) << "EmptyCopy should return BRep_TEdge";
+  EXPECT_FALSE(aCopyEdge->Curve3D().IsNull()) << "EmptyCopy should preserve Curve3D cache";
+}
+
+TEST(BRep_TEdge_Test, EmptyCopy_PreservesTolerance)
+{
+  Handle(BRep_TEdge) aTEdge = new BRep_TEdge();
+  aTEdge->Tolerance(0.25);
+  Handle(TopoDS_TShape)     aCopy     = aTEdge->EmptyCopy();
+  const Handle(BRep_TEdge)& aCopyEdge = Handle(BRep_TEdge)::DownCast(aCopy);
+  ASSERT_FALSE(aCopyEdge.IsNull());
+  EXPECT_NEAR(aCopyEdge->Tolerance(), 0.25, 1e-15)
+    << "EmptyCopy should preserve tolerance";
+}
+
+TEST(BRep_TEdge_Test, EmptyCopy_PreservesFlags)
+{
+  Handle(BRep_TEdge) aTEdge = new BRep_TEdge();
+  aTEdge->Degenerated(true);
+  aTEdge->SameParameter(false);
+  aTEdge->SameRange(false);
+
+  Handle(TopoDS_TShape)     aCopy     = aTEdge->EmptyCopy();
+  const Handle(BRep_TEdge)& aCopyEdge = Handle(BRep_TEdge)::DownCast(aCopy);
+  ASSERT_FALSE(aCopyEdge.IsNull());
+  EXPECT_TRUE(aCopyEdge->Degenerated()) << "EmptyCopy should preserve Degenerated flag";
+  EXPECT_FALSE(aCopyEdge->SameParameter()) << "EmptyCopy should preserve SameParameter flag";
+  EXPECT_FALSE(aCopyEdge->SameRange()) << "EmptyCopy should preserve SameRange flag";
+}
+
+TEST(BRep_TEdge_Test, Tolerance_ClampedOnSet)
+{
+  Handle(BRep_TEdge) aTEdge = new BRep_TEdge();
+  aTEdge->Tolerance(1e-20);
+  EXPECT_GE(aTEdge->Tolerance(), Precision::Confusion())
+    << "Tolerance should be clamped to Precision::Confusion()";
+}
+
+TEST(BRep_TEdge_Test, UpdateTolerance_OnlyIncreases)
+{
+  Handle(BRep_TEdge) aTEdge = new BRep_TEdge();
+  aTEdge->Tolerance(1.0);
+  const double aOrigTol = aTEdge->Tolerance();
+
+  // Try to decrease via UpdateTolerance — should not change
+  aTEdge->UpdateTolerance(0.5);
+  EXPECT_NEAR(aTEdge->Tolerance(), aOrigTol, 1e-15)
+    << "UpdateTolerance should not decrease tolerance";
+
+  // Increase via UpdateTolerance — should update
+  aTEdge->UpdateTolerance(2.0);
+  EXPECT_NEAR(aTEdge->Tolerance(), 2.0, 1e-15)
+    << "UpdateTolerance should increase tolerance";
+}

--- a/src/ModelingData/TKBRep/GTests/BRep_TFace_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_TFace_Test.cxx
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRep_TFace.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_OffsetSurface.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
+#include <Precision.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Pln.hxx>
+
+TEST(BRep_TFace_Test, DefaultConstruction_IsPlaneIsFalse)
+{
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  EXPECT_FALSE(aTFace->IsPlane()) << "New TFace should have IsPlane == false";
+}
+
+TEST(BRep_TFace_Test, Surface_Plane_IsPlaneTrue)
+{
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  Handle(Geom_Plane) aPlane = new Geom_Plane(gp_Pln());
+  aTFace->Surface(aPlane);
+  EXPECT_TRUE(aTFace->IsPlane()) << "Setting Geom_Plane should make IsPlane true";
+}
+
+TEST(BRep_TFace_Test, Surface_Cylinder_IsPlaneFalse)
+{
+  Handle(BRep_TFace)              aTFace = new BRep_TFace();
+  Handle(Geom_CylindricalSurface) aCyl =
+    new Geom_CylindricalSurface(gp_Ax3(), 1.0);
+  aTFace->Surface(aCyl);
+  EXPECT_FALSE(aTFace->IsPlane()) << "Setting Geom_CylindricalSurface should make IsPlane false";
+}
+
+TEST(BRep_TFace_Test, Surface_TrimmedPlane_IsPlaneTrue)
+{
+  Handle(Geom_Plane) aPlane = new Geom_Plane(gp_Pln());
+  Handle(Geom_RectangularTrimmedSurface) aTrimmed =
+    new Geom_RectangularTrimmedSurface(aPlane, 0.0, 1.0, 0.0, 1.0);
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  aTFace->Surface(aTrimmed);
+  EXPECT_TRUE(aTFace->IsPlane())
+    << "RectangularTrimmedSurface wrapping a plane should make IsPlane true";
+}
+
+TEST(BRep_TFace_Test, Surface_OffsetPlane_IsPlaneTrue)
+{
+  Handle(Geom_Plane)         aPlane  = new Geom_Plane(gp_Pln());
+  Handle(Geom_OffsetSurface) anOffset = new Geom_OffsetSurface(aPlane, 5.0);
+  Handle(BRep_TFace)         aTFace  = new BRep_TFace();
+  aTFace->Surface(anOffset);
+  EXPECT_TRUE(aTFace->IsPlane())
+    << "OffsetSurface wrapping a plane should make IsPlane true";
+}
+
+TEST(BRep_TFace_Test, Surface_Null_IsPlaneFalse)
+{
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  Handle(Geom_Plane) aPlane = new Geom_Plane(gp_Pln());
+  aTFace->Surface(aPlane);
+  EXPECT_TRUE(aTFace->IsPlane()) << "Should be plane initially";
+
+  // Now set null surface
+  aTFace->Surface(Handle(Geom_Surface)());
+  EXPECT_FALSE(aTFace->IsPlane()) << "Setting null surface should make IsPlane false";
+}
+
+TEST(BRep_TFace_Test, Surface_ChangeFromPlaneToNonPlane)
+{
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  Handle(Geom_Plane) aPlane = new Geom_Plane(gp_Pln());
+  aTFace->Surface(aPlane);
+  EXPECT_TRUE(aTFace->IsPlane()) << "Should be plane after setting plane";
+
+  Handle(Geom_CylindricalSurface) aCyl =
+    new Geom_CylindricalSurface(gp_Ax3(), 1.0);
+  aTFace->Surface(aCyl);
+  EXPECT_FALSE(aTFace->IsPlane()) << "Should not be plane after changing to cylinder";
+}
+
+TEST(BRep_TFace_Test, EmptyCopy_PreservesIsPlane)
+{
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  Handle(Geom_Plane) aPlane = new Geom_Plane(gp_Pln());
+  aTFace->Surface(aPlane);
+  ASSERT_TRUE(aTFace->IsPlane());
+
+  Handle(TopoDS_TShape)     aCopy     = aTFace->EmptyCopy();
+  const Handle(BRep_TFace)& aCopyFace = Handle(BRep_TFace)::DownCast(aCopy);
+  ASSERT_FALSE(aCopyFace.IsNull()) << "EmptyCopy should return BRep_TFace";
+  EXPECT_TRUE(aCopyFace->IsPlane()) << "EmptyCopy should preserve IsPlane flag";
+}
+
+TEST(BRep_TFace_Test, Tolerance_ClampedOnSet)
+{
+  Handle(BRep_TFace) aTFace = new BRep_TFace();
+  aTFace->Tolerance(1e-20);
+  EXPECT_GE(aTFace->Tolerance(), Precision::Confusion())
+    << "Tolerance should be clamped to Precision::Confusion()";
+}

--- a/src/ModelingData/TKBRep/GTests/BRep_TFace_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_TFace_Test.cxx
@@ -19,6 +19,7 @@
 #include <Geom_Plane.hxx>
 #include <Geom_RectangularTrimmedSurface.hxx>
 #include <Precision.hxx>
+#include <TopoDS_Shape.hxx>
 #include <gp_Ax3.hxx>
 #include <gp_Pln.hxx>
 

--- a/src/ModelingData/TKBRep/GTests/BRep_Tool_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_Tool_Test.cxx
@@ -1,0 +1,230 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRep_Builder.hxx>
+#include <BRep_TEdge.hxx>
+#include <BRep_TFace.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <Precision.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Vertex.hxx>
+
+TEST(BRep_Tool_Test, Curve_ReturnsValidCurve)
+{
+  TopoDS_Edge anEdge = BRepBuilderAPI_MakeEdge(gp_Pnt(0., 0., 0.), gp_Pnt(1., 0., 0.));
+  TopLoc_Location aLoc;
+  double          aFirst = 0.0, aLast = 0.0;
+  const Handle(Geom_Curve)& aCurve = BRep_Tool::Curve(anEdge, aLoc, aFirst, aLast);
+  EXPECT_FALSE(aCurve.IsNull()) << "Edge from MakeEdge should have a 3D curve";
+  EXPECT_LT(aFirst, aLast) << "First parameter should be less than Last";
+}
+
+TEST(BRep_Tool_Test, Curve_NullForDegenerateEdge)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  aBuilder.Degenerated(anEdge, true);
+
+  TopLoc_Location aLoc;
+  double          aFirst = 0.0, aLast = 0.0;
+  const Handle(Geom_Curve)& aCurve = BRep_Tool::Curve(anEdge, aLoc, aFirst, aLast);
+  EXPECT_TRUE(aCurve.IsNull()) << "Edge without 3D curve should return null";
+}
+
+TEST(BRep_Tool_Test, Curve_LocationComposition)
+{
+  // Create an edge
+  TopoDS_Edge anEdge = BRepBuilderAPI_MakeEdge(gp_Pnt(0., 0., 0.), gp_Pnt(1., 0., 0.));
+
+  // Move it with a non-identity location
+  gp_Trsf aTrsf;
+  aTrsf.SetTranslation(gp_Vec(10., 20., 30.));
+  anEdge.Move(aTrsf);
+
+  TopLoc_Location aLoc;
+  double          aFirst = 0.0, aLast = 0.0;
+  const Handle(Geom_Curve)& aCurve = BRep_Tool::Curve(anEdge, aLoc, aFirst, aLast);
+  EXPECT_FALSE(aCurve.IsNull()) << "Moved edge should still have a curve";
+  EXPECT_FALSE(aLoc.IsIdentity()) << "Location should be non-identity after move";
+}
+
+TEST(BRep_Tool_Test, Polygon3D_ReturnsNullForNewEdge)
+{
+  TopoDS_Edge anEdge = BRepBuilderAPI_MakeEdge(gp_Pnt(0., 0., 0.), gp_Pnt(1., 0., 0.));
+  TopLoc_Location                aLoc;
+  const Handle(Poly_Polygon3D)& aPoly = BRep_Tool::Polygon3D(anEdge, aLoc);
+  EXPECT_TRUE(aPoly.IsNull()) << "Fresh edge should have no polygon3D";
+}
+
+TEST(BRep_Tool_Test, IsGeometric_TrueForEdgeWithCurve)
+{
+  TopoDS_Edge anEdge = BRepBuilderAPI_MakeEdge(gp_Pnt(0., 0., 0.), gp_Pnt(1., 0., 0.));
+  EXPECT_TRUE(BRep_Tool::IsGeometric(anEdge)) << "Edge with 3D curve should be geometric";
+}
+
+TEST(BRep_Tool_Test, IsGeometric_FalseForEmptyEdge)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  EXPECT_FALSE(BRep_Tool::IsGeometric(anEdge)) << "Edge with no representations should not be geometric";
+}
+
+TEST(BRep_Tool_Test, Range_MatchesCurveParameters)
+{
+  Handle(Geom_Line) aLine = new Geom_Line(gp_Pnt(0., 0., 0.), gp_Dir(1., 0., 0.));
+  TopoDS_Edge       anEdge = BRepBuilderAPI_MakeEdge(aLine, 2.0, 7.0);
+  double            aFirst = 0.0, aLast = 0.0;
+  BRep_Tool::Range(anEdge, aFirst, aLast);
+  EXPECT_NEAR(aFirst, 2.0, Precision::Confusion()) << "First parameter should match";
+  EXPECT_NEAR(aLast, 7.0, Precision::Confusion()) << "Last parameter should match";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Edge_DefaultValue)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  const double aTol = BRep_Tool::Tolerance(anEdge);
+  EXPECT_GE(aTol, Precision::Confusion()) << "Default edge tolerance should be >= Precision::Confusion()";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Edge_SetAndGet)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  aBuilder.UpdateEdge(anEdge, 0.5);
+  const double aTol = BRep_Tool::Tolerance(anEdge);
+  EXPECT_NEAR(aTol, 0.5, 1e-15) << "Tolerance should match the set value";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Edge_ClampedToConfusion)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  aBuilder.UpdateEdge(anEdge, 1e-20);
+  const double aTol = BRep_Tool::Tolerance(anEdge);
+  EXPECT_GE(aTol, Precision::Confusion()) << "Tolerance should be clamped to Precision::Confusion()";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Face_DefaultValue)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Face  aFace;
+  aBuilder.MakeFace(aFace);
+  const double aTol = BRep_Tool::Tolerance(aFace);
+  EXPECT_GE(aTol, Precision::Confusion()) << "Default face tolerance should be >= Precision::Confusion()";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Face_ClampedToConfusion)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Face  aFace;
+  aBuilder.MakeFace(aFace);
+  aBuilder.UpdateFace(aFace, 1e-20);
+  const double aTol = BRep_Tool::Tolerance(aFace);
+  EXPECT_GE(aTol, Precision::Confusion()) << "Face tolerance should be clamped to Precision::Confusion()";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Vertex_DefaultValue)
+{
+  BRep_Builder  aBuilder;
+  TopoDS_Vertex aVertex;
+  aBuilder.MakeVertex(aVertex, gp_Pnt(0., 0., 0.), Precision::Confusion());
+  const double aTol = BRep_Tool::Tolerance(aVertex);
+  EXPECT_GE(aTol, Precision::Confusion())
+    << "Default vertex tolerance should be >= Precision::Confusion()";
+}
+
+TEST(BRep_Tool_Test, Tolerance_Vertex_ClampedToConfusion)
+{
+  BRep_Builder  aBuilder;
+  TopoDS_Vertex aVertex;
+  aBuilder.MakeVertex(aVertex, gp_Pnt(0., 0., 0.), 1e-20);
+  const double aTol = BRep_Tool::Tolerance(aVertex);
+  EXPECT_GE(aTol, Precision::Confusion())
+    << "Vertex tolerance should be clamped to Precision::Confusion()";
+}
+
+TEST(BRep_Tool_Test, IsClosed_PlaneSkipsParametricCheck)
+{
+  // Create a planar face with a simple edge - planes are never periodic
+  TopoDS_Shape aBox  = BRepPrimAPI_MakeBox(1.0, 1.0, 1.0).Shape();
+  TopoDS_Face  aFace;
+  for (TopExp_Explorer anExp(aBox, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    aFace = TopoDS::Face(anExp.Current());
+    break;
+  }
+  // Get an edge on this planar face
+  TopoDS_Edge anEdge;
+  for (TopExp_Explorer anExp(aFace, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    anEdge = TopoDS::Edge(anExp.Current());
+    break;
+  }
+  // On a plane, edges are never closed (plane is not periodic)
+  EXPECT_FALSE(BRep_Tool::IsClosed(anEdge, aFace))
+    << "Edge on planar face should not be closed (plane is not periodic)";
+}
+
+TEST(BRep_Tool_Test, IsClosed_CylindricalFace)
+{
+  // Create a cylinder - the seam edge should be closed on the cylindrical face
+  TopoDS_Shape aCylinder = BRepPrimAPI_MakeCylinder(1.0, 2.0).Shape();
+  bool         aFoundClosed = false;
+  for (TopExp_Explorer aFaceExp(aCylinder, TopAbs_FACE); aFaceExp.More(); aFaceExp.Next())
+  {
+    const TopoDS_Face& aFace = TopoDS::Face(aFaceExp.Current());
+    TopLoc_Location    aLoc;
+    const Handle(Geom_Surface)& aSurf = BRep_Tool::Surface(aFace, aLoc);
+    if (aSurf.IsNull())
+    {
+      continue;
+    }
+    // Check only the cylindrical face
+    if (Handle(Geom_CylindricalSurface)::DownCast(aSurf).IsNull())
+    {
+      continue;
+    }
+    for (TopExp_Explorer anEdgeExp(aFace, TopAbs_EDGE); anEdgeExp.More(); anEdgeExp.Next())
+    {
+      const TopoDS_Edge& anEdge = TopoDS::Edge(anEdgeExp.Current());
+      if (BRep_Tool::IsClosed(anEdge, aFace))
+      {
+        aFoundClosed = true;
+        break;
+      }
+    }
+    if (aFoundClosed)
+    {
+      break;
+    }
+  }
+  EXPECT_TRUE(aFoundClosed) << "Cylinder should have a seam edge that is closed on the cylindrical face";
+}

--- a/src/ModelingData/TKBRep/GTests/FILES.cmake
+++ b/src/ModelingData/TKBRep/GTests/FILES.cmake
@@ -2,6 +2,11 @@
 set(OCCT_TKBRep_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKBRep_GTests_FILES
+  BRep_CurveRepresentation_Test.cxx
+  BRep_PointRepresentation_Test.cxx
+  BRep_TEdge_Test.cxx
+  BRep_TFace_Test.cxx
+  BRep_Tool_Test.cxx
   BRepAdaptor_CompCurve_Test.cxx
   TopoDS_Builder_Test.cxx
   TopoDS_Edge_Test.cxx

--- a/src/ModelingData/TKBRep/TopoDS/TopoDS_Iterator.cxx
+++ b/src/ModelingData/TKBRep/TopoDS/TopoDS_Iterator.cxx
@@ -64,8 +64,6 @@ void TopoDS_Iterator::Next()
 void TopoDS_Iterator::updateCurrentShape()
 {
   myShape = myIterator.Value();
-  // Compose(FORWARD, x) == x, so skip the table lookup + assignment
-  // for the common case of FORWARD-oriented parent shapes.
   if (myOrientation != TopAbs_FORWARD)
     myShape.Orientation(TopAbs::Compose(myOrientation, myShape.Orientation()));
   if (!myLocation.IsIdentity())

--- a/src/ModelingData/TKBRep/TopoDS/TopoDS_Iterator.cxx
+++ b/src/ModelingData/TKBRep/TopoDS/TopoDS_Iterator.cxx
@@ -64,7 +64,10 @@ void TopoDS_Iterator::Next()
 void TopoDS_Iterator::updateCurrentShape()
 {
   myShape = myIterator.Value();
-  myShape.Orientation(TopAbs::Compose(myOrientation, myShape.Orientation()));
+  // Compose(FORWARD, x) == x, so skip the table lookup + assignment
+  // for the common case of FORWARD-oriented parent shapes.
+  if (myOrientation != TopAbs_FORWARD)
+    myShape.Orientation(TopAbs::Compose(myOrientation, myShape.Orientation()));
   if (!myLocation.IsIdentity())
     myShape.Move(myLocation, false);
 }

--- a/src/ModelingData/TKBRep/TopoDS/TopoDS_Shape.hxx
+++ b/src/ModelingData/TKBRep/TopoDS/TopoDS_Shape.hxx
@@ -94,10 +94,9 @@ public:
   //! @param theRaiseExc flag to raise exception in case of transformation with scale or negative.
   void Location(const TopLoc_Location& theLoc, const bool theRaiseExc = false)
   {
-    const gp_Trsf& aTrsf = theLoc.Transformation();
     if (theRaiseExc)
     {
-      validateTransformation(aTrsf);
+      validateTransformation(theLoc.Transformation());
     }
     myLocation = theLoc;
   }
@@ -192,10 +191,9 @@ public:
   //! @param theRaiseExc flag to raise exception in case of transformation with scale or negative.
   void Move(const TopLoc_Location& thePosition, const bool theRaiseExc = false)
   {
-    const gp_Trsf& aTrsf = thePosition.Transformation();
     if (theRaiseExc)
     {
-      validateTransformation(aTrsf);
+      validateTransformation(thePosition.Transformation());
     }
     myLocation = thePosition * myLocation;
   }


### PR DESCRIPTION
Replace virtual dispatch with enum-based type discrimination and add
targeted caching to eliminate overhead in the most frequently called
BRep functions.

Enum discriminants:
- Add BRep_CurveRepKind (9 variants) and BRep_PointRepKind (3 variants)
  as uint8_t enums set once at construction time.
- Replace all virtual Is*() queries (IsCurve3D, IsCurveOnSurface,
  IsRegularity, IsPolygon3D, etc.) with inline enum comparisons,
  eliminating vtable lookups in tight iteration loops.
- Closed variant constructors overwrite the kind in the body after
  base class initialization.

Tag pre-filters:
- Gate expensive virtual parameter-matching calls (e.g.
  IsCurveOnSurface(S, L)) behind cheap enum checks in BRep_Builder
  and BRep_Tool search loops.
- Fix dead code in BRep_Builder::Transfert() by checking
  IsCurveOnClosedSurface() before IsCurveOnSurface(), making the
  closed surface branch reachable.
- Change BRep_Tool::Continuity()/MaxContinuity() from ChangeCurves()
  to Curves() to avoid needless cache invalidation on read-only access.

Cached Curve3D/Polygon3D on BRep_TEdge:
- Add myCurve3D and myPolygon3D handle members for O(1) lookup in
  BRep_Tool::Curve(), Polygon3D(), IsGeometric(), and Range().
- ChangeCurves() nullifies both caches; BRep_Builder re-populates
  after modification; fallback list scan when cache is null.
- EmptyCopy() preserves the Curve3D cache for cloned edges.

Cached IsPlane flag on BRep_TFace:
- Compute and cache myIsPlane when surface is set, avoiding repeated
  RTTI downcasts in BRep_Tool::IsClosed(E, F).
- EmptyCopy() copies the flag directly.

Tolerance clamping at write time:
- Move std::max(T, Precision::Confusion()) from BRep_Tool::Tolerance()
  read path to Tolerance() setters on BRep_TEdge, BRep_TVertex, and
  BRep_TFace, removing a branch from the hot read path.
- Default-construct tolerance to Precision::Confusion() instead of
  RealEpsilon().

TopLoc_Location identity shortcuts:
- Predivided()/Divided() return early when the other location is
  Identity, skipping SList traversal and gp_Trsf composition.
- BRep_Tool::Surface/Curve/Polygon3D skip location multiplication
  when sub-location is Identity.

Minor hot-path optimizations:
- TopLoc_SListOfItemLocation::Construct() uses move assignment to
  avoid atomic refcount increment.
- TopoDS_Iterator skips TopAbs::Compose() for FORWARD-oriented
  parent shapes (the common case).
- TopoDS_Shape::Location()/Move() defer Transformation() extraction
  to the rare validation path.