### PR TITLE
Modeling Data - Fix continuity order mapping in BRepProp_Curve to match GeomProp_Curve

### DIFF
--- a/src/ModelingData/TKBRep/BRepProp/BRepProp_Curve.cxx
+++ b/src/ModelingData/TKBRep/BRepProp/BRepProp_Curve.cxx
@@ -155,13 +155,13 @@ GeomAbs_Shape BRepProp_Curve::Continuity(const BRepAdaptor_Curve& theCurve1,
     aN1 = 3;
   else if (aCont1 == 4)
     aN1 = 2;
-  else if (aCont1 == 2)
+  else if (aCont1 >= 2)
     aN1 = 1;
   if (aCont2 >= 5)
     aN2 = 3;
   else if (aCont2 == 4)
     aN2 = 2;
-  else if (aCont2 == 2)
+  else if (aCont2 >= 2)
     aN2 = 1;
 
   // Evaluate properties at junction points.


### PR DESCRIPTION
  The condition == 2 only matched GeomAbs_C1 curves for D1 evaluation, while >= 2 (as used in GeomProp_Curve::Continuity())
  correctly includes GeomAbs_G2 and higher, since G2 implies G1 which guarantees D1 exists.