### PR TITLE
Modeling Algorithms - CPU performance optimizations for Draw display and Bop

### DIFF
--- a/src/Draw/TKDraw/Draw/Draw_Window.hxx
+++ b/src/Draw/TKDraw/Draw/Draw_Window.hxx
@@ -34,6 +34,14 @@ struct Draw_XSegment
 {
   NCollection_Vec2<short> Points[2]; // same as XSegment
 
+  Draw_XSegment() = default;
+
+  Draw_XSegment(short theXStart, short theYStart, short theXEnd, short theYEnd)
+      : Points{NCollection_Vec2<short>(theXStart, theYStart),
+               NCollection_Vec2<short>(theXEnd, theYEnd)}
+  {
+  }
+
   NCollection_Vec2<short>& operator[](int theIndex) { return Points[theIndex]; }
 
   const NCollection_Vec2<short>& operator[](int theIndex) const { return Points[theIndex]; }

--- a/tests/boolean/bopcommon_complex/D1
+++ b/tests/boolean/bopcommon_complex/D1
@@ -7,3 +7,6 @@ bopcommon result
 
 checkprops result -s 152908
 checkview -display result -2d -otherwise { sh_2 sh_1 } -s -path ${imagedir}/${test_image}.png
+
+# test boolean bopcommon_complex D1 -echo
+


### PR DESCRIPTION
Draw segment batching: replace fixed-size `Draw_XSegment[1000]` array with `std::vector` to eliminate forced flushes every 1000 segments. Add constructor to `Draw_XSegment` for in-place construction via `emplace_back`. Remove dead `#else` code path in `DrawTo`.

Boolean IsClosedFF caching: pre-compute edge closedness per face into `NCollection_DataMap` before the 4-level nested edge loop in `BOPAlgo_PaveFiller::PerformFF`, reducing O(N1*N2) calls to O(N1+N2) pre-computation with O(1) lookups.

Boolean IsInside edge bounds caching: pre-compute `TopExp::MapShapes` edge maps per solid in `BOPAlgo_BuilderSolid::PerformAreas` before the hole-matching loop, avoiding redundant topology traversal when the same solid is checked against multiple hole shells.