### PR TITLE
Foundation Classes, Modeling Data - Add multi-span BSpline cache grid for adaptors

### DIFF
--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.cxx
@@ -245,7 +245,7 @@ void BSplCLib_CacheGrid::D0(const double& theParameter, gp_Pnt& thePoint) const
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D0(theParameter, thePoint);
       return;
@@ -262,7 +262,7 @@ void BSplCLib_CacheGrid::D0(const double& theParameter, gp_Pnt2d& thePoint) cons
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D0(theParameter, thePoint);
       return;
@@ -279,7 +279,7 @@ void BSplCLib_CacheGrid::D1(const double& theParameter, gp_Pnt& thePoint, gp_Vec
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D1(theParameter, thePoint, theTangent);
       return;
@@ -298,7 +298,7 @@ void BSplCLib_CacheGrid::D1(const double& theParameter,
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D1(theParameter, thePoint, theTangent);
       return;
@@ -318,7 +318,7 @@ void BSplCLib_CacheGrid::D2(const double& theParameter,
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D2(theParameter, thePoint, theTangent, theCurvature);
       return;
@@ -338,7 +338,7 @@ void BSplCLib_CacheGrid::D2(const double& theParameter,
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D2(theParameter, thePoint, theTangent, theCurvature);
       return;
@@ -359,7 +359,7 @@ void BSplCLib_CacheGrid::D3(const double& theParameter,
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D3(theParameter, thePoint, theTangent, theCurvature, theTorsion);
       return;
@@ -380,7 +380,7 @@ void BSplCLib_CacheGrid::D3(const double& theParameter,
   if (myCellValid[myLastCell])
   {
     const double aDelta = theParameter - myCellSpanStart[myLastCell];
-    if (aDelta >= 0.0 && aDelta <= myCellSpanLength[myLastCell])
+    if (aDelta >= 0.0 && aDelta < myCellSpanLength[myLastCell])
     {
       myCache[myLastCell]->D3(theParameter, thePoint, theTangent, theCurvature, theTorsion);
       return;

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.cxx
@@ -1,0 +1,315 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BSplCLib_CacheGrid.hxx>
+#include <BSplCLib.hxx>
+#include <BSplCLib_CacheParams.hxx>
+
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec.hxx>
+#include <gp_Vec2d.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(BSplCLib_CacheGrid, Standard_Transient)
+
+//==================================================================================================
+
+BSplCLib_CacheGrid::BSplCLib_CacheGrid(int                               theDegree,
+                                       bool                              thePeriodic,
+                                       const NCollection_Array1<double>& theFlatKnots,
+                                       const NCollection_Array1<gp_Pnt>& thePoles,
+                                       const NCollection_Array1<double>* theWeights)
+    : myDegree(theDegree),
+      myIsPeriodic(thePeriodic),
+      myIs3D(true),
+      myFirstParam(theFlatKnots.Value(theFlatKnots.Lower() + theDegree)),
+      myLastParam(theFlatKnots.Value(theFlatKnots.Upper() - theDegree)),
+      mySpanIndexMin(theFlatKnots.Lower() + theDegree),
+      mySpanIndexMax(theFlatKnots.Upper() - theDegree - 1),
+      myFlatKnots(&theFlatKnots),
+      myPoles3D(&thePoles),
+      myPoles2D(nullptr),
+      myWeights(theWeights)
+{
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    myCellSpanIndex[i] = -1;
+    myCellSpanStart[i] = 0.0;
+    myCellSpanEnd[i]   = 0.0;
+    myCellValid[i]     = false;
+    myCache[i] = new BSplCLib_Cache(myDegree, myIsPeriodic, *myFlatKnots, *myPoles3D, myWeights);
+  }
+
+  rebuildGrid(myFirstParam);
+}
+
+//==================================================================================================
+
+BSplCLib_CacheGrid::BSplCLib_CacheGrid(int                                 theDegree,
+                                       bool                                thePeriodic,
+                                       const NCollection_Array1<double>&   theFlatKnots,
+                                       const NCollection_Array1<gp_Pnt2d>& thePoles2d,
+                                       const NCollection_Array1<double>*   theWeights)
+    : myDegree(theDegree),
+      myIsPeriodic(thePeriodic),
+      myIs3D(false),
+      myFirstParam(theFlatKnots.Value(theFlatKnots.Lower() + theDegree)),
+      myLastParam(theFlatKnots.Value(theFlatKnots.Upper() - theDegree)),
+      mySpanIndexMin(theFlatKnots.Lower() + theDegree),
+      mySpanIndexMax(theFlatKnots.Upper() - theDegree - 1),
+      myFlatKnots(&theFlatKnots),
+      myPoles3D(nullptr),
+      myPoles2D(&thePoles2d),
+      myWeights(theWeights)
+{
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    myCellSpanIndex[i] = -1;
+    myCellSpanStart[i] = 0.0;
+    myCellSpanEnd[i]   = 0.0;
+    myCellValid[i]     = false;
+    myCache[i] = new BSplCLib_Cache(myDegree, myIsPeriodic, *myFlatKnots, *myPoles2D, myWeights);
+  }
+
+  rebuildGrid(myFirstParam);
+}
+
+//==================================================================================================
+
+int BSplCLib_CacheGrid::neighborSpanIndex(int theCenterSpanIndex, int theOffset) const
+{
+  const int aNeighborIdx = theCenterSpanIndex + theOffset;
+  if (myIsPeriodic)
+  {
+    const int aRange = mySpanIndexMax - mySpanIndexMin + 1;
+    if (aRange <= 0)
+      return -1;
+    int aWrapped = aNeighborIdx - mySpanIndexMin;
+    aWrapped     = ((aWrapped % aRange) + aRange) % aRange;
+    return mySpanIndexMin + aWrapped;
+  }
+
+  if (aNeighborIdx < mySpanIndexMin || aNeighborIdx > mySpanIndexMax)
+    return -1;
+  return aNeighborIdx;
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::centerGrid(int theCenterSpanIndex) const
+{
+  // Cell 0 = prev span, Cell 1 = center span, Cell 2 = next span
+  const int aSpanIndices[THE_GRID_SIZE] = {neighborSpanIndex(theCenterSpanIndex, -1),
+                                           theCenterSpanIndex,
+                                           neighborSpanIndex(theCenterSpanIndex, +1)};
+
+  // Update span boundaries. Cache objects stay in place — never moved or released.
+  // Cells whose span changed are marked invalid and will be rebuilt on demand
+  // by calling BuildCache on the existing cache object (no reallocation).
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    myCellValid[i]     = (myCellSpanIndex[i] == aSpanIndices[i] && myCellValid[i]);
+    myCellSpanIndex[i] = aSpanIndices[i];
+    if (aSpanIndices[i] >= 0)
+    {
+      myCellSpanStart[i] = myFlatKnots->Value(aSpanIndices[i]);
+      myCellSpanEnd[i]   = myFlatKnots->Value(aSpanIndices[i] + 1);
+    }
+    else
+    {
+      myCellSpanStart[i] = 0.0;
+      myCellSpanEnd[i]   = 0.0;
+    }
+  }
+}
+
+//==================================================================================================
+
+int BSplCLib_CacheGrid::locateCell(double theParameter) const
+{
+  // Normalize for periodic curves
+  double aParam = theParameter;
+  if (myIsPeriodic)
+  {
+    const double aPeriod = myLastParam - myFirstParam;
+    if (aParam < myFirstParam)
+    {
+      const double aScale = std::trunc((myFirstParam - aParam) / aPeriod);
+      aParam += aPeriod * (aScale + 1.0);
+    }
+    else if (aParam > myLastParam)
+    {
+      const double aScale = std::trunc((aParam - myLastParam) / aPeriod);
+      aParam -= aPeriod * (aScale + 1.0);
+    }
+  }
+
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    if (myCellSpanIndex[i] < 0)
+      continue;
+
+    const double aDelta = aParam - myCellSpanStart[i];
+    const double aLen   = myCellSpanEnd[i] - myCellSpanStart[i];
+
+    if (aDelta < 0.0)
+      continue;
+
+    if (myCellSpanIndex[i] == mySpanIndexMax)
+    {
+      // Last span: parameter is valid if within [start, end]
+      if (aDelta <= aLen)
+        return i;
+      continue;
+    }
+
+    // Non-last span: parameter must be in [start, end)
+    if (aDelta >= aLen)
+      continue;
+
+    // Check proximity to span end — if within machine epsilon of the next
+    // knot boundary, prefer the next span (consistent with BSplCLib::LocateParameter)
+    const double anEps = Epsilon((std::min)(std::fabs(myLastParam), std::fabs(aParam)));
+    if (aLen - aDelta <= anEps)
+      continue;
+
+    return i;
+  }
+  return -1;
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::rebuildGrid(double theParameter) const
+{
+  BSplCLib_CacheParams aParams(myDegree, myIsPeriodic, *myFlatKnots);
+  double               aParam = aParams.PeriodicNormalization(theParameter);
+  aParams.LocateParameter(aParam, *myFlatKnots);
+
+  centerGrid(aParams.SpanIndex);
+
+  // Build center cell if not reused from a previous grid position
+  if (!myCellValid[1])
+    buildCell(1);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::buildCell(int theCellIndex) const
+{
+  const double aParam = myCellSpanStart[theCellIndex];
+  if (myIs3D)
+    myCache[theCellIndex]->BuildCache(aParam, *myFlatKnots, *myPoles3D, myWeights);
+  else
+    myCache[theCellIndex]->BuildCache(aParam, *myFlatKnots, *myPoles2D, myWeights);
+  myCellValid[theCellIndex] = true;
+}
+
+//==================================================================================================
+
+int BSplCLib_CacheGrid::ensureCell(double theParameter) const
+{
+  const int aCell = locateCell(theParameter);
+  if (aCell < 0)
+  {
+    // Parameter outside grid - recenter on this span
+    rebuildGrid(theParameter);
+    return 1; // center cell is always built by rebuildGrid
+  }
+  if (!myCellValid[aCell])
+  {
+    // Cell span is known but cache not yet built (lazy neighbor)
+    buildCell(aCell);
+  }
+  return aCell;
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D0(const double& theParameter, gp_Pnt& thePoint) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D0(theParameter, thePoint);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D0(const double& theParameter, gp_Pnt2d& thePoint) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D0(theParameter, thePoint);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D1(const double& theParameter, gp_Pnt& thePoint, gp_Vec& theTangent) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D1(theParameter, thePoint, theTangent);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D1(const double& theParameter,
+                            gp_Pnt2d&     thePoint,
+                            gp_Vec2d&     theTangent) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D1(theParameter, thePoint, theTangent);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D2(const double& theParameter,
+                            gp_Pnt&       thePoint,
+                            gp_Vec&       theTangent,
+                            gp_Vec&       theCurvature) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D2(theParameter, thePoint, theTangent, theCurvature);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D2(const double& theParameter,
+                            gp_Pnt2d&     thePoint,
+                            gp_Vec2d&     theTangent,
+                            gp_Vec2d&     theCurvature) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D2(theParameter, thePoint, theTangent, theCurvature);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D3(const double& theParameter,
+                            gp_Pnt&       thePoint,
+                            gp_Vec&       theTangent,
+                            gp_Vec&       theCurvature,
+                            gp_Vec&       theTorsion) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D3(theParameter, thePoint, theTangent, theCurvature, theTorsion);
+}
+
+//==================================================================================================
+
+void BSplCLib_CacheGrid::D3(const double& theParameter,
+                            gp_Pnt2d&     thePoint,
+                            gp_Vec2d&     theTangent,
+                            gp_Vec2d&     theCurvature,
+                            gp_Vec2d&     theTorsion) const
+{
+  const int aCell = ensureCell(theParameter);
+  myCache[aCell]->D3(theParameter, thePoint, theTangent, theCurvature, theTorsion);
+}

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.cxx
@@ -113,7 +113,7 @@ void BSplCLib_CacheGrid::centerGrid(int theCenterSpanIndex) const
                                            theCenterSpanIndex,
                                            neighborSpanIndex(theCenterSpanIndex, +1)};
 
-  // Update span boundaries. Cache objects stay in place — never moved or released.
+  // Update span boundaries. Cache objects stay in place - never moved or released.
   // Cells whose span changed are marked invalid and will be rebuilt on demand
   // by calling BuildCache on the existing cache object (no reallocation).
   for (int i = 0; i < THE_GRID_SIZE; ++i)
@@ -177,7 +177,7 @@ int BSplCLib_CacheGrid::locateCell(double theParameter) const
     if (aDelta >= aLen)
       continue;
 
-    // Check proximity to span end — if within machine epsilon of the next
+    // Check proximity to span end - if within machine epsilon of the next
     // knot boundary, prefer the next span (consistent with BSplCLib::LocateParameter)
     const double anEps = Epsilon((std::min)(std::fabs(myLastParam), std::fabs(aParam)));
     if (aLen - aDelta <= anEps)

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.hxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.hxx
@@ -157,10 +157,11 @@ private:
   const NCollection_Array1<gp_Pnt2d>* myPoles2D;
   const NCollection_Array1<double>*   myWeights;
 
-  mutable int    myCellSpanIndex[THE_GRID_SIZE]; //!< span index per cell (-1 = unused)
-  mutable double myCellSpanStart[THE_GRID_SIZE]; //!< span start parameter per cell
-  mutable double myCellSpanEnd[THE_GRID_SIZE];   //!< span end parameter per cell
+  mutable int    myCellSpanIndex[THE_GRID_SIZE];  //!< span index per cell (-1 = unused)
+  mutable double myCellSpanStart[THE_GRID_SIZE];  //!< span start parameter per cell
+  mutable double myCellSpanLength[THE_GRID_SIZE]; //!< span length per cell (end - start)
 
+  mutable int  myLastCell;                 //!< last-used cell index (fast-path hint)
   mutable bool myCellValid[THE_GRID_SIZE]; //!< true if cache is built for current span
   mutable occ::handle<BSplCLib_Cache> myCache[THE_GRID_SIZE]; //!< cache objects
 };

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.hxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheGrid.hxx
@@ -1,0 +1,168 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _BSplCLib_CacheGrid_Headerfile
+#define _BSplCLib_CacheGrid_Headerfile
+
+#include <BSplCLib_Cache.hxx>
+
+class gp_Pnt;
+class gp_Pnt2d;
+class gp_Vec;
+class gp_Vec2d;
+
+//! \brief A multi-span cache for B-spline curve evaluation.
+//!
+//! Maintains a sliding window of 3 caches covering adjacent knot spans
+//! (previous, center, next). When evaluation crosses a span boundary
+//! within the window, the correct cache is used directly with O(1) lookup.
+//! Only when the parameter leaves all 3 cached spans is the grid re-centered.
+//! Neighbor caches are built lazily on first access.
+//!
+//! The grid stores references to the curve data arrays (flat knots, poles,
+//! weights) and manages all cache building internally. Evaluation methods
+//! (D0, D1, D2, D3) are fully self-contained: they locate the correct cell,
+//! build it if needed, recenter the grid if the parameter falls outside,
+//! and evaluate -- all in a single call with exactly one O(1) cell lookup.
+//!
+//! This eliminates the expensive cache rebuild cost when Newton iterations
+//! or sequential traversals oscillate near span boundaries.
+class BSplCLib_CacheGrid : public Standard_Transient
+{
+public:
+  static constexpr int THE_GRID_SIZE = 3;
+
+  //! Constructor for 3D curves.
+  //! Stores references to the data arrays and builds the initial grid
+  //! centered on the first knot span.
+  //! @param[in] theDegree     degree of the B-spline
+  //! @param[in] thePeriodic   whether the curve is periodic
+  //! @param[in] theFlatKnots  flat knots array (with repetitions)
+  //! @param[in] thePoles      array of 3D poles
+  //! @param[in] theWeights    array of weights (nullptr for non-rational)
+  Standard_EXPORT BSplCLib_CacheGrid(int                               theDegree,
+                                     bool                              thePeriodic,
+                                     const NCollection_Array1<double>& theFlatKnots,
+                                     const NCollection_Array1<gp_Pnt>& thePoles,
+                                     const NCollection_Array1<double>* theWeights = nullptr);
+
+  //! Constructor for 2D curves.
+  //! Stores references to the data arrays and builds the initial grid
+  //! centered on the first knot span.
+  //! @param[in] theDegree     degree of the B-spline
+  //! @param[in] thePeriodic   whether the curve is periodic
+  //! @param[in] theFlatKnots  flat knots array (with repetitions)
+  //! @param[in] thePoles2d    array of 2D poles
+  //! @param[in] theWeights    array of weights (nullptr for non-rational)
+  Standard_EXPORT BSplCLib_CacheGrid(int                                 theDegree,
+                                     bool                                thePeriodic,
+                                     const NCollection_Array1<double>&   theFlatKnots,
+                                     const NCollection_Array1<gp_Pnt2d>& thePoles2d,
+                                     const NCollection_Array1<double>*   theWeights = nullptr);
+
+  //! Evaluate 3D point. Handles grid management internally.
+  Standard_EXPORT void D0(const double& theParameter, gp_Pnt& thePoint) const;
+
+  //! Evaluate 2D point. Handles grid management internally.
+  Standard_EXPORT void D0(const double& theParameter, gp_Pnt2d& thePoint) const;
+
+  //! Evaluate 3D point and first derivative.
+  Standard_EXPORT void D1(const double& theParameter, gp_Pnt& thePoint, gp_Vec& theTangent) const;
+
+  //! Evaluate 2D point and first derivative.
+  Standard_EXPORT void D1(const double& theParameter,
+                          gp_Pnt2d&     thePoint,
+                          gp_Vec2d&     theTangent) const;
+
+  //! Evaluate 3D point, first and second derivatives.
+  Standard_EXPORT void D2(const double& theParameter,
+                          gp_Pnt&       thePoint,
+                          gp_Vec&       theTangent,
+                          gp_Vec&       theCurvature) const;
+
+  //! Evaluate 2D point, first and second derivatives.
+  Standard_EXPORT void D2(const double& theParameter,
+                          gp_Pnt2d&     thePoint,
+                          gp_Vec2d&     theTangent,
+                          gp_Vec2d&     theCurvature) const;
+
+  //! Evaluate 3D point, first, second and third derivatives.
+  Standard_EXPORT void D3(const double& theParameter,
+                          gp_Pnt&       thePoint,
+                          gp_Vec&       theTangent,
+                          gp_Vec&       theCurvature,
+                          gp_Vec&       theTorsion) const;
+
+  //! Evaluate 2D point, first, second and third derivatives.
+  Standard_EXPORT void D3(const double& theParameter,
+                          gp_Pnt2d&     thePoint,
+                          gp_Vec2d&     theTangent,
+                          gp_Vec2d&     theCurvature,
+                          gp_Vec2d&     theTorsion) const;
+
+  DEFINE_STANDARD_RTTIEXT(BSplCLib_CacheGrid, Standard_Transient)
+
+private:
+  //! O(1) find cell index covering theParameter, -1 if outside grid.
+  int locateCell(double theParameter) const;
+
+  //! Recompute cell boundaries centered on theCenterSpanIndex.
+  //! Reuses matching old caches when the grid shifts.
+  void centerGrid(int theCenterSpanIndex) const;
+
+  //! Compute the span index for a neighbor cell, handling boundaries and periodicity.
+  //! @param[in] theCenterSpanIndex the center span index
+  //! @param[in] theOffset          offset from center (-1 or +1)
+  //! @return span index for the neighbor, or -1 if out of bounds
+  int neighborSpanIndex(int theCenterSpanIndex, int theOffset) const;
+
+  //! Rebuild grid centered on span containing theParameter.
+  //! Reuses overlapping caches and builds the center cell immediately.
+  void rebuildGrid(double theParameter) const;
+
+  //! Build cache for a single cell (lazy load).
+  //! Uses stored data references to construct and populate the cell.
+  void buildCell(int theCellIndex) const;
+
+  //! Locate the cell covering theParameter, building or recentering as needed.
+  //! @return the cell index guaranteed to have a valid built cache
+  int ensureCell(double theParameter) const;
+
+  // copying is prohibited
+  BSplCLib_CacheGrid(const BSplCLib_CacheGrid&)            = delete;
+  BSplCLib_CacheGrid& operator=(const BSplCLib_CacheGrid&) = delete;
+
+private:
+  int    myDegree;
+  bool   myIsPeriodic;
+  bool   myIs3D;
+  double myFirstParam;
+  double myLastParam;
+  int    mySpanIndexMin;
+  int    mySpanIndexMax;
+
+  // Stored data references (owned by the Geom_BSpline* object via adaptor handle)
+  const NCollection_Array1<double>*   myFlatKnots;
+  const NCollection_Array1<gp_Pnt>*   myPoles3D;
+  const NCollection_Array1<gp_Pnt2d>* myPoles2D;
+  const NCollection_Array1<double>*   myWeights;
+
+  mutable int    myCellSpanIndex[THE_GRID_SIZE]; //!< span index per cell (-1 = unused)
+  mutable double myCellSpanStart[THE_GRID_SIZE]; //!< span start parameter per cell
+  mutable double myCellSpanEnd[THE_GRID_SIZE];   //!< span end parameter per cell
+
+  mutable bool myCellValid[THE_GRID_SIZE]; //!< true if cache is built for current span
+  mutable occ::handle<BSplCLib_Cache> myCache[THE_GRID_SIZE]; //!< cache objects
+};
+
+#endif

--- a/src/FoundationClasses/TKMath/BSplCLib/FILES.cmake
+++ b/src/FoundationClasses/TKMath/BSplCLib/FILES.cmake
@@ -11,6 +11,8 @@ set(OCCT_BSplCLib_FILES
   BSplCLib_BzSyntaxes.cxx
   BSplCLib_Cache.cxx
   BSplCLib_Cache.hxx
+  BSplCLib_CacheGrid.cxx
+  BSplCLib_CacheGrid.hxx
   BSplCLib_CacheParams.hxx
   BSplCLib_CurveComputation.pxx
   BSplCLib_EvaluatorFunction.hxx

--- a/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.cxx
+++ b/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.cxx
@@ -177,7 +177,7 @@ int BSplSLib_CacheGrid::locateCellDir(double        theParam,
     if (aDelta >= aLen)
       continue;
 
-    // Check proximity to span end — if within machine epsilon of the next
+    // Check proximity to span end - if within machine epsilon of the next
     // knot boundary, prefer the next span (consistent with BSplCLib::LocateParameter)
     const double anEps = Epsilon((std::min)(std::fabs(theLast), std::fabs(aParam)));
     if (aLen - aDelta <= anEps)
@@ -253,7 +253,7 @@ void BSplSLib_CacheGrid::rebuildGrid(double theU, double theV) const
                 myCellSpanStartV,
                 myCellSpanEndV);
 
-  // Mark cells whose span changed as invalid. Cache objects stay in place —
+  // Mark cells whose span changed as invalid. Cache objects stay in place --
   // never moved or released. Invalid cells are rebuilt on demand by calling
   // BuildCache on the existing cache object (no reallocation).
   for (int iU = 0; iU < THE_GRID_SIZE; ++iU)

--- a/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.cxx
+++ b/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.cxx
@@ -1,0 +1,352 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BSplSLib_CacheGrid.hxx>
+#include <BSplCLib.hxx>
+#include <BSplCLib_CacheParams.hxx>
+
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(BSplSLib_CacheGrid, Standard_Transient)
+
+//==================================================================================================
+
+BSplSLib_CacheGrid::BSplSLib_CacheGrid(int                               theDegreeU,
+                                       bool                              thePeriodicU,
+                                       const NCollection_Array1<double>& theFlatKnotsU,
+                                       int                               theDegreeV,
+                                       bool                              thePeriodicV,
+                                       const NCollection_Array1<double>& theFlatKnotsV,
+                                       const NCollection_Array2<gp_Pnt>& thePoles,
+                                       const NCollection_Array2<double>* theWeights)
+    : myDegreeU(theDegreeU),
+      myDegreeV(theDegreeV),
+      myIsPeriodicU(thePeriodicU),
+      myIsPeriodicV(thePeriodicV),
+      myFirstParamU(theFlatKnotsU.Value(theFlatKnotsU.Lower() + theDegreeU)),
+      myLastParamU(theFlatKnotsU.Value(theFlatKnotsU.Upper() - theDegreeU)),
+      myFirstParamV(theFlatKnotsV.Value(theFlatKnotsV.Lower() + theDegreeV)),
+      myLastParamV(theFlatKnotsV.Value(theFlatKnotsV.Upper() - theDegreeV)),
+      mySpanIndexMinU(theFlatKnotsU.Lower() + theDegreeU),
+      mySpanIndexMaxU(theFlatKnotsU.Upper() - theDegreeU - 1),
+      mySpanIndexMinV(theFlatKnotsV.Lower() + theDegreeV),
+      mySpanIndexMaxV(theFlatKnotsV.Upper() - theDegreeV - 1),
+      myFlatKnotsU(&theFlatKnotsU),
+      myFlatKnotsV(&theFlatKnotsV),
+      myPoles(&thePoles),
+      myWeights(theWeights)
+{
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    myCellSpanIndexU[i] = -1;
+    myCellSpanStartU[i] = 0.0;
+    myCellSpanEndU[i]   = 0.0;
+    myCellSpanIndexV[i] = -1;
+    myCellSpanStartV[i] = 0.0;
+    myCellSpanEndV[i]   = 0.0;
+  }
+  for (int i = 0; i < THE_GRID_SIZE * THE_GRID_SIZE; ++i)
+  {
+    myCellValid[i] = false;
+    myCache[i]     = new BSplSLib_Cache(myDegreeU,
+                                    myIsPeriodicU,
+                                    *myFlatKnotsU,
+                                    myDegreeV,
+                                    myIsPeriodicV,
+                                    *myFlatKnotsV,
+                                    myWeights);
+  }
+
+  rebuildGrid(myFirstParamU, myFirstParamV);
+}
+
+//==================================================================================================
+
+int BSplSLib_CacheGrid::neighborSpanIndex(int  theCenterSpanIndex,
+                                          int  theOffset,
+                                          int  theSpanMin,
+                                          int  theSpanMax,
+                                          bool theIsPeriodic)
+{
+  const int aNeighborIdx = theCenterSpanIndex + theOffset;
+  if (theIsPeriodic)
+  {
+    const int aRange = theSpanMax - theSpanMin + 1;
+    if (aRange <= 0)
+      return -1;
+    int aWrapped = aNeighborIdx - theSpanMin;
+    aWrapped     = ((aWrapped % aRange) + aRange) % aRange;
+    return theSpanMin + aWrapped;
+  }
+
+  if (aNeighborIdx < theSpanMin || aNeighborIdx > theSpanMax)
+    return -1;
+  return aNeighborIdx;
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::centerGridDir(int                               theCenterSpanIndex,
+                                       int                               theSpanMin,
+                                       int                               theSpanMax,
+                                       bool                              theIsPeriodic,
+                                       const NCollection_Array1<double>& theFlatKnots,
+                                       int*                              theCellSpanIndex,
+                                       double*                           theCellSpanStart,
+                                       double*                           theCellSpanEnd)
+{
+  const int aSpanIndices[THE_GRID_SIZE] = {
+    neighborSpanIndex(theCenterSpanIndex, -1, theSpanMin, theSpanMax, theIsPeriodic),
+    theCenterSpanIndex,
+    neighborSpanIndex(theCenterSpanIndex, +1, theSpanMin, theSpanMax, theIsPeriodic)};
+
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    theCellSpanIndex[i] = aSpanIndices[i];
+    if (aSpanIndices[i] >= 0)
+    {
+      theCellSpanStart[i] = theFlatKnots.Value(aSpanIndices[i]);
+      theCellSpanEnd[i]   = theFlatKnots.Value(aSpanIndices[i] + 1);
+    }
+    else
+    {
+      theCellSpanStart[i] = 0.0;
+      theCellSpanEnd[i]   = 0.0;
+    }
+  }
+}
+
+//==================================================================================================
+
+int BSplSLib_CacheGrid::locateCellDir(double        theParam,
+                                      const int*    theSpanIdx,
+                                      const double* theSpanStart,
+                                      const double* theSpanEnd,
+                                      int           theSpanMax,
+                                      double        theFirst,
+                                      double        theLast,
+                                      bool          theIsPeriodic)
+{
+  double aParam = theParam;
+  if (theIsPeriodic)
+  {
+    const double aPeriod = theLast - theFirst;
+    if (aParam < theFirst)
+    {
+      const double aScale = std::trunc((theFirst - aParam) / aPeriod);
+      aParam += aPeriod * (aScale + 1.0);
+    }
+    else if (aParam > theLast)
+    {
+      const double aScale = std::trunc((aParam - theLast) / aPeriod);
+      aParam -= aPeriod * (aScale + 1.0);
+    }
+  }
+
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    if (theSpanIdx[i] < 0)
+      continue;
+
+    const double aDelta = aParam - theSpanStart[i];
+    const double aLen   = theSpanEnd[i] - theSpanStart[i];
+
+    if (aDelta < 0.0)
+      continue;
+
+    if (theSpanIdx[i] == theSpanMax)
+    {
+      // Last span: parameter is valid if within [start, end]
+      if (aDelta <= aLen)
+        return i;
+      continue;
+    }
+
+    // Non-last span: parameter must be in [start, end)
+    if (aDelta >= aLen)
+      continue;
+
+    // Check proximity to span end — if within machine epsilon of the next
+    // knot boundary, prefer the next span (consistent with BSplCLib::LocateParameter)
+    const double anEps = Epsilon((std::min)(std::fabs(theLast), std::fabs(aParam)));
+    if (aLen - aDelta <= anEps)
+      continue;
+
+    return i;
+  }
+  return -1;
+}
+
+//==================================================================================================
+
+bool BSplSLib_CacheGrid::locateCell(double theU, double theV, int& theCellU, int& theCellV) const
+{
+  theCellU = locateCellDir(theU,
+                           myCellSpanIndexU,
+                           myCellSpanStartU,
+                           myCellSpanEndU,
+                           mySpanIndexMaxU,
+                           myFirstParamU,
+                           myLastParamU,
+                           myIsPeriodicU);
+  if (theCellU < 0)
+    return false;
+
+  theCellV = locateCellDir(theV,
+                           myCellSpanIndexV,
+                           myCellSpanStartV,
+                           myCellSpanEndV,
+                           mySpanIndexMaxV,
+                           myFirstParamV,
+                           myLastParamV,
+                           myIsPeriodicV);
+  return theCellV >= 0;
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::rebuildGrid(double theU, double theV) const
+{
+  // Find the span indices for U and V
+  BSplCLib_CacheParams aParamsU(myDegreeU, myIsPeriodicU, *myFlatKnotsU);
+  double               aParamU = aParamsU.PeriodicNormalization(theU);
+  aParamsU.LocateParameter(aParamU, *myFlatKnotsU);
+
+  BSplCLib_CacheParams aParamsV(myDegreeV, myIsPeriodicV, *myFlatKnotsV);
+  double               aParamV = aParamsV.PeriodicNormalization(theV);
+  aParamsV.LocateParameter(aParamV, *myFlatKnotsV);
+
+  // Save old span indices to detect which cells can keep their cache
+  int aOldSpanU[THE_GRID_SIZE], aOldSpanV[THE_GRID_SIZE];
+  for (int i = 0; i < THE_GRID_SIZE; ++i)
+  {
+    aOldSpanU[i] = myCellSpanIndexU[i];
+    aOldSpanV[i] = myCellSpanIndexV[i];
+  }
+
+  // Center grids in both directions
+  centerGridDir(aParamsU.SpanIndex,
+                mySpanIndexMinU,
+                mySpanIndexMaxU,
+                myIsPeriodicU,
+                *myFlatKnotsU,
+                myCellSpanIndexU,
+                myCellSpanStartU,
+                myCellSpanEndU);
+  centerGridDir(aParamsV.SpanIndex,
+                mySpanIndexMinV,
+                mySpanIndexMaxV,
+                myIsPeriodicV,
+                *myFlatKnotsV,
+                myCellSpanIndexV,
+                myCellSpanStartV,
+                myCellSpanEndV);
+
+  // Mark cells whose span changed as invalid. Cache objects stay in place —
+  // never moved or released. Invalid cells are rebuilt on demand by calling
+  // BuildCache on the existing cache object (no reallocation).
+  for (int iU = 0; iU < THE_GRID_SIZE; ++iU)
+  {
+    const bool aSameU = (myCellSpanIndexU[iU] == aOldSpanU[iU]);
+    for (int iV = 0; iV < THE_GRID_SIZE; ++iV)
+    {
+      const int aIdx    = cacheIndex(iU, iV);
+      myCellValid[aIdx] = (aSameU && myCellSpanIndexV[iV] == aOldSpanV[iV] && myCellValid[aIdx]);
+    }
+  }
+
+  // Build center cell if not still valid
+  const int aCenterIdx = cacheIndex(1, 1);
+  if (!myCellValid[aCenterIdx])
+    buildCell(1, 1);
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::buildCell(int theCellU, int theCellV) const
+{
+  const int aIdx = cacheIndex(theCellU, theCellV);
+  myCache[aIdx]->BuildCache(myCellSpanStartU[theCellU],
+                            myCellSpanStartV[theCellV],
+                            *myFlatKnotsU,
+                            *myFlatKnotsV,
+                            *myPoles,
+                            myWeights);
+  myCellValid[aIdx] = true;
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::ensureCell(double theU, double theV, int& theCellU, int& theCellV) const
+{
+  if (!locateCell(theU, theV, theCellU, theCellV))
+  {
+    // Parameters outside grid - recenter
+    rebuildGrid(theU, theV);
+    theCellU = 1;
+    theCellV = 1;
+    return;
+  }
+  const int aIdx = cacheIndex(theCellU, theCellV);
+  if (!myCellValid[aIdx])
+  {
+    // Cell span is known but cache not yet built for current span
+    buildCell(theCellU, theCellV);
+  }
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::D0(const double& theU, const double& theV, gp_Pnt& thePoint) const
+{
+  int aCellU = -1, aCellV = -1;
+  ensureCell(theU, theV, aCellU, aCellV);
+  myCache[cacheIndex(aCellU, aCellV)]->D0(theU, theV, thePoint);
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::D1(const double& theU,
+                            const double& theV,
+                            gp_Pnt&       thePoint,
+                            gp_Vec&       theTangentU,
+                            gp_Vec&       theTangentV) const
+{
+  int aCellU = -1, aCellV = -1;
+  ensureCell(theU, theV, aCellU, aCellV);
+  myCache[cacheIndex(aCellU, aCellV)]->D1(theU, theV, thePoint, theTangentU, theTangentV);
+}
+
+//==================================================================================================
+
+void BSplSLib_CacheGrid::D2(const double& theU,
+                            const double& theV,
+                            gp_Pnt&       thePoint,
+                            gp_Vec&       theTangentU,
+                            gp_Vec&       theTangentV,
+                            gp_Vec&       theCurvatureU,
+                            gp_Vec&       theCurvatureV,
+                            gp_Vec&       theCurvatureUV) const
+{
+  int aCellU = -1, aCellV = -1;
+  ensureCell(theU, theV, aCellU, aCellV);
+  myCache[cacheIndex(aCellU, aCellV)]->D2(theU,
+                                          theV,
+                                          thePoint,
+                                          theTangentU,
+                                          theTangentV,
+                                          theCurvatureU,
+                                          theCurvatureV,
+                                          theCurvatureUV);
+}

--- a/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.cxx
+++ b/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.cxx
@@ -322,8 +322,8 @@ void BSplSLib_CacheGrid::D0(const double& theU, const double& theV, gp_Pnt& theP
   {
     const double aDeltaU = theU - myCellSpanStartU[myLastCellU];
     const double aDeltaV = theV - myCellSpanStartV[myLastCellV];
-    if (aDeltaU >= 0.0 && aDeltaU <= myCellSpanLengthU[myLastCellU] && aDeltaV >= 0.0
-        && aDeltaV <= myCellSpanLengthV[myLastCellV])
+    if (aDeltaU >= 0.0 && aDeltaU < myCellSpanLengthU[myLastCellU] && aDeltaV >= 0.0
+        && aDeltaV < myCellSpanLengthV[myLastCellV])
     {
       myCache[myLastCacheIdx]->D0(theU, theV, thePoint);
       return;
@@ -346,8 +346,8 @@ void BSplSLib_CacheGrid::D1(const double& theU,
   {
     const double aDeltaU = theU - myCellSpanStartU[myLastCellU];
     const double aDeltaV = theV - myCellSpanStartV[myLastCellV];
-    if (aDeltaU >= 0.0 && aDeltaU <= myCellSpanLengthU[myLastCellU] && aDeltaV >= 0.0
-        && aDeltaV <= myCellSpanLengthV[myLastCellV])
+    if (aDeltaU >= 0.0 && aDeltaU < myCellSpanLengthU[myLastCellU] && aDeltaV >= 0.0
+        && aDeltaV < myCellSpanLengthV[myLastCellV])
     {
       myCache[myLastCacheIdx]->D1(theU, theV, thePoint, theTangentU, theTangentV);
       return;
@@ -373,8 +373,8 @@ void BSplSLib_CacheGrid::D2(const double& theU,
   {
     const double aDeltaU = theU - myCellSpanStartU[myLastCellU];
     const double aDeltaV = theV - myCellSpanStartV[myLastCellV];
-    if (aDeltaU >= 0.0 && aDeltaU <= myCellSpanLengthU[myLastCellU] && aDeltaV >= 0.0
-        && aDeltaV <= myCellSpanLengthV[myLastCellV])
+    if (aDeltaU >= 0.0 && aDeltaU < myCellSpanLengthU[myLastCellU] && aDeltaV >= 0.0
+        && aDeltaV < myCellSpanLengthV[myLastCellV])
     {
       myCache[myLastCacheIdx]->D2(theU,
                                   theV,

--- a/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.hxx
+++ b/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.hxx
@@ -1,0 +1,179 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _BSplSLib_CacheGrid_Headerfile
+#define _BSplSLib_CacheGrid_Headerfile
+
+#include <BSplSLib_Cache.hxx>
+
+class gp_Pnt;
+class gp_Vec;
+
+//! \brief A multi-span cache for B-spline surface evaluation.
+//!
+//! Maintains a sliding window of 3x3 caches covering adjacent knot spans
+//! in both U and V directions. When evaluation crosses a span boundary
+//! within the grid, the correct cache is used directly with O(1) lookup.
+//! Only when the parameter leaves all cached spans is the grid re-centered.
+//! Neighbor caches are built lazily on first access.
+//!
+//! The grid stores references to the surface data arrays (flat knots, poles,
+//! weights) and manages all cache building internally. Evaluation methods
+//! (D0, D1, D2) are fully self-contained: they locate the correct cell,
+//! build it if needed, recenter the grid if parameters fall outside,
+//! and evaluate -- all in a single call with exactly one O(1) cell lookup.
+//!
+//! This eliminates the expensive cache rebuild cost when Newton iterations
+//! or sequential traversals oscillate near span boundaries in either direction.
+class BSplSLib_CacheGrid : public Standard_Transient
+{
+public:
+  static constexpr int THE_GRID_SIZE = 3;
+
+  //! Constructor.
+  //! Stores references to the data arrays and builds the initial grid
+  //! centered on the first knot spans in both U and V directions.
+  //! @param[in] theDegreeU     degree along U
+  //! @param[in] thePeriodicU   whether the surface is periodic in U
+  //! @param[in] theFlatKnotsU  flat knots along U
+  //! @param[in] theDegreeV     degree along V
+  //! @param[in] thePeriodicV   whether the surface is periodic in V
+  //! @param[in] theFlatKnotsV  flat knots along V
+  //! @param[in] thePoles       array of 3D poles
+  //! @param[in] theWeights     array of weights (nullptr for non-rational)
+  Standard_EXPORT BSplSLib_CacheGrid(int                               theDegreeU,
+                                     bool                              thePeriodicU,
+                                     const NCollection_Array1<double>& theFlatKnotsU,
+                                     int                               theDegreeV,
+                                     bool                              thePeriodicV,
+                                     const NCollection_Array1<double>& theFlatKnotsV,
+                                     const NCollection_Array2<gp_Pnt>& thePoles,
+                                     const NCollection_Array2<double>* theWeights = nullptr);
+
+  //! Evaluate 3D point. Handles grid management internally.
+  Standard_EXPORT void D0(const double& theU, const double& theV, gp_Pnt& thePoint) const;
+
+  //! Evaluate 3D point and first derivatives.
+  Standard_EXPORT void D1(const double& theU,
+                          const double& theV,
+                          gp_Pnt&       thePoint,
+                          gp_Vec&       theTangentU,
+                          gp_Vec&       theTangentV) const;
+
+  //! Evaluate 3D point, first and second derivatives.
+  Standard_EXPORT void D2(const double& theU,
+                          const double& theV,
+                          gp_Pnt&       thePoint,
+                          gp_Vec&       theTangentU,
+                          gp_Vec&       theTangentV,
+                          gp_Vec&       theCurvatureU,
+                          gp_Vec&       theCurvatureV,
+                          gp_Vec&       theCurvatureUV) const;
+
+  DEFINE_STANDARD_RTTIEXT(BSplSLib_CacheGrid, Standard_Transient)
+
+private:
+  //! Locate (iU, iV) cell covering the given parameters.
+  //! @param[in]  theU     first parameter
+  //! @param[in]  theV     second parameter
+  //! @param[out] theCellU cell index in U direction (0..2)
+  //! @param[out] theCellV cell index in V direction (0..2)
+  //! @return true if a valid cell was found
+  bool locateCell(double theU, double theV, int& theCellU, int& theCellV) const;
+
+  //! Locate cell in one direction.
+  //! @param[in] theParam     parameter value
+  //! @param[in] theSpanIdx   array of span indices for 3 cells
+  //! @param[in] theSpanStart array of span start values for 3 cells
+  //! @param[in] theSpanEnd   array of span end values for 3 cells
+  //! @param[in] theSpanMax   maximum span index
+  //! @param[in] theFirst     first parameter
+  //! @param[in] theLast      last parameter
+  //! @param[in] theIsPeriodic whether the direction is periodic
+  //! @return cell index (0..2) or -1 if not found
+  static int locateCellDir(double        theParam,
+                           const int*    theSpanIdx,
+                           const double* theSpanStart,
+                           const double* theSpanEnd,
+                           int           theSpanMax,
+                           double        theFirst,
+                           double        theLast,
+                           bool          theIsPeriodic);
+
+  //! Recompute cell boundaries for one direction.
+  static void centerGridDir(int                               theCenterSpanIndex,
+                            int                               theSpanMin,
+                            int                               theSpanMax,
+                            bool                              theIsPeriodic,
+                            const NCollection_Array1<double>& theFlatKnots,
+                            int*                              theCellSpanIndex,
+                            double*                           theCellSpanStart,
+                            double*                           theCellSpanEnd);
+
+  //! Compute neighbor span index handling periodicity.
+  static int neighborSpanIndex(int  theCenterSpanIndex,
+                               int  theOffset,
+                               int  theSpanMin,
+                               int  theSpanMax,
+                               bool theIsPeriodic);
+
+  //! Compute flat cache index from (iU, iV).
+  static int cacheIndex(int iU, int iV) { return iU * THE_GRID_SIZE + iV; }
+
+  //! Rebuild grid centered on spans containing (theU, theV).
+  //! Reuses overlapping caches and builds the center cell immediately.
+  void rebuildGrid(double theU, double theV) const;
+
+  //! Build cache for a single cell (lazy load).
+  //! Uses stored data references to construct and populate the cell.
+  //! @param[in] theCellU cell index in U direction
+  //! @param[in] theCellV cell index in V direction
+  void buildCell(int theCellU, int theCellV) const;
+
+  //! Locate the cell covering (theU, theV), building or recentering as needed.
+  //! @param[in]  theU     first parameter
+  //! @param[in]  theV     second parameter
+  //! @param[out] theCellU cell index in U direction
+  //! @param[out] theCellV cell index in V direction
+  void ensureCell(double theU, double theV, int& theCellU, int& theCellV) const;
+
+  // copying is prohibited
+  BSplSLib_CacheGrid(const BSplSLib_CacheGrid&)            = delete;
+  BSplSLib_CacheGrid& operator=(const BSplSLib_CacheGrid&) = delete;
+
+private:
+  int  myDegreeU, myDegreeV;
+  bool myIsPeriodicU, myIsPeriodicV;
+
+  double myFirstParamU, myLastParamU;
+  double myFirstParamV, myLastParamV;
+  int    mySpanIndexMinU, mySpanIndexMaxU;
+  int    mySpanIndexMinV, mySpanIndexMaxV;
+
+  // Stored data references (owned by the Geom_BSplineSurface object via adaptor handle)
+  const NCollection_Array1<double>* myFlatKnotsU;
+  const NCollection_Array1<double>* myFlatKnotsV;
+  const NCollection_Array2<gp_Pnt>* myPoles;
+  const NCollection_Array2<double>* myWeights;
+
+  mutable int    myCellSpanIndexU[THE_GRID_SIZE], myCellSpanIndexV[THE_GRID_SIZE];
+  mutable double myCellSpanStartU[THE_GRID_SIZE], myCellSpanStartV[THE_GRID_SIZE];
+  mutable double myCellSpanEndU[THE_GRID_SIZE], myCellSpanEndV[THE_GRID_SIZE];
+
+  // 3x3 cache: myCache[iU * THE_GRID_SIZE + iV]
+  mutable bool myCellValid[THE_GRID_SIZE * THE_GRID_SIZE]; //!< true if built for current span
+  //! reused across grid shifts
+  mutable occ::handle<BSplSLib_Cache> myCache[THE_GRID_SIZE * THE_GRID_SIZE];
+};
+
+#endif

--- a/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.hxx
+++ b/src/FoundationClasses/TKMath/BSplSLib/BSplSLib_CacheGrid.hxx
@@ -92,19 +92,19 @@ private:
   bool locateCell(double theU, double theV, int& theCellU, int& theCellV) const;
 
   //! Locate cell in one direction.
-  //! @param[in] theParam     parameter value
-  //! @param[in] theSpanIdx   array of span indices for 3 cells
-  //! @param[in] theSpanStart array of span start values for 3 cells
-  //! @param[in] theSpanEnd   array of span end values for 3 cells
-  //! @param[in] theSpanMax   maximum span index
-  //! @param[in] theFirst     first parameter
-  //! @param[in] theLast      last parameter
+  //! @param[in] theParam      parameter value
+  //! @param[in] theSpanIdx    array of span indices for 3 cells
+  //! @param[in] theSpanStart  array of span start values for 3 cells
+  //! @param[in] theSpanLength array of span lengths for 3 cells
+  //! @param[in] theSpanMax    maximum span index
+  //! @param[in] theFirst      first parameter
+  //! @param[in] theLast       last parameter
   //! @param[in] theIsPeriodic whether the direction is periodic
   //! @return cell index (0..2) or -1 if not found
   static int locateCellDir(double        theParam,
                            const int*    theSpanIdx,
                            const double* theSpanStart,
-                           const double* theSpanEnd,
+                           const double* theSpanLength,
                            int           theSpanMax,
                            double        theFirst,
                            double        theLast,
@@ -118,7 +118,7 @@ private:
                             const NCollection_Array1<double>& theFlatKnots,
                             int*                              theCellSpanIndex,
                             double*                           theCellSpanStart,
-                            double*                           theCellSpanEnd);
+                            double*                           theCellSpanLength);
 
   //! Compute neighbor span index handling periodicity.
   static int neighborSpanIndex(int  theCenterSpanIndex,
@@ -168,7 +168,11 @@ private:
 
   mutable int    myCellSpanIndexU[THE_GRID_SIZE], myCellSpanIndexV[THE_GRID_SIZE];
   mutable double myCellSpanStartU[THE_GRID_SIZE], myCellSpanStartV[THE_GRID_SIZE];
-  mutable double myCellSpanEndU[THE_GRID_SIZE], myCellSpanEndV[THE_GRID_SIZE];
+  mutable double myCellSpanLengthU[THE_GRID_SIZE], myCellSpanLengthV[THE_GRID_SIZE];
+
+  mutable int myLastCellU;    //!< last-used cell U index (fast-path hint)
+  mutable int myLastCellV;    //!< last-used cell V index (fast-path hint)
+  mutable int myLastCacheIdx; //!< last-used flat cache index
 
   // 3x3 cache: myCache[iU * THE_GRID_SIZE + iV]
   mutable bool myCellValid[THE_GRID_SIZE * THE_GRID_SIZE]; //!< true if built for current span

--- a/src/FoundationClasses/TKMath/BSplSLib/FILES.cmake
+++ b/src/FoundationClasses/TKMath/BSplSLib/FILES.cmake
@@ -8,5 +8,7 @@ set(OCCT_BSplSLib_FILES
   BSplSLib_BzSyntaxes.cxx
   BSplSLib_Cache.cxx
   BSplSLib_Cache.hxx
+  BSplSLib_CacheGrid.cxx
+  BSplSLib_CacheGrid.hxx
   BSplSLib_EvaluatorFunction.hxx
 )

--- a/src/FoundationClasses/TKMath/GTests/BSplCLib_CacheGrid_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/BSplCLib_CacheGrid_Test.cxx
@@ -1,0 +1,425 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BSplCLib.hxx>
+#include <BSplCLib_Cache.hxx>
+#include <BSplCLib_CacheGrid.hxx>
+
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec.hxx>
+#include <gp_Vec2d.hxx>
+
+#include <NCollection_Array1.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr double THE_TOLERANCE = 1e-10;
+}
+
+//==================================================================================================
+// Test fixture
+//==================================================================================================
+
+class BSplCLib_CacheGridTest : public ::testing::Test
+{
+protected:
+  //! Creates flat knots array from knots and multiplicities
+  void createFlatKnots(const NCollection_Array1<double>& theKnots,
+                       const NCollection_Array1<int>&    theMults,
+                       NCollection_Array1<double>&       theFlatKnots) const
+  {
+    int aFlatIndex = theFlatKnots.Lower();
+    for (int i = theKnots.Lower(); i <= theKnots.Upper(); ++i)
+    {
+      for (int j = 0; j < theMults(i); ++j)
+      {
+        theFlatKnots(aFlatIndex++) = theKnots(i);
+      }
+    }
+  }
+
+  //! Setup a multi-span cubic B-spline with 3 spans: [0,1], [1,2], [2,3]
+  void setupMultiSpan3D(NCollection_Array1<gp_Pnt>& thePoles,
+                        NCollection_Array1<double>& theKnots,
+                        NCollection_Array1<int>&    theMults,
+                        NCollection_Array1<double>& theFlatKnots,
+                        int&                        theDegree) const
+  {
+    theDegree = 3;
+    // 6 poles for a cubic with 3 interior spans (knots 0, 1, 2, 3)
+    thePoles.Resize(1, 6, false);
+    thePoles(1) = gp_Pnt(0, 0, 0);
+    thePoles(2) = gp_Pnt(0.5, 1, 0);
+    thePoles(3) = gp_Pnt(1.5, 1.5, 0);
+    thePoles(4) = gp_Pnt(2.0, 0.5, 1);
+    thePoles(5) = gp_Pnt(2.5, -0.5, 0.5);
+    thePoles(6) = gp_Pnt(3, 0, 0);
+
+    theKnots.Resize(1, 4, false);
+    theKnots(1) = 0.0;
+    theKnots(2) = 1.0;
+    theKnots(3) = 2.0;
+    theKnots(4) = 3.0;
+
+    theMults.Resize(1, 4, false);
+    theMults(1) = 4; // degree+1 at ends
+    theMults(2) = 1;
+    theMults(3) = 1;
+    theMults(4) = 4;
+
+    // Total flat knots = 4 + 1 + 1 + 4 = 10
+    theFlatKnots.Resize(1, 10, false);
+    createFlatKnots(theKnots, theMults, theFlatKnots);
+  }
+
+  //! Setup a multi-span quadratic 2D B-spline
+  void setupMultiSpan2D(NCollection_Array1<gp_Pnt2d>& thePoles,
+                        NCollection_Array1<double>&   theFlatKnots,
+                        int&                          theDegree) const
+  {
+    theDegree = 2;
+    thePoles.Resize(1, 5, false);
+    thePoles(1) = gp_Pnt2d(0, 0);
+    thePoles(2) = gp_Pnt2d(1, 2);
+    thePoles(3) = gp_Pnt2d(2, 1);
+    thePoles(4) = gp_Pnt2d(3, 3);
+    thePoles(5) = gp_Pnt2d(4, 0);
+
+    NCollection_Array1<double> aKnots(1, 4);
+    aKnots(1) = 0.0;
+    aKnots(2) = 1.0;
+    aKnots(3) = 2.0;
+    aKnots(4) = 3.0;
+
+    NCollection_Array1<int> aMults(1, 4);
+    aMults(1) = 3; // degree+1
+    aMults(2) = 1;
+    aMults(3) = 1;
+    aMults(4) = 3;
+
+    // Total = 3 + 1 + 1 + 3 = 8
+    theFlatKnots.Resize(1, 8, false);
+    createFlatKnots(aKnots, aMults, theFlatKnots);
+  }
+};
+
+//==================================================================================================
+// D0 correctness - compare grid vs single cache
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, D0_MatchesSingleCache_3D)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.1)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+    gp_Pnt aGridPnt, aSinglePnt;
+    aGrid->D0(u, aGridPnt);
+    aSingleCache->D0(u, aSinglePnt);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "at u=" << u;
+    EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE) << "at u=" << u;
+    EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE) << "at u=" << u;
+  }
+}
+
+TEST_F(BSplCLib_CacheGridTest, D0_MatchesSingleCache_2D)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles;
+  NCollection_Array1<double>   aFlatKnots;
+  int                          aDeg = 0;
+  setupMultiSpan2D(aPoles, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.1)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+    gp_Pnt2d aGridPnt, aSinglePnt;
+    aGrid->D0(u, aGridPnt);
+    aSingleCache->D0(u, aSinglePnt);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "at u=" << u;
+    EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE) << "at u=" << u;
+  }
+}
+
+//==================================================================================================
+// D1 correctness
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, D1_MatchesSingleCache_3D)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.15)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+    gp_Pnt aGridPnt, aSinglePnt;
+    gp_Vec aGridTan, aSingleTan;
+    aGrid->D1(u, aGridPnt, aGridTan);
+    aSingleCache->D1(u, aSinglePnt, aSingleTan);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "D1 point at u=" << u;
+    EXPECT_NEAR(aGridTan.X(), aSingleTan.X(), THE_TOLERANCE) << "D1 tangent at u=" << u;
+    EXPECT_NEAR(aGridTan.Y(), aSingleTan.Y(), THE_TOLERANCE) << "D1 tangent at u=" << u;
+    EXPECT_NEAR(aGridTan.Z(), aSingleTan.Z(), THE_TOLERANCE) << "D1 tangent at u=" << u;
+  }
+}
+
+//==================================================================================================
+// D2 correctness
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, D2_MatchesSingleCache_3D)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.2)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+    gp_Pnt aGridPnt, aSinglePnt;
+    gp_Vec aGridD1, aSingleD1, aGridD2, aSingleD2;
+    aGrid->D2(u, aGridPnt, aGridD1, aGridD2);
+    aSingleCache->D2(u, aSinglePnt, aSingleD1, aSingleD2);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "D2 point at u=" << u;
+    EXPECT_NEAR(aGridD2.X(), aSingleD2.X(), THE_TOLERANCE) << "D2 curvature at u=" << u;
+    EXPECT_NEAR(aGridD2.Y(), aSingleD2.Y(), THE_TOLERANCE) << "D2 curvature at u=" << u;
+    EXPECT_NEAR(aGridD2.Z(), aSingleD2.Z(), THE_TOLERANCE) << "D2 curvature at u=" << u;
+  }
+}
+
+//==================================================================================================
+// D3 correctness
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, D3_MatchesSingleCache_3D)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.25)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+    gp_Pnt aGridPnt, aSinglePnt;
+    gp_Vec aGridD1, aSingleD1, aGridD2, aSingleD2, aGridD3, aSingleD3;
+    aGrid->D3(u, aGridPnt, aGridD1, aGridD2, aGridD3);
+    aSingleCache->D3(u, aSinglePnt, aSingleD1, aSingleD2, aSingleD3);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "D3 point at u=" << u;
+    EXPECT_NEAR(aGridD3.X(), aSingleD3.X(), THE_TOLERANCE) << "D3 torsion at u=" << u;
+    EXPECT_NEAR(aGridD3.Y(), aSingleD3.Y(), THE_TOLERANCE) << "D3 torsion at u=" << u;
+    EXPECT_NEAR(aGridD3.Z(), aSingleD3.Z(), THE_TOLERANCE) << "D3 torsion at u=" << u;
+  }
+}
+
+//==================================================================================================
+// Grid shift / span boundary crossing test
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, SpanBoundary_Oscillation)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  // First evaluate at center to set up the grid around span boundary 1.0
+  gp_Pnt aDummyPnt;
+  aGrid->D0(1.5, aDummyPnt);
+
+  // Oscillate near span boundary at u=1.0
+  const double aParams[] = {0.95, 1.05, 0.98, 1.02, 0.99, 1.01, 1.0};
+  for (double u : aParams)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+    gp_Pnt aGridPnt, aSinglePnt;
+    aGrid->D0(u, aGridPnt);
+    aSingleCache->D0(u, aSinglePnt);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "Oscillation at u=" << u;
+    EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE) << "Oscillation at u=" << u;
+    EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE) << "Oscillation at u=" << u;
+  }
+}
+
+//==================================================================================================
+// Single-span curve (Bezier-like BSpline)
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, SingleSpan_D0)
+{
+  // Cubic Bezier has 1 span
+  NCollection_Array1<gp_Pnt> aPoles(1, 4);
+  aPoles(1) = gp_Pnt(0, 0, 0);
+  aPoles(2) = gp_Pnt(1, 2, 0);
+  aPoles(3) = gp_Pnt(2, 2, 0);
+  aPoles(4) = gp_Pnt(3, 0, 0);
+
+  NCollection_Array1<double> aFlatKnots(1, 8);
+  for (int i = 1; i <= 4; ++i)
+    aFlatKnots(i) = 0.0;
+  for (int i = 5; i <= 8; ++i)
+    aFlatKnots(i) = 1.0;
+
+  const int aDeg = 3;
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+  aSingleCache->BuildCache(0.5, aFlatKnots, aPoles, nullptr);
+
+  for (double u = 0.0; u <= 1.0; u += 0.1)
+  {
+    gp_Pnt aGridPnt, aSinglePnt;
+    aGrid->D0(u, aGridPnt);
+    aSingleCache->D0(u, aSinglePnt);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE);
+    EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE);
+    EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE);
+  }
+}
+
+//==================================================================================================
+// Grid shift when parameter leaves all cells
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, GridShift_LargeJump)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, nullptr);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, nullptr);
+
+  // Build at start (center span = [0,1])
+  // Jump to far end, requiring full grid rebuild
+  const double u = 2.8;
+  aSingleCache->BuildCache(u, aFlatKnots, aPoles, nullptr);
+
+  gp_Pnt aGridPnt, aSinglePnt;
+  aGrid->D0(u, aGridPnt);
+  aSingleCache->D0(u, aSinglePnt);
+
+  EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE);
+  EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE);
+  EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE);
+}
+
+//==================================================================================================
+// Rational (weighted) curve test
+//==================================================================================================
+
+TEST_F(BSplCLib_CacheGridTest, D0_RationalCurve_MatchesSingleCache)
+{
+  NCollection_Array1<gp_Pnt> aPoles;
+  NCollection_Array1<double> aKnots, aFlatKnots;
+  NCollection_Array1<int>    aMults;
+  int                        aDeg = 0;
+  setupMultiSpan3D(aPoles, aKnots, aMults, aFlatKnots, aDeg);
+
+  NCollection_Array1<double> aWeights(1, 6);
+  aWeights(1) = 1.0;
+  aWeights(2) = 2.0;
+  aWeights(3) = 1.5;
+  aWeights(4) = 0.5;
+  aWeights(5) = 1.0;
+  aWeights(6) = 1.0;
+
+  occ::handle<BSplCLib_CacheGrid> aGrid =
+    new BSplCLib_CacheGrid(aDeg, false, aFlatKnots, aPoles, &aWeights);
+  occ::handle<BSplCLib_Cache> aSingleCache =
+    new BSplCLib_Cache(aDeg, false, aFlatKnots, aPoles, &aWeights);
+
+  for (double u = 0.0; u <= 3.0; u += 0.15)
+  {
+    if (!aSingleCache->IsCacheValid(u))
+      aSingleCache->BuildCache(u, aFlatKnots, aPoles, &aWeights);
+
+    gp_Pnt aGridPnt, aSinglePnt;
+    aGrid->D0(u, aGridPnt);
+    aSingleCache->D0(u, aSinglePnt);
+
+    EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "Rational D0 at u=" << u;
+    EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE) << "Rational D0 at u=" << u;
+    EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE) << "Rational D0 at u=" << u;
+  }
+}

