### PR TITLE
Modeling Data - Add BRepProp package for modern BRep differential pro perties

### DIFF
--- a/src/ModelingData/TKBRep/BRepProp/BRepProp_Curve.cxx
+++ b/src/ModelingData/TKBRep/BRepProp/BRepProp_Curve.cxx
@@ -1,0 +1,233 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepProp_Curve.hxx>
+
+#include <gp_Dir.hxx>
+#include <gp_Vec.hxx>
+#include <Precision.hxx>
+#include <Standard_Failure.hxx>
+#include <TopAbs_Orientation.hxx>
+#include <TopoDS_Edge.hxx>
+
+//==================================================================================================
+
+void BRepProp_Curve::Initialize(const TopoDS_Edge& theEdge)
+{
+  if (theEdge.IsNull())
+  {
+    myOwned.Nullify();
+    myPtr = nullptr;
+    return;
+  }
+  myOwned = new BRepAdaptor_Curve(theEdge);
+  myPtr   = myOwned.get();
+}
+
+//==================================================================================================
+
+void BRepProp_Curve::Initialize(const BRepAdaptor_Curve& theCurve)
+{
+  myOwned.Nullify();
+  myPtr = &theCurve;
+}
+
+//==================================================================================================
+
+void BRepProp_Curve::Initialize(const occ::handle<BRepAdaptor_Curve>& theCurve)
+{
+  myOwned = theCurve;
+  myPtr   = myOwned.get();
+}
+
+//==================================================================================================
+
+GeomProp::TangentResult BRepProp_Curve::Tangent(const double theParam, const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {{}, false};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1, aD2, aD3;
+  myPtr->D3(theParam, aPnt, aD1, aD2, aD3);
+  return GeomProp::ComputeTangent(aD1, aD2, aD3, theTol);
+}
+
+//==================================================================================================
+
+GeomProp::CurvatureResult BRepProp_Curve::Curvature(const double theParam,
+                                                    const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1, aD2;
+  myPtr->D2(theParam, aPnt, aD1, aD2);
+  return GeomProp::ComputeCurvature(aD1, aD2, theTol);
+}
+
+//==================================================================================================
+
+GeomProp::NormalResult BRepProp_Curve::Normal(const double theParam, const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {{}, false};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1, aD2;
+  myPtr->D2(theParam, aPnt, aD1, aD2);
+  return GeomProp::ComputeNormal(aD1, aD2, theTol);
+}
+
+//==================================================================================================
+
+GeomProp::CentreResult BRepProp_Curve::CentreOfCurvature(const double theParam,
+                                                         const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {{}, false};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1, aD2;
+  myPtr->D2(theParam, aPnt, aD1, aD2);
+  return GeomProp::ComputeCentreOfCurvature(aPnt, aD1, aD2, theTol);
+}
+
+//==================================================================================================
+
+GeomAbs_Shape BRepProp_Curve::Continuity(const BRepAdaptor_Curve& theCurve1,
+                                         const BRepAdaptor_Curve& theCurve2,
+                                         const double             theU1,
+                                         const double             theU2,
+                                         const double             theTolLinear,
+                                         const double             theTolAngular)
+{
+  GeomAbs_Shape aCont     = GeomAbs_C0;
+  bool          isChecked = false;
+
+  // Determine maximum derivative order for each curve.
+  const GeomAbs_Shape aCont1 = theCurve1.Continuity();
+  const GeomAbs_Shape aCont2 = theCurve2.Continuity();
+  int                 aN1    = 0;
+  int                 aN2    = 0;
+  if (aCont1 >= 5)
+    aN1 = 3;
+  else if (aCont1 == 4)
+    aN1 = 2;
+  else if (aCont1 == 2)
+    aN1 = 1;
+  if (aCont2 >= 5)
+    aN2 = 3;
+  else if (aCont2 == 4)
+    aN2 = 2;
+  else if (aCont2 == 2)
+    aN2 = 1;
+
+  // Evaluate properties at junction points.
+  BRepProp_Curve aProp1, aProp2;
+  aProp1.Initialize(theCurve1);
+  aProp2.Initialize(theCurve2);
+
+  // Check point coincidence.
+  gp_Pnt aPnt1, aPnt2;
+  gp_Vec aD1_1, aD1_2;
+  theCurve1.D1(theU1, aPnt1, aD1_1);
+  theCurve2.D1(theU2, aPnt2, aD1_2);
+  if (!aPnt1.IsEqual(aPnt2, theTolLinear))
+  {
+    throw Standard_Failure("Curves not connected");
+  }
+
+  const int aMinOrder = std::min(aN1, aN2);
+  if (aMinOrder >= 1)
+  {
+    // Account for edge orientation.
+    gp_Vec aVec1 = aD1_1;
+    gp_Vec aVec2 = aD1_2;
+    if (theCurve1.Edge().Orientation() == TopAbs_REVERSED)
+      aVec1.Reverse();
+    if (theCurve2.Edge().Orientation() == TopAbs_REVERSED)
+      aVec2.Reverse();
+
+    if (aVec1.IsEqual(aVec2, theTolLinear, theTolAngular))
+    {
+      aCont = GeomAbs_C1;
+    }
+    else
+    {
+      // Check G1 continuity via tangent directions.
+      const GeomProp::TangentResult aTan1 = aProp1.Tangent(theU1, theTolLinear);
+      const GeomProp::TangentResult aTan2 = aProp2.Tangent(theU2, theTolLinear);
+      if (aTan1.IsDefined && aTan2.IsDefined)
+      {
+        gp_Dir aDir1 = aTan1.Direction;
+        gp_Dir aDir2 = aTan2.Direction;
+        if (theCurve1.Edge().Orientation() == TopAbs_REVERSED)
+          aDir1.Reverse();
+        if (theCurve2.Edge().Orientation() == TopAbs_REVERSED)
+          aDir2.Reverse();
+        if (aDir1.IsEqual(aDir2, theTolAngular))
+        {
+          aCont = GeomAbs_G1;
+        }
+        isChecked = true;
+      }
+      else
+      {
+        isChecked = true;
+      }
+    }
+  }
+
+  if (aMinOrder >= 2 && !isChecked)
+  {
+    // Compare second derivatives.
+    gp_Pnt aDummy;
+    gp_Vec aDummy1, aDummy2;
+    gp_Vec aD2_1, aD2_2;
+    theCurve1.D2(theU1, aDummy, aDummy1, aD2_1);
+    theCurve2.D2(theU2, aDummy, aDummy2, aD2_2);
+    if (aD2_1.IsEqual(aD2_2, theTolLinear, theTolAngular))
+    {
+      aCont = GeomAbs_C2;
+    }
+  }
+
+  // Same periodic edge implies CN.
+  const TopoDS_Edge& anEdge1 = theCurve1.Edge();
+  const TopoDS_Edge& anEdge2 = theCurve2.Edge();
+  if (anEdge1.IsSame(anEdge2) && theCurve1.IsPeriodic() && aCont >= GeomAbs_G1)
+    aCont = GeomAbs_CN;
+
+  return aCont;
+}
+
+//==================================================================================================
+
+GeomAbs_Shape BRepProp_Curve::Continuity(const BRepAdaptor_Curve& theCurve1,
+                                         const BRepAdaptor_Curve& theCurve2,
+                                         const double             theU1,
+                                         const double             theU2)
+{
+  return Continuity(theCurve1,
+                    theCurve2,
+                    theU1,
+                    theU2,
+                    Precision::Confusion(),
+                    Precision::Angular());
+}

