### PR TITLE
Modeling Data - Optimize adaptor Bezier cache and grid eval threshold

### DIFF
--- a/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
+++ b/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
@@ -683,7 +683,7 @@ std::optional<gp_Pnt2d> Geom2dAdaptor_Curve::EvalD0(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aBezierData = std::get<BezierData>(myCurveData);
-      if (aBezierData.Cache.IsNull() || !aBezierData.Cache->IsCacheValid(U))
+      if (aBezierData.Cache.IsNull())
         RebuildCache(U);
       aBezierData.Cache->D0(U, P);
       return P;
@@ -762,7 +762,7 @@ std::optional<Geom2d_Curve::ResD1> Geom2dAdaptor_Curve::EvalD1(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aBezierData = std::get<BezierData>(myCurveData);
-      if (aBezierData.Cache.IsNull() || !aBezierData.Cache->IsCacheValid(U))
+      if (aBezierData.Cache.IsNull())
         RebuildCache(U);
       aBezierData.Cache->D1(U, aResult.Point, aResult.D1);
       return aResult;
@@ -844,7 +844,7 @@ std::optional<Geom2d_Curve::ResD2> Geom2dAdaptor_Curve::EvalD2(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aBezierData = std::get<BezierData>(myCurveData);
-      if (aBezierData.Cache.IsNull() || !aBezierData.Cache->IsCacheValid(U))
+      if (aBezierData.Cache.IsNull())
         RebuildCache(U);
       aBezierData.Cache->D2(U, aResult.Point, aResult.D1, aResult.D2);
       return aResult;
@@ -949,7 +949,7 @@ std::optional<Geom2d_Curve::ResD3> Geom2dAdaptor_Curve::EvalD3(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aBezierData = std::get<BezierData>(myCurveData);
-      if (aBezierData.Cache.IsNull() || !aBezierData.Cache->IsCacheValid(U))
+      if (aBezierData.Cache.IsNull())
         RebuildCache(U);
       aBezierData.Cache->D3(U, aResult.Point, aResult.D1, aResult.D2, aResult.D3);
       return aResult;

--- a/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Curve.cxx
+++ b/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Curve.cxx
@@ -657,7 +657,7 @@ std::optional<gp_Pnt> GeomAdaptor_Curve::EvalD0(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aCache = std::get<BezierData>(myCurveData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U))
+      if (aCache.IsNull())
         RebuildCache(U);
       aCache->D0(U, P);
       return P;
@@ -737,7 +737,7 @@ std::optional<Geom_Curve::ResD1> GeomAdaptor_Curve::EvalD1(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aCache = std::get<BezierData>(myCurveData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U))
+      if (aCache.IsNull())
         RebuildCache(U);
       aCache->D1(U, aResult.Point, aResult.D1);
       return aResult;
@@ -820,7 +820,7 @@ std::optional<Geom_Curve::ResD2> GeomAdaptor_Curve::EvalD2(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aCache = std::get<BezierData>(myCurveData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U))
+      if (aCache.IsNull())
         RebuildCache(U);
       aCache->D2(U, aResult.Point, aResult.D1, aResult.D2);
       return aResult;
@@ -922,7 +922,7 @@ std::optional<Geom_Curve::ResD3> GeomAdaptor_Curve::EvalD3(double U) const
 
     case GeomAbs_BezierCurve: {
       auto& aCache = std::get<BezierData>(myCurveData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U))
+      if (aCache.IsNull())
         RebuildCache(U);
       aCache->D3(U, aResult.Point, aResult.D1, aResult.D2, aResult.D3);
       return aResult;

--- a/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Surface.cxx
+++ b/src/ModelingData/TKG3d/GeomAdaptor/GeomAdaptor_Surface.cxx
@@ -1016,7 +1016,7 @@ std::optional<gp_Pnt> GeomAdaptor_Surface::EvalD0(double U, double V) const
 
     case GeomAbs_BezierSurface: {
       auto& aCache = std::get<BezierData>(mySurfaceData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U, V))
+      if (aCache.IsNull())
         RebuildCache(U, V);
       aCache->D0(U, V, P);
       return P;
@@ -1124,7 +1124,7 @@ std::optional<Geom_Surface::ResD1> GeomAdaptor_Surface::EvalD1(double U, double 
 
     case GeomAbs_BezierSurface: {
       auto& aCache = std::get<BezierData>(mySurfaceData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U, V))
+      if (aCache.IsNull())
         RebuildCache(U, V);
       aCache->D1(U, V, aResult.Point, aResult.D1U, aResult.D1V);
       return aResult;
@@ -1286,7 +1286,7 @@ std::optional<Geom_Surface::ResD2> GeomAdaptor_Surface::EvalD2(double U, double 
 
     case GeomAbs_BezierSurface: {
       auto& aCache = std::get<BezierData>(mySurfaceData).Cache;
-      if (aCache.IsNull() || !aCache->IsCacheValid(U, V))
+      if (aCache.IsNull())
         RebuildCache(U, V);
       aCache
         ->D2(U, V, aResult.Point, aResult.D1U, aResult.D1V, aResult.D2U, aResult.D2V, aResult.D2UV);

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineCurve.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineCurve.cxx
@@ -22,7 +22,7 @@ namespace
 {
 
 //! Threshold for using cache vs direct evaluation.
-constexpr int THE_CACHE_THRESHOLD = 4;
+constexpr int THE_CACHE_THRESHOLD = 2;
 
 //! Helper structure holding extracted B-spline curve data.
 struct CurveData

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
@@ -24,7 +24,7 @@ namespace
 
 //! Threshold for using cache vs direct evaluation.
 //! For small spans (few points), direct BSplSLib evaluation is faster than building cache.
-constexpr int THE_CACHE_THRESHOLD = 4;
+constexpr int THE_CACHE_THRESHOLD = 2;
 
 //! Helper structure holding extracted B-spline surface data.
 struct SurfaceData


### PR DESCRIPTION
Remove redundant IsCacheValid() checks for Bezier curves and surfaces in EvalD0/D1/D2/D3 methods. Bezier geometry has a single span, so the cache is always valid once constructed, unlike multi-span B-splines.

Lower THE_CACHE_THRESHOLD from 4 to 2 in GeomGridEval B-spline evaluators to use cache-based evaluation more aggressively.