### PR TITLE
Modeling Data - Performance optimizations for hot-path curve representation lookups and map access

### DIFF
--- a/src/ModelingData/TKBRep/BRep/BRep_Curve3D.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Curve3D.cxx
@@ -26,7 +26,8 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_Curve3D, BRep_GCurve)
 //=================================================================================================
 
 BRep_Curve3D::BRep_Curve3D(const occ::handle<Geom_Curve>& C, const TopLoc_Location& L)
-    : BRep_GCurve(L,
+    : BRep_GCurve(Type_Curve3D,
+                  L,
                   C.IsNull() ? RealFirst() : C->FirstParameter(),
                   C.IsNull() ? RealLast() : C->LastParameter()),
       myCurve(C)

--- a/src/ModelingData/TKBRep/BRep/BRep_Curve3D.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Curve3D.cxx
@@ -42,15 +42,6 @@ void BRep_Curve3D::D0(const double U, gp_Pnt& P) const
   P = myCurve->Value(U);
 }
 
-//=================================================================================================
-
-bool BRep_Curve3D::IsCurve3D() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 const occ::handle<Geom_Curve>& BRep_Curve3D::Curve3D() const
 {
   return myCurve;

--- a/src/ModelingData/TKBRep/BRep/BRep_Curve3D.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Curve3D.hxx
@@ -36,9 +36,6 @@ public:
   //! Computes the point at parameter U.
   Standard_EXPORT void D0(const double U, gp_Pnt& P) const override;
 
-  //! Returns True.
-  Standard_EXPORT bool IsCurve3D() const override;
-
   Standard_EXPORT const occ::handle<Geom_Curve>& Curve3D() const override;
 
   Standard_EXPORT void Curve3D(const occ::handle<Geom_Curve>& C) override;

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.cxx
@@ -46,15 +46,6 @@ void BRep_CurveOn2Surfaces::D0(const double, gp_Pnt&) const
   throw Standard_NullObject("BRep_CurveOn2Surfaces::D0");
 }
 
