### PR TITLE
Foundation Classes, math_FunctionRoot - Constructor exception

### DIFF
--- a/src/FoundationClasses/TKMath/math/math_FunctionRoot.cxx
+++ b/src/FoundationClasses/TKMath/math/math_FunctionRoot.cxx
@@ -81,7 +81,7 @@ math_FunctionRoot::math_FunctionRoot(math_FunctionWithDerivative& F,
   Tol(1) = Tolerance;
   math_FunctionSetRoot Sol(Ff, Tol, NbIterations);
   Sol.Perform(Ff, V);
-  Done   = Sol.IsDone();
+  Done = Sol.IsDone();
   if (Done)
   {
     NbIter = Sol.NbIterations();
@@ -107,7 +107,7 @@ math_FunctionRoot::math_FunctionRoot(math_FunctionWithDerivative& F,
   Bb(1)  = B;
   math_FunctionSetRoot Sol(Ff, Tol, NbIterations);
   Sol.Perform(Ff, V, Aa, Bb);
-  Done   = Sol.IsDone();
+  Done = Sol.IsDone();
   if (Done)
   {
     NbIter = Sol.NbIterations();


### PR DESCRIPTION
A fix - a call to NbIterations() is performed only if the algorithm is done. 