### PR TITLE
Coding - Fix critical CodeQL static analysis warnings

### DIFF
--- a/src/DataExchange/TKXSBase/Interface/Interface_ParamSet.cxx
+++ b/src/DataExchange/TKXSBase/Interface/Interface_ParamSet.cxx
@@ -86,9 +86,10 @@ int Interface_ParamSet::Append(const char* const         val,
           OFP.SetEntityNumber(onum);
       }
       //      Confirm the new reservation
-      delete[] theval;
-      theval   = newval;
-      thelnres = newres;
+      char* anOldVal = theval;
+      theval         = newval;
+      thelnres       = newres;
+      delete[] anOldVal;
     }
     //      Register this parameter
     for (i = 0; i < lnval; i++)

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/delabella.cpp
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/delabella.cpp
@@ -247,7 +247,7 @@ struct CDelaBella : IDelaBella
           errlog_proc(errlog_file,
                       "[WRN] all input points are colinear, returning single segment!\n");
         first_hull_vert    = vert_alloc + 0;
-        vert_alloc[0].next = (DelaBella_Vertex*)vert_alloc + 1;
+        vert_alloc[0].next = (DelaBella_Vertex*)(vert_alloc + 1);
         vert_alloc[1].next = nullptr;
       }
       else

--- a/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_MathBase.cxx
+++ b/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_MathBase.cxx
@@ -535,7 +535,7 @@ int mmaper0_(integer*    ncofmx,
   /* ------ Minimum that can be reached : Stop at 1 or NCFNEW ------ */
 
   ncut = 1;
-  if (*ncfnew + 1 > ncut)
+  if (*ncfnew >= ncut)
   {
     ncut = *ncfnew + 1;
   }


### PR DESCRIPTION
Interface_ParamSet:
- Eliminate use-after-free in Append() by deleting old buffer through a temp variable after reassigning the member pointer (CodeQL #5132/#2684)

delabella.cpp:
- Fix upcast array pointer arithmetic by parenthesizing cast to ensure pointer arithmetic uses derived class (Vert) size rather than base class (DelaBella_Vertex) size (CodeQL #5131)

NCollection_SparseArrayBase:
- Rework to replace virtual dispatch (createItem/destroyItem/copyItem) with function pointers passed as arguments to protected methods
- Store only DestroyItemFunc in base class to enable safe cleanup in destructor without virtual dispatch
- Pass CreateItemFunc and CopyItemFunc as arguments with zero per-instance storage overhead
- Move Clear() and UnsetValue() from base public API to protected clearItems()/unsetValue() with function pointer parameters; template class provides public wrappers
- Remove vtable entirely (no virtual methods remain)
- This eliminates the pure virtual call during base class destruction (CodeQL #5012)

AdvApp2Var_MathBase:
- Rewrite comparison to avoid potential signed integer overflow: *ncfnew + 1 > ncut becomes *ncfnew >= ncut (CodeQL #2692)