### PR TITLE
Foundation Classes - Improved error handling for unit conversion.

### DIFF
--- a/src/FoundationClasses/TKernel/GTests/UnitsAPI_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/UnitsAPI_Test.cxx
@@ -27,3 +27,13 @@ TEST(UnitsAPI_Test, BUC60727_AnyToLS_Conversion)
   double aResult = UnitsAPI::AnyToLS(3.0, "mm");
   EXPECT_DOUBLE_EQ(3.0, aResult);
 }
+
+// Test of fix for bug 33176: UnitsAPI::AnyToAny must not crash when one of the units is unknown.
+TEST(UnitsAPI_Test, AnyToAny_UnknownUnit)
+{
+  // Attempt to convert using an unknown unit, should not crash and return the input value.
+  const double aResult1 = UnitsAPI::AnyToAny(1.0, "unknown_unit", "mm");
+  const double aResult2 = UnitsAPI::AnyToAny(1.0, "mm", "unknown_unit");
+  EXPECT_DOUBLE_EQ(1.0, aResult1);
+  EXPECT_DOUBLE_EQ(1.0, aResult2);
+}

--- a/src/FoundationClasses/TKernel/Units/Units.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units.cxx
@@ -72,14 +72,11 @@ occ::handle<Units_UnitsDictionary> Units::DictionaryOfUnits(const bool amode)
   std::lock_guard<std::recursive_mutex> aLock(THE_UNITS_MUTEX);
   if (unitsdictionary.IsNull())
   {
-    //      std::cout<<"Allocation du dictionnaire"<<std::endl;
     unitsdictionary = new Units_UnitsDictionary();
-    //      std::cout<<"Creation du dictionnaire"<<std::endl;
     unitsdictionary->Creates();
   }
   else if (amode)
   {
-    //      std::cout<<"Creation du dictionnaire"<<std::endl;
     unitsdictionary->Creates();
   }
   return unitsdictionary;
@@ -102,11 +99,6 @@ occ::handle<Units_Quantity> Units::Quantity(const char* const aquantity)
     if (quantity->Name() == aquantity)
       return quantity;
   }
-
-#ifdef OCCT_DEBUG
-  std::cout << "Warning: BAD Quantity = Units::Quantity(quantity('" << aquantity << "'))"
-            << std::endl;
-#endif
   return nullquantity;
 }
 
@@ -148,10 +140,6 @@ const char* Units::FirstQuantity(const char* const aunit)
       }
     }
   }
-
-#ifdef OCCT_DEBUG
-  std::cout << "Warning: BAD Quantity = Units::Quantity(unit('" << symbol << "'))" << std::endl;
-#endif
   return nullptr;
 }
 
@@ -162,9 +150,7 @@ occ::handle<Units_Lexicon> Units::LexiconUnits(const bool amode)
   std::lock_guard<std::recursive_mutex> aLock(THE_UNITS_MUTEX);
   if (lexiconunits.IsNull())
   {
-    //      std::cout<<"Allocation du lexique d'unites"<<std::endl;
     lexiconunits = new Units_UnitsLexicon();
-    //      std::cout<<"Creation du lexique d'unites"<<std::endl;
     lexiconunits->Creates(amode);
   }
   return lexiconunits;
@@ -177,9 +163,7 @@ occ::handle<Units_Lexicon> Units::LexiconFormula()
   std::lock_guard<std::recursive_mutex> aLock(THE_UNITS_MUTEX);
   if (lexiconformula.IsNull())
   {
-    //      std::cout<<"Allocation du lexique d'expression"<<std::endl;
     lexiconformula = new Units_Lexicon();
-    //      std::cout<<"Creation du lexique d'expression"<<std::endl;
     lexiconformula->Creates();
   }
   return lexiconformula;