--- a/src/ModelingData/TKBRep/BRepProp/BRepProp_Curve.hxx
+++ b/src/ModelingData/TKBRep/BRepProp/BRepProp_Curve.hxx
@@ -1,0 +1,133 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _BRepProp_Curve_HeaderFile
+#define _BRepProp_Curve_HeaderFile
+
+#include <BRepAdaptor_Curve.hxx>
+#include <GeomAbs_Shape.hxx>
+#include <GeomProp.hxx>
+#include <Standard.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+class TopoDS_Edge;
+
+//! @brief Local differential property evaluator for BRep edges.
+//!
+//! Thin wrapper over GeomProp:: free functions.
+//! Delegates derivative computation to BRepAdaptor_Curve and passes
+//! results to GeomProp::ComputeTangent, ComputeCurvature, etc.
+//!
+//! Can be initialized from a TopoDS_Edge or a BRepAdaptor_Curve.
+//! When initialized from an existing BRepAdaptor_Curve, the adaptor is
+//! referenced without copying (non-owning); when initialized from a
+//! TopoDS_Edge, an internal adaptor is created and owned.
+//!
+//! Usage:
+//! @code
+//!   BRepProp_Curve aProp;
+//!   aProp.Initialize(myEdge);
+//!   GeomProp::CurvatureResult aCurv = aProp.Curvature(0.5, Precision::Confusion());
+//!   if (aCurv.IsDefined)
+//!   {
+//!     double aValue = aCurv.Value;
+//!   }
+//! @endcode
+class BRepProp_Curve
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Default constructor - uninitialized state.
+  BRepProp_Curve() = default;
+
+  //! Non-copyable and non-movable.
+  BRepProp_Curve(const BRepProp_Curve&)            = delete;
+  BRepProp_Curve& operator=(const BRepProp_Curve&) = delete;
+  BRepProp_Curve(BRepProp_Curve&&)                 = delete;
+  BRepProp_Curve& operator=(BRepProp_Curve&&)      = delete;
+
+  //! Initialize from a TopoDS_Edge.
+  //! Creates an internal BRepAdaptor_Curve (owning).
+  //! @param[in] theEdge the edge to evaluate
+  Standard_EXPORT void Initialize(const TopoDS_Edge& theEdge);
+
+  //! Initialize from an existing BRepAdaptor_Curve.
+  //! The adaptor is referenced without copying (non-owning);
+  //! the caller must ensure the adaptor outlives this object.
+  //! @param[in] theCurve the adaptor to reference
+  Standard_EXPORT void Initialize(const BRepAdaptor_Curve& theCurve);
+
+  //! Initialize from a handle to BRepAdaptor_Curve.
+  //! Shares ownership of the adaptor (no copy).
+  //! @param[in] theCurve handle to the adaptor
+  Standard_EXPORT void Initialize(const occ::handle<BRepAdaptor_Curve>& theCurve);
+
+  //! Returns true if properly initialized.
+  bool IsInitialized() const { return myPtr != nullptr; }
+
+  //! Returns the underlying adaptor.
+  const BRepAdaptor_Curve& Adaptor() const { return *myPtr; }
+
+  //! Compute tangent at given parameter.
+  //! @param[in] theParam curve parameter
+  //! @param[in] theTol linear tolerance
+  //! @return tangent result with validity flag
+  Standard_EXPORT GeomProp::TangentResult Tangent(double theParam, double theTol) const;
+
+  //! Compute curvature at given parameter.
+  //! @param[in] theParam curve parameter
+  //! @param[in] theTol linear tolerance
+  //! @return curvature result with validity and infinity flags
+  Standard_EXPORT GeomProp::CurvatureResult Curvature(double theParam, double theTol) const;
+
+  //! Compute normal at given parameter.
+  //! @param[in] theParam curve parameter
+  //! @param[in] theTol linear tolerance
+  //! @return normal result with validity flag
+  Standard_EXPORT GeomProp::NormalResult Normal(double theParam, double theTol) const;
+
+  //! Compute centre of curvature at given parameter.
+  //! @param[in] theParam curve parameter
+  //! @param[in] theTol linear tolerance
+  //! @return centre result with validity flag
+  Standard_EXPORT GeomProp::CentreResult CentreOfCurvature(double theParam, double theTol) const;
+
+  //! Computes the regularity at the junction between two curves.
+  //! The point theU1 on theCurve1 and the point theU2 on theCurve2 must be coincident.
+  //! @param[in] theCurve1 first curve adaptor
+  //! @param[in] theCurve2 second curve adaptor
+  //! @param[in] theU1 parameter on theCurve1
+  //! @param[in] theU2 parameter on theCurve2
+  //! @param[in] theTolLinear linear tolerance
+  //! @param[in] theTolAngular angular tolerance
+  //! @return the continuity order (C0, G1, C1, C2, CN)
+  Standard_EXPORT static GeomAbs_Shape Continuity(const BRepAdaptor_Curve& theCurve1,
+                                                  const BRepAdaptor_Curve& theCurve2,
+                                                  double                   theU1,
+                                                  double                   theU2,
+                                                  double                   theTolLinear,
+                                                  double                   theTolAngular);
+
+  //! Same as above but using the standard tolerances from package Precision.
+  Standard_EXPORT static GeomAbs_Shape Continuity(const BRepAdaptor_Curve& theCurve1,
+                                                  const BRepAdaptor_Curve& theCurve2,
+                                                  double                   theU1,
+                                                  double                   theU2);
+
+private:
+  occ::handle<BRepAdaptor_Curve> myOwned; //!< Owns the adaptor when created from TopoDS_Edge.
+  const BRepAdaptor_Curve*       myPtr = nullptr; //!< Non-owning pointer to the active adaptor.
+};
+
+#endif // _BRepProp_Curve_HeaderFile