-//=================================================================================================
-
-bool BRep_CurveOn2Surfaces::IsRegularity() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 bool BRep_CurveOn2Surfaces::IsRegularity(const occ::handle<Geom_Surface>& S1,
                                          const occ::handle<Geom_Surface>& S2,
                                          const TopLoc_Location&           L1,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.cxx
@@ -31,7 +31,7 @@ BRep_CurveOn2Surfaces::BRep_CurveOn2Surfaces(const occ::handle<Geom_Surface>& S1
                                              const TopLoc_Location&           L1,
                                              const TopLoc_Location&           L2,
                                              const GeomAbs_Shape              C)
-    : BRep_CurveRepresentation(L1),
+    : BRep_CurveRepresentation(Type_CurveOn2Surfaces, L1),
       mySurface(S1),
       mySurface2(S2),
       myLocation2(L2),

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOn2Surfaces.hxx
@@ -29,14 +29,13 @@ class BRep_CurveOn2Surfaces : public BRep_CurveRepresentation
 {
 
 public:
+  using BRep_CurveRepresentation::IsRegularity;
+
   Standard_EXPORT BRep_CurveOn2Surfaces(const occ::handle<Geom_Surface>& S1,
                                         const occ::handle<Geom_Surface>& S2,
                                         const TopLoc_Location&           L1,
                                         const TopLoc_Location&           L2,
                                         const GeomAbs_Shape              C);
-
-  //! Returns True.
-  Standard_EXPORT bool IsRegularity() const override;
 
   //! A curve on two surfaces (continuity).
   Standard_EXPORT bool IsRegularity(const occ::handle<Geom_Surface>& S1,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
@@ -32,7 +32,7 @@ BRep_CurveOnClosedSurface::BRep_CurveOnClosedSurface(const occ::handle<Geom2d_Cu
                                                      const occ::handle<Geom_Surface>& S,
                                                      const TopLoc_Location&           L,
                                                      const GeomAbs_Shape              C)
-    : BRep_CurveOnSurface(PC1, S, L),
+    : BRep_CurveOnSurface(Type_CurveOnClosedSurface, PC1, S, L),
       myPCurve2(PC2),
       myContinuity(C)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.cxx
@@ -38,22 +38,6 @@ BRep_CurveOnClosedSurface::BRep_CurveOnClosedSurface(const occ::handle<Geom2d_Cu
 {
 }
 
-//=================================================================================================
-
-bool BRep_CurveOnClosedSurface::IsCurveOnClosedSurface() const
-{
-  return true;
-}
-
-//=================================================================================================
-
-bool BRep_CurveOnClosedSurface::IsRegularity() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 bool BRep_CurveOnClosedSurface::IsRegularity(const occ::handle<Geom_Surface>& S1,
                                              const occ::handle<Geom_Surface>& S2,
                                              const TopLoc_Location&           L1,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnClosedSurface.hxx
@@ -31,6 +31,8 @@ class BRep_CurveOnClosedSurface : public BRep_CurveOnSurface
 {
 
 public:
+  using BRep_CurveRepresentation::IsRegularity;
+
   Standard_EXPORT BRep_CurveOnClosedSurface(const occ::handle<Geom2d_Curve>& PC1,
                                             const occ::handle<Geom2d_Curve>& PC2,
                                             const occ::handle<Geom_Surface>& S,
@@ -40,12 +42,6 @@ public:
   void SetUVPoints2(const gp_Pnt2d& P1, const gp_Pnt2d& P2);
 
   void UVPoints2(gp_Pnt2d& P1, gp_Pnt2d& P2) const;
-
-  //! Returns True.
-  Standard_EXPORT bool IsCurveOnClosedSurface() const override;
-
-  //! Returns True
-  Standard_EXPORT bool IsRegularity() const override;
 
   //! A curve on two surfaces (continuity).
   Standard_EXPORT bool IsRegularity(const occ::handle<Geom_Surface>& S1,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
@@ -57,15 +57,6 @@ void BRep_CurveOnSurface::D0(const double U, gp_Pnt& P) const
   P.Transform(myLocation.Transformation());
 }
 
-//=================================================================================================
-
-bool BRep_CurveOnSurface::IsCurveOnSurface() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 bool BRep_CurveOnSurface::IsCurveOnSurface(const occ::handle<Geom_Surface>& S,
                                            const TopLoc_Location&           L) const
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.cxx
@@ -31,9 +31,19 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveOnSurface, BRep_GCurve)
 BRep_CurveOnSurface::BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
                                          const occ::handle<Geom_Surface>& S,
                                          const TopLoc_Location&           L)
-    : BRep_GCurve(L, PC->FirstParameter(), PC->LastParameter()),
-      myPCurve(PC),
-      mySurface(S)
+    : BRep_CurveOnSurface(Type_CurveOnSurface, PC, S, L)
+{
+}
+
+//=================================================================================================
+
+BRep_CurveOnSurface::BRep_CurveOnSurface(TypeEnum                         theType,
+                                         const occ::handle<Geom2d_Curve>& thePCurve,
+                                         const occ::handle<Geom_Surface>& theSurface,
+                                         const TopLoc_Location&           theLocation)
+    : BRep_GCurve(theType, theLocation, thePCurve->FirstParameter(), thePCurve->LastParameter()),
+      myPCurve(thePCurve),
+      mySurface(theSurface)
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
@@ -71,6 +71,11 @@ public:
   DEFINE_STANDARD_RTTIEXT(BRep_CurveOnSurface, BRep_GCurve)
 
 protected:
+  Standard_EXPORT BRep_CurveOnSurface(TypeEnum                         theType,
+                                      const occ::handle<Geom2d_Curve>& thePCurve,
+                                      const occ::handle<Geom_Surface>& theSurface,
+                                      const TopLoc_Location&           theLocation);
+
   gp_Pnt2d myUV1;
   gp_Pnt2d myUV2;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveOnSurface.hxx
@@ -34,6 +34,8 @@ class BRep_CurveOnSurface : public BRep_GCurve
 {
 
 public:
+  using BRep_CurveRepresentation::IsCurveOnSurface;
+
   Standard_EXPORT BRep_CurveOnSurface(const occ::handle<Geom2d_Curve>& PC,
                                       const occ::handle<Geom_Surface>& S,
                                       const TopLoc_Location&           L);
@@ -44,9 +46,6 @@ public:
 
   //! Computes the point at parameter U.
   Standard_EXPORT void D0(const double U, gp_Pnt& P) const override;
-
-  //! Returns True.
-  Standard_EXPORT bool IsCurveOnSurface() const override;
 
   //! A curve in the parametric space of a surface.
   Standard_EXPORT bool IsCurveOnSurface(const occ::handle<Geom_Surface>& S,

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
@@ -35,36 +35,6 @@ BRep_CurveRepresentation::BRep_CurveRepresentation(TypeEnum theType, const TopLo
 {
 }
 
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsCurve3D() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsCurveOnSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsCurveOnClosedSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsRegularity() const
-{
-  return false;
-}
-
-//=================================================================================================
-
 bool BRep_CurveRepresentation::IsCurveOnSurface(const occ::handle<Geom_Surface>&,
                                                 const TopLoc_Location&) const
 {
@@ -81,45 +51,8 @@ bool BRep_CurveRepresentation::IsRegularity(const occ::handle<Geom_Surface>&,
   return false;
 }
 
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygon3D() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnTriangulation() const
-{
-  return false;
-}
-
-//=================================================================================================
-
 bool BRep_CurveRepresentation::IsPolygonOnTriangulation(const occ::handle<Poly_Triangulation>&,
                                                         const TopLoc_Location&) const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnClosedTriangulation() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnClosedSurface() const
-{
-  return false;
-}
-
-//=================================================================================================
-
-bool BRep_CurveRepresentation::IsPolygonOnSurface() const
 {
   return false;
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
@@ -29,8 +29,7 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveRepresentation, Standard_Transient)
 
 //=================================================================================================
 
-BRep_CurveRepresentation::BRep_CurveRepresentation(TypeEnum           theType,
-                                                   const TopLoc_Location& L)
+BRep_CurveRepresentation::BRep_CurveRepresentation(TypeEnum theType, const TopLoc_Location& L)
     : myLocation(L),
       myType(theType)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.cxx
@@ -29,8 +29,10 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveRepresentation, Standard_Transient)
 
 //=================================================================================================
 
-BRep_CurveRepresentation::BRep_CurveRepresentation(const TopLoc_Location& L)
-    : myLocation(L)
+BRep_CurveRepresentation::BRep_CurveRepresentation(TypeEnum           theType,
+                                                   const TopLoc_Location& L)
+    : myLocation(L),
+      myType(theType)
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
@@ -47,24 +47,25 @@ public:
     Type_PolygonOnSurface,
     Type_PolygonOnClosedSurface,
     Type_PolygonOnTriangulation,
-    Type_PolygonOnClosedTriangulation
+    Type_PolygonOnClosedTriangulation,
+    Type_Other
   };
 
   //! Returns the type discriminator of this representation.
   TypeEnum Type() const { return myType; }
 
   //! A 3D curve representation.
-  Standard_EXPORT virtual bool IsCurve3D() const;
+  bool IsCurve3D() const;
 
   //! A curve in the parametric space of a surface.
-  Standard_EXPORT virtual bool IsCurveOnSurface() const;
+  bool IsCurveOnSurface() const;
 
   //! A continuity between two surfaces.
-  Standard_EXPORT virtual bool IsRegularity() const;
+  bool IsRegularity() const;
 
   //! A curve with two parametric curves on the same
   //! surface.
-  Standard_EXPORT virtual bool IsCurveOnClosedSurface() const;
+  bool IsCurveOnClosedSurface() const;
 
   //! Is it a curve in the parametric space of <S> with
   //! location <L>.
@@ -79,11 +80,11 @@ public:
                                             const TopLoc_Location&           L2) const;
 
   //! A 3D polygon representation.
-  Standard_EXPORT virtual bool IsPolygon3D() const;
+  bool IsPolygon3D() const;
 
   //! A representation by an array of nodes on a
   //! triangulation.
-  Standard_EXPORT virtual bool IsPolygonOnTriangulation() const;
+  bool IsPolygonOnTriangulation() const;
 
   //! Is it a polygon in the definition of <T> with
   //! location <L>.
@@ -92,10 +93,10 @@ public:
 
   //! A representation by two arrays of nodes on a
   //! triangulation.
-  Standard_EXPORT virtual bool IsPolygonOnClosedTriangulation() const;
+  bool IsPolygonOnClosedTriangulation() const;
 
   //! A polygon in the parametric space of a surface.
-  Standard_EXPORT virtual bool IsPolygonOnSurface() const;
+  bool IsPolygonOnSurface() const;
 
   //! Is it a polygon in the parametric space of <S> with
   //! location <L>.
@@ -104,7 +105,7 @@ public:
 
   //! Two 2D polygon representations in the parametric
   //! space of a surface.
-  Standard_EXPORT virtual bool IsPolygonOnClosedSurface() const;
+  bool IsPolygonOnClosedSurface() const;
 
   const TopLoc_Location& Location() const;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.hxx
@@ -36,6 +36,23 @@ class BRep_CurveRepresentation : public Standard_Transient
 {
 
 public:
+  //! Type discriminator enum for fast type checks without virtual dispatch.
+  enum TypeEnum : uint8_t
+  {
+    Type_Curve3D = 0,
+    Type_CurveOnSurface,
+    Type_CurveOnClosedSurface,
+    Type_CurveOn2Surfaces,
+    Type_Polygon3D,
+    Type_PolygonOnSurface,
+    Type_PolygonOnClosedSurface,
+    Type_PolygonOnTriangulation,
+    Type_PolygonOnClosedTriangulation
+  };
+
+  //! Returns the type discriminator of this representation.
+  TypeEnum Type() const { return myType; }
+
   //! A 3D curve representation.
   Standard_EXPORT virtual bool IsCurve3D() const;
 
@@ -150,9 +167,12 @@ public:
   DEFINE_STANDARD_RTTIEXT(BRep_CurveRepresentation, Standard_Transient)
 
 protected:
-  Standard_EXPORT BRep_CurveRepresentation(const TopLoc_Location& L);
+  Standard_EXPORT BRep_CurveRepresentation(TypeEnum theType, const TopLoc_Location& L);
 
   TopLoc_Location myLocation;
+
+private:
+  TypeEnum myType;
 };
 
 #include <BRep_CurveRepresentation.lxx>

--- a/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.lxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_CurveRepresentation.lxx
@@ -16,6 +16,73 @@
 
 //=================================================================================================
 
+inline bool BRep_CurveRepresentation::IsCurve3D() const
+{
+  return Type() == Type_Curve3D;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsCurveOnSurface() const
+{
+  const TypeEnum aType = Type();
+  return aType == Type_CurveOnSurface || aType == Type_CurveOnClosedSurface;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsRegularity() const
+{
+  const TypeEnum aType = Type();
+  return aType == Type_CurveOn2Surfaces || aType == Type_CurveOnClosedSurface;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsCurveOnClosedSurface() const
+{
+  return Type() == Type_CurveOnClosedSurface;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsPolygon3D() const
+{
+  return Type() == Type_Polygon3D;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsPolygonOnTriangulation() const
+{
+  const TypeEnum aType = Type();
+  return aType == Type_PolygonOnTriangulation || aType == Type_PolygonOnClosedTriangulation;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsPolygonOnClosedTriangulation() const
+{
+  return Type() == Type_PolygonOnClosedTriangulation;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsPolygonOnSurface() const
+{
+  const TypeEnum aType = Type();
+  return aType == Type_PolygonOnSurface || aType == Type_PolygonOnClosedSurface;
+}
+
+//=================================================================================================
+
+inline bool BRep_CurveRepresentation::IsPolygonOnClosedSurface() const
+{
+  return Type() == Type_PolygonOnClosedSurface;
+}
+
+//=================================================================================================
+
 inline const TopLoc_Location& BRep_CurveRepresentation::Location() const
 {
   return myLocation;

--- a/src/ModelingData/TKBRep/BRep/BRep_GCurve.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_GCurve.cxx
@@ -22,11 +22,13 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_GCurve, BRep_CurveRepresentation)
 
 //=================================================================================================
 
-BRep_GCurve::BRep_GCurve(const TopLoc_Location& L, const double First, const double Last)
-    : BRep_CurveRepresentation(L),
+BRep_GCurve::BRep_GCurve(TypeEnum               theType,
+                         const TopLoc_Location& L,
+                         const double           First,
+                         const double           Last)
+    : BRep_CurveRepresentation(theType, L),
       myFirst(First),
       myLast(Last)
-
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_GCurve.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_GCurve.hxx
@@ -56,7 +56,10 @@ public:
   DEFINE_STANDARD_RTTIEXT(BRep_GCurve, BRep_CurveRepresentation)
 
 protected:
-  Standard_EXPORT BRep_GCurve(const TopLoc_Location& L, const double First, const double Last);
+  Standard_EXPORT BRep_GCurve(TypeEnum               theType,
+                              const TopLoc_Location& L,
+                              const double           First,
+                              const double           Last);
 
 private:
   double myFirst;

--- a/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.cxx
@@ -31,15 +31,6 @@ BRep_Polygon3D::BRep_Polygon3D(const occ::handle<Poly_Polygon3D>& P, const TopLo
 {
 }
 
-//=================================================================================================
-
-bool BRep_Polygon3D::IsPolygon3D() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 const occ::handle<Poly_Polygon3D>& BRep_Polygon3D::Polygon3D() const
 {
   return myPolygon3D;

--- a/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.cxx
@@ -26,7 +26,7 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_Polygon3D, BRep_CurveRepresentation)
 //=================================================================================================
 
 BRep_Polygon3D::BRep_Polygon3D(const occ::handle<Poly_Polygon3D>& P, const TopLoc_Location& L)
-    : BRep_CurveRepresentation(L),
+    : BRep_CurveRepresentation(Type_Polygon3D, L),
       myPolygon3D(P)
 {
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Polygon3D.hxx
@@ -31,9 +31,6 @@ class BRep_Polygon3D : public BRep_CurveRepresentation
 public:
   Standard_EXPORT BRep_Polygon3D(const occ::handle<Poly_Polygon3D>& P, const TopLoc_Location& L);
 
-  //! Returns True.
-  Standard_EXPORT bool IsPolygon3D() const override;
-
   Standard_EXPORT const occ::handle<Poly_Polygon3D>& Polygon3D() const override;
 
   Standard_EXPORT void Polygon3D(const occ::handle<Poly_Polygon3D>& P) override;

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
@@ -29,7 +29,7 @@ BRep_PolygonOnClosedSurface::BRep_PolygonOnClosedSurface(const occ::handle<Poly_
                                                          const occ::handle<Poly_Polygon2D>& P2,
                                                          const occ::handle<Geom_Surface>&   S,
                                                          const TopLoc_Location&             L)
-    : BRep_PolygonOnSurface(P1, S, L),
+    : BRep_PolygonOnSurface(Type_PolygonOnClosedSurface, P1, S, L),
       myPolygon2(P2)
 {
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.cxx
@@ -34,15 +34,6 @@ BRep_PolygonOnClosedSurface::BRep_PolygonOnClosedSurface(const occ::handle<Poly_
 {
 }
 
-//=================================================================================================
-
-bool BRep_PolygonOnClosedSurface::IsPolygonOnClosedSurface() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 const occ::handle<Poly_Polygon2D>& BRep_PolygonOnClosedSurface::Polygon2() const
 {
   return myPolygon2;

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedSurface.hxx
@@ -37,9 +37,6 @@ public:
                                               const occ::handle<Geom_Surface>&   S,
                                               const TopLoc_Location&             L);
 
-  //! returns True.
-  Standard_EXPORT bool IsPolygonOnClosedSurface() const override;
-
   Standard_EXPORT const occ::handle<Poly_Polygon2D>& Polygon2() const override;
 
   Standard_EXPORT void Polygon2(const occ::handle<Poly_Polygon2D>& P) override;

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
@@ -35,15 +35,6 @@ BRep_PolygonOnClosedTriangulation::BRep_PolygonOnClosedTriangulation(
 {
 }
 
-//=================================================================================================
-
-bool BRep_PolygonOnClosedTriangulation::IsPolygonOnClosedTriangulation() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 void BRep_PolygonOnClosedTriangulation::PolygonOnTriangulation2(
   const occ::handle<Poly_PolygonOnTriangulation>& P2)
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.cxx
@@ -30,7 +30,7 @@ BRep_PolygonOnClosedTriangulation::BRep_PolygonOnClosedTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P2,
   const occ::handle<Poly_Triangulation>&          T,
   const TopLoc_Location&                          L)
-    : BRep_PolygonOnTriangulation(P1, T, L),
+    : BRep_PolygonOnTriangulation(Type_PolygonOnClosedTriangulation, P1, T, L),
       myPolygon2(P2)
 {
 }

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnClosedTriangulation.hxx
@@ -38,9 +38,6 @@ public:
     const occ::handle<Poly_Triangulation>&          Tr,
     const TopLoc_Location&                          L);
 
-  //! Returns True.
-  Standard_EXPORT bool IsPolygonOnClosedTriangulation() const override;
-
   Standard_EXPORT void PolygonOnTriangulation2(
     const occ::handle<Poly_PolygonOnTriangulation>& P2) override;
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
@@ -45,15 +45,6 @@ BRep_PolygonOnSurface::BRep_PolygonOnSurface(TypeEnum                           
 {
 }
 
-//=================================================================================================
-
-bool BRep_PolygonOnSurface::IsPolygonOnSurface() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 bool BRep_PolygonOnSurface::IsPolygonOnSurface(const occ::handle<Geom_Surface>& S,
                                                const TopLoc_Location&           L) const
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.cxx
@@ -29,9 +29,19 @@ IMPLEMENT_STANDARD_RTTIEXT(BRep_PolygonOnSurface, BRep_CurveRepresentation)
 BRep_PolygonOnSurface::BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
                                              const occ::handle<Geom_Surface>&   S,
                                              const TopLoc_Location&             L)
-    : BRep_CurveRepresentation(L),
-      myPolygon2D(P),
-      mySurface(S)
+    : BRep_PolygonOnSurface(Type_PolygonOnSurface, P, S, L)
+{
+}
+
+//=================================================================================================
+
+BRep_PolygonOnSurface::BRep_PolygonOnSurface(TypeEnum                           theType,
+                                             const occ::handle<Poly_Polygon2D>& thePolygon,
+                                             const occ::handle<Geom_Surface>&   theSurface,
+                                             const TopLoc_Location&             theLocation)
+    : BRep_CurveRepresentation(theType, theLocation),
+      myPolygon2D(thePolygon),
+      mySurface(theSurface)
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
@@ -58,6 +58,12 @@ public:
 
   DEFINE_STANDARD_RTTIEXT(BRep_PolygonOnSurface, BRep_CurveRepresentation)
 
+protected:
+  Standard_EXPORT BRep_PolygonOnSurface(TypeEnum                           theType,
+                                        const occ::handle<Poly_Polygon2D>& thePolygon,
+                                        const occ::handle<Geom_Surface>&   theSurface,
+                                        const TopLoc_Location&             theLocation);
+
 private:
   occ::handle<Poly_Polygon2D> myPolygon2D;
   occ::handle<Geom_Surface>   mySurface;

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnSurface.hxx
@@ -31,13 +31,11 @@ class BRep_PolygonOnSurface : public BRep_CurveRepresentation
 {
 
 public:
+  using BRep_CurveRepresentation::IsPolygonOnSurface;
+
   Standard_EXPORT BRep_PolygonOnSurface(const occ::handle<Poly_Polygon2D>& P,
                                         const occ::handle<Geom_Surface>&   S,
                                         const TopLoc_Location&             L);
-
-  //! A 2D polygon representation in the parametric
-  //! space of a surface.
-  Standard_EXPORT bool IsPolygonOnSurface() const override;
 
   //! A 2D polygon representation in the parametric
   //! space of a surface.

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
@@ -29,9 +29,20 @@ BRep_PolygonOnTriangulation::BRep_PolygonOnTriangulation(
   const occ::handle<Poly_PolygonOnTriangulation>& P,
   const occ::handle<Poly_Triangulation>&          T,
   const TopLoc_Location&                          L)
-    : BRep_CurveRepresentation(L),
-      myPolygon(P),
-      myTriangulation(T)
+    : BRep_PolygonOnTriangulation(Type_PolygonOnTriangulation, P, T, L)
+{
+}
+
+//=================================================================================================
+
+BRep_PolygonOnTriangulation::BRep_PolygonOnTriangulation(
+  TypeEnum                                        theType,
+  const occ::handle<Poly_PolygonOnTriangulation>& thePolygon,
+  const occ::handle<Poly_Triangulation>&          theTriangulation,
+  const TopLoc_Location&                          theLocation)
+    : BRep_CurveRepresentation(theType, theLocation),
+      myPolygon(thePolygon),
+      myTriangulation(theTriangulation)
 {
 }
 

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.cxx
@@ -46,15 +46,6 @@ BRep_PolygonOnTriangulation::BRep_PolygonOnTriangulation(
 {
 }
 
-//=================================================================================================
-
-bool BRep_PolygonOnTriangulation::IsPolygonOnTriangulation() const
-{
-  return true;
-}
-
-//=================================================================================================
-
 bool BRep_PolygonOnTriangulation::IsPolygonOnTriangulation(const occ::handle<Poly_Triangulation>& T,
                                                            const TopLoc_Location& L) const
 {

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
@@ -31,12 +31,11 @@ class BRep_PolygonOnTriangulation : public BRep_CurveRepresentation
 {
 
 public:
+  using BRep_CurveRepresentation::IsPolygonOnTriangulation;
+
   Standard_EXPORT BRep_PolygonOnTriangulation(const occ::handle<Poly_PolygonOnTriangulation>& P,
                                               const occ::handle<Poly_Triangulation>&          T,
                                               const TopLoc_Location&                          L);
-
-  //! returns True.
-  Standard_EXPORT bool IsPolygonOnTriangulation() const override;
 
   //! Is it a polygon in the definition of <T> with
   //! location <L>.

--- a/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_PolygonOnTriangulation.hxx
@@ -60,6 +60,13 @@ public:
 
   DEFINE_STANDARD_RTTIEXT(BRep_PolygonOnTriangulation, BRep_CurveRepresentation)
 
+protected:
+  Standard_EXPORT BRep_PolygonOnTriangulation(
+    TypeEnum                                        theType,
+    const occ::handle<Poly_PolygonOnTriangulation>& thePolygon,
+    const occ::handle<Poly_Triangulation>&          theTriangulation,
+    const TopLoc_Location&                          theLocation);
+
 private:
   occ::handle<Poly_PolygonOnTriangulation> myPolygon;
   occ::handle<Poly_Triangulation>          myTriangulation;

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -174,13 +174,13 @@ const occ::handle<Geom_Curve>& BRep_Tool::Curve(const TopoDS_Edge& E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->Type() == BRep_CurveRepresentation::Type_Curve3D)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurve3D())
     {
-      const BRep_Curve3D* GC = static_cast<const BRep_Curve3D*>(cr.get());
-      L                      = E.Location() * GC->Location();
-      GC->Range(First, Last);
-      return GC->Curve3D();
+      const BRep_Curve3D* aCurve3D = static_cast<const BRep_Curve3D*>(aCurveRepresentation.get());
+      L                            = E.Location() * aCurve3D->Location();
+      aCurve3D->Range(First, Last);
+      return aCurve3D->Curve3D();
     }
     itcr.Next();
   }
@@ -216,6 +216,7 @@ occ::handle<Geom_Curve> BRep_Tool::Curve(const TopoDS_Edge& E, double& First, do
 // function : IsGeometric
 // purpose  : Returns True if <F> has a surface.
 //=================================================================================================
+
 bool BRep_Tool::IsGeometric(const TopoDS_Face& F)
 {
   const BRep_TFace*                TF = static_cast<const BRep_TFace*>(F.TShape().get());
@@ -237,16 +238,14 @@ bool BRep_Tool::IsGeometric(const TopoDS_Edge& E)
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_Curve3D)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurve3D())
     {
-      const BRep_Curve3D* GC = static_cast<const BRep_Curve3D*>(cr.get());
-      if (!GC->Curve3D().IsNull())
+      const occ::handle<BRep_Curve3D> aCurve3D = occ::down_cast<BRep_Curve3D>(aCurveRepresentation);
+      if (!aCurve3D.IsNull() && !aCurve3D->Curve3D().IsNull())
         return true;
     }
-    else if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
-             || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
+    else if (aCurveRepresentation->IsCurveOnSurface())
       return true;
     itcr.Next();
   }
@@ -269,12 +268,13 @@ const occ::handle<Poly_Polygon3D>& BRep_Tool::Polygon3D(const TopoDS_Edge& E, To
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->Type() == BRep_CurveRepresentation::Type_Polygon3D)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygon3D())
     {
-      const BRep_Polygon3D* GC = static_cast<const BRep_Polygon3D*>(cr.get());
-      L                        = E.Location() * GC->Location();
-      return GC->Polygon3D();
+      const BRep_Polygon3D* aPolygon3D =
+        static_cast<const BRep_Polygon3D*>(aCurveRepresentation.get());
+      L = E.Location() * aPolygon3D->Location();
+      return aPolygon3D->Polygon3D();
     }
     itcr.Next();
   }
@@ -336,15 +336,16 @@ occ::handle<Geom2d_Curve> BRep_Tool::CurveOnSurface(const TopoDS_Edge&          
 
     while (itcr.More())
     {
-      const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-      if (cr->IsCurveOnSurface(S, loc))
+      const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+      if (aCurveRepresentation->IsCurveOnSurface(S, loc))
       {
-        const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
-        GC->Range(First, Last);
-        if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface && Eisreversed)
-          return GC->PCurve2();
+        const BRep_GCurve* aGCurve = static_cast<const BRep_GCurve*>(aCurveRepresentation.get());
+        aGCurve->Range(First, Last);
+        if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
+            && Eisreversed)
+          return aGCurve->PCurve2();
         else
-          return GC->PCurve();
+          return aGCurve->PCurve();
       }
       itcr.Next();
     }
@@ -360,6 +361,7 @@ occ::handle<Geom2d_Curve> BRep_Tool::CurveOnSurface(const TopoDS_Edge&          
 // function : CurveOnPlane
 // purpose  : For planar surface returns projection of the edge on the plane
 //=================================================================================================
+
 occ::handle<Geom2d_Curve> BRep_Tool::CurveOnPlane(const TopoDS_Edge&               E,
                                                   const occ::handle<Geom_Surface>& S,
                                                   const TopLoc_Location&           L,
@@ -440,16 +442,14 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
-        || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurveOnSurface())
     {
-      const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
-      C                     = GC->PCurve();
-      S                     = GC->Surface();
-      L                     = E.Location() * GC->Location();
-      GC->Range(First, Last);
+      const BRep_GCurve* aGCurve = static_cast<const BRep_GCurve*>(aCurveRepresentation.get());
+      C                          = aGCurve->PCurve();
+      S                          = aGCurve->Surface();
+      L                          = E.Location() * aGCurve->Location();
+      aGCurve->Range(First, Last);
       return;
     }
     itcr.Next();
@@ -480,25 +480,23 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   for (; itcr.More(); itcr.Next())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
-        || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurveOnSurface())
     {
-      const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
+      const BRep_GCurve* aGCurve = static_cast<const BRep_GCurve*>(aCurveRepresentation.get());
       ++i;
       // Compare index taking into account the fact that for the curves on
       // closed surfaces there are two PCurves
       if (i == Index)
-        C = GC->PCurve();
-      else if (aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface && (++i == Index))
-        C = GC->PCurve2();
+        C = aGCurve->PCurve();
+      else if (aCurveRepresentation->IsCurveOnClosedSurface() && (++i == Index))
+        C = aGCurve->PCurve2();
       else
         continue;
 
-      S = GC->Surface();
-      L = E.Location() * GC->Location();
-      GC->Range(First, Last);
+      S = aGCurve->Surface();
+      L = E.Location() * aGCurve->Location();
+      aGCurve->Range(First, Last);
       return;
     }
   }
@@ -554,13 +552,14 @@ occ::handle<Poly_Polygon2D> BRep_Tool::PolygonOnSurface(const TopoDS_Edge&      
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnSurface(S, l))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygonOnSurface(S, l))
     {
-      if (cr->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedSurface && Eisreversed)
-        return cr->Polygon2();
+      if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedSurface
+          && Eisreversed)
+        return aCurveRepresentation->Polygon2();
       else
-        return cr->Polygon();
+        return aCurveRepresentation->Polygon();
     }
     itcr.Next();
   }
@@ -581,15 +580,14 @@ void BRep_Tool::PolygonOnSurface(const TopoDS_Edge&           E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_PolygonOnSurface
-        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedSurface)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygonOnSurface())
     {
-      const BRep_PolygonOnSurface* PS = static_cast<const BRep_PolygonOnSurface*>(cr.get());
-      P                               = PS->Polygon();
-      S                               = PS->Surface();
-      L                               = E.Location() * PS->Location();
+      const BRep_PolygonOnSurface* aPolygonOnSurface =
+        static_cast<const BRep_PolygonOnSurface*>(aCurveRepresentation.get());
+      P = aPolygonOnSurface->Polygon();
+      S = aPolygonOnSurface->Surface();
+      L = E.Location() * aPolygonOnSurface->Location();
       return;
     }
     itcr.Next();
@@ -616,20 +614,19 @@ void BRep_Tool::PolygonOnSurface(const TopoDS_Edge&           E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_PolygonOnSurface
-        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedSurface)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygonOnSurface())
     {
-      const BRep_PolygonOnSurface* PS = static_cast<const BRep_PolygonOnSurface*>(cr.get());
+      const BRep_PolygonOnSurface* aPolygonOnSurface =
+        static_cast<const BRep_PolygonOnSurface*>(aCurveRepresentation.get());
       i++;
       if (i > Index)
         break;
       if (i == Index)
       {
-        P = PS->Polygon();
-        S = PS->Surface();
-        L = E.Location() * PS->Location();
+        P = aPolygonOnSurface->Polygon();
+        S = aPolygonOnSurface->Surface();
+        L = E.Location() * aPolygonOnSurface->Location();
         return;
       }
     }
@@ -664,13 +661,15 @@ const occ::handle<Poly_PolygonOnTriangulation>& BRep_Tool::PolygonOnTriangulatio
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnTriangulation(T, l))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygonOnTriangulation(T, l))
     {
-      if (cr->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation && Eisreversed)
-        return cr->PolygonOnTriangulation2();
+      if (aCurveRepresentation->Type()
+            == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation
+          && Eisreversed)
+        return aCurveRepresentation->PolygonOnTriangulation2();
       else
-        return cr->PolygonOnTriangulation();
+        return aCurveRepresentation->PolygonOnTriangulation();
     }
     itcr.Next();
   }
@@ -691,16 +690,14 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_PolygonOnTriangulation
-        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygonOnTriangulation())
     {
-      const BRep_PolygonOnTriangulation* PT =
-        static_cast<const BRep_PolygonOnTriangulation*>(cr.get());
-      P = PT->PolygonOnTriangulation();
-      T = PT->Triangulation();
-      L = E.Location() * PT->Location();
+      const BRep_PolygonOnTriangulation* aPolygonOnTriangulation =
+        static_cast<const BRep_PolygonOnTriangulation*>(aCurveRepresentation.get());
+      P = aPolygonOnTriangulation->PolygonOnTriangulation();
+      T = aPolygonOnTriangulation->Triangulation();
+      L = E.Location() * aPolygonOnTriangulation->Location();
       return;
     }
     itcr.Next();
@@ -727,21 +724,19 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_PolygonOnTriangulation
-        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsPolygonOnTriangulation())
     {
-      const BRep_PolygonOnTriangulation* PT =
-        static_cast<const BRep_PolygonOnTriangulation*>(cr.get());
+      const BRep_PolygonOnTriangulation* aPolygonOnTriangulation =
+        static_cast<const BRep_PolygonOnTriangulation*>(aCurveRepresentation.get());
       i++;
       if (i > Index)
         break;
       if (i == Index)
       {
-        T = PT->Triangulation();
-        P = PT->PolygonOnTriangulation();
-        L = E.Location() * PT->Location();
+        T = aPolygonOnTriangulation->Triangulation();
+        P = aPolygonOnTriangulation->PolygonOnTriangulation();
+        L = E.Location() * aPolygonOnTriangulation->Location();
         return;
       }
     }
@@ -796,9 +791,9 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
-        && cr->IsCurveOnSurface(S, l))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
+        && aCurveRepresentation->IsCurveOnSurface(S, l))
       return true;
     itcr.Next();
   }