@@ -207,8 +191,8 @@ double Units::Convert(const double      avalue,
   {
     // No token means that the unit is not correct, so we can not convert. We return the value
     // without conversionv to preserve the original behavior, and print a warning.
-    std::cout << "Units_Measurement: can not convert - incorrect unit '" << afirstunit
-              << "' => result is not correct" << std::endl;
+    Message::SendWarning() << "Units_Measurement: can not convert - incorrect unit '" << afirstunit
+                           << "' => result is not correct";
     return avalue;
   }
   measurement.Convert(asecondunit);
@@ -234,9 +218,6 @@ double Units::ToSI(const double aData, const char* const aUnit, occ::handle<Unit
     Units_UnitSentence unitsentence(aUnit);
     if (!unitsentence.IsDone())
     {
-#ifdef OCCT_DEBUG
-      std::cout << "can not convert - incorrect unit => return 0.0" << std::endl;
-#endif
       return 0.0;
     }
     occ::handle<Units_Token> token = unitsentence.Evaluate();
@@ -275,9 +256,6 @@ double Units::FromSI(const double                   aData,
     Units_UnitSentence unitsentence(aUnit);
     if (!unitsentence.IsDone())
     {
-#ifdef OCCT_DEBUG
-      std::cout << "Warning: can not convert - incorrect unit => return 0.0" << std::endl;
-#endif
       return 0.0;
     }
     occ::handle<Units_Token> token = unitsentence.Evaluate();

--- a/src/FoundationClasses/TKernel/Units/Units.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units.cxx
@@ -191,8 +191,8 @@ double Units::Convert(const double      avalue,
   if (!measurement.HasToken())
   {
     // No token means that the unit is not correct, so we can not convert. We return the value
-    // without conversionv to preserve the original behavior, and print a warning.
-    Message::SendWarning() << "Units_Measurement: can not convert - incorrect unit '" << afirstunit
+    // without conversion to preserve the original behavior, and print a warning.
+    Message::SendWarning() << "Units::Convert: can not convert - incorrect unit '" << afirstunit
                            << "' => result is not correct";
     return avalue;
   }

--- a/src/FoundationClasses/TKernel/Units/Units.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units.cxx
@@ -203,6 +203,14 @@ double Units::Convert(const double      avalue,
 {
   std::lock_guard<std::recursive_mutex> aLock(THE_UNITS_MUTEX);
   Units_Measurement                     measurement(avalue, afirstunit);
+  if (!measurement.HasToken())
+  {
+    // No token means that the unit is not correct, so we can not convert. We return the value
+    // without conversionv to preserve the original behavior, and print a warning.
+    std::cout << "Units_Measurement: can not convert - incorrect unit '" << afirstunit
+              << "' => result is not correct" << std::endl;
+    return avalue;
+  }
   measurement.Convert(asecondunit);
   return measurement.Measurement();
 }

--- a/src/FoundationClasses/TKernel/Units/Units.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units.cxx
@@ -28,6 +28,7 @@
 #include <Units_ShiftedToken.hxx>
 #include <Standard_NoSuchObject.hxx>
 #include <TCollection_HAsciiString.hxx>
+#include <Message.hxx>
 #include <NCollection_Sequence.hxx>
 #include <NCollection_HSequence.hxx>
 #include <Units_Operators.hxx>

--- a/src/FoundationClasses/TKernel/Units/Units_Measurement.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units_Measurement.cxx
@@ -19,6 +19,7 @@
 #include <Units_Operators.hxx>
 #include <Units_Token.hxx>
 #include <Units_UnitSentence.hxx>
+#include <Message.hxx>
 
 //=================================================================================================
 

--- a/src/FoundationClasses/TKernel/Units/Units_Measurement.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units_Measurement.cxx
@@ -25,7 +25,7 @@
 Units_Measurement::Units_Measurement()
 {
   themeasurement = 0.;
-  myHasToken     = false;
+  myToken        = nullptr;
 }
 
 //=================================================================================================
@@ -33,8 +33,7 @@ Units_Measurement::Units_Measurement()
 Units_Measurement::Units_Measurement(const double avalue, const occ::handle<Units_Token>& atoken)
 {
   themeasurement = avalue;
-  thetoken       = atoken;
-  myHasToken     = true;
+  myToken        = atoken;
 }
 
 //=================================================================================================
@@ -45,17 +44,13 @@ Units_Measurement::Units_Measurement(const double avalue, const char* const auni
   Units_UnitSentence unit(aunit);
   if (!unit.IsDone())
   {
-#ifdef OCCT_DEBUG
-    std::cout << "can not create Units_Measurement - incorrect unit" << std::endl;
-#endif
-    myHasToken = false;
+    myToken = nullptr;
   }
   else
   {
-    thetoken = unit.Evaluate();
-    thetoken->Word(aunit);
-    thetoken->Mean("U");
-    myHasToken = true;
+    myToken = unit.Evaluate();
+    myToken->Word(aunit);
+    myToken->Mean("U");
   }
 }
 
@@ -63,12 +58,19 @@ Units_Measurement::Units_Measurement(const double avalue, const char* const auni
 
 void Units_Measurement::Convert(const char* const aunit)
 {
-  occ::handle<Units_Token> oldtoken = thetoken;
-  Units_UnitSentence       newunit(aunit);
-  if (!newunit.IsDone())
+  occ::handle<Units_Token> oldtoken = myToken;
+  if (oldtoken.IsNull())
   {
     std::cout << "Units_Measurement: can not convert - incorrect unit => result is not correct"
               << std::endl;
+    return;
+  }
+
+  Units_UnitSentence newunit(aunit);
+  if (!newunit.IsDone())
+  {
+    std::cout << "Units_Measurement: can not convert - incorrect unit '" << aunit
+              << "' => result is not correct" << std::endl;
     return;
   }
   occ::handle<Units_Token>      newtoken   = newunit.Evaluate();
@@ -77,32 +79,26 @@ void Units_Measurement::Convert(const char* const aunit)
 
   if (dimensions->IsEqual(Units::NullDimensions()))
   {
-    thetoken = new Units_Token(aunit, "U");
-    thetoken->Value(((newunit.Sequence())->Value(1))->Value());
-    thetoken->Dimensions(((newunit.Sequence())->Value(1))->Dimensions());
+    myToken = new Units_Token(aunit, "U");
+    myToken->Value(((newunit.Sequence())->Value(1))->Value());
+    myToken->Dimensions(((newunit.Sequence())->Value(1))->Dimensions());
     themeasurement = oldtoken->Multiplied(themeasurement);
     themeasurement = newtoken->Divided(themeasurement);
   }
-#ifdef OCCT_DEBUG
-  else
-  {
-    std::cout << " The units don't have the same physical dimensions" << std::endl;
-  }
-#endif
 }
 
 //=================================================================================================
 
 Units_Measurement Units_Measurement::Integer() const
 {
-  return Units_Measurement((int)themeasurement, thetoken);
+  return Units_Measurement((int)themeasurement, myToken);
 }
 
 //=================================================================================================
 
 Units_Measurement Units_Measurement::Fractional() const
 {
-  return Units_Measurement(themeasurement - (int)themeasurement, thetoken);
+  return Units_Measurement(themeasurement - (int)themeasurement, myToken);
 }
 
 //=================================================================================================
@@ -116,7 +112,7 @@ double Units_Measurement::Measurement() const
 
 occ::handle<Units_Token> Units_Measurement::Token() const
 {
-  return thetoken;
+  return myToken;
 }
 
 //=================================================================================================
@@ -125,12 +121,12 @@ Units_Measurement Units_Measurement::Add(const Units_Measurement& ameasurement) 
 {
   double            value;
   Units_Measurement measurement;
-  if (thetoken->Dimensions()->IsNotEqual((ameasurement.Token())->Dimensions()))
+  if (myToken->Dimensions()->IsNotEqual((ameasurement.Token())->Dimensions()))
     return measurement;
   value                          = ameasurement.Token()->Multiplied(ameasurement.Measurement());
-  value                          = thetoken->Divided(value);
+  value                          = myToken->Divided(value);
   value                          = themeasurement + value;
-  occ::handle<Units_Token> token = thetoken->Creates();
+  occ::handle<Units_Token> token = myToken->Creates();
   return Units_Measurement(value, token);
 }
 
@@ -140,12 +136,12 @@ Units_Measurement Units_Measurement::Subtract(const Units_Measurement& ameasurem
 {
   double            value;
   Units_Measurement measurement;
-  if (thetoken->Dimensions()->IsNotEqual((ameasurement.Token())->Dimensions()))
+  if (myToken->Dimensions()->IsNotEqual((ameasurement.Token())->Dimensions()))
     return measurement;
   value                          = ameasurement.Token()->Multiplied(ameasurement.Measurement());
-  value                          = thetoken->Divided(value);
+  value                          = myToken->Divided(value);
   value                          = themeasurement - value;
-  occ::handle<Units_Token> token = thetoken->Creates();
+  occ::handle<Units_Token> token = myToken->Creates();
   return Units_Measurement(value, token);
 }
 
@@ -154,7 +150,7 @@ Units_Measurement Units_Measurement::Subtract(const Units_Measurement& ameasurem
 Units_Measurement Units_Measurement::Multiply(const Units_Measurement& ameasurement) const
 {
   double                   value = themeasurement * ameasurement.Measurement();
-  occ::handle<Units_Token> token = thetoken * ameasurement.Token();
+  occ::handle<Units_Token> token = myToken * ameasurement.Token();
   return Units_Measurement(value, token);
 }
 
@@ -163,7 +159,7 @@ Units_Measurement Units_Measurement::Multiply(const Units_Measurement& ameasurem
 Units_Measurement Units_Measurement::Multiply(const double avalue) const
 {
   double                   value = themeasurement * avalue;
-  occ::handle<Units_Token> token = thetoken->Creates();
+  occ::handle<Units_Token> token = myToken->Creates();
   return Units_Measurement(value, token);
 }
 
@@ -172,7 +168,7 @@ Units_Measurement Units_Measurement::Multiply(const double avalue) const
 Units_Measurement Units_Measurement::Divide(const Units_Measurement& ameasurement) const
 {
   double                   value = themeasurement / ameasurement.Measurement();
-  occ::handle<Units_Token> token = thetoken / ameasurement.Token();
+  occ::handle<Units_Token> token = myToken / ameasurement.Token();
   return Units_Measurement(value, token);
 }
 
@@ -181,7 +177,7 @@ Units_Measurement Units_Measurement::Divide(const Units_Measurement& ameasuremen
 Units_Measurement Units_Measurement::Divide(const double avalue) const
 {
   double                   value = themeasurement / avalue;
-  occ::handle<Units_Token> token = thetoken->Creates();
+  occ::handle<Units_Token> token = myToken->Creates();
   return Units_Measurement(value, token);
 }
 
@@ -190,7 +186,7 @@ Units_Measurement Units_Measurement::Divide(const double avalue) const
 Units_Measurement Units_Measurement::Power(const double anexponent) const
 {
   double                   value = pow(themeasurement, anexponent);
-  occ::handle<Units_Token> token = pow(thetoken, anexponent);
+  occ::handle<Units_Token> token = pow(myToken, anexponent);
   return Units_Measurement(value, token);
 }
 
@@ -198,7 +194,7 @@ Units_Measurement Units_Measurement::Power(const double anexponent) const
 
 bool Units_Measurement::HasToken() const
 {
-  return myHasToken;
+  return !myToken.IsNull();
 }
 
 //=================================================================================================
@@ -206,7 +202,7 @@ bool Units_Measurement::HasToken() const
 void Units_Measurement::Dump() const
 {
   std::cout << " Measurement : " << themeasurement << std::endl;
-  thetoken->Dump(1, 1);
+  myToken->Dump(1, 1);
 }
 
 #ifdef BUG

--- a/src/FoundationClasses/TKernel/Units/Units_Measurement.cxx
+++ b/src/FoundationClasses/TKernel/Units/Units_Measurement.cxx
@@ -61,16 +61,16 @@ void Units_Measurement::Convert(const char* const aunit)
   occ::handle<Units_Token> oldtoken = myToken;
   if (oldtoken.IsNull())
   {
-    std::cout << "Units_Measurement: can not convert - incorrect unit => result is not correct"
-              << std::endl;
+    Message::SendWarning()
+      << "Units_Measurement: can not convert - incorrect unit => result is not correct";
     return;
   }
 
   Units_UnitSentence newunit(aunit);
   if (!newunit.IsDone())
   {
-    std::cout << "Units_Measurement: can not convert - incorrect unit '" << aunit
-              << "' => result is not correct" << std::endl;
+    Message::SendWarning() << "Units_Measurement: can not convert - incorrect unit '" << aunit
+                           << "' => result is not correct";
     return;
   }
   occ::handle<Units_Token>      newtoken   = newunit.Evaluate();
@@ -201,7 +201,7 @@ bool Units_Measurement::HasToken() const
 
 void Units_Measurement::Dump() const
 {
-  std::cout << " Measurement : " << themeasurement << std::endl;
+  Message::SendInfo() << " Measurement : " << themeasurement;
   myToken->Dump(1, 1);
 }
 

--- a/src/FoundationClasses/TKernel/Units/Units_Measurement.hxx
+++ b/src/FoundationClasses/TKernel/Units/Units_Measurement.hxx
@@ -124,8 +124,7 @@ public:
 
 private:
   double                   themeasurement;
-  occ::handle<Units_Token> thetoken;
-  bool                     myHasToken;
+  occ::handle<Units_Token> myToken;
 };
 
 #endif // _Units_Measurement_HeaderFile

--- a/src/FoundationClasses/TKernel/UnitsAPI/UnitsAPI.hxx
+++ b/src/FoundationClasses/TKernel/UnitsAPI/UnitsAPI.hxx
@@ -122,7 +122,7 @@ public:
                                                const char* const aUnit);
 
   //! Converts the local unit value to another local unit value.
-  //! Example: AnyToAny(0.0254,"in.","millimeter") returns 1. ;
+  //! Example: AnyToAny(0.0254,"in.","mm") returns 1. ;
   Standard_EXPORT static double AnyToAny(const double      aData,
                                          const char* const aUnit1,
                                          const char* const aUnit2);
@@ -145,7 +145,7 @@ public:
   Standard_EXPORT static UnitsAPI_SystemUnits LocalSystem();
 
   //! Sets the current unit dimension <aUnit> to the unit quantity <aQuantity>.
-  //! Example: SetCurrentUnit("LENGTH","millimeter")
+  //! Example: SetCurrentUnit("LENGTH","mm")
   Standard_EXPORT static void SetCurrentUnit(const char* const aQuantity, const char* const aUnit);
 
   //! Returns the current unit dimension <aUnit> from the unit quantity <aQuantity>.


### PR DESCRIPTION
Units_Measurement now prints name of unknown unit if conversion failed.
Units::Convert() now prints name of unknown unit if conversion failed.
Units::Convert() no longer crashes when first unit is unknown.
Updated incorrect descriptions of methods UnitsAPI - non-existing unit type "millimeter" is replaced with "mm".