### PR TITLE
Foundation Classes - Improve OSD_Parallel and OSD_ThreadPool parallel infrastructure

### DIFF
--- a/src/FoundationClasses/TKernel/GTests/FILES.cmake
+++ b/src/FoundationClasses/TKernel/GTests/FILES.cmake
@@ -23,6 +23,7 @@ set(OCCT_TKernel_GTests_FILES
   NCollection_SparseArray_Test.cxx
   NCollection_Vec4_Test.cxx
   NCollection_Vector_Test.cxx
+  OSD_Parallel_Test.cxx
   OSD_Path_Test.cxx
   OSD_PerfMeter_Test.cxx
   Quantity_Color_Test.cxx

--- a/src/FoundationClasses/TKernel/GTests/OSD_Parallel_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/OSD_Parallel_Test.cxx
@@ -1,0 +1,144 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <NCollection_List.hxx>
+#include <OSD_Parallel.hxx>
+
+#include <atomic>
+
+// Test: For with large range ensures all indices are visited (chunked distribution).
+// Verifying via sum of unique indices — correct sum proves each index visited exactly once.
+TEST(OSD_ParallelTest, For_LargeRange_AllIndicesVisited)
+{
+  const int              THE_N = 100000;
+  std::atomic<long long> aSum(0);
+  std::atomic<int>       aCount(0);
+
+  OSD_Parallel::For(0, THE_N, [&aSum, &aCount](int theIndex) {
+    aSum.fetch_add(static_cast<long long>(theIndex));
+    aCount.fetch_add(1);
+  });
+
+  const long long anExpectedSum = static_cast<long long>(THE_N - 1) * THE_N / 2;
+  EXPECT_EQ(anExpectedSum, aSum.load());
+  EXPECT_EQ(THE_N, aCount.load());
+}
+
+// Test: For with explicit grain size produces correct results.
+TEST(OSD_ParallelTest, For_WithGrainSize_CorrectResults)
+{
+  const int              THE_N = 50000;
+  std::atomic<long long> aSum(0);
+
+  OSD_Parallel::For(
+    0,
+    THE_N,
+    [&aSum](int theIndex) { aSum.fetch_add(theIndex); },
+    /* theGrainSize = */ 1000);
+
+  const long long anExpected = static_cast<long long>(THE_N - 1) * THE_N / 2;
+  EXPECT_EQ(anExpected, aSum.load());
+}
+
+// Test: ForEach with list iterator processes all elements correctly.
+TEST(OSD_ParallelTest, ForEach_ListIterator_CorrectResults)
+{
+  const int             THE_N = 10000;
+  NCollection_List<int> aList;
+  for (int i = 0; i < THE_N; ++i)
+  {
+    aList.Append(i);
+  }
+
+  std::atomic<long long> aSum(0);
+  OSD_Parallel::ForEach(
+    aList.begin(),
+    aList.end(),
+    [&aSum](int theValue) { aSum.fetch_add(static_cast<long long>(theValue)); },
+    false,
+    THE_N);
+
+  const long long anExpected = static_cast<long long>(THE_N - 1) * THE_N / 2;
+  EXPECT_EQ(anExpected, aSum.load());
+}
+
+// Test: Reduce computes a parallel sum correctly.
+TEST(OSD_ParallelTest, Reduce_Sum_CorrectResult)
+{
+  const int       THE_N      = 100000;
+  const long long anExpected = static_cast<long long>(THE_N - 1) * THE_N / 2;
+
+  const long long aResult = OSD_Parallel::Reduce<long long>(
+    0,
+    THE_N,
+    0LL, // identity
+    [](int theIndex, long long& theAccum) { theAccum += theIndex; },
+    [](const long long& thePartial, long long& theTotal) { theTotal += thePartial; });
+
+  EXPECT_EQ(anExpected, aResult);
+}
+
+// Test: For with empty range does not execute functor.
+TEST(OSD_ParallelTest, For_EmptyRange_NoWork)
+{
+  std::atomic<int> aCounter(0);
+
+  OSD_Parallel::For(5, 5, [&aCounter](int) { aCounter.fetch_add(1); });
+
+  EXPECT_EQ(0, aCounter.load());
+}
+
+// Test: For with single item executes exactly once.
+TEST(OSD_ParallelTest, For_SingleItem_Executes)
+{
+  std::atomic<int> aCounter(0);
+
+  OSD_Parallel::For(7, 8, [&aCounter](int theIndex) {
+    EXPECT_EQ(7, theIndex);
+    aCounter.fetch_add(1);
+  });
+
+  EXPECT_EQ(1, aCounter.load());
+}
+
+// Test: Reduce with single thread mode.
+TEST(OSD_ParallelTest, Reduce_SingleThread_CorrectResult)
+{
+  const int THE_N      = 1000;
+  const int anExpected = (THE_N - 1) * THE_N / 2;
+
+  const int aResult = OSD_Parallel::Reduce<int>(
+    0,
+    THE_N,
+    0,
+    [](int theIndex, int& theAccum) { theAccum += theIndex; },
+    [](const int& thePartial, int& theTotal) { theTotal += thePartial; },
+    true); // force single thread
+
+  EXPECT_EQ(anExpected, aResult);
+}
+
+// Test: Reduce with empty range returns identity.
+TEST(OSD_ParallelTest, Reduce_EmptyRange_ReturnsIdentity)
+{
+  const double aResult = OSD_Parallel::Reduce<double>(
+    10,
+    10,
+    42.0,
+    [](int, double& theAccum) { theAccum += 1.0; },
+    [](const double& thePartial, double& theTotal) { theTotal += thePartial; });
+
+  EXPECT_NEAR(42.0, aResult, 1e-15);
+}

--- a/src/FoundationClasses/TKernel/OSD/OSD_Parallel_TBB.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_Parallel_TBB.cxx
@@ -32,11 +32,10 @@ Standard_DISABLE_DEPRECATION_WARNINGS
 
   //=================================================================================================
 
-  void
-  OSD_Parallel::forEachExternal(UniversalIterator&      theBegin,
-                                UniversalIterator&      theEnd,
-                                const FunctorInterface& theFunctor,
-                                int                     theNbItems)
+  void OSD_Parallel::forEachExternal(UniversalIterator&      theBegin,
+                                     UniversalIterator&      theEnd,
+                                     const FunctorInterface& theFunctor,
+                                     int                     theNbItems)
 {
   #if TBB_VERSION_MAJOR >= 2021
   // task_scheduler_init is removed,
@@ -56,6 +55,35 @@ Standard_DISABLE_DEPRECATION_WARNINGS
     throw Standard_ProgramError(anException.what());
   }
   #endif
+}
+
+//=================================================================================================
+
+void OSD_Parallel::forIntExternal(int                           theBegin,
+                                  int                           theEnd,
+                                  const ForIntFunctorInterface& theFunctor,
+                                  int                           theGrainSize)
+{
+  if (theGrainSize <= 0)
+  {
+    tbb::parallel_for(tbb::blocked_range<int>(theBegin, theEnd),
+                      [&](const tbb::blocked_range<int>& theRange) {
+                        for (int anIndex = theRange.begin(); anIndex < theRange.end(); ++anIndex)
+                        {
+                          theFunctor(anIndex);
+                        }
+                      });
+  }
+  else
+  {
+    tbb::parallel_for(tbb::blocked_range<int>(theBegin, theEnd, theGrainSize),
+                      [&](const tbb::blocked_range<int>& theRange) {
+                        for (int anIndex = theRange.begin(); anIndex < theRange.end(); ++anIndex)
+                        {
+                          theFunctor(anIndex);
+                        }
+                      });
+  }
 }
 
 #endif /* HAVE_TBB */