@@ -828,9 +823,9 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&                     E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation
-        && cr->IsPolygonOnTriangulation(T, l))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation
+        && aCurveRepresentation->IsPolygonOnTriangulation(T, l))
       return true;
     itcr.Next();
   }
@@ -896,24 +891,22 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
-    if (aType == BRep_CurveRepresentation::Type_Curve3D)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurve3D())
     {
-      const BRep_Curve3D* CR = static_cast<const BRep_Curve3D*>(cr.get());
-      if (!CR->Curve3D().IsNull())
+      const BRep_Curve3D* aCurve3D = static_cast<const BRep_Curve3D*>(aCurveRepresentation.get());
+      if (!aCurve3D->Curve3D().IsNull())
       {
-        First = CR->First();
-        Last  = CR->Last();
+        First = aCurve3D->First();
+        Last  = aCurve3D->Last();
         return;
       }
     }
-    else if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
-             || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
+    else if (aCurveRepresentation->IsCurveOnSurface())
     {
-      const BRep_GCurve* CR = static_cast<const BRep_GCurve*>(cr.get());
-      First                 = CR->First();
-      Last                  = CR->Last();
+      const BRep_GCurve* aGCurve = static_cast<const BRep_GCurve*>(aCurveRepresentation.get());
+      First                      = aGCurve->First();
+      Last                       = aGCurve->Last();
       return;
     }
     itcr.Next();