--- a/src/ModelingData/TKBRep/BRepProp/BRepProp_Surface.cxx
+++ b/src/ModelingData/TKBRep/BRepProp/BRepProp_Surface.cxx
@@ -1,0 +1,94 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepProp_Surface.hxx>
+
+#include <TopoDS_Face.hxx>
+
+//==================================================================================================
+
+void BRepProp_Surface::Initialize(const TopoDS_Face& theFace)
+{
+  if (theFace.IsNull())
+  {
+    myOwned.Nullify();
+    myPtr = nullptr;
+    return;
+  }
+  myOwned = new BRepAdaptor_Surface(theFace);
+  myPtr   = myOwned.get();
+}
+
+//==================================================================================================
+
+void BRepProp_Surface::Initialize(const BRepAdaptor_Surface& theSurface)
+{
+  myOwned.Nullify();
+  myPtr = &theSurface;
+}
+
+//==================================================================================================
+
+void BRepProp_Surface::Initialize(const occ::handle<BRepAdaptor_Surface>& theSurface)
+{
+  myOwned = theSurface;
+  myPtr   = myOwned.get();
+}
+
+//==================================================================================================
+
+GeomProp::SurfaceNormalResult BRepProp_Surface::Normal(const double theU,
+                                                       const double theV,
+                                                       const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {{}, false};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1U, aD1V;
+  myPtr->D1(theU, theV, aPnt, aD1U, aD1V);
+  return GeomProp::ComputeSurfaceNormal(aD1U, aD1V, theTol);
+}
+
+//==================================================================================================
+
+GeomProp::SurfaceCurvatureResult BRepProp_Surface::Curvatures(const double theU,
+                                                              const double theV,
+                                                              const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1U, aD1V, aD2U, aD2V, aD2UV;
+  myPtr->D2(theU, theV, aPnt, aD1U, aD1V, aD2U, aD2V, aD2UV);
+  return GeomProp::ComputeSurfaceCurvatures(aD1U, aD1V, aD2U, aD2V, aD2UV, theTol);
+}
+
+//==================================================================================================
+
+GeomProp::MeanGaussianResult BRepProp_Surface::MeanGaussian(const double theU,
+                                                            const double theV,
+                                                            const double theTol) const
+{
+  if (!IsInitialized())
+  {
+    return {};
+  }
+  gp_Pnt aPnt;
+  gp_Vec aD1U, aD1V, aD2U, aD2V, aD2UV;
+  myPtr->D2(theU, theV, aPnt, aD1U, aD1V, aD2U, aD2V, aD2UV);
+  return GeomProp::ComputeMeanGaussian(aD1U, aD1V, aD2U, aD2V, aD2UV, theTol);
+}

--- a/src/ModelingData/TKBRep/BRepProp/BRepProp_Surface.hxx
+++ b/src/ModelingData/TKBRep/BRepProp/BRepProp_Surface.hxx
@@ -1,0 +1,113 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _BRepProp_Surface_HeaderFile
+#define _BRepProp_Surface_HeaderFile
+
+#include <BRepAdaptor_Surface.hxx>
+#include <GeomProp.hxx>
+#include <Standard.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+class TopoDS_Face;
+
+//! @brief Local differential property evaluator for BRep faces.
+//!
+//! Thin wrapper over GeomProp:: free functions.
+//! Delegates derivative computation to BRepAdaptor_Surface and passes
+//! results to GeomProp::ComputeSurfaceNormal, ComputeSurfaceCurvatures, etc.
+//!
+//! Can be initialized from a TopoDS_Face or a BRepAdaptor_Surface.
+//! When initialized from an existing BRepAdaptor_Surface, the adaptor is
+//! referenced without copying (non-owning); when initialized from a
+//! TopoDS_Face, an internal adaptor is created and owned.
+//!
+//! Usage:
+//! @code
+//!   BRepProp_Surface aProp;
+//!   aProp.Initialize(myFace);
+//!   GeomProp::SurfaceNormalResult aNorm = aProp.Normal(0.5, 0.5, Precision::Confusion());
+//!   if (aNorm.IsDefined)
+//!   {
+//!     gp_Dir aDir = aNorm.Direction;
+//!   }
+//! @endcode
+class BRepProp_Surface
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Default constructor - uninitialized state.
+  BRepProp_Surface() = default;
+
+  //! Non-copyable and non-movable.
+  BRepProp_Surface(const BRepProp_Surface&)            = delete;
+  BRepProp_Surface& operator=(const BRepProp_Surface&) = delete;
+  BRepProp_Surface(BRepProp_Surface&&)                 = delete;
+  BRepProp_Surface& operator=(BRepProp_Surface&&)      = delete;
+
+  //! Initialize from a TopoDS_Face.
+  //! Creates an internal BRepAdaptor_Surface (owning).
+  //! @param[in] theFace the face to evaluate
+  Standard_EXPORT void Initialize(const TopoDS_Face& theFace);
+
+  //! Initialize from an existing BRepAdaptor_Surface.
+  //! The adaptor is referenced without copying (non-owning);
+  //! the caller must ensure the adaptor outlives this object.
+  //! @param[in] theSurface the adaptor to reference
+  Standard_EXPORT void Initialize(const BRepAdaptor_Surface& theSurface);
+
+  //! Initialize from a handle to BRepAdaptor_Surface.
+  //! Shares ownership of the adaptor (no copy).
+  //! @param[in] theSurface handle to the adaptor
+  Standard_EXPORT void Initialize(const occ::handle<BRepAdaptor_Surface>& theSurface);
+
+  //! Returns true if properly initialized.
+  bool IsInitialized() const { return myPtr != nullptr; }
+
+  //! Returns the underlying adaptor.
+  const BRepAdaptor_Surface& Adaptor() const { return *myPtr; }
+
+  //! Compute surface normal at given (U, V) parameter.
+  //! @param[in] theU U parameter
+  //! @param[in] theV V parameter
+  //! @param[in] theTol linear tolerance
+  //! @return normal result with validity flag
+  Standard_EXPORT GeomProp::SurfaceNormalResult Normal(double theU,
+                                                       double theV,
+                                                       double theTol) const;
+
+  //! Compute principal curvatures at given (U, V) parameter.
+  //! @param[in] theU U parameter
+  //! @param[in] theV V parameter
+  //! @param[in] theTol linear tolerance
+  //! @return curvature result with min/max values, directions, and validity flag
+  Standard_EXPORT GeomProp::SurfaceCurvatureResult Curvatures(double theU,
+                                                              double theV,
+                                                              double theTol) const;
+
+  //! Compute mean and Gaussian curvatures at given (U, V) parameter.
+  //! @param[in] theU U parameter
+  //! @param[in] theV V parameter
+  //! @param[in] theTol linear tolerance
+  //! @return mean/Gaussian curvature result with validity flag
+  Standard_EXPORT GeomProp::MeanGaussianResult MeanGaussian(double theU,
+                                                            double theV,
+                                                            double theTol) const;
+
+private:
+  occ::handle<BRepAdaptor_Surface> myOwned; //!< Owns the adaptor when created from TopoDS_Face.
+  const BRepAdaptor_Surface*       myPtr = nullptr; //!< Non-owning pointer to the active adaptor.
+};
+
+#endif // _BRepProp_Surface_HeaderFile