--- a/src/FoundationClasses/TKernel/OSD/OSD_Parallel_Threads.cxx
+++ b/src/FoundationClasses/TKernel/OSD/OSD_Parallel_Threads.cxx
@@ -147,6 +147,23 @@ void OSD_Parallel::forEachOcct(UniversalIterator&      theBegin,
   aLauncher.Perform(theBegin, theEnd, theFunctor);
 }
 
+//=================================================================================================
+
+void OSD_Parallel::forIntExternal(int                           theBegin,
+                                  int                           theEnd,
+                                  const ForIntFunctorInterface& theFunctor,
+                                  int                           theGrainSize)
+{
+  const occ::handle<OSD_ThreadPool>& aThreadPool = OSD_ThreadPool::DefaultPool();
+  const int                          aRange      = theEnd - theBegin;
+  OSD_ThreadPool::Launcher           aLauncher(*aThreadPool,
+                                     std::min(aRange, aThreadPool->NbDefaultThreadsToLaunch()));
+  auto aWrappedFunctor = [&theFunctor](int /*theThreadIndex*/, int theElemIndex) {
+    theFunctor(theElemIndex);
+  };
+  aLauncher.Perform(theBegin, theEnd, aWrappedFunctor, theGrainSize);
+}
+
 // Version of parallel executor used when TBB is not available
 #ifndef HAVE_TBB
 //=================================================================================================


### PR DESCRIPTION
OSD_ThreadPool - chunked work distribution:
- JobRange: added grain size support with NextChunk() method returning [begin,end) pairs via fetch_add(grainSize), reducing atomic contention for large ranges from one atomic RMW per item to one per chunk. Auto-grain formula: max(1, range / (nThreads * 4)).
- Job::Perform: replaced single-item It() loop with chunked NextChunk() loop.
- Launcher::Perform: added theGrainSize parameter (0 = auto-compute).

OSD_Parallel - TBB For() fix:
- Added ForIntFunctorInterface for integer-range dispatch.
- Added forIntExternal() using tbb::parallel_for with blocked_range<int> instead of routing through type-erased tbb::parallel_for_each.
- Non-TBB fallback uses Launcher::Perform directly.

OSD_Parallel::For() - grain size API:
- New overload For(begin, end, functor, grainSize, forceSingle) with explicit grain size control. Parameter order avoids int-to-bool ambiguity with the existing signature.

OSD_Parallel::ForEach() - OCCT-threads optimization:
- Replaced type-erased path (mutex per item, heap alloc per Clone(), dynamic_cast, virtual dispatch) with pre-collected iterator array backed by NCollection_LocalArray (stack allocation for <= 1024 items) and direct Launcher::Perform. TBB path unchanged.

OSD_Parallel::Reduce() - new parallel map-reduce primitive:
- Per-thread accumulators indexed by thread index, parallel map phase via Launcher::Perform, sequential reduce phase merging partials.

Added GTests covering For (large range, grain size, empty, single item), ForEach (list iterator), and Reduce (parallel sum, single-thread, empty).