@@ -937,11 +930,12 @@ void BRep_Tool::Range(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurveOnSurface(S, l))
     {
-      const BRep_CurveOnSurface* CR = static_cast<const BRep_CurveOnSurface*>(cr.get());
-      CR->Range(First, Last);
+      const BRep_CurveOnSurface* aCurveOnSurface =
+        static_cast<const BRep_CurveOnSurface*>(aCurveRepresentation.get());
+      aCurveOnSurface->Range(First, Last);
       break;
     }
     itcr.Next();
@@ -979,19 +973,21 @@ void BRep_Tool::UVPoints(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurveOnSurface(S, l))
     {
-      if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface && Eisreversed)
+      if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
+          && Eisreversed)
       {
-        const BRep_CurveOnClosedSurface* CR =
-          static_cast<const BRep_CurveOnClosedSurface*>(cr.get());
-        CR->UVPoints2(PFirst, PLast);
+        const BRep_CurveOnClosedSurface* aCurveOnClosedSurface =
+          static_cast<const BRep_CurveOnClosedSurface*>(aCurveRepresentation.get());
+        aCurveOnClosedSurface->UVPoints2(PFirst, PLast);
       }
       else
       {
-        const BRep_CurveOnSurface* CR = static_cast<const BRep_CurveOnSurface*>(cr.get());
-        CR->UVPoints(PFirst, PLast);
+        const BRep_CurveOnSurface* aCurveOnSurface =
+          static_cast<const BRep_CurveOnSurface*>(aCurveRepresentation.get());
+        aCurveOnSurface->UVPoints(PFirst, PLast);
       }
       return;
     }
@@ -1081,18 +1077,21 @@ void BRep_Tool::SetUVPoints(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    occ::handle<BRep_CurveRepresentation> cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l))
+    occ::handle<BRep_CurveRepresentation> aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsCurveOnSurface(S, l))
     {
-      if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface && Eisreversed)
+      if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
+          && Eisreversed)
       {
-        BRep_CurveOnClosedSurface* CS = static_cast<BRep_CurveOnClosedSurface*>(cr.get());
-        CS->SetUVPoints2(PFirst, PLast);
+        BRep_CurveOnClosedSurface* aCurveOnClosedSurface =
+          static_cast<BRep_CurveOnClosedSurface*>(aCurveRepresentation.get());
+        aCurveOnClosedSurface->SetUVPoints2(PFirst, PLast);
       }
       else
       {
-        BRep_CurveOnSurface* CS = static_cast<BRep_CurveOnSurface*>(cr.get());
-        CS->SetUVPoints(PFirst, PLast);
+        BRep_CurveOnSurface* aCurveOnSurface =
+          static_cast<BRep_CurveOnSurface*>(aCurveRepresentation.get());
+        aCurveOnSurface->SetUVPoints(PFirst, PLast);
       }
     }
     itcr.Next();
@@ -1169,8 +1168,8 @@ bool BRep_Tool::HasContinuity(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsRegularity(S1, S2, l1, l2))
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsRegularity(S1, S2, l1, l2))
       return true;
     itcr.Next();
   }
@@ -1197,9 +1196,9 @@ GeomAbs_Shape BRep_Tool::Continuity(const TopoDS_Edge&               E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsRegularity(S1, S2, l1, l2))
-      return cr->Continuity();
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsRegularity(S1, S2, l1, l2))
+      return aCurveRepresentation->Continuity();
     itcr.Next();
   }
   return GeomAbs_C0;
