### PR TITLE
Configuration - Fix Cmake static linking warnings missing some spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,9 +116,9 @@ if ("${BUILD_LIBRARY_TYPE}" STREQUAL "Shared")
     set (BUILD_SHARED_LIBRARY_NAME_POSTFIX "" CACHE STRING "${BUILD_SHARED_LIBRARY_NAME_POSTFIX_DESCR}" FORCE)
   endif()
 else()
-  message(AUTHOR_WARNING "OCCT is licensed under LGPL 2.1, which has limitations on"
-                         "static linking with proprietary software."
-                         "OCCT3D offers commercial licensing exceptions to LGPL 2.1."
+  message(AUTHOR_WARNING "OCCT is licensed under LGPL 2.1, which has limitations on "
+                         "static linking with proprietary software. "
+                         "OCCT3D offers commercial licensing exceptions to LGPL 2.1. "
                          "Please use our contact form at https://occt3d.com/")
   unset (BUILD_SHARED_LIBS)
   unset (BUILD_SHARED_LIBRARY_NAME_POSTFIX)


### PR DESCRIPTION
Hi! Just a small thing - noticed that some spaces were missing in this warning, so "on static" appeared as a single word and no spaces between sentences.

<img width="763" height="178" alt="image" src="https://github.com/user-attachments/assets/d7e9bd9d-811c-4ffa-ab7a-f3c9dcab2048" />