--- a/src/FoundationClasses/TKMath/GTests/BSplSLib_CacheGrid_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/BSplSLib_CacheGrid_Test.cxx
@@ -1,0 +1,266 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BSplCLib.hxx>
+#include <BSplSLib_Cache.hxx>
+#include <BSplSLib_CacheGrid.hxx>
+
+#include <gp_Pnt.hxx>
+#include <gp_Vec.hxx>
+
+#include <NCollection_Array1.hxx>
+#include <NCollection_Array2.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr double THE_TOLERANCE = 1e-10;
+}
+
+//==================================================================================================
+// Test fixture
+//==================================================================================================
+
+class BSplSLib_CacheGridTest : public ::testing::Test
+{
+protected:
+  //! Creates flat knots array from knots and multiplicities
+  void createFlatKnots(const NCollection_Array1<double>& theKnots,
+                       const NCollection_Array1<int>&    theMults,
+                       NCollection_Array1<double>&       theFlatKnots) const
+  {
+    int aFlatIndex = theFlatKnots.Lower();
+    for (int i = theKnots.Lower(); i <= theKnots.Upper(); ++i)
+    {
+      for (int j = 0; j < theMults(i); ++j)
+      {
+        theFlatKnots(aFlatIndex++) = theKnots(i);
+      }
+    }
+  }
+
+  //! Setup a biquadratic B-spline surface with multiple spans in both U and V.
+  //! U: 3 spans [0,1], [1,2], [2,3]
+  //! V: 2 spans [0,1], [1,2]
+  void setupMultiSpanSurface(NCollection_Array2<gp_Pnt>& thePoles,
+                             NCollection_Array1<double>& theFlatKnotsU,
+                             NCollection_Array1<double>& theFlatKnotsV,
+                             int&                        theDegreeU,
+                             int&                        theDegreeV) const
+  {
+    theDegreeU = 2;
+    theDegreeV = 2;
+
+    // 4 poles in U x 4 poles in V
+    thePoles.Resize(1, 4, 1, 4, false);
+    thePoles(1, 1) = gp_Pnt(0, 0, 0);
+    thePoles(2, 1) = gp_Pnt(1, 0, 1);
+    thePoles(3, 1) = gp_Pnt(2, 0, 0.5);
+    thePoles(4, 1) = gp_Pnt(3, 0, 0);
+    thePoles(1, 2) = gp_Pnt(0, 0.7, 1);
+    thePoles(2, 2) = gp_Pnt(1, 0.7, 2);
+    thePoles(3, 2) = gp_Pnt(2, 0.7, 1.5);
+    thePoles(4, 2) = gp_Pnt(3, 0.7, 1);
+    thePoles(1, 3) = gp_Pnt(0, 1.3, 0.5);
+    thePoles(2, 3) = gp_Pnt(1, 1.3, 1.5);
+    thePoles(3, 3) = gp_Pnt(2, 1.3, 1.0);
+    thePoles(4, 3) = gp_Pnt(3, 1.3, 0.5);
+    thePoles(1, 4) = gp_Pnt(0, 2, 0);
+    thePoles(2, 4) = gp_Pnt(1, 2, 0.5);
+    thePoles(3, 4) = gp_Pnt(2, 2, 0);
+    thePoles(4, 4) = gp_Pnt(3, 2, 0);
+
+    // U knots: 0, 1, 2, 3 with mults 3,1,1,3 -> flat: 0,0,0,1,2,3,3,3
+    NCollection_Array1<double> aKnotsU(1, 4);
+    aKnotsU(1) = 0.0;
+    aKnotsU(2) = 1.0;
+    aKnotsU(3) = 2.0;
+    aKnotsU(4) = 3.0;
+    NCollection_Array1<int> aMultsU(1, 4);
+    aMultsU(1) = 3;
+    aMultsU(2) = 1;
+    aMultsU(3) = 1;
+    aMultsU(4) = 3;
+    theFlatKnotsU.Resize(1, 8, false);
+    createFlatKnots(aKnotsU, aMultsU, theFlatKnotsU);
+
+    // V knots: 0, 1, 2 with mults 3,1,3 -> flat: [0,0,0,1,2,2,2] -> 7 flat knots
+    NCollection_Array1<double> aKnotsV(1, 3);
+    aKnotsV(1) = 0.0;
+    aKnotsV(2) = 1.0;
+    aKnotsV(3) = 2.0;
+    NCollection_Array1<int> aMultsV(1, 3);
+    aMultsV(1) = 3;
+    aMultsV(2) = 1;
+    aMultsV(3) = 3;
+    theFlatKnotsV.Resize(1, 7, false);
+    createFlatKnots(aKnotsV, aMultsV, theFlatKnotsV);
+  }
+};
+
+//==================================================================================================
+// D0 correctness
+//==================================================================================================
+
+TEST_F(BSplSLib_CacheGridTest, D0_MatchesSingleCache)
+{
+  NCollection_Array2<gp_Pnt> aPoles;
+  NCollection_Array1<double> aFlatKnotsU, aFlatKnotsV;
+  int                        aDegU = 0, aDegV = 0;
+  setupMultiSpanSurface(aPoles, aFlatKnotsU, aFlatKnotsV, aDegU, aDegV);
+
+  occ::handle<BSplSLib_CacheGrid> aGrid =
+    new BSplSLib_CacheGrid(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, aPoles, nullptr);
+  occ::handle<BSplSLib_Cache> aSingleCache =
+    new BSplSLib_Cache(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.5)
+  {
+    for (double v = 0.0; v <= 2.0; v += 0.5)
+    {
+      if (!aSingleCache->IsCacheValid(u, v))
+        aSingleCache->BuildCache(u, v, aFlatKnotsU, aFlatKnotsV, aPoles, nullptr);
+
+      gp_Pnt aGridPnt, aSinglePnt;
+      aGrid->D0(u, v, aGridPnt);
+      aSingleCache->D0(u, v, aSinglePnt);
+
+      EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE) << "D0 at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE) << "D0 at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE) << "D0 at u=" << u << " v=" << v;
+    }
+  }
+}
+
+//==================================================================================================
+// D1 correctness
+//==================================================================================================
+
+TEST_F(BSplSLib_CacheGridTest, D1_MatchesSingleCache)
+{
+  NCollection_Array2<gp_Pnt> aPoles;
+  NCollection_Array1<double> aFlatKnotsU, aFlatKnotsV;
+  int                        aDegU = 0, aDegV = 0;
+  setupMultiSpanSurface(aPoles, aFlatKnotsU, aFlatKnotsV, aDegU, aDegV);
+
+  occ::handle<BSplSLib_CacheGrid> aGrid =
+    new BSplSLib_CacheGrid(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, aPoles, nullptr);
+  occ::handle<BSplSLib_Cache> aSingleCache =
+    new BSplSLib_Cache(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, nullptr);
+
+  for (double u = 0.0; u <= 3.0; u += 0.7)
+  {
+    for (double v = 0.0; v <= 2.0; v += 0.7)
+    {
+      if (!aSingleCache->IsCacheValid(u, v))
+        aSingleCache->BuildCache(u, v, aFlatKnotsU, aFlatKnotsV, aPoles, nullptr);
+
+      gp_Pnt aGridPnt, aSinglePnt;
+      gp_Vec aGridDU, aGridDV, aSingleDU, aSingleDV;
+      aGrid->D1(u, v, aGridPnt, aGridDU, aGridDV);
+      aSingleCache->D1(u, v, aSinglePnt, aSingleDU, aSingleDV);
+
+      EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE)
+        << "D1 point at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridDU.X(), aSingleDU.X(), THE_TOLERANCE)
+        << "D1 tangentU at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridDV.Y(), aSingleDV.Y(), THE_TOLERANCE)
+        << "D1 tangentV at u=" << u << " v=" << v;
+    }
+  }
+}
+
+//==================================================================================================
+// D2 correctness
+//==================================================================================================
+
+TEST_F(BSplSLib_CacheGridTest, D2_MatchesSingleCache)
+{
+  NCollection_Array2<gp_Pnt> aPoles;
+  NCollection_Array1<double> aFlatKnotsU, aFlatKnotsV;
+  int                        aDegU = 0, aDegV = 0;
+  setupMultiSpanSurface(aPoles, aFlatKnotsU, aFlatKnotsV, aDegU, aDegV);
+
+  occ::handle<BSplSLib_CacheGrid> aGrid =
+    new BSplSLib_CacheGrid(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, aPoles, nullptr);
+  occ::handle<BSplSLib_Cache> aSingleCache =
+    new BSplSLib_Cache(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, nullptr);
+
+  for (double u = 0.1; u <= 2.9; u += 0.9)
+  {
+    for (double v = 0.1; v <= 1.9; v += 0.9)
+    {
+      if (!aSingleCache->IsCacheValid(u, v))
+        aSingleCache->BuildCache(u, v, aFlatKnotsU, aFlatKnotsV, aPoles, nullptr);
+
+      gp_Pnt aGridPnt, aSinglePnt;
+      gp_Vec aGridDU, aGridDV, aGridD2U, aGridD2V, aGridD2UV;
+      gp_Vec aSingleDU, aSingleDV, aSingleD2U, aSingleD2V, aSingleD2UV;
+      aGrid->D2(u, v, aGridPnt, aGridDU, aGridDV, aGridD2U, aGridD2V, aGridD2UV);
+      aSingleCache->D2(u, v, aSinglePnt, aSingleDU, aSingleDV, aSingleD2U, aSingleD2V, aSingleD2UV);
+
+      EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE)
+        << "D2 point at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridD2U.Z(), aSingleD2U.Z(), THE_TOLERANCE)
+        << "D2 curvatureU at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridD2UV.Z(), aSingleD2UV.Z(), THE_TOLERANCE)
+        << "D2 mixed at u=" << u << " v=" << v;
+    }
+  }
+}
+
+//==================================================================================================
+// Span boundary oscillation
+//==================================================================================================
+
+TEST_F(BSplSLib_CacheGridTest, SpanBoundary_Oscillation)
+{
+  NCollection_Array2<gp_Pnt> aPoles;
+  NCollection_Array1<double> aFlatKnotsU, aFlatKnotsV;
+  int                        aDegU = 0, aDegV = 0;
+  setupMultiSpanSurface(aPoles, aFlatKnotsU, aFlatKnotsV, aDegU, aDegV);
+
+  occ::handle<BSplSLib_CacheGrid> aGrid =
+    new BSplSLib_CacheGrid(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, aPoles, nullptr);
+  occ::handle<BSplSLib_Cache> aSingleCache =
+    new BSplSLib_Cache(aDegU, false, aFlatKnotsU, aDegV, false, aFlatKnotsV, nullptr);
+
+  // First evaluate at center to set up the grid
+  gp_Pnt aDummyPnt;
+  aGrid->D0(1.5, 0.5, aDummyPnt);
+
+  // Oscillate near U=1, V=1 boundary
+  const double aUParams[] = {0.95, 1.05, 0.98, 1.02};
+  const double aVParams[] = {0.95, 1.05, 0.98, 1.02};
+
+  for (double u : aUParams)
+  {
+    for (double v : aVParams)
+    {
+      if (!aSingleCache->IsCacheValid(u, v))
+        aSingleCache->BuildCache(u, v, aFlatKnotsU, aFlatKnotsV, aPoles, nullptr);
+
+      gp_Pnt aGridPnt, aSinglePnt;
+      aGrid->D0(u, v, aGridPnt);
+      aSingleCache->D0(u, v, aSinglePnt);
+
+      EXPECT_NEAR(aGridPnt.X(), aSinglePnt.X(), THE_TOLERANCE)
+        << "Oscillation at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridPnt.Y(), aSinglePnt.Y(), THE_TOLERANCE)
+        << "Oscillation at u=" << u << " v=" << v;
+      EXPECT_NEAR(aGridPnt.Z(), aSinglePnt.Z(), THE_TOLERANCE)
+        << "Oscillation at u=" << u << " v=" << v;
+    }
+  }
+}