@@ -1217,10 +1216,8 @@ bool BRep_Tool::HasContinuity(const TopoDS_Edge& E)
 
   for (; itcr.More(); itcr.Next())
   {
-    const occ::handle<BRep_CurveRepresentation>& CR = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum     aT = CR->Type();
-    if (aT == BRep_CurveRepresentation::Type_CurveOn2Surfaces
-        || aT == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
+    const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
+    if (aCurveRepresentation->IsRegularity())
       return true;
   }
   return false;
@@ -1237,9 +1234,7 @@ GeomAbs_Shape BRep_Tool::MaxContinuity(const TopoDS_Edge& theEdge)
        aReprIter.Next())
   {
     const occ::handle<BRep_CurveRepresentation>& aRepr = aReprIter.Value();
-    const BRep_CurveRepresentation::TypeEnum     aT    = aRepr->Type();
-    if (aT == BRep_CurveRepresentation::Type_CurveOn2Surfaces
-        || aT == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
+    if (aRepr->IsRegularity())
     {
       const GeomAbs_Shape aCont = aRepr->Continuity();
       if ((int)aCont > (int)aMaxCont)

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -341,8 +341,7 @@ occ::handle<Geom2d_Curve> BRep_Tool::CurveOnSurface(const TopoDS_Edge&          
       {
         const BRep_GCurve* aGCurve = static_cast<const BRep_GCurve*>(aCurveRepresentation.get());
         aGCurve->Range(First, Last);
-        if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
-            && Eisreversed)
+        if (aCurveRepresentation->IsCurveOnClosedSurface() && Eisreversed)
           return aGCurve->PCurve2();
         else
           return aGCurve->PCurve();
@@ -555,8 +554,7 @@ occ::handle<Poly_Polygon2D> BRep_Tool::PolygonOnSurface(const TopoDS_Edge&      
     const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
     if (aCurveRepresentation->IsPolygonOnSurface(S, l))
     {
-      if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedSurface
-          && Eisreversed)
+      if (aCurveRepresentation->IsPolygonOnClosedSurface() && Eisreversed)
         return aCurveRepresentation->Polygon2();
       else
         return aCurveRepresentation->Polygon();
@@ -792,7 +790,7 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
-    if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
+    if (aCurveRepresentation->IsCurveOnClosedSurface()
         && aCurveRepresentation->IsCurveOnSurface(S, l))
       return true;
     itcr.Next();
@@ -824,7 +822,7 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&                     E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
-    if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation
+    if (aCurveRepresentation->IsPolygonOnClosedTriangulation()
         && aCurveRepresentation->IsPolygonOnTriangulation(T, l))
       return true;
     itcr.Next();
@@ -976,8 +974,7 @@ void BRep_Tool::UVPoints(const TopoDS_Edge&               E,
     const occ::handle<BRep_CurveRepresentation>& aCurveRepresentation = itcr.Value();
     if (aCurveRepresentation->IsCurveOnSurface(S, l))
     {
-      if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
-          && Eisreversed)
+      if (aCurveRepresentation->IsCurveOnClosedSurface() && Eisreversed)
       {
         const BRep_CurveOnClosedSurface* aCurveOnClosedSurface =
           static_cast<const BRep_CurveOnClosedSurface*>(aCurveRepresentation.get());
@@ -1080,8 +1077,7 @@ void BRep_Tool::SetUVPoints(const TopoDS_Edge&               E,
     occ::handle<BRep_CurveRepresentation> aCurveRepresentation = itcr.Value();
     if (aCurveRepresentation->IsCurveOnSurface(S, l))
     {
-      if (aCurveRepresentation->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
-          && Eisreversed)
+      if (aCurveRepresentation->IsCurveOnClosedSurface() && Eisreversed)
       {
         BRep_CurveOnClosedSurface* aCurveOnClosedSurface =
           static_cast<BRep_CurveOnClosedSurface*>(aCurveRepresentation.get());

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -175,7 +175,7 @@ const occ::handle<Geom_Curve>& BRep_Tool::Curve(const TopoDS_Edge& E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurve3D())
+    if (cr->Type() == BRep_CurveRepresentation::Type_Curve3D)
     {
       const BRep_Curve3D* GC = static_cast<const BRep_Curve3D*>(cr.get());
       L                      = E.Location() * GC->Location();
@@ -238,13 +238,15 @@ bool BRep_Tool::IsGeometric(const TopoDS_Edge& E)
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurve3D())
+    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_Curve3D)
     {
-      occ::handle<BRep_Curve3D> GC(occ::down_cast<BRep_Curve3D>(cr));
-      if (!GC.IsNull() && !GC->Curve3D().IsNull())
+      const BRep_Curve3D* GC = static_cast<const BRep_Curve3D*>(cr.get());
+      if (!GC->Curve3D().IsNull())
         return true;
     }
-    else if (cr->IsCurveOnSurface())
+    else if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
+             || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
       return true;
     itcr.Next();
   }
@@ -268,7 +270,7 @@ const occ::handle<Poly_Polygon3D>& BRep_Tool::Polygon3D(const TopoDS_Edge& E, To
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygon3D())
+    if (cr->Type() == BRep_CurveRepresentation::Type_Polygon3D)
     {
       const BRep_Polygon3D* GC = static_cast<const BRep_Polygon3D*>(cr.get());
       L                        = E.Location() * GC->Location();
@@ -339,7 +341,7 @@ occ::handle<Geom2d_Curve> BRep_Tool::CurveOnSurface(const TopoDS_Edge&          
       {
         const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
         GC->Range(First, Last);
-        if (GC->IsCurveOnClosedSurface() && Eisreversed)
+        if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface && Eisreversed)
           return GC->PCurve2();
         else
           return GC->PCurve();
@@ -438,8 +440,10 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface())
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum      aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
+        || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {
       const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
       C                     = GC->PCurve();
@@ -477,7 +481,9 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
   for (; itcr.More(); itcr.Next())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface())
+    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
+        || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {
       const BRep_GCurve* GC = static_cast<const BRep_GCurve*>(cr.get());
       ++i;
@@ -485,7 +491,7 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
       // closed surfaces there are two PCurves
       if (i == Index)
         C = GC->PCurve();
-      else if (GC->IsCurveOnClosedSurface() && (++i == Index))
+      else if (aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface && (++i == Index))
         C = GC->PCurve2();
       else
         continue;
@@ -551,7 +557,7 @@ occ::handle<Poly_Polygon2D> BRep_Tool::PolygonOnSurface(const TopoDS_Edge&      
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
     if (cr->IsPolygonOnSurface(S, l))
     {
-      if (cr->IsPolygonOnClosedSurface() && Eisreversed)
+      if (cr->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedSurface && Eisreversed)
         return cr->Polygon2();
       else
         return cr->Polygon();
@@ -576,7 +582,9 @@ void BRep_Tool::PolygonOnSurface(const TopoDS_Edge&           E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnSurface())
+    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_PolygonOnSurface
+        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedSurface)
     {
       const BRep_PolygonOnSurface* PS = static_cast<const BRep_PolygonOnSurface*>(cr.get());
       P                               = PS->Polygon();
@@ -608,8 +616,10 @@ void BRep_Tool::PolygonOnSurface(const TopoDS_Edge&           E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnSurface())
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum      aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_PolygonOnSurface
+        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedSurface)
     {
       const BRep_PolygonOnSurface* PS = static_cast<const BRep_PolygonOnSurface*>(cr.get());
       i++;
@@ -657,7 +667,7 @@ const occ::handle<Poly_PolygonOnTriangulation>& BRep_Tool::PolygonOnTriangulatio
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
     if (cr->IsPolygonOnTriangulation(T, l))
     {
-      if (cr->IsPolygonOnClosedTriangulation() && Eisreversed)
+      if (cr->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation && Eisreversed)
         return cr->PolygonOnTriangulation2();
       else
         return cr->PolygonOnTriangulation();
@@ -682,7 +692,9 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnTriangulation())
+    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_PolygonOnTriangulation
+        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation)
     {
       const BRep_PolygonOnTriangulation* PT =
         static_cast<const BRep_PolygonOnTriangulation*>(cr.get());
@@ -715,8 +727,10 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnTriangulation())
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum      aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_PolygonOnTriangulation
+        || aType == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation)
     {
       const BRep_PolygonOnTriangulation* PT =
         static_cast<const BRep_PolygonOnTriangulation*>(cr.get());
@@ -783,7 +797,8 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&               E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurveOnSurface(S, l) && cr->IsCurveOnClosedSurface())
+    if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface
+        && cr->IsCurveOnSurface(S, l))
       return true;
     itcr.Next();
   }
@@ -814,7 +829,8 @@ bool BRep_Tool::IsClosed(const TopoDS_Edge&                     E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsPolygonOnTriangulation(T, l) && cr->IsPolygonOnClosedTriangulation())
+    if (cr->Type() == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation
+        && cr->IsPolygonOnTriangulation(T, l))
       return true;
     itcr.Next();
   }
@@ -881,7 +897,8 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    if (cr->IsCurve3D())
+    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    if (aType == BRep_CurveRepresentation::Type_Curve3D)
     {
       const BRep_Curve3D* CR = static_cast<const BRep_Curve3D*>(cr.get());
       if (!CR->Curve3D().IsNull())
@@ -891,7 +908,8 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
         return;
       }
     }
-    else if (cr->IsCurveOnSurface())
+    else if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
+             || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {
       const BRep_GCurve* CR = static_cast<const BRep_GCurve*>(cr.get());
       First                 = CR->First();
@@ -964,7 +982,7 @@ void BRep_Tool::UVPoints(const TopoDS_Edge&               E,
     const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
     if (cr->IsCurveOnSurface(S, l))
     {
-      if (cr->IsCurveOnClosedSurface() && Eisreversed)
+      if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface && Eisreversed)
       {
         const BRep_CurveOnClosedSurface* CR =
           static_cast<const BRep_CurveOnClosedSurface*>(cr.get());
@@ -1066,7 +1084,7 @@ void BRep_Tool::SetUVPoints(const TopoDS_Edge&               E,
     occ::handle<BRep_CurveRepresentation> cr = itcr.Value();
     if (cr->IsCurveOnSurface(S, l))
     {
-      if (cr->IsCurveOnClosedSurface() && Eisreversed)
+      if (cr->Type() == BRep_CurveRepresentation::Type_CurveOnClosedSurface && Eisreversed)
       {
         BRep_CurveOnClosedSurface* CS = static_cast<BRep_CurveOnClosedSurface*>(cr.get());
         CS->SetUVPoints2(PFirst, PLast);
@@ -1200,7 +1218,9 @@ bool BRep_Tool::HasContinuity(const TopoDS_Edge& E)
   for (; itcr.More(); itcr.Next())
   {
     const occ::handle<BRep_CurveRepresentation>& CR = itcr.Value();
-    if (CR->IsRegularity())
+    const BRep_CurveRepresentation::TypeEnum      aT = CR->Type();
+    if (aT == BRep_CurveRepresentation::Type_CurveOn2Surfaces
+        || aT == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
       return true;
   }
   return false;
@@ -1217,7 +1237,9 @@ GeomAbs_Shape BRep_Tool::MaxContinuity(const TopoDS_Edge& theEdge)
        aReprIter.Next())
   {
     const occ::handle<BRep_CurveRepresentation>& aRepr = aReprIter.Value();
-    if (aRepr->IsRegularity())
+    const BRep_CurveRepresentation::TypeEnum      aT    = aRepr->Type();
+    if (aT == BRep_CurveRepresentation::Type_CurveOn2Surfaces
+        || aT == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {
       const GeomAbs_Shape aCont = aRepr->Continuity();
       if ((int)aCont > (int)aMaxCont)

--- a/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRep/BRep_Tool.cxx
@@ -237,8 +237,8 @@ bool BRep_Tool::IsGeometric(const TopoDS_Edge& E)
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_Curve3D)
     {
       const BRep_Curve3D* GC = static_cast<const BRep_Curve3D*>(cr.get());
@@ -441,7 +441,7 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum      aType = cr->Type();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
         || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {
@@ -480,8 +480,8 @@ void BRep_Tool::CurveOnSurface(const TopoDS_Edge&         E,
   NCollection_List<occ::handle<BRep_CurveRepresentation>>::Iterator itcr(TE->Curves());
   for (; itcr.More(); itcr.Next())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_CurveOnSurface
         || aType == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {
@@ -581,8 +581,8 @@ void BRep_Tool::PolygonOnSurface(const TopoDS_Edge&           E,
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_PolygonOnSurface
         || aType == BRep_CurveRepresentation::Type_PolygonOnClosedSurface)
     {
@@ -617,7 +617,7 @@ void BRep_Tool::PolygonOnSurface(const TopoDS_Edge&           E,
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum      aType = cr->Type();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_PolygonOnSurface
         || aType == BRep_CurveRepresentation::Type_PolygonOnClosedSurface)
     {
@@ -691,8 +691,8 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_PolygonOnTriangulation
         || aType == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation)
     {
@@ -728,7 +728,7 @@ void BRep_Tool::PolygonOnTriangulation(const TopoDS_Edge&                       
   while (itcr.More())
   {
     const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum      aType = cr->Type();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_PolygonOnTriangulation
         || aType == BRep_CurveRepresentation::Type_PolygonOnClosedTriangulation)
     {
@@ -896,8 +896,8 @@ void BRep_Tool::Range(const TopoDS_Edge& E, double& First, double& Last)
 
   while (itcr.More())
   {
-    const occ::handle<BRep_CurveRepresentation>& cr = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum aType = cr->Type();
+    const occ::handle<BRep_CurveRepresentation>& cr    = itcr.Value();
+    const BRep_CurveRepresentation::TypeEnum     aType = cr->Type();
     if (aType == BRep_CurveRepresentation::Type_Curve3D)
     {
       const BRep_Curve3D* CR = static_cast<const BRep_Curve3D*>(cr.get());
@@ -1218,7 +1218,7 @@ bool BRep_Tool::HasContinuity(const TopoDS_Edge& E)
   for (; itcr.More(); itcr.Next())
   {
     const occ::handle<BRep_CurveRepresentation>& CR = itcr.Value();
-    const BRep_CurveRepresentation::TypeEnum      aT = CR->Type();
+    const BRep_CurveRepresentation::TypeEnum     aT = CR->Type();
     if (aT == BRep_CurveRepresentation::Type_CurveOn2Surfaces
         || aT == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
       return true;
@@ -1237,7 +1237,7 @@ GeomAbs_Shape BRep_Tool::MaxContinuity(const TopoDS_Edge& theEdge)
        aReprIter.Next())
   {
     const occ::handle<BRep_CurveRepresentation>& aRepr = aReprIter.Value();
-    const BRep_CurveRepresentation::TypeEnum      aT    = aRepr->Type();
+    const BRep_CurveRepresentation::TypeEnum     aT    = aRepr->Type();
     if (aT == BRep_CurveRepresentation::Type_CurveOn2Surfaces
         || aT == BRep_CurveRepresentation::Type_CurveOnClosedSurface)
     {

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_History.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_History.cxx
@@ -334,7 +334,8 @@ bool BRepTools_History::prepareGenerated(const TopoDS_Shape& theInitial,
                          myMsgUnsupportedType,
                          false);
 
-  if (myShapeToModified.IsBound(theInitial) && myShapeToModified(theInitial).Remove(theGenerated))
+  NCollection_List<TopoDS_Shape>* aModList = myShapeToModified.ChangeSeek(theInitial);
+  if (aModList != nullptr && aModList->Remove(theGenerated))
   {
     Standard_ASSERT_INVOKE_(, myMsgGeneratedAndModified);
   }
@@ -354,7 +355,8 @@ bool BRepTools_History::prepareModified(const TopoDS_Shape& theInitial,
     Standard_ASSERT_INVOKE_(, myMsgModifiedAndRemoved);
   }
 
-  if (myShapeToGenerated.IsBound(theInitial) && myShapeToGenerated(theInitial).Remove(theModified))
+  NCollection_List<TopoDS_Shape>* aGenList = myShapeToGenerated.ChangeSeek(theInitial);
+  if (aGenList != nullptr && aGenList->Remove(theModified))
   {
     Standard_ASSERT_INVOKE_(, myMsgGeneratedAndModified);
   }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
@@ -249,10 +249,11 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
   switch (ts)
   {
     case TopAbs_FACE: {
-      rebuild = myNSInfo.IsBound(TopoDS::Face(S));
+      const NewSurfaceInfo* aNSinfoPtr = myNSInfo.Seek(TopoDS::Face(S));
+      rebuild                          = (aNSinfoPtr != nullptr);
       if (rebuild)
       {
-        const NewSurfaceInfo& aNSinfo = myNSInfo(TopoDS::Face(S));
+        const NewSurfaceInfo& aNSinfo = *aNSinfoPtr;
         RevWires                      = aNSinfo.myRevWires;
         B.MakeFace(TopoDS::Face(result),
                    aNSinfo.mySurface,
@@ -282,10 +283,11 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
     break;
 
     case TopAbs_EDGE: {
-      rebuild = myNCInfo.IsBound(TopoDS::Edge(S));
+      const NewCurveInfo* aNCinfoPtr = myNCInfo.Seek(TopoDS::Edge(S));
+      rebuild                        = (aNCinfoPtr != nullptr);
       if (rebuild)
       {
-        const NewCurveInfo& aNCinfo = myNCInfo(TopoDS::Edge(S));
+        const NewCurveInfo& aNCinfo = *aNCinfoPtr;
         if (aNCinfo.myCurve.IsNull())
         {
           B.MakeEdge(TopoDS::Edge(result));
@@ -335,13 +337,7 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
   TopoDS_Iterator it;
 
   {
-    int aShapeCount = 0;
-    {
-      for (it.Initialize(S, false); it.More(); it.Next())
-        ++aShapeCount;
-    }
-
-    Message_ProgressScope aPS(theProgress, "Converting SubShapes", aShapeCount);
+    Message_ProgressScope aPS(theProgress, "Converting SubShapes", S.NbChildren());
     //
     for (it.Initialize(S, false); it.More() && aPS.More(); it.Next())
     {
@@ -423,7 +419,8 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
             if (!isClosed)
             {
               TopLoc_Location aLoc;
-              TopoDS_Shape    resface = (myMap.IsBound(face) ? myMap(face) : face);
+              const TopoDS_Shape* aResFacePtr = myMap.Seek(face);
+              TopoDS_Shape        resface    = (aResFacePtr != nullptr ? *aResFacePtr : face);
               if (resface.IsNull())
                 resface = face;
               occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(TopoDS::Face(resface), aLoc);
@@ -434,7 +431,8 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
                 TopoDS_Face anOther = TopoDS::Face(aExpF.Current());
                 if (anOther.IsSame(face))
                   continue;
-                TopoDS_Shape resface2 = (myMap.IsBound(anOther) ? myMap(anOther) : anOther);
+                const TopoDS_Shape* aResFace2Ptr = myMap.Seek(anOther);
+                TopoDS_Shape        resface2    = (aResFace2Ptr != nullptr ? *aResFace2Ptr : anOther);
                 if (resface2.IsNull())
                   resface2 = anOther;
                 TopLoc_Location           anOtherLoc;
@@ -694,7 +692,7 @@ void BRepTools_Modifier::FillNewSurfaceInfo(const occ::handle<BRepTools_Modifica
       while (exE.More() && notRebuilded)
       {
         const TopoDS_Edge& anEE = TopoDS::Edge(exE.Current());
-        if (myNCInfo.IsBound(anEE))
+        if (myNCInfo.Seek(anEE) != nullptr)
         {
           notRebuilded = false;
           break;
@@ -750,7 +748,8 @@ void BRepTools_Modifier::CreateOtherVertices(
       for (; it.More() && !toReplace; it.Next())
       {
         const TopoDS_Edge& anE = TopoDS::Edge(it.Value());
-        if (myNCInfo.IsBound(anE) && !myNCInfo(anE).myCurve.IsNull())
+        const NewCurveInfo* aNCSeek = myNCInfo.Seek(anE);
+        if (aNCSeek != nullptr && !aNCSeek->myCurve.IsNull())
           toReplace = true;
 
         if (!toReplace)

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Modifier.cxx
@@ -418,9 +418,9 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
             isClosed = (!newgeom || BRepTools::IsReallyClosed(edge, face));
             if (!isClosed)
             {
-              TopLoc_Location aLoc;
+              TopLoc_Location     aLoc;
               const TopoDS_Shape* aResFacePtr = myMap.Seek(face);
-              TopoDS_Shape        resface    = (aResFacePtr != nullptr ? *aResFacePtr : face);
+              TopoDS_Shape        resface     = (aResFacePtr != nullptr ? *aResFacePtr : face);
               if (resface.IsNull())
                 resface = face;
               occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(TopoDS::Face(resface), aLoc);
@@ -432,7 +432,7 @@ bool BRepTools_Modifier::Rebuild(const TopoDS_Shape&                        S,
                 if (anOther.IsSame(face))
                   continue;
                 const TopoDS_Shape* aResFace2Ptr = myMap.Seek(anOther);
-                TopoDS_Shape        resface2    = (aResFace2Ptr != nullptr ? *aResFace2Ptr : anOther);
+                TopoDS_Shape        resface2 = (aResFace2Ptr != nullptr ? *aResFace2Ptr : anOther);
                 if (resface2.IsNull())
                   resface2 = anOther;
                 TopLoc_Location           anOtherLoc;
@@ -747,7 +747,7 @@ void BRepTools_Modifier::CreateOtherVertices(
       NCollection_List<TopoDS_Shape>::Iterator it(aLEdges);
       for (; it.More() && !toReplace; it.Next())
       {
-        const TopoDS_Edge& anE = TopoDS::Edge(it.Value());
+        const TopoDS_Edge&  anE     = TopoDS::Edge(it.Value());
         const NewCurveInfo* aNCSeek = myNCInfo.Seek(anE);
         if (aNCSeek != nullptr && !aNCSeek->myCurve.IsNull())
           toReplace = true;

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_NurbsConvertModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_NurbsConvertModification.cxx
@@ -107,8 +107,7 @@ static occ::handle<Geom2d_Curve> newCurve(
   double&                                                            theLast)
 {
   occ::handle<Geom2d_Curve> aC2d = BRep_Tool::CurveOnSurface(theEdge, theFace, theFirst, theLast);
-  const occ::handle<Standard_Transient>* aC2dFound =
-    (!aC2d.IsNull()) ? theMap.Seek(aC2d) : nullptr;
+  const occ::handle<Standard_Transient>* aC2dFound = (!aC2d.IsNull()) ? theMap.Seek(aC2d) : nullptr;
   return (aC2dFound != nullptr) ? occ::down_cast<Geom2d_Curve>(*aC2dFound)
                                 : occ::handle<Geom2d_Curve>();
 }
@@ -121,8 +120,8 @@ static occ::handle<Geom_Surface> newSurface(
 {
   occ::handle<Geom_Surface> aNewSurf;
 
-  TopLoc_Location           aLoc;
-  occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(theFace, aLoc);
+  TopLoc_Location                        aLoc;
+  occ::handle<Geom_Surface>              aSurf = BRep_Tool::Surface(theFace, aLoc);
   const occ::handle<Standard_Transient>* aSurfFound =
     (!aSurf.IsNull()) ? theMap.Seek(aSurf) : nullptr;
   if (aSurfFound != nullptr)

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_NurbsConvertModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_NurbsConvertModification.cxx
@@ -87,9 +87,11 @@ static occ::handle<Geom_Curve> newCurve(
 
   TopLoc_Location         aLoc;
   occ::handle<Geom_Curve> aCurve = BRep_Tool::Curve(theEdge, aLoc, theFirst, theLast);
-  if (!aCurve.IsNull() && theMap.Contains(aCurve))
+  const occ::handle<Standard_Transient>* aFound =
+    (!aCurve.IsNull()) ? theMap.Seek(aCurve) : nullptr;
+  if (aFound != nullptr)
   {
-    aNewCurve = occ::down_cast<Geom_Curve>(theMap.FindFromKey(aCurve));
+    aNewCurve = occ::down_cast<Geom_Curve>(*aFound);
     aNewCurve = occ::down_cast<Geom_Curve>(aNewCurve->Transformed(aLoc.Transformation()));
   }
   return aNewCurve;
@@ -105,9 +107,10 @@ static occ::handle<Geom2d_Curve> newCurve(
   double&                                                            theLast)
 {
   occ::handle<Geom2d_Curve> aC2d = BRep_Tool::CurveOnSurface(theEdge, theFace, theFirst, theLast);
-  return (!aC2d.IsNull() && theMap.Contains(aC2d))
-           ? occ::down_cast<Geom2d_Curve>(theMap.FindFromKey(aC2d))
-           : occ::handle<Geom2d_Curve>();
+  const occ::handle<Standard_Transient>* aC2dFound =
+    (!aC2d.IsNull()) ? theMap.Seek(aC2d) : nullptr;
+  return (aC2dFound != nullptr) ? occ::down_cast<Geom2d_Curve>(*aC2dFound)
+                                : occ::handle<Geom2d_Curve>();
 }
 
 // find surface from theFace in theMap, and return the transformed surface or NULL
@@ -120,9 +123,11 @@ static occ::handle<Geom_Surface> newSurface(
 
   TopLoc_Location           aLoc;
   occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(theFace, aLoc);
-  if (!aSurf.IsNull() && theMap.Contains(aSurf))
+  const occ::handle<Standard_Transient>* aSurfFound =
+    (!aSurf.IsNull()) ? theMap.Seek(aSurf) : nullptr;
+  if (aSurfFound != nullptr)
   {
-    aNewSurf = occ::down_cast<Geom_Surface>(theMap.FindFromKey(aSurf));
+    aNewSurf = occ::down_cast<Geom_Surface>(*aSurfFound);
     aNewSurf = occ::down_cast<Geom_Surface>(aNewSurf->Transformed(aLoc.Transformation()));
   }
   return aNewSurf;

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
@@ -53,7 +53,7 @@ static bool NeedCopied(
   TopoDS_Iterator itv(theShape);
   for (; itv.More(); itv.Next())
   {
-    if (myBounds.Contains(itv.Value()))
+    if (myBounds.Seek(itv.Value()) != nullptr)
     {
       IsCopied = true;
       break;
@@ -76,9 +76,10 @@ static void CopyShape(
   for (; itv.More(); itv.Next())
   {
     const TopoDS_Shape& V = itv.Value();
-    if (myBounds.Contains(V))
+    const TopoDS_Shape* aBoundV = myBounds.Seek(V);
+    if (aBoundV != nullptr)
     {
-      B.Add(NE, myBounds.FindFromKey(V).Oriented(V.Orientation()));
+      B.Add(NE, aBoundV->Oriented(V.Orientation()));
     }
     else
     {
@@ -234,9 +235,10 @@ void BRepTools_Quilt::Add(const TopoDS_Shape& S)
         {
           const TopoDS_Edge& E  = TopoDS::Edge(ite.Value());
           TopAbs_Orientation OE = E.Orientation();
-          if (myBounds.Contains(E))
+          const TopoDS_Shape* aBoundE = myBounds.Seek(E);
+          if (aBoundE != nullptr)
           {
-            const TopoDS_Edge& NE = TopoDS::Edge(myBounds.FindFromKey(E));
+            const TopoDS_Edge& NE = TopoDS::Edge(*aBoundE);
             // pcurve.
             if (NE.Orientation() == TopAbs_FORWARD)
             {
@@ -348,12 +350,12 @@ void BRepTools_Quilt::Bind(const TopoDS_Edge& Eold, const TopoDS_Edge& Enew)
 
 bool BRepTools_Quilt::IsCopied(const TopoDS_Shape& S) const
 {
-  if (myBounds.Contains(S))
+  const TopoDS_Shape* aBound = myBounds.Seek(S);
+  if (aBound != nullptr)
   {
-    return !S.IsSame(myBounds.FindFromKey(S));
+    return !S.IsSame(*aBound);
   }
-  else
-    return false;
+  return false;
 }
 
 //=================================================================================================
@@ -548,9 +550,10 @@ TopoDS_Shape BRepTools_Quilt::Shells() const
     MapOtherShape); // gka version for free edges
   for (; itother.More(); itother.Next())
   {
-    if (!EdgesFaces.Contains(itother.Key()) && myBounds.Contains(itother.Key()))
+    const TopoDS_Shape* aBoundOther = myBounds.Seek(itother.Key());
+    if (!EdgesFaces.Contains(itother.Key()) && aBoundOther != nullptr)
     {
-      TopoDS_Shape aSh = myBounds.FindFromKey(itother.Key());
+      const TopoDS_Shape& aSh = *aBoundOther;
       B.Add(result, aSh);
     }
   }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Quilt.cxx
@@ -75,7 +75,7 @@ static void CopyShape(
   itv.Initialize(E, false); // TCollection_DataMap
   for (; itv.More(); itv.Next())
   {
-    const TopoDS_Shape& V = itv.Value();
+    const TopoDS_Shape& V       = itv.Value();
     const TopoDS_Shape* aBoundV = myBounds.Seek(V);
     if (aBoundV != nullptr)
     {
@@ -233,8 +233,8 @@ void BRepTools_Quilt::Add(const TopoDS_Shape& S)
 
         for (; ite.More(); ite.Next())
         {
-          const TopoDS_Edge& E  = TopoDS::Edge(ite.Value());
-          TopAbs_Orientation OE = E.Orientation();
+          const TopoDS_Edge&  E       = TopoDS::Edge(ite.Value());
+          TopAbs_Orientation  OE      = E.Orientation();
           const TopoDS_Shape* aBoundE = myBounds.Seek(E);
           if (aBoundE != nullptr)
           {

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_ReShape.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_ReShape.cxx
@@ -533,6 +533,8 @@ occ::handle<BRepTools_History> BRepTools_ReShape::History() const
   occ::handle<BRepTools_History> aHistory = new BRepTools_History;
 
   // Fill the history.
+  NCollection_IndexedMap<TopoDS_Shape> aIntermediates;
+  NCollection_Map<TopoDS_Shape>        aModified;
   for (TShapeToReplacement::Iterator aRIt(myShapeToReplacement); aRIt.More(); aRIt.Next())
   {
     const TopoDS_Shape& aShape = aRIt.Key();
@@ -541,8 +543,8 @@ occ::handle<BRepTools_History> BRepTools_ReShape::History() const
       continue;
     }
 
-    NCollection_IndexedMap<TopoDS_Shape> aIntermediates;
-    NCollection_Map<TopoDS_Shape>        aModified;
+    aIntermediates.Clear();
+    aModified.Clear();
     aIntermediates.Add(aShape);
     for (int aI = 1; aI <= aIntermediates.Size(); ++aI)
     {

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_Substitution.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_Substitution.cxx
@@ -140,15 +140,15 @@ void BRepTools_Substitution::Build(const TopoDS_Shape& S)
 
 bool BRepTools_Substitution::IsCopied(const TopoDS_Shape& S) const
 {
-  if (myMap.IsBound(S))
+  const NCollection_List<TopoDS_Shape>* aList = myMap.Seek(S);
+  if (aList != nullptr)
   {
-    if (myMap(S).IsEmpty())
+    if (aList->IsEmpty())
       return true;
     else
-      return !S.IsSame(myMap(S).First());
+      return !S.IsSame(aList->First());
   }
-  else
-    return false;
+  return false;
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_WireExplorer.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_WireExplorer.cxx
@@ -227,9 +227,10 @@ void BRepTools_WireExplorer::Init(const TopoDS_Wire& W,
 
     if (!V1.IsNull())
     {
-      if (!myMap.IsBound(V1))
-        myMap.Bind(V1, empty);
-      myMap(V1).Append(E);
+      NCollection_List<TopoDS_Shape>* aV1List = myMap.ChangeSeek(V1);
+      if (aV1List == nullptr)
+        aV1List = myMap.Bound(V1, empty);
+      aV1List->Append(E);
 
       // add or remove in the vertex map
       V1.Orientation(TopAbs_FORWARD);
@@ -344,10 +345,11 @@ void BRepTools_WireExplorer::Init(const TopoDS_Wire& W,
 
   if (V1.IsNull())
     return;
-  if (!myMap.IsBound(V1))
+  NCollection_List<TopoDS_Shape>* aListPtr = myMap.ChangeSeek(V1);
+  if (aListPtr == nullptr)
     return;
 
-  NCollection_List<TopoDS_Shape>& l = myMap(V1);
+  NCollection_List<TopoDS_Shape>& l = *aListPtr;
   myEdge                            = TopoDS::Edge(l.First());
   l.RemoveFirst();
   myVertex = TopExp::FirstVertex(myEdge, true);
@@ -371,13 +373,14 @@ void BRepTools_WireExplorer::Next()
     myEdge = TopoDS_Edge();
     return;
   }
-  if (!myMap.IsBound(myVertex))
+  NCollection_List<TopoDS_Shape>* aVertListPtr = myMap.ChangeSeek(myVertex);
+  if (aVertListPtr == nullptr)
   {
     myEdge = TopoDS_Edge();
     return;
   }
 
-  NCollection_List<TopoDS_Shape>& l = myMap(myVertex);
+  NCollection_List<TopoDS_Shape>& l = *aVertListPtr;
 
   if (l.IsEmpty())
   {

--- a/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Curve3D.hxx>
+#include <BRep_CurveOn2Surfaces.hxx>
+#include <BRep_CurveOnClosedSurface.hxx>
+#include <BRep_CurveOnSurface.hxx>
+#include <BRep_CurveRepresentation.hxx>
+#include <BRep_Polygon3D.hxx>
+#include <BRep_PolygonOnClosedSurface.hxx>
+#include <BRep_PolygonOnClosedTriangulation.hxx>
+#include <BRep_PolygonOnSurface.hxx>
+#include <BRep_PolygonOnTriangulation.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <Poly_Polygon2D.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopLoc_Location.hxx>
+
+#include <gtest/gtest.h>
+
+using TypeEnum = BRep_CurveRepresentation::TypeEnum;
+
+TEST(BRep_CurveRepresentationTest, Curve3D_Type)
+{
+  occ::handle<Geom_Line> aLine    = new Geom_Line(gp_Pnt(), gp_Dir(1, 0, 0));
+  occ::handle<BRep_Curve3D> aCurve = new BRep_Curve3D(aLine, TopLoc_Location());
+  EXPECT_EQ(aCurve->Type(), TypeEnum::Type_Curve3D);
+  EXPECT_TRUE(aCurve->IsCurve3D());
+}
+
+TEST(BRep_CurveRepresentationTest, CurveOnSurface_Type)
+{
+  occ::handle<Geom2d_Line> aPC   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1, 0));
+  occ::handle<Geom_Plane>  aPlane = new Geom_Plane(gp::XOY());
+  occ::handle<BRep_CurveOnSurface> aCOS =
+    new BRep_CurveOnSurface(aPC, aPlane, TopLoc_Location());
+  EXPECT_EQ(aCOS->Type(), TypeEnum::Type_CurveOnSurface);
+  EXPECT_TRUE(aCOS->IsCurveOnSurface());
+  EXPECT_FALSE(aCOS->IsCurveOnClosedSurface());
+}
+
+TEST(BRep_CurveRepresentationTest, CurveOnClosedSurface_Type)
+{
+  occ::handle<Geom2d_Line> aPC1   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1, 0));
+  occ::handle<Geom2d_Line> aPC2   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(0, 1));
+  occ::handle<Geom_Plane>  aPlane = new Geom_Plane(gp::XOY());
+  occ::handle<BRep_CurveOnClosedSurface> aCOCS =
+    new BRep_CurveOnClosedSurface(aPC1, aPC2, aPlane, TopLoc_Location(), GeomAbs_C0);
+  EXPECT_EQ(aCOCS->Type(), TypeEnum::Type_CurveOnClosedSurface);
+  EXPECT_TRUE(aCOCS->IsCurveOnSurface());
+  EXPECT_TRUE(aCOCS->IsCurveOnClosedSurface());
+  EXPECT_TRUE(aCOCS->IsRegularity());
+}
+
+TEST(BRep_CurveRepresentationTest, CurveOn2Surfaces_Type)
+{
+  occ::handle<Geom_Plane> aP1 = new Geom_Plane(gp::XOY());
+  occ::handle<Geom_Plane> aP2 = new Geom_Plane(gp::ZOX());
+  occ::handle<BRep_CurveOn2Surfaces> aC2S =
+    new BRep_CurveOn2Surfaces(aP1, aP2, TopLoc_Location(), TopLoc_Location(), GeomAbs_C0);
+  EXPECT_EQ(aC2S->Type(), TypeEnum::Type_CurveOn2Surfaces);
+  EXPECT_TRUE(aC2S->IsRegularity());
+}
+
+TEST(BRep_CurveRepresentationTest, Polygon3D_Type)
+{
+  NCollection_Array1<gp_Pnt> aNodes(1, 2);
+  aNodes(1) = gp_Pnt(0, 0, 0);
+  aNodes(2) = gp_Pnt(1, 0, 0);
+  occ::handle<Poly_Polygon3D> aPoly = new Poly_Polygon3D(aNodes);
+  occ::handle<BRep_Polygon3D> aRep  = new BRep_Polygon3D(aPoly, TopLoc_Location());
+  EXPECT_EQ(aRep->Type(), TypeEnum::Type_Polygon3D);
+  EXPECT_TRUE(aRep->IsPolygon3D());
+}
+
+TEST(BRep_CurveRepresentationTest, PolygonOnSurface_Type)
+{
+  NCollection_Array1<gp_Pnt2d> aNodes(1, 2);
+  aNodes(1) = gp_Pnt2d(0, 0);
+  aNodes(2) = gp_Pnt2d(1, 0);
+  occ::handle<Poly_Polygon2D> aPoly  = new Poly_Polygon2D(aNodes);
+  occ::handle<Geom_Plane>     aPlane = new Geom_Plane(gp::XOY());
+  occ::handle<BRep_PolygonOnSurface> aRep =
+    new BRep_PolygonOnSurface(aPoly, aPlane, TopLoc_Location());
+  EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnSurface);
+  EXPECT_TRUE(aRep->IsPolygonOnSurface());
+  EXPECT_FALSE(aRep->IsPolygonOnClosedSurface());
+}
+
+TEST(BRep_CurveRepresentationTest, PolygonOnClosedSurface_Type)
+{
+  NCollection_Array1<gp_Pnt2d> aNodes(1, 2);
+  aNodes(1) = gp_Pnt2d(0, 0);
+  aNodes(2) = gp_Pnt2d(1, 0);
+  occ::handle<Poly_Polygon2D> aP1    = new Poly_Polygon2D(aNodes);
+  occ::handle<Poly_Polygon2D> aP2    = new Poly_Polygon2D(aNodes);
+  occ::handle<Geom_Plane>     aPlane = new Geom_Plane(gp::XOY());
+  occ::handle<BRep_PolygonOnClosedSurface> aRep =
+    new BRep_PolygonOnClosedSurface(aP1, aP2, aPlane, TopLoc_Location());
+  EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnClosedSurface);
+  EXPECT_TRUE(aRep->IsPolygonOnSurface());
+  EXPECT_TRUE(aRep->IsPolygonOnClosedSurface());
+}
+
+TEST(BRep_CurveRepresentationTest, PolygonOnTriangulation_Type)
+{
+  NCollection_Array1<int> aNodes(1, 2);
+  aNodes(1) = 1;
+  aNodes(2) = 2;
+  occ::handle<Poly_PolygonOnTriangulation> aPoly = new Poly_PolygonOnTriangulation(aNodes);
+  occ::handle<Poly_Triangulation>          aTri  = new Poly_Triangulation(2, 1, false);
+  occ::handle<BRep_PolygonOnTriangulation> aRep =
+    new BRep_PolygonOnTriangulation(aPoly, aTri, TopLoc_Location());
+  EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnTriangulation);
+  EXPECT_TRUE(aRep->IsPolygonOnTriangulation());
+  EXPECT_FALSE(aRep->IsPolygonOnClosedTriangulation());
+}
+
+TEST(BRep_CurveRepresentationTest, PolygonOnClosedTriangulation_Type)
+{
+  NCollection_Array1<int> aNodes(1, 2);
+  aNodes(1) = 1;
+  aNodes(2) = 2;
+  occ::handle<Poly_PolygonOnTriangulation> aP1  = new Poly_PolygonOnTriangulation(aNodes);
+  occ::handle<Poly_PolygonOnTriangulation> aP2  = new Poly_PolygonOnTriangulation(aNodes);
+  occ::handle<Poly_Triangulation>          aTri = new Poly_Triangulation(2, 1, false);
+  occ::handle<BRep_PolygonOnClosedTriangulation> aRep =
+    new BRep_PolygonOnClosedTriangulation(aP1, aP2, aTri, TopLoc_Location());
+  EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnClosedTriangulation);
+  EXPECT_TRUE(aRep->IsPolygonOnTriangulation());
+  EXPECT_TRUE(aRep->IsPolygonOnClosedTriangulation());
+}

--- a/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
@@ -34,12 +34,35 @@
 
 using TypeEnum = BRep_CurveRepresentation::TypeEnum;
 
+namespace
+{
+class BRep_CurveRepresentation_CustomOther : public BRep_CurveRepresentation
+{
+public:
+  BRep_CurveRepresentation_CustomOther()
+      : BRep_CurveRepresentation(Type_Other, TopLoc_Location())
+  {
+  }
+
+  occ::handle<BRep_CurveRepresentation> Copy() const override
+  {
+    return new BRep_CurveRepresentation_CustomOther();
+  }
+
+  DEFINE_STANDARD_RTTIEXT(BRep_CurveRepresentation_CustomOther, BRep_CurveRepresentation)
+};
+} // namespace
+
+IMPLEMENT_STANDARD_RTTIEXT(BRep_CurveRepresentation_CustomOther, BRep_CurveRepresentation)
+
 TEST(BRep_CurveRepresentationTest, Curve3D_Type)
 {
   occ::handle<Geom_Line>    aLine  = new Geom_Line(gp_Pnt(), gp_Dir(1, 0, 0));
   occ::handle<BRep_Curve3D> aCurve = new BRep_Curve3D(aLine, TopLoc_Location());
   EXPECT_EQ(aCurve->Type(), TypeEnum::Type_Curve3D);
   EXPECT_TRUE(aCurve->IsCurve3D());
+  EXPECT_FALSE(aCurve->IsCurveOnSurface());
+  EXPECT_FALSE(aCurve->IsRegularity());
 }
 
 TEST(BRep_CurveRepresentationTest, CurveOnSurface_Type)
@@ -50,6 +73,7 @@ TEST(BRep_CurveRepresentationTest, CurveOnSurface_Type)
   EXPECT_EQ(aCOS->Type(), TypeEnum::Type_CurveOnSurface);
   EXPECT_TRUE(aCOS->IsCurveOnSurface());
   EXPECT_FALSE(aCOS->IsCurveOnClosedSurface());
+  EXPECT_FALSE(aCOS->IsRegularity());
 }
 
 TEST(BRep_CurveRepresentationTest, CurveOnClosedSurface_Type)
@@ -72,6 +96,7 @@ TEST(BRep_CurveRepresentationTest, CurveOn2Surfaces_Type)
   occ::handle<BRep_CurveOn2Surfaces> aC2S =
     new BRep_CurveOn2Surfaces(aP1, aP2, TopLoc_Location(), TopLoc_Location(), GeomAbs_C0);
   EXPECT_EQ(aC2S->Type(), TypeEnum::Type_CurveOn2Surfaces);
+  EXPECT_FALSE(aC2S->IsCurveOnSurface());
   EXPECT_TRUE(aC2S->IsRegularity());
 }
 
@@ -84,6 +109,8 @@ TEST(BRep_CurveRepresentationTest, Polygon3D_Type)
   occ::handle<BRep_Polygon3D> aRep  = new BRep_Polygon3D(aPoly, TopLoc_Location());
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_Polygon3D);
   EXPECT_TRUE(aRep->IsPolygon3D());
+  EXPECT_FALSE(aRep->IsPolygonOnSurface());
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation());
 }
 
 TEST(BRep_CurveRepresentationTest, PolygonOnSurface_Type)
@@ -98,6 +125,7 @@ TEST(BRep_CurveRepresentationTest, PolygonOnSurface_Type)
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnSurface);
   EXPECT_TRUE(aRep->IsPolygonOnSurface());
   EXPECT_FALSE(aRep->IsPolygonOnClosedSurface());
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation());
 }
 
 TEST(BRep_CurveRepresentationTest, PolygonOnClosedSurface_Type)
@@ -113,6 +141,7 @@ TEST(BRep_CurveRepresentationTest, PolygonOnClosedSurface_Type)
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnClosedSurface);
   EXPECT_TRUE(aRep->IsPolygonOnSurface());
   EXPECT_TRUE(aRep->IsPolygonOnClosedSurface());
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation());
 }
 
 TEST(BRep_CurveRepresentationTest, PolygonOnTriangulation_Type)
@@ -127,6 +156,7 @@ TEST(BRep_CurveRepresentationTest, PolygonOnTriangulation_Type)
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnTriangulation);
   EXPECT_TRUE(aRep->IsPolygonOnTriangulation());
   EXPECT_FALSE(aRep->IsPolygonOnClosedTriangulation());
+  EXPECT_FALSE(aRep->IsPolygonOnSurface());
 }
 
 TEST(BRep_CurveRepresentationTest, PolygonOnClosedTriangulation_Type)
@@ -142,4 +172,20 @@ TEST(BRep_CurveRepresentationTest, PolygonOnClosedTriangulation_Type)
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnClosedTriangulation);
   EXPECT_TRUE(aRep->IsPolygonOnTriangulation());
   EXPECT_TRUE(aRep->IsPolygonOnClosedTriangulation());
+  EXPECT_FALSE(aRep->IsPolygonOnSurface());
+}
+
+TEST(BRep_CurveRepresentationTest, OtherType_DefaultPredicates)
+{
+  occ::handle<BRep_CurveRepresentation> aRep = new BRep_CurveRepresentation_CustomOther();
+  EXPECT_EQ(aRep->Type(), TypeEnum::Type_Other);
+  EXPECT_FALSE(aRep->IsCurve3D());
+  EXPECT_FALSE(aRep->IsCurveOnSurface());
+  EXPECT_FALSE(aRep->IsCurveOnClosedSurface());
+  EXPECT_FALSE(aRep->IsRegularity());
+  EXPECT_FALSE(aRep->IsPolygon3D());
+  EXPECT_FALSE(aRep->IsPolygonOnSurface());
+  EXPECT_FALSE(aRep->IsPolygonOnClosedSurface());
+  EXPECT_FALSE(aRep->IsPolygonOnTriangulation());
+  EXPECT_FALSE(aRep->IsPolygonOnClosedTriangulation());
 }

--- a/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRep_CurveRepresentation_Test.cxx
@@ -36,7 +36,7 @@ using TypeEnum = BRep_CurveRepresentation::TypeEnum;
 
 TEST(BRep_CurveRepresentationTest, Curve3D_Type)
 {
-  occ::handle<Geom_Line> aLine    = new Geom_Line(gp_Pnt(), gp_Dir(1, 0, 0));
+  occ::handle<Geom_Line>    aLine  = new Geom_Line(gp_Pnt(), gp_Dir(1, 0, 0));
   occ::handle<BRep_Curve3D> aCurve = new BRep_Curve3D(aLine, TopLoc_Location());
   EXPECT_EQ(aCurve->Type(), TypeEnum::Type_Curve3D);
   EXPECT_TRUE(aCurve->IsCurve3D());
@@ -44,10 +44,9 @@ TEST(BRep_CurveRepresentationTest, Curve3D_Type)
 
 TEST(BRep_CurveRepresentationTest, CurveOnSurface_Type)
 {
-  occ::handle<Geom2d_Line> aPC   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1, 0));
-  occ::handle<Geom_Plane>  aPlane = new Geom_Plane(gp::XOY());
-  occ::handle<BRep_CurveOnSurface> aCOS =
-    new BRep_CurveOnSurface(aPC, aPlane, TopLoc_Location());
+  occ::handle<Geom2d_Line>         aPC    = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1, 0));
+  occ::handle<Geom_Plane>          aPlane = new Geom_Plane(gp::XOY());
+  occ::handle<BRep_CurveOnSurface> aCOS   = new BRep_CurveOnSurface(aPC, aPlane, TopLoc_Location());
   EXPECT_EQ(aCOS->Type(), TypeEnum::Type_CurveOnSurface);
   EXPECT_TRUE(aCOS->IsCurveOnSurface());
   EXPECT_FALSE(aCOS->IsCurveOnClosedSurface());
@@ -55,9 +54,9 @@ TEST(BRep_CurveRepresentationTest, CurveOnSurface_Type)
 
 TEST(BRep_CurveRepresentationTest, CurveOnClosedSurface_Type)
 {
-  occ::handle<Geom2d_Line> aPC1   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1, 0));
-  occ::handle<Geom2d_Line> aPC2   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(0, 1));
-  occ::handle<Geom_Plane>  aPlane = new Geom_Plane(gp::XOY());
+  occ::handle<Geom2d_Line>               aPC1   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1, 0));
+  occ::handle<Geom2d_Line>               aPC2   = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(0, 1));
+  occ::handle<Geom_Plane>                aPlane = new Geom_Plane(gp::XOY());
   occ::handle<BRep_CurveOnClosedSurface> aCOCS =
     new BRep_CurveOnClosedSurface(aPC1, aPC2, aPlane, TopLoc_Location(), GeomAbs_C0);
   EXPECT_EQ(aCOCS->Type(), TypeEnum::Type_CurveOnClosedSurface);
@@ -68,8 +67,8 @@ TEST(BRep_CurveRepresentationTest, CurveOnClosedSurface_Type)
 
 TEST(BRep_CurveRepresentationTest, CurveOn2Surfaces_Type)
 {
-  occ::handle<Geom_Plane> aP1 = new Geom_Plane(gp::XOY());
-  occ::handle<Geom_Plane> aP2 = new Geom_Plane(gp::ZOX());
+  occ::handle<Geom_Plane>            aP1 = new Geom_Plane(gp::XOY());
+  occ::handle<Geom_Plane>            aP2 = new Geom_Plane(gp::ZOX());
   occ::handle<BRep_CurveOn2Surfaces> aC2S =
     new BRep_CurveOn2Surfaces(aP1, aP2, TopLoc_Location(), TopLoc_Location(), GeomAbs_C0);
   EXPECT_EQ(aC2S->Type(), TypeEnum::Type_CurveOn2Surfaces);
@@ -79,8 +78,8 @@ TEST(BRep_CurveRepresentationTest, CurveOn2Surfaces_Type)
 TEST(BRep_CurveRepresentationTest, Polygon3D_Type)
 {
   NCollection_Array1<gp_Pnt> aNodes(1, 2);
-  aNodes(1) = gp_Pnt(0, 0, 0);
-  aNodes(2) = gp_Pnt(1, 0, 0);
+  aNodes(1)                         = gp_Pnt(0, 0, 0);
+  aNodes(2)                         = gp_Pnt(1, 0, 0);
   occ::handle<Poly_Polygon3D> aPoly = new Poly_Polygon3D(aNodes);
   occ::handle<BRep_Polygon3D> aRep  = new BRep_Polygon3D(aPoly, TopLoc_Location());
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_Polygon3D);
@@ -90,10 +89,10 @@ TEST(BRep_CurveRepresentationTest, Polygon3D_Type)
 TEST(BRep_CurveRepresentationTest, PolygonOnSurface_Type)
 {
   NCollection_Array1<gp_Pnt2d> aNodes(1, 2);
-  aNodes(1) = gp_Pnt2d(0, 0);
-  aNodes(2) = gp_Pnt2d(1, 0);
-  occ::handle<Poly_Polygon2D> aPoly  = new Poly_Polygon2D(aNodes);
-  occ::handle<Geom_Plane>     aPlane = new Geom_Plane(gp::XOY());
+  aNodes(1)                                 = gp_Pnt2d(0, 0);
+  aNodes(2)                                 = gp_Pnt2d(1, 0);
+  occ::handle<Poly_Polygon2D>        aPoly  = new Poly_Polygon2D(aNodes);
+  occ::handle<Geom_Plane>            aPlane = new Geom_Plane(gp::XOY());
   occ::handle<BRep_PolygonOnSurface> aRep =
     new BRep_PolygonOnSurface(aPoly, aPlane, TopLoc_Location());
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnSurface);
@@ -104,11 +103,11 @@ TEST(BRep_CurveRepresentationTest, PolygonOnSurface_Type)
 TEST(BRep_CurveRepresentationTest, PolygonOnClosedSurface_Type)
 {
   NCollection_Array1<gp_Pnt2d> aNodes(1, 2);
-  aNodes(1) = gp_Pnt2d(0, 0);
-  aNodes(2) = gp_Pnt2d(1, 0);
-  occ::handle<Poly_Polygon2D> aP1    = new Poly_Polygon2D(aNodes);
-  occ::handle<Poly_Polygon2D> aP2    = new Poly_Polygon2D(aNodes);
-  occ::handle<Geom_Plane>     aPlane = new Geom_Plane(gp::XOY());
+  aNodes(1)                                       = gp_Pnt2d(0, 0);
+  aNodes(2)                                       = gp_Pnt2d(1, 0);
+  occ::handle<Poly_Polygon2D>              aP1    = new Poly_Polygon2D(aNodes);
+  occ::handle<Poly_Polygon2D>              aP2    = new Poly_Polygon2D(aNodes);
+  occ::handle<Geom_Plane>                  aPlane = new Geom_Plane(gp::XOY());
   occ::handle<BRep_PolygonOnClosedSurface> aRep =
     new BRep_PolygonOnClosedSurface(aP1, aP2, aPlane, TopLoc_Location());
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnClosedSurface);
@@ -119,8 +118,8 @@ TEST(BRep_CurveRepresentationTest, PolygonOnClosedSurface_Type)
 TEST(BRep_CurveRepresentationTest, PolygonOnTriangulation_Type)
 {
   NCollection_Array1<int> aNodes(1, 2);
-  aNodes(1) = 1;
-  aNodes(2) = 2;
+  aNodes(1)                                      = 1;
+  aNodes(2)                                      = 2;
   occ::handle<Poly_PolygonOnTriangulation> aPoly = new Poly_PolygonOnTriangulation(aNodes);
   occ::handle<Poly_Triangulation>          aTri  = new Poly_Triangulation(2, 1, false);
   occ::handle<BRep_PolygonOnTriangulation> aRep =
@@ -133,11 +132,11 @@ TEST(BRep_CurveRepresentationTest, PolygonOnTriangulation_Type)
 TEST(BRep_CurveRepresentationTest, PolygonOnClosedTriangulation_Type)
 {
   NCollection_Array1<int> aNodes(1, 2);
-  aNodes(1) = 1;
-  aNodes(2) = 2;
-  occ::handle<Poly_PolygonOnTriangulation> aP1  = new Poly_PolygonOnTriangulation(aNodes);
-  occ::handle<Poly_PolygonOnTriangulation> aP2  = new Poly_PolygonOnTriangulation(aNodes);
-  occ::handle<Poly_Triangulation>          aTri = new Poly_Triangulation(2, 1, false);
+  aNodes(1)                                           = 1;
+  aNodes(2)                                           = 2;
+  occ::handle<Poly_PolygonOnTriangulation>       aP1  = new Poly_PolygonOnTriangulation(aNodes);
+  occ::handle<Poly_PolygonOnTriangulation>       aP2  = new Poly_PolygonOnTriangulation(aNodes);
+  occ::handle<Poly_Triangulation>                aTri = new Poly_Triangulation(2, 1, false);
   occ::handle<BRep_PolygonOnClosedTriangulation> aRep =
     new BRep_PolygonOnClosedTriangulation(aP1, aP2, aTri, TopLoc_Location());
   EXPECT_EQ(aRep->Type(), TypeEnum::Type_PolygonOnClosedTriangulation);

--- a/src/ModelingData/TKBRep/GTests/FILES.cmake
+++ b/src/ModelingData/TKBRep/GTests/FILES.cmake
@@ -2,6 +2,7 @@
 set(OCCT_TKBRep_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKBRep_GTests_FILES
+  BRep_CurveRepresentation_Test.cxx
   BRep_Tool_Test.cxx
   BRepAdaptor_CompCurve_Test.cxx
   BRepProp_Test.cxx

--- a/src/ModelingData/TKBRep/TopExp/TopExp.cxx
+++ b/src/ModelingData/TKBRep/TopExp/TopExp.cxx
@@ -264,8 +264,7 @@ void TopExp::Vertices(const TopoDS_Wire& W, TopoDS_Vertex& Vfirst, TopoDS_Vertex
   }
   else if (vmap.Extent() == 2)
   { // open
-    for (NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>::Iterator ite(vmap);
-         ite.More();
+    for (NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>::Iterator ite(vmap); ite.More();
          ite.Next())
     {
       if (ite.Key().Orientation() == TopAbs_FORWARD)

--- a/src/ModelingData/TKBRep/TopExp/TopExp.cxx
+++ b/src/ModelingData/TKBRep/TopExp/TopExp.cxx
@@ -264,17 +264,15 @@ void TopExp::Vertices(const TopoDS_Wire& W, TopoDS_Vertex& Vfirst, TopoDS_Vertex
   }
   else if (vmap.Extent() == 2)
   { // open
-    NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>::Iterator ite(vmap);
-
-    while (ite.More() && ite.Key().Orientation() != TopAbs_FORWARD)
-      ite.Next();
-    if (ite.More())
-      Vfirst = TopoDS::Vertex(ite.Key());
-    ite.Initialize(vmap);
-    while (ite.More() && ite.Key().Orientation() != TopAbs_REVERSED)
-      ite.Next();
-    if (ite.More())
-      Vlast = TopoDS::Vertex(ite.Key());
+    for (NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>::Iterator ite(vmap);
+         ite.More();
+         ite.Next())
+    {
+      if (ite.Key().Orientation() == TopAbs_FORWARD)
+        Vfirst = TopoDS::Vertex(ite.Key());
+      else if (ite.Key().Orientation() == TopAbs_REVERSED)
+        Vlast = TopoDS::Vertex(ite.Key());
+    }
   }
 }
 

--- a/src/ModelingData/TKBRep/TopoDS/TopoDS_Iterator.cxx
+++ b/src/ModelingData/TKBRep/TopoDS/TopoDS_Iterator.cxx
@@ -64,7 +64,8 @@ void TopoDS_Iterator::Next()
 void TopoDS_Iterator::updateCurrentShape()
 {
   myShape = myIterator.Value();
-  myShape.Orientation(TopAbs::Compose(myOrientation, myShape.Orientation()));
+  if (myOrientation != TopAbs_FORWARD)
+    myShape.Orientation(TopAbs::Compose(myOrientation, myShape.Orientation()));
   if (!myLocation.IsIdentity())
     myShape.Move(myLocation, false);
 }


### PR DESCRIPTION
Add type discriminator enum to BRep_CurveRepresentation hierarchy to eliminate virtual dispatch in BRep_Tool inner loops. Each of the 9 concrete subclasses now stores a TypeEnum tag set at construction time; BRep_Tool::Curve(), CurveOnSurface(), Polygon3D(), IsGeometric(), Range(), IsClosed(), HasContinuity(), and MaxContinuity() use the enum instead of calling virtual Is*() methods per list element. The virtual Is*() API is kept unchanged for external compatibility.

Replace double hash-map lookups (IsBound + operator(), Contains + FindFromKey) with single Seek()/ChangeSeek() calls across BRepTools_Modifier, BRepTools_WireExplorer, BRepTools_Quilt, BRepTools_Substitution, BRepTools_History, and
BRepTools_NurbsConvertModification.

Apply minor optimizations: use NbChildren() instead of a counting loop in BRepTools_Modifier; guard TopAbs::Compose identity case in TopoDS_Iterator; combine two vertex-map passes into one loop in TopExp::Vertices; hoist per-iteration map allocations out of the loop in BRepTools_ReShape::History().

Add GTest BRep_CurveRepresentation_Test verifying enum consistency with virtual Is*() for all 9 concrete types.