### PR TITLE
Visualization - Include shape transformation in sub-owner bounding box calculation

### DIFF
--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_SelectableObject.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_SelectableObject.cxx
@@ -538,6 +538,11 @@ Bnd_Box SelectMgr_SelectableObject::BndBoxOfSelected(
     }
   }
 
+  if (!aBnd.IsVoid() && HasTransformation())
+  {
+    aBnd = aBnd.Transformed(Transformation());
+  }
+
   return aBnd;
 }
 

--- a/tests/vselect/bugs/bug1164_1
+++ b/tests/vselect/bugs/bug1164_1
@@ -1,0 +1,23 @@
+puts "============"
+puts "Verify vfit -selected works correctly for a primitive TopoDS_Shape with transformation"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION
+box b 100 200 300
+
+vinit View1
+
+vdisplay b -dispMode 1
+vlocation b -location 500 0 0
+vfit
+
+vzoom 0.5
+vselmode b FACE 1
+vselect 250 125
+
+vfit -selected
+
+if { [vreadpixel 250 250 rgb name] == "BLACK" } {
+    puts "Error: face should be in the middle"
+}

--- a/tests/vselect/bugs/bug1164_2
+++ b/tests/vselect/bugs/bug1164_2
@@ -1,0 +1,28 @@
+puts "============"
+puts "Verify vfit -selected works correctly for MeshVS_Mesh with transformation"
+puts "============"
+puts ""
+
+pload MODELING VISUALIZATION STL
+
+vclear
+vinit View1
+
+meshfromstl m [locate_data_file bearing.stl]
+vfit
+
+vlocation m -setLocation 500 0 0
+vfit
+vzoom 0.5
+
+vsetdispmode m 2
+vselmode m 8 1
+vselect 200 200
+
+vfit -selected
+
+if { [vreadpixel 200 200 rgb name] == "BLACK" } {
+  puts "Error: mesh should be visible after vfit -selected with transformation"
+}
+
+vdump $imagedir/${casename}.png


### PR DESCRIPTION
I was having an issue where when using AIS_ViewCube, my view transform would go to the vertices I had picked (as a part of a `MeshVS_EntityOwner` selecting vertices) in the local space of the mesh rather than in global space.

This small change in logic (so we transform the returned bounding box) seems to fix this behaviour for this use case. Fitting bounds of selected sub-shapes in `TopoDS_Shape` items seem unaffected.