--- a/src/FoundationClasses/TKMath/GTests/FILES.cmake
+++ b/src/FoundationClasses/TKMath/GTests/FILES.cmake
@@ -11,8 +11,10 @@ set(OCCT_TKMath_GTests_FILES
   Bnd_Range_Test.cxx
   Bnd_Sphere_Test.cxx
   BSplCLib_Cache_Test.cxx
+  BSplCLib_CacheGrid_Test.cxx
   BSplCLib_Test.cxx
   BSplSLib_Cache_Test.cxx
+  BSplSLib_CacheGrid_Test.cxx
   BSplSLib_Test.cxx
   BVH_BinnedBuilder_Test.cxx
   BVH_Box_Test.cxx

--- a/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
+++ b/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
@@ -27,6 +27,7 @@
 #include <BSplCLib.hxx>
 #include <ElCLib.hxx>
 #include <BSplCLib_Cache.hxx>
+#include <BSplCLib_CacheGrid.hxx>
 #include <Geom2d_BezierCurve.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <Geom2d_Circle.hxx>
@@ -307,7 +308,7 @@ void Geom2dAdaptor_Curve::load(const occ::handle<Geom2d_Curve>& C,
     // Same curve but potentially different parameters - invalidate cache
     if (auto* aBSplineData = std::get_if<BSplineData>(&myCurveData))
     {
-      aBSplineData->Cache.Nullify();
+      aBSplineData->CacheGrid.Nullify();
     }
     else if (auto* aBezierData = std::get_if<BezierData>(&myCurveData))
     {
@@ -589,19 +590,15 @@ void Geom2dAdaptor_Curve::RebuildCache(const double theParameter) const
   }
   else if (myTypeCurve == GeomAbs_BSplineCurve)
   {
-    // Create cache for B-spline
+    // Create cache grid for B-spline
     auto&       aBSplineData = std::get<BSplineData>(myCurveData);
     const auto& aBSpline     = aBSplineData.Curve;
-    if (aBSplineData.Cache.IsNull())
-      aBSplineData.Cache = new BSplCLib_Cache(aBSpline->Degree(),
-                                              aBSpline->IsPeriodic(),
-                                              aBSpline->KnotSequence(),
-                                              aBSpline->Poles(),
-                                              aBSpline->Weights());
-    aBSplineData.Cache->BuildCache(theParameter,
-                                   aBSpline->KnotSequence(),
-                                   aBSpline->Poles(),
-                                   aBSpline->Weights());
+    if (aBSplineData.CacheGrid.IsNull())
+      aBSplineData.CacheGrid = new BSplCLib_CacheGrid(aBSpline->Degree(),
+                                                      aBSpline->IsPeriodic(),
+                                                      aBSpline->KnotSequence(),
+                                                      aBSpline->Poles(),
+                                                      aBSpline->Weights());
   }
 }
 
@@ -685,9 +682,9 @@ void Geom2dAdaptor_Curve::D0(const double U, gp_Pnt2d& P) const
       else
       {
         // use cached data
-        if (aBSplineData.Cache.IsNull() || !aBSplineData.Cache->IsCacheValid(U))
+        if (aBSplineData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplineData.Cache->D0(U, P);
+        aBSplineData.CacheGrid->D0(U, P);
       }
       break;
     }
@@ -750,9 +747,9 @@ void Geom2dAdaptor_Curve::D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const
       else
       {
         // use cached data
-        if (aBSplineData.Cache.IsNull() || !aBSplineData.Cache->IsCacheValid(U))
+        if (aBSplineData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplineData.Cache->D1(U, P, V);
+        aBSplineData.CacheGrid->D1(U, P, V);
       }
       break;
     }
@@ -817,9 +814,9 @@ void Geom2dAdaptor_Curve::D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d
       else
       {
         // use cached data
-        if (aBSplineData.Cache.IsNull() || !aBSplineData.Cache->IsCacheValid(U))
+        if (aBSplineData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplineData.Cache->D2(U, P, V1, V2);
+        aBSplineData.CacheGrid->D2(U, P, V1, V2);
       }
       break;
     }
@@ -891,9 +888,9 @@ void Geom2dAdaptor_Curve::D3(const double U,
       else
       {
         // use cached data
-        if (aBSplineData.Cache.IsNull() || !aBSplineData.Cache->IsCacheValid(U))
+        if (aBSplineData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplineData.Cache->D3(U, P, V1, V2, V3);
+        aBSplineData.CacheGrid->D3(U, P, V1, V2, V3);
       }
       break;
     }

--- a/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.hxx
+++ b/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.hxx
@@ -19,6 +19,7 @@
 
 #include <Adaptor2d_Curve2d.hxx>
 #include <BSplCLib_Cache.hxx>
+#include <BSplCLib_CacheGrid.hxx>
 #include <Geom2d_Curve.hxx>
 #include <GeomAbs_CurveType.hxx>
 #include <GeomAbs_Shape.hxx>
@@ -65,8 +66,8 @@ public:
   //! Internal structure for BSpline curve evaluation data.
   struct BSplineData
   {
-    occ::handle<Geom2d_BSplineCurve>    Curve; //!< BSpline curve to prevent downcasts
-    mutable occ::handle<BSplCLib_Cache> Cache; //!< Cached data for evaluation
+    occ::handle<Geom2d_BSplineCurve>        Curve;     //!< BSpline curve to prevent downcasts
+    mutable occ::handle<BSplCLib_CacheGrid> CacheGrid; //!< Multi-span cached data for evaluation
   };
 
   //! Variant type for 2D curve-specific evaluation data.

--- a/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Curve.cxx
+++ b/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Curve.cxx
@@ -26,6 +26,7 @@
 #include <Adaptor3d_Curve.hxx>
 #include <BSplCLib.hxx>
 #include <BSplCLib_Cache.hxx>
+#include <BSplCLib_CacheGrid.hxx>
 #include <ElCLib.hxx>
 #include <Geom_BezierCurve.hxx>
 #include <Geom_BSplineCurve.hxx>
@@ -270,7 +271,7 @@ void GeomAdaptor_Curve::load(const occ::handle<Geom_Curve>& C,
     // Same curve, but need to invalidate cache if bounds changed
     if (auto* aBSplineData = std::get_if<BSplineData>(&myCurveData))
     {
-      aBSplineData->Cache.Nullify();
+      aBSplineData->CacheGrid.Nullify();
     }
     else if (auto* aBezierData = std::get_if<BezierData>(&myCurveData))
     {
@@ -564,17 +565,16 @@ void GeomAdaptor_Curve::RebuildCache(const double theParameter) const
   }
   else if (myTypeCurve == GeomAbs_BSplineCurve)
   {
-    // Create cache for B-spline
-    auto&       aBSplData = std::get<BSplineData>(myCurveData);
-    const auto& aBSpl     = aBSplData.Curve;
-    auto&       aCache    = aBSplData.Cache;
-    if (aCache.IsNull())
-      aCache = new BSplCLib_Cache(aBSpl->Degree(),
-                                  aBSpl->IsPeriodic(),
-                                  aBSpl->KnotSequence(),
-                                  aBSpl->Poles(),
-                                  aBSpl->Weights());
-    aCache->BuildCache(theParameter, aBSpl->KnotSequence(), aBSpl->Poles(), aBSpl->Weights());
+    // Create cache grid for B-spline
+    auto&       aBSplData  = std::get<BSplineData>(myCurveData);
+    const auto& aBSpl      = aBSplData.Curve;
+    auto&       aCacheGrid = aBSplData.CacheGrid;
+    if (aCacheGrid.IsNull())
+      aCacheGrid = new BSplCLib_CacheGrid(aBSpl->Degree(),
+                                          aBSpl->IsPeriodic(),
+                                          aBSpl->KnotSequence(),
+                                          aBSpl->Poles(),
+                                          aBSpl->Weights());
   }
 }
 
@@ -660,9 +660,9 @@ void GeomAdaptor_Curve::D0(const double U, gp_Pnt& P) const
       else
       {
         // use cached data
-        if (aBSplData.Cache.IsNull() || !aBSplData.Cache->IsCacheValid(U))
+        if (aBSplData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplData.Cache->D0(U, P);
+        aBSplData.CacheGrid->D0(U, P);
       }
       break;
     }
@@ -729,9 +729,9 @@ void GeomAdaptor_Curve::D1(const double U, gp_Pnt& P, gp_Vec& V) const
       else
       {
         // use cached data
-        if (aBSplData.Cache.IsNull() || !aBSplData.Cache->IsCacheValid(U))
+        if (aBSplData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplData.Cache->D1(U, P, V);
+        aBSplData.CacheGrid->D1(U, P, V);
       }
       break;
     }
@@ -800,9 +800,9 @@ void GeomAdaptor_Curve::D2(const double U, gp_Pnt& P, gp_Vec& V1, gp_Vec& V2) co
       else
       {
         // use cached data
-        if (aBSplData.Cache.IsNull() || !aBSplData.Cache->IsCacheValid(U))
+        if (aBSplData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplData.Cache->D2(U, P, V1, V2);
+        aBSplData.CacheGrid->D2(U, P, V1, V2);
       }
       break;
     }
@@ -874,9 +874,9 @@ void GeomAdaptor_Curve::D3(const double U, gp_Pnt& P, gp_Vec& V1, gp_Vec& V2, gp
       else
       {
         // use cached data
-        if (aBSplData.Cache.IsNull() || !aBSplData.Cache->IsCacheValid(U))
+        if (aBSplData.CacheGrid.IsNull())
           RebuildCache(U);
-        aBSplData.Cache->D3(U, P, V1, V2, V3);
+        aBSplData.CacheGrid->D3(U, P, V1, V2, V3);
       }
       break;
     }

--- a/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Curve.hxx
+++ b/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Curve.hxx
@@ -19,6 +19,7 @@
 
 #include <Adaptor3d_Curve.hxx>
 #include <BSplCLib_Cache.hxx>
+#include <BSplCLib_CacheGrid.hxx>
 #include <Geom_Curve.hxx>
 #include <GeomAbs_Shape.hxx>
 #include <gp_Circ.hxx>
@@ -63,8 +64,8 @@ public:
   //! Internal structure for BSpline curve cache data.
   struct BSplineData
   {
-    occ::handle<Geom_BSplineCurve>      Curve; //!< BSpline curve to prevent downcasts
-    mutable occ::handle<BSplCLib_Cache> Cache; //!< Cached data for evaluation
+    occ::handle<Geom_BSplineCurve>          Curve;     //!< BSpline curve to prevent downcasts
+    mutable occ::handle<BSplCLib_CacheGrid> CacheGrid; //!< Multi-span cached data for evaluation
   };
 
   //! Variant type for curve-specific evaluation data.

--- a/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Surface.cxx
+++ b/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Surface.cxx
@@ -32,6 +32,7 @@
 #include <BSplCLib.hxx>
 #include <ElSLib.hxx>
 #include <BSplSLib_Cache.hxx>
+#include <BSplSLib_CacheGrid.hxx>
 #include <CSLib.hxx>
 #include <CSLib_NormalStatus.hxx>
 #include <Geom_BezierSurface.hxx>
@@ -941,23 +942,18 @@ void GeomAdaptor_Surface::RebuildCache(const double theU, const double theV) con
   }
   else if (mySurfaceType == GeomAbs_BSplineSurface)
   {
-    // Create cache for B-spline
+    // Create cache grid for B-spline
     auto&       aBSplData = std::get<BSplineData>(mySurfaceData);
     const auto& aBSpl     = aBSplData.Surface;
-    if (aBSplData.Cache.IsNull())
-      aBSplData.Cache = new BSplSLib_Cache(aBSpl->UDegree(),
-                                           aBSpl->IsUPeriodic(),
-                                           aBSpl->UKnotSequence(),
-                                           aBSpl->VDegree(),
-                                           aBSpl->IsVPeriodic(),
-                                           aBSpl->VKnotSequence(),
-                                           aBSpl->Weights());
-    aBSplData.Cache->BuildCache(theU,
-                                theV,
-                                aBSpl->UKnotSequence(),
-                                aBSpl->VKnotSequence(),
-                                aBSpl->Poles(),
-                                aBSpl->Weights());
+    if (aBSplData.CacheGrid.IsNull())
+      aBSplData.CacheGrid = new BSplSLib_CacheGrid(aBSpl->UDegree(),
+                                                   aBSpl->IsUPeriodic(),
+                                                   aBSpl->UKnotSequence(),
+                                                   aBSpl->VDegree(),
+                                                   aBSpl->IsVPeriodic(),
+                                                   aBSpl->VKnotSequence(),
+                                                   aBSpl->Poles(),
+                                                   aBSpl->Weights());
   }
 }
 