--- a/src/ModelingData/TKBRep/BRepProp/FILES.cmake
+++ b/src/ModelingData/TKBRep/BRepProp/FILES.cmake
@@ -1,0 +1,9 @@
+# Source files for BRepProp package
+set(OCCT_BRepProp_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+set(OCCT_BRepProp_FILES
+  BRepProp_Curve.cxx
+  BRepProp_Curve.hxx
+  BRepProp_Surface.cxx
+  BRepProp_Surface.hxx
+)

--- a/src/ModelingData/TKBRep/GTests/BRepProp_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepProp_Test.cxx
@@ -1,0 +1,339 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+// Unit tests for BRepProp_Curve and BRepProp_Surface on built BRep shapes.
+
+#include <BRep_Tool.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepProp_Curve.hxx>
+#include <BRepProp_Surface.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Line.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Pnt.hxx>
+#include <Precision.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr double THE_LIN_TOL   = Precision::PConfusion();
+constexpr double THE_CURV_TOL  = 1.0e-8;
+constexpr double THE_DIR_TOL   = Precision::Confusion();
+constexpr double THE_POINT_TOL = Precision::Confusion();
+} // namespace
+
+// ============================================================
+// BRepProp_Curve tests
+// ============================================================
+
+TEST(BRepProp_CurveTest, UninitializedState)
+{
+  BRepProp_Curve aProp;
+  EXPECT_FALSE(aProp.IsInitialized());
+
+  const GeomProp::TangentResult   aTan  = aProp.Tangent(0.0, THE_LIN_TOL);
+  const GeomProp::CurvatureResult aCurv = aProp.Curvature(0.0, THE_LIN_TOL);
+  const GeomProp::NormalResult    aNorm = aProp.Normal(0.0, THE_LIN_TOL);
+  const GeomProp::CentreResult    aCent = aProp.CentreOfCurvature(0.0, THE_LIN_TOL);
+
+  EXPECT_FALSE(aTan.IsDefined);
+  EXPECT_FALSE(aCurv.IsDefined);
+  EXPECT_FALSE(aNorm.IsDefined);
+  EXPECT_FALSE(aCent.IsDefined);
+}
+
+TEST(BRepProp_CurveTest, InitializeFromEdge_Line)
+{
+  BRepBuilderAPI_MakeEdge aMakeEdge(gp_Lin(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0)), 0.0, 10.0);
+  ASSERT_TRUE(aMakeEdge.IsDone());
+  const TopoDS_Edge& anEdge = aMakeEdge.Edge();
+
+  BRepProp_Curve aProp;
+  aProp.Initialize(anEdge);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  // Tangent on a line should be defined.
+  const GeomProp::TangentResult aTan = aProp.Tangent(5.0, THE_LIN_TOL);
+  ASSERT_TRUE(aTan.IsDefined);
+  EXPECT_NEAR(std::abs(aTan.Direction.Dot(gp_Dir(1, 0, 0))), 1.0, THE_DIR_TOL);
+
+  // Curvature of a line should be zero.
+  const GeomProp::CurvatureResult aCurv = aProp.Curvature(5.0, THE_LIN_TOL);
+  ASSERT_TRUE(aCurv.IsDefined);
+  EXPECT_NEAR(aCurv.Value, 0.0, THE_CURV_TOL);
+}
+
+TEST(BRepProp_CurveTest, InitializeFromEdge_Circle)
+{
+  constexpr double        aRadius = 5.0;
+  gp_Circ                 aCirc(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), aRadius);
+  BRepBuilderAPI_MakeEdge aMakeEdge(aCirc);
+  ASSERT_TRUE(aMakeEdge.IsDone());
+  const TopoDS_Edge& anEdge = aMakeEdge.Edge();
+
+  BRepProp_Curve aProp;
+  aProp.Initialize(anEdge);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  // Check curvature = 1/R at midpoint.
+  const GeomProp::CurvatureResult aCurv = aProp.Curvature(M_PI, THE_LIN_TOL);
+  ASSERT_TRUE(aCurv.IsDefined);
+  EXPECT_NEAR(aCurv.Value, 1.0 / aRadius, THE_CURV_TOL);
+
+  // Check normal is defined.
+  const GeomProp::NormalResult aNorm = aProp.Normal(M_PI, THE_LIN_TOL);
+  ASSERT_TRUE(aNorm.IsDefined);
+
+  // Check centre of curvature should be at origin.
+  const GeomProp::CentreResult aCent = aProp.CentreOfCurvature(M_PI, THE_LIN_TOL);
+  ASSERT_TRUE(aCent.IsDefined);
+  EXPECT_NEAR(aCent.Centre.Distance(gp_Pnt(0, 0, 0)), 0.0, THE_POINT_TOL);
+}
+
+TEST(BRepProp_CurveTest, InitializeFromAdaptor)
+{
+  constexpr double        aRadius = 3.0;
+  gp_Circ                 aCirc(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), aRadius);
+  BRepBuilderAPI_MakeEdge aMakeEdge(aCirc);
+  ASSERT_TRUE(aMakeEdge.IsDone());
+
+  BRepAdaptor_Curve anAdaptor(aMakeEdge.Edge());
+
+  BRepProp_Curve aProp;
+  aProp.Initialize(anAdaptor);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  const GeomProp::CurvatureResult aCurv = aProp.Curvature(M_PI / 2.0, THE_LIN_TOL);
+  ASSERT_TRUE(aCurv.IsDefined);
+  EXPECT_NEAR(aCurv.Value, 1.0 / aRadius, THE_CURV_TOL);
+}
+
+TEST(BRepProp_CurveTest, BoxEdge_Tangent)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 20.0, 30.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+  ASSERT_TRUE(aBoxMaker.IsDone());
+
+  // Get the first edge.
+  TopExp_Explorer anExp(aBox, TopAbs_EDGE);
+  ASSERT_TRUE(anExp.More());
+  const TopoDS_Edge& anEdge = TopoDS::Edge(anExp.Current());
+
+  BRepProp_Curve aProp;
+  aProp.Initialize(anEdge);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  double aFirst = 0.0, aLast = 0.0;
+  BRep_Tool::Range(anEdge, aFirst, aLast);
+  const double aMid = 0.5 * (aFirst + aLast);
+
+  // Box edges are lines - tangent should be defined and curvature zero.
+  const GeomProp::TangentResult aTan = aProp.Tangent(aMid, THE_LIN_TOL);
+  EXPECT_TRUE(aTan.IsDefined);
+
+  const GeomProp::CurvatureResult aCurv = aProp.Curvature(aMid, THE_LIN_TOL);
+  ASSERT_TRUE(aCurv.IsDefined);
+  EXPECT_NEAR(aCurv.Value, 0.0, THE_CURV_TOL);
+}
+
+TEST(BRepProp_CurveTest, CylinderEdge_Curvature)
+{
+  constexpr double         aRadius = 4.0;
+  constexpr double         aHeight = 10.0;
+  BRepPrimAPI_MakeCylinder aCylMaker(aRadius, aHeight);
+  const TopoDS_Shape&      aCyl = aCylMaker.Shape();
+  ASSERT_TRUE(aCylMaker.IsDone());
+
+  // Find a circular edge (not a seam line).
+  for (TopExp_Explorer anExp(aCyl, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Edge& anEdge = TopoDS::Edge(anExp.Current());
+    BRepProp_Curve     aProp;
+    aProp.Initialize(anEdge);
+    ASSERT_TRUE(aProp.IsInitialized());
+
+    double aFirst = 0.0, aLast = 0.0;
+    BRep_Tool::Range(anEdge, aFirst, aLast);
+    const double aMid = 0.5 * (aFirst + aLast);
+
+    const GeomProp::CurvatureResult aCurv = aProp.Curvature(aMid, THE_LIN_TOL);
+    if (aCurv.IsDefined && aCurv.Value > THE_CURV_TOL)
+    {
+      // Circular edge: curvature = 1/R.
+      EXPECT_NEAR(aCurv.Value, 1.0 / aRadius, THE_CURV_TOL);
+      return;
+    }
+  }
+  // At least one circular edge should have been found.
+  FAIL() << "No circular edge found on cylinder";
+}
+
+// ============================================================
+// BRepProp_Surface tests
+// ============================================================
+
+TEST(BRepProp_SurfaceTest, UninitializedState)
+{
+  BRepProp_Surface aProp;
+  EXPECT_FALSE(aProp.IsInitialized());
+
+  const GeomProp::SurfaceNormalResult aNorm = aProp.Normal(0.0, 0.0, THE_LIN_TOL);
+  EXPECT_FALSE(aNorm.IsDefined);
+
+  const GeomProp::SurfaceCurvatureResult aCurv = aProp.Curvatures(0.0, 0.0, THE_LIN_TOL);
+  EXPECT_FALSE(aCurv.IsDefined);
+
+  const GeomProp::MeanGaussianResult aMG = aProp.MeanGaussian(0.0, 0.0, THE_LIN_TOL);
+  EXPECT_FALSE(aMG.IsDefined);
+}
+
+TEST(BRepProp_SurfaceTest, BoxFace_PlanarNormal)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 20.0, 30.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+  ASSERT_TRUE(aBoxMaker.IsDone());
+
+  TopExp_Explorer anExp(aBox, TopAbs_FACE);
+  ASSERT_TRUE(anExp.More());
+  const TopoDS_Face& aFace = TopoDS::Face(anExp.Current());
+
+  BRepProp_Surface aProp;
+  aProp.Initialize(aFace);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  const GeomProp::SurfaceNormalResult aNorm = aProp.Normal(0.5, 0.5, THE_LIN_TOL);
+  ASSERT_TRUE(aNorm.IsDefined);
+
+  // Plane curvatures should be zero.
+  const GeomProp::SurfaceCurvatureResult aCurv = aProp.Curvatures(0.5, 0.5, THE_LIN_TOL);
+  ASSERT_TRUE(aCurv.IsDefined);
+  EXPECT_NEAR(aCurv.MinCurvature, 0.0, THE_CURV_TOL);
+  EXPECT_NEAR(aCurv.MaxCurvature, 0.0, THE_CURV_TOL);
+
+  const GeomProp::MeanGaussianResult aMG = aProp.MeanGaussian(0.5, 0.5, THE_LIN_TOL);
+  ASSERT_TRUE(aMG.IsDefined);
+  EXPECT_NEAR(aMG.MeanCurvature, 0.0, THE_CURV_TOL);
+  EXPECT_NEAR(aMG.GaussianCurvature, 0.0, THE_CURV_TOL);
+}
+
+TEST(BRepProp_SurfaceTest, InitializeFromAdaptor)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 20.0, 30.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+  ASSERT_TRUE(aBoxMaker.IsDone());
+
+  TopExp_Explorer anExp(aBox, TopAbs_FACE);
+  ASSERT_TRUE(anExp.More());
+  const TopoDS_Face& aFace = TopoDS::Face(anExp.Current());
+
+  BRepAdaptor_Surface anAdaptor(aFace);
+  BRepProp_Surface    aProp;
+  aProp.Initialize(anAdaptor);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  const GeomProp::SurfaceNormalResult aNorm = aProp.Normal(0.5, 0.5, THE_LIN_TOL);
+  ASSERT_TRUE(aNorm.IsDefined);
+}
+
+TEST(BRepProp_SurfaceTest, SphereFace_Curvatures)
+{
+  constexpr double       aRadius = 5.0;
+  BRepPrimAPI_MakeSphere aSphMaker(aRadius);
+  const TopoDS_Shape&    aSph = aSphMaker.Shape();
+  ASSERT_TRUE(aSphMaker.IsDone());
+
+  // Find the spherical face.
+  TopExp_Explorer anExp(aSph, TopAbs_FACE);
+  ASSERT_TRUE(anExp.More());
+  const TopoDS_Face& aFace = TopoDS::Face(anExp.Current());
+
+  BRepProp_Surface aProp;
+  aProp.Initialize(aFace);
+  ASSERT_TRUE(aProp.IsInitialized());
+
+  // Evaluate at equator-like parameter (away from poles).
+  const double aU = M_PI;
+  const double aV = 0.0;
+
+  const GeomProp::SurfaceCurvatureResult aCurv = aProp.Curvatures(aU, aV, THE_LIN_TOL);
+  ASSERT_TRUE(aCurv.IsDefined);
+
+  // Sphere: both principal curvatures = 1/R in absolute value.
+  // Sign depends on face orientation (BRepAdaptor_Surface accounts for it).
+  EXPECT_NEAR(std::abs(aCurv.MinCurvature), 1.0 / aRadius, THE_POINT_TOL);
+  EXPECT_NEAR(std::abs(aCurv.MaxCurvature), 1.0 / aRadius, THE_POINT_TOL);
+
+  const GeomProp::MeanGaussianResult aMG = aProp.MeanGaussian(aU, aV, THE_LIN_TOL);
+  ASSERT_TRUE(aMG.IsDefined);
+  EXPECT_NEAR(std::abs(aMG.MeanCurvature), 1.0 / aRadius, THE_POINT_TOL);
+  EXPECT_NEAR(aMG.GaussianCurvature, 1.0 / (aRadius * aRadius), THE_POINT_TOL);
+}
+
+TEST(BRepProp_SurfaceTest, CylinderFace_Curvatures)
+{
+  constexpr double         aRadius = 3.0;
+  constexpr double         aHeight = 10.0;
+  BRepPrimAPI_MakeCylinder aCylMaker(aRadius, aHeight);
+  const TopoDS_Shape&      aCyl = aCylMaker.Shape();
+  ASSERT_TRUE(aCylMaker.IsDone());
+
+  // Find the cylindrical face (lateral).
+  for (TopExp_Explorer anExp(aCyl, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Face&  aFace = TopoDS::Face(anExp.Current());
+    BRepAdaptor_Surface anAdaptor(aFace);
+    if (anAdaptor.GetType() != GeomAbs_Cylinder)
+    {
+      continue;
+    }
+
+    BRepProp_Surface aProp;
+    aProp.Initialize(aFace);
+    ASSERT_TRUE(aProp.IsInitialized());
+
+    const double aU = M_PI / 4.0;
+    const double aV = aHeight / 2.0;
+
+    const GeomProp::SurfaceCurvatureResult aCurv = aProp.Curvatures(aU, aV, THE_LIN_TOL);
+    ASSERT_TRUE(aCurv.IsDefined);
+
+    // Cylinder: one curvature = 1/R, the other = 0.
+    const double aMin = std::min(std::abs(aCurv.MinCurvature), std::abs(aCurv.MaxCurvature));
+    const double aMax = std::max(std::abs(aCurv.MinCurvature), std::abs(aCurv.MaxCurvature));
+    EXPECT_NEAR(aMin, 0.0, THE_CURV_TOL);
+    EXPECT_NEAR(aMax, 1.0 / aRadius, THE_POINT_TOL);
+
+    const GeomProp::MeanGaussianResult aMG = aProp.MeanGaussian(aU, aV, THE_LIN_TOL);
+    ASSERT_TRUE(aMG.IsDefined);
+    // Gaussian curvature of cylinder = 0.
+    EXPECT_NEAR(aMG.GaussianCurvature, 0.0, THE_CURV_TOL);
+    return;
+  }
+  FAIL() << "No cylindrical face found";
+}

--- a/src/ModelingData/TKBRep/GTests/BRepProp_VsBRepLProp_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepProp_VsBRepLProp_Test.cxx
@@ -1,0 +1,336 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+// Cross-validation tests comparing BRepProp_Curve / BRepProp_Surface
+// against old BRepLProp_CLProps / BRepLProp_SLProps.
+
+#include <BRep_Tool.hxx>
+#include <BRepAdaptor_Curve.hxx>
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepLProp_CLProps.hxx>
+#include <BRepLProp_SLProps.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRepProp_Curve.hxx>
+#include <BRepProp_Surface.hxx>
+#include <GeomAbs_SurfaceType.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Pnt.hxx>
+#include <Precision.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr double THE_LIN_TOL   = Precision::PConfusion();
+constexpr double THE_CURV_TOL  = 1.0e-8;
+constexpr double THE_DIR_TOL   = 1.0e-6;
+constexpr double THE_POINT_TOL = 1.0e-6;
+
+// ============================================================
+// Curve cross-validation helpers
+// ============================================================
+
+void compareCurveTangent(const TopoDS_Edge& theEdge, const double theParam)
+{
+  BRepAdaptor_Curve anAdaptor(theEdge);
+
+  // New API
+  BRepProp_Curve aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::TangentResult aNew = aNewProp.Tangent(theParam, THE_LIN_TOL);
+
+  // Old API
+  BRepLProp_CLProps anOld(anAdaptor, theParam, 2, THE_LIN_TOL);
+  if (anOld.IsTangentDefined())
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New tangent undefined but old is defined at param=" << theParam;
+    gp_Dir anOldDir;
+    anOld.Tangent(anOldDir);
+    const double aDot = aNew.Direction.Dot(anOldDir);
+    EXPECT_NEAR(std::abs(aDot), 1.0, THE_DIR_TOL)
+      << "Tangent direction mismatch at param=" << theParam;
+  }
+}
+
+void compareCurveCurvature(const TopoDS_Edge& theEdge, const double theParam)
+{
+  BRepAdaptor_Curve anAdaptor(theEdge);
+
+  BRepProp_Curve aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::CurvatureResult aNew = aNewProp.Curvature(theParam, THE_LIN_TOL);
+
+  BRepLProp_CLProps anOld(anAdaptor, theParam, 2, THE_LIN_TOL);
+  if (anOld.IsTangentDefined())
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New curvature undefined at param=" << theParam;
+    EXPECT_NEAR(aNew.Value, anOld.Curvature(), THE_CURV_TOL)
+      << "Curvature mismatch at param=" << theParam;
+  }
+}
+
+void compareCurveNormal(const TopoDS_Edge& theEdge, const double theParam)
+{
+  BRepAdaptor_Curve anAdaptor(theEdge);
+
+  BRepProp_Curve aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::NormalResult aNew = aNewProp.Normal(theParam, THE_LIN_TOL);
+
+  BRepLProp_CLProps anOld(anAdaptor, theParam, 2, THE_LIN_TOL);
+  if (anOld.IsTangentDefined() && std::abs(anOld.Curvature()) > THE_LIN_TOL)
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New normal undefined but old is defined at param=" << theParam;
+    gp_Dir anOldDir;
+    anOld.Normal(anOldDir);
+    const double aDot = aNew.Direction.Dot(anOldDir);
+    EXPECT_NEAR(std::abs(aDot), 1.0, THE_DIR_TOL)
+      << "Normal direction mismatch at param=" << theParam;
+  }
+}
+
+void compareCurveCentre(const TopoDS_Edge& theEdge, const double theParam)
+{
+  BRepAdaptor_Curve anAdaptor(theEdge);
+
+  BRepProp_Curve aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::CentreResult aNew = aNewProp.CentreOfCurvature(theParam, THE_LIN_TOL);
+
+  BRepLProp_CLProps anOld(anAdaptor, theParam, 2, THE_LIN_TOL);
+  if (anOld.IsTangentDefined() && std::abs(anOld.Curvature()) > THE_LIN_TOL)
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New centre undefined at param=" << theParam;
+    gp_Pnt anOldPnt;
+    anOld.CentreOfCurvature(anOldPnt);
+    EXPECT_NEAR(aNew.Centre.Distance(anOldPnt), 0.0, THE_POINT_TOL)
+      << "Centre of curvature mismatch at param=" << theParam;
+  }
+}
+
+// ============================================================
+// Surface cross-validation helpers
+// ============================================================
+
+void compareSurfaceNormal(const TopoDS_Face& theFace, const double theU, const double theV)
+{
+  BRepAdaptor_Surface anAdaptor(theFace);
+
+  BRepProp_Surface aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::SurfaceNormalResult aNew = aNewProp.Normal(theU, theV, THE_LIN_TOL);
+
+  BRepLProp_SLProps anOld(anAdaptor, theU, theV, 2, THE_LIN_TOL);
+  if (anOld.IsNormalDefined())
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New normal undefined but old is defined at (" << theU << ", "
+                                << theV << ")";
+    const gp_Dir& anOldDir = anOld.Normal();
+    const double  aDot     = aNew.Direction.Dot(anOldDir);
+    EXPECT_NEAR(std::abs(aDot), 1.0, THE_DIR_TOL)
+      << "Surface normal mismatch at (" << theU << ", " << theV << ")";
+  }
+}
+
+void compareSurfaceCurvatures(const TopoDS_Face& theFace, const double theU, const double theV)
+{
+  BRepAdaptor_Surface anAdaptor(theFace);
+
+  BRepProp_Surface aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::SurfaceCurvatureResult aNew = aNewProp.Curvatures(theU, theV, THE_LIN_TOL);
+
+  BRepLProp_SLProps anOld(anAdaptor, theU, theV, 2, THE_LIN_TOL);
+  if (anOld.IsCurvatureDefined())
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New curvatures undefined at (" << theU << ", " << theV << ")";
+    EXPECT_NEAR(aNew.MinCurvature, anOld.MinCurvature(), THE_CURV_TOL)
+      << "Min curvature mismatch at (" << theU << ", " << theV << ")";
+    EXPECT_NEAR(aNew.MaxCurvature, anOld.MaxCurvature(), THE_CURV_TOL)
+      << "Max curvature mismatch at (" << theU << ", " << theV << ")";
+  }
+}
+
+void compareSurfaceMeanGaussian(const TopoDS_Face& theFace, const double theU, const double theV)
+{
+  BRepAdaptor_Surface anAdaptor(theFace);
+
+  BRepProp_Surface aNewProp;
+  aNewProp.Initialize(anAdaptor);
+  const GeomProp::MeanGaussianResult aNew = aNewProp.MeanGaussian(theU, theV, THE_LIN_TOL);
+
+  BRepLProp_SLProps anOld(anAdaptor, theU, theV, 2, THE_LIN_TOL);
+  if (anOld.IsCurvatureDefined())
+  {
+    ASSERT_TRUE(aNew.IsDefined) << "New mean/gaussian undefined at (" << theU << ", " << theV
+                                << ")";
+    EXPECT_NEAR(aNew.MeanCurvature, anOld.MeanCurvature(), THE_CURV_TOL)
+      << "Mean curvature mismatch at (" << theU << ", " << theV << ")";
+    EXPECT_NEAR(aNew.GaussianCurvature, anOld.GaussianCurvature(), THE_CURV_TOL)
+      << "Gaussian curvature mismatch at (" << theU << ", " << theV << ")";
+  }
+}
+} // namespace
+
+// ============================================================
+// Curve cross-validation tests
+// ============================================================
+
+TEST(BRepProp_VsBRepLPropTest, Curve_LineEdge)
+{
+  BRepBuilderAPI_MakeEdge aMakeEdge(gp_Lin(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0)), 0.0, 10.0);
+  ASSERT_TRUE(aMakeEdge.IsDone());
+  const TopoDS_Edge& anEdge = aMakeEdge.Edge();
+
+  for (double aParam = 1.0; aParam <= 9.0; aParam += 2.0)
+  {
+    compareCurveTangent(anEdge, aParam);
+    compareCurveCurvature(anEdge, aParam);
+  }
+}
+
+TEST(BRepProp_VsBRepLPropTest, Curve_CircleEdge)
+{
+  constexpr double        aRadius = 5.0;
+  gp_Circ                 aCirc(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), aRadius);
+  BRepBuilderAPI_MakeEdge aMakeEdge(aCirc);
+  ASSERT_TRUE(aMakeEdge.IsDone());
+  const TopoDS_Edge& anEdge = aMakeEdge.Edge();
+
+  for (double aParam = 0.5; aParam < 2.0 * M_PI; aParam += 1.0)
+  {
+    compareCurveTangent(anEdge, aParam);
+    compareCurveCurvature(anEdge, aParam);
+    compareCurveNormal(anEdge, aParam);
+    compareCurveCentre(anEdge, aParam);
+  }
+}
+
+TEST(BRepProp_VsBRepLPropTest, Curve_BoxEdges)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 20.0, 30.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+  ASSERT_TRUE(aBoxMaker.IsDone());
+
+  for (TopExp_Explorer anExp(aBox, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Edge& anEdge = TopoDS::Edge(anExp.Current());
+    double             aFirst = 0.0, aLast = 0.0;
+    BRep_Tool::Range(anEdge, aFirst, aLast);
+    const double aMid = 0.5 * (aFirst + aLast);
+
+    compareCurveTangent(anEdge, aMid);
+    compareCurveCurvature(anEdge, aMid);
+  }
+}
+
+TEST(BRepProp_VsBRepLPropTest, Curve_CylinderEdges)
+{
+  BRepPrimAPI_MakeCylinder aCylMaker(4.0, 10.0);
+  const TopoDS_Shape&      aCyl = aCylMaker.Shape();
+  ASSERT_TRUE(aCylMaker.IsDone());
+
+  for (TopExp_Explorer anExp(aCyl, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Edge& anEdge = TopoDS::Edge(anExp.Current());
+    double             aFirst = 0.0, aLast = 0.0;
+    BRep_Tool::Range(anEdge, aFirst, aLast);
+    const double aMid = 0.5 * (aFirst + aLast);
+
+    compareCurveTangent(anEdge, aMid);
+    compareCurveCurvature(anEdge, aMid);
+    compareCurveNormal(anEdge, aMid);
+    compareCurveCentre(anEdge, aMid);
+  }
+}
+
+// ============================================================
+// Surface cross-validation tests
+// ============================================================
+
+TEST(BRepProp_VsBRepLPropTest, Surface_BoxFaces)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 20.0, 30.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+  ASSERT_TRUE(aBoxMaker.IsDone());
+
+  for (TopExp_Explorer anExp(aBox, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Face& aFace = TopoDS::Face(anExp.Current());
+    compareSurfaceNormal(aFace, 0.5, 0.5);
+    compareSurfaceCurvatures(aFace, 0.5, 0.5);
+    compareSurfaceMeanGaussian(aFace, 0.5, 0.5);
+  }
+}
+
+TEST(BRepProp_VsBRepLPropTest, Surface_SphereFace)
+{
+  constexpr double       aRadius = 5.0;
+  BRepPrimAPI_MakeSphere aSphMaker(aRadius);
+  const TopoDS_Shape&    aSph = aSphMaker.Shape();
+  ASSERT_TRUE(aSphMaker.IsDone());
+
+  TopExp_Explorer anExp(aSph, TopAbs_FACE);
+  ASSERT_TRUE(anExp.More());
+  const TopoDS_Face& aFace = TopoDS::Face(anExp.Current());
+
+  // Evaluate at several points away from poles.
+  for (double aU = 0.5; aU < 2.0 * M_PI; aU += 1.0)
+  {
+    compareSurfaceNormal(aFace, aU, 0.0);
+    compareSurfaceCurvatures(aFace, aU, 0.0);
+    compareSurfaceMeanGaussian(aFace, aU, 0.0);
+  }
+}
+
+TEST(BRepProp_VsBRepLPropTest, Surface_CylinderFace)
+{
+  constexpr double         aRadius = 3.0;
+  constexpr double         aHeight = 10.0;
+  BRepPrimAPI_MakeCylinder aCylMaker(aRadius, aHeight);
+  const TopoDS_Shape&      aCyl = aCylMaker.Shape();
+  ASSERT_TRUE(aCylMaker.IsDone());
+
+  for (TopExp_Explorer anExp(aCyl, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Face&  aFace = TopoDS::Face(anExp.Current());
+    BRepAdaptor_Surface anAdaptor(aFace);
+    if (anAdaptor.GetType() != GeomAbs_Cylinder)
+    {
+      continue;
+    }
+
+    for (double aU = 0.5; aU < 2.0 * M_PI; aU += 1.5)
+    {
+      const double aV = aHeight / 2.0;
+      compareSurfaceNormal(aFace, aU, aV);
+      compareSurfaceCurvatures(aFace, aU, aV);
+      compareSurfaceMeanGaussian(aFace, aU, aV);
+    }
+    return;
+  }
+  FAIL() << "No cylindrical face found";
+}

--- a/src/ModelingData/TKBRep/GTests/FILES.cmake
+++ b/src/ModelingData/TKBRep/GTests/FILES.cmake
@@ -4,6 +4,8 @@ set(OCCT_TKBRep_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 set(OCCT_TKBRep_GTests_FILES
   BRep_Tool_Test.cxx
   BRepAdaptor_CompCurve_Test.cxx
+  BRepProp_Test.cxx
+  BRepProp_VsBRepLProp_Test.cxx
   TopExp_Test.cxx
   TopoDS_Builder_Test.cxx
   TopoDS_Edge_Test.cxx

--- a/src/ModelingData/TKBRep/PACKAGES.cmake
+++ b/src/ModelingData/TKBRep/PACKAGES.cmake
@@ -5,6 +5,7 @@ set(OCCT_TKBRep_LIST_OF_PACKAGES
   TopTools
   BRep
   BRepLProp
+  BRepProp
   BRepAdaptor
   BRepTools
   BinTools


### PR DESCRIPTION
Add new BRepProp package to TKBRep as a thin wrapper over GeomProp:: free functions for computing local differential properties of BRep edges and faces without exceptions. Replaces the legacy BRepLProp macro-based (.gxx) pattern.

New package BRepProp (TKBRep) provides:
- BRepProp_Curve: Local curve property evaluator for BRep edges. Delegates derivative computation to BRepAdaptor_Curve and passes results to GeomProp::ComputeTangent, ComputeCurvature, ComputeNormal, ComputeCentreOfCurvature. Three Initialize overloads: from TopoDS_Edge (owning), from BRepAdaptor_Curve reference (non-owning), and from occ::handle<BRepAdaptor_Curve> (shared ownership). Includes static Continuity() methods for regularity analysis at curve junctions (replaces BRepLProp::Continuity).
- BRepProp_Surface: Local surface property evaluator for BRep faces. Delegates derivative computation to BRepAdaptor_Surface and passes results to GeomProp::ComputeSurfaceNormal, ComputeSurfaceCurvatures, ComputeMeanGaussian. Same three Initialize overloads as BRepProp_Curve.

Key design decisions:
- No variant dispatch needed: BRepAdaptor_Curve/Surface handle geometry-type dispatch internally via virtual methods, so BRepProp is a thin wrapper calling adaptor D1/D2/D3 then GeomProp:: free functions.
- Ownership pattern: occ::handle for owning case + raw const pointer for non-owning case, consistent with GeomProp_Curve/Surface.
- Returns result structs with IsDefined flags instead of throwing exceptions.

18 GTests: 11 unit tests (line, circle, box, cylinder, sphere) and 7 cross-validation tests against BRepLProp_CLProps/BRepLProp_SLProps.