### PR TITLE
Modeling Data - Add lazy evaluation cache to Bezier curves and surface

### DIFF
--- a/src/ModelingData/TKG2d/Geom2d/Geom2d_BezierCurve.hxx
+++ b/src/ModelingData/TKG2d/Geom2d/Geom2d_BezierCurve.hxx
@@ -25,6 +25,9 @@
 #include <GeomAbs_Shape.hxx>
 #include <BSplCLib.hxx>
 
+#include <atomic>
+
+class BSplCLib_Cache;
 class gp_Trsf2d;
 class Geom2d_Geometry;
 
@@ -340,9 +343,15 @@ protected:
             const NCollection_Array1<double>*   theWeights);
 
 private:
+  //! Builds the evaluation cache for this Bezier curve.
+  //! @return the newly built cache handle
+  Handle(BSplCLib_Cache) buildEvalCache() const;
+
   NCollection_Array1<gp_Pnt2d>               myPoles;
   NCollection_Array1<double>                 myWeights;
   occ::handle<Geom2d_EvalRepCurveDesc::Base> myEvalRep;
+  mutable Handle(BSplCLib_Cache)             myEvalCache;
+  mutable std::atomic<bool>                  myEvalCacheBuilding{false};
   bool                                       myRational      = false;
   bool                                       myClosed        = false;
   double                                     myMaxDerivInv   = 0.0;

--- a/src/ModelingData/TKG3d/Geom/Geom_BezierCurve.hxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BezierCurve.hxx
@@ -25,6 +25,9 @@
 #include <GeomAbs_Shape.hxx>
 #include <BSplCLib.hxx>
 
+#include <atomic>
+
+class BSplCLib_Cache;
 class gp_Trsf;
 class Geom_Geometry;
 
@@ -357,9 +360,15 @@ protected:
             const NCollection_Array1<double>* theWeights);
 
 private:
+  //! Builds the evaluation cache for this Bezier curve.
+  //! @return the newly built cache handle
+  Handle(BSplCLib_Cache) buildEvalCache() const;
+
   NCollection_Array1<gp_Pnt>               myPoles;
   NCollection_Array1<double>               myWeights;
   occ::handle<Geom_EvalRepCurveDesc::Base> myEvalRep;
+  mutable Handle(BSplCLib_Cache)           myEvalCache;
+  mutable std::atomic<bool>                myEvalCacheBuilding{false};
   bool                                     myRational      = false;
   bool                                     myClosed        = false;
   double                                   myMaxDerivInv   = 0.0;

--- a/src/ModelingData/TKG3d/Geom/Geom_BezierSurface.hxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BezierSurface.hxx
@@ -26,6 +26,9 @@
 #include <GeomAbs_Shape.hxx>
 #include <BSplSLib.hxx>
 
+#include <atomic>
+
+class BSplSLib_Cache;
 class Geom_Curve;
 class gp_Trsf;
 class Geom_Geometry;
@@ -630,9 +633,15 @@ protected:
             const NCollection_Array2<double>* theWeights);
 
 private:
+  //! Builds the evaluation cache for this Bezier surface.
+  //! @return the newly built cache handle
+  Handle(BSplSLib_Cache) buildEvalCache() const;
+
   NCollection_Array2<gp_Pnt>                 myPoles;
   NCollection_Array2<double>                 myWeights;
   occ::handle<Geom_EvalRepSurfaceDesc::Base> myEvalRep;
+  mutable Handle(BSplSLib_Cache)             myEvalCache;
+  mutable std::atomic<bool>                  myEvalCacheBuilding{false};
   bool                                       myURational     = false;
   bool                                       myVRational     = false;
   double                                     myUMaxDerivInv  = 0.0;


### PR DESCRIPTION
Add Handle(BSplCLib_Cache)/Handle(BSplSLib_Cache) lazy cache with std::atomic<bool> try-lock to Geom_BezierCurve, Geom2d_BezierCurve, and Geom_BezierSurface for EvalD0-D3 methods.

The cache is built on first evaluation and invalidated in all mutators. Concurrent evaluation on the same object is supported: the first thread builds the cache while others fall back to direct BSplCLib/BSplSLib computation. The cache handle is not copied in copy constructors.

Add parallel evaluation GTests using OSD_Parallel to verify thread safety of the cache try-lock pattern for all three classes.