@@ -1000,10 +996,10 @@ void GeomAdaptor_Surface::D0(const double U, const double V, gp_Pnt& P) const
       break;
     }
     case GeomAbs_BSplineSurface: {
-      auto& aCache = std::get<BSplineData>(mySurfaceData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U, V))
+      auto& aCacheGrid = std::get<BSplineData>(mySurfaceData).CacheGrid;
+      if (aCacheGrid.IsNull())
         RebuildCache(U, V);
-      aCache->D0(U, V, P);
+      aCacheGrid->D0(U, V, P);
       break;
     }
 
@@ -1093,9 +1089,9 @@ void GeomAdaptor_Surface::D1(const double U,
         aBSpl->LocalD1(u, v, Ideb, Ifin, IVdeb, IVfin, P, D1U, D1V);
       else
       {
-        if (aBSplData.Cache.IsNull() || !aBSplData.Cache->IsCacheValid(U, V))
+        if (aBSplData.CacheGrid.IsNull())
           RebuildCache(U, V);
-        aBSplData.Cache->D1(U, V, P, D1U, D1V);
+        aBSplData.CacheGrid->D1(U, V, P, D1U, D1V);
       }
       break;
     }
@@ -1192,9 +1188,9 @@ void GeomAdaptor_Surface::D2(const double U,
         aBSpl->LocalD2(u, v, Ideb, Ifin, IVdeb, IVfin, P, D1U, D1V, D2U, D2V, D2UV);
       else
       {
-        if (aBSplData.Cache.IsNull() || !aBSplData.Cache->IsCacheValid(U, V))
+        if (aBSplData.CacheGrid.IsNull())
           RebuildCache(U, V);
-        aBSplData.Cache->D2(U, V, P, D1U, D1V, D2U, D2V, D2UV);
+        aBSplData.CacheGrid->D2(U, V, P, D1U, D1V, D2U, D2V, D2UV);
       }
       break;
     }

--- a/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Surface.hxx
+++ b/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Surface.hxx
@@ -20,6 +20,7 @@
 #include <Adaptor3d_Curve.hxx>
 #include <Adaptor3d_Surface.hxx>
 #include <BSplSLib_Cache.hxx>
+#include <BSplSLib_CacheGrid.hxx>
 #include <GeomAbs_Shape.hxx>
 #include <Geom_Surface.hxx>
 #include <gp_Ax1.hxx>
@@ -84,8 +85,8 @@ public:
   //! Internal structure for BSpline surface cache data.
   struct BSplineData
   {
-    occ::handle<Geom_BSplineSurface>    Surface; //!< BSpline surface to prevent downcasts
-    mutable occ::handle<BSplSLib_Cache> Cache;   //!< Cached data for evaluation
+    occ::handle<Geom_BSplineSurface>        Surface;   //!< BSpline surface to prevent downcasts
+    mutable occ::handle<BSplSLib_CacheGrid> CacheGrid; //!< Multi-span cached data for evaluation
   };
 
   //! Variant type for surface-specific evaluation data.


### PR DESCRIPTION
Introduce BSplCLib_CacheGrid and BSplSLib_CacheGrid classes that maintain a sliding window of 3 (curve) or 3x3 (surface) pre-computed polynomial caches over adjacent knot spans. This eliminates expensive cache rebuilds when evaluation parameters oscillate across span boundaries (e.g. during Newton iterations, intersections, projections).

Key design points:
- O(1) span routing via stored boundary arrays; lazy neighbor loading
- Grid auto-recenters when parameter leaves all cached spans
- All cache objects pre-allocated in constructor; zero heap allocations during evaluation and grid shifts (only BuildCache is called to update polynomial coefficients in existing objects)
- Stores pointers to source data (flat knots, poles, weights) so D0/D1/D2/D3 methods are fully self-contained — no external data passing needed

Integration into GeomAdaptor_Curve, Geom2dAdaptor_Curve, and GeomAdaptor_Surface replaces single BSplCLib_Cache/BSplSLib_Cache with CacheGrid for BSpline geometry. Bezier paths remain unchanged (single span).