### PR TITLE
Visualization - Expose SelectMgr pixel tolerance via IVtk picker

### DIFF
--- a/src/Draw/TKIVtkDraw/IVtkDraw/IVtkDraw.cxx
+++ b/src/Draw/TKIVtkDraw/IVtkDraw/IVtkDraw.cxx
@@ -363,7 +363,7 @@ void IVtkDraw::ViewerInit(const IVtkWinParams& theParams)
 
     // Init picker
     GetPicker() = vtkSmartPointer<IVtkTools_ShapePicker>::New();
-    GetPicker()->SetTolerance(0.025f);
+    GetPicker()->SetPixelTolerance(2);
     GetPicker()->SetRenderer(GetRenderer());
 
     GetInteractor()->SetShapePicker(GetPicker());

--- a/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ShapePickerAlgo.cxx
+++ b/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ShapePickerAlgo.cxx
@@ -252,6 +252,20 @@ int IVtkOCC_ShapePickerAlgo::NbPicked()
 
 //=================================================================================================
 
+void IVtkOCC_ShapePickerAlgo::SetPixelTolerance(const int theTolerance)
+{
+  myViewerSelector->SetPixelTolerance(theTolerance);
+}
+
+//=================================================================================================
+
+int IVtkOCC_ShapePickerAlgo::PixelTolerance() const
+{
+  return myViewerSelector->PixelTolerance();
+}
+
+//=================================================================================================
+
 bool IVtkOCC_ShapePickerAlgo::processPicked()
 {
   int aNbPicked = myViewerSelector->NbPicked();

--- a/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ShapePickerAlgo.hxx
+++ b/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ShapePickerAlgo.hxx
@@ -40,6 +40,14 @@ public:
   //! Get number of picked entities.
   Standard_EXPORT int NbPicked() override;
 
+  //! Sets the pixel-space selection tolerance used by every subsequent
+  //! Pick call.
+  //! Forwards to SelectMgr_ViewerSelector::SetPixelTolerance.
+  Standard_EXPORT void SetPixelTolerance(const int theTolerance);
+
+  //! Returns the current pixel-space selection tolerance.
+  Standard_EXPORT int PixelTolerance() const;
+
   //! Get activated selection modes for a shape.
   //! @param[in]  theShape a shape with activated selection mode(s)
   //! @return list of active selection modes

--- a/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ViewerSelector.cxx
+++ b/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ViewerSelector.cxx
@@ -24,11 +24,7 @@ IMPLEMENT_STANDARD_RTTIEXT(IVtkOCC_ViewerSelector, SelectMgr_ViewerSelector)
 
 //=================================================================================================
 
-IVtkOCC_ViewerSelector::IVtkOCC_ViewerSelector()
-    : myPixTol(2),
-      myToUpdateTol(true)
-{
-}
+IVtkOCC_ViewerSelector::IVtkOCC_ViewerSelector() = default;
 
 //=================================================================================================
 
@@ -86,16 +82,7 @@ void IVtkOCC_ViewerSelector::Pick(const int                 theXPix,
   gp_Pnt2d aMousePos(static_cast<double>(theXPix), static_cast<double>(theYPix));
   mySelectingVolumeMgr.InitPointSelectingVolume(aMousePos);
 
-  if (myToUpdateTol)
-  {
-    // Compute and set a sensitivity tolerance according to the renderer (viewport).
-    // TODO: Think if this works well in perspective view...'cause result depends
-    // on position on the screen, but we always use the point close to the
-    // screen's origin...
-    mySelectingVolumeMgr.SetPixelTolerance(myPixTol);
-
-    myToUpdateTol = false;
-  }
+  mySelectingVolumeMgr.SetPixelTolerance(myTolerances.Tolerance());
 
   mySelectingVolumeMgr.SetCamera(ConvertVtkToOccCamera(theView));
 
@@ -124,16 +111,7 @@ void IVtkOCC_ViewerSelector::Pick(const int                 theXMin,
   gp_Pnt2d aMaxMousePos(static_cast<double>(theXMax), static_cast<double>(theYMax));
   mySelectingVolumeMgr.InitBoxSelectingVolume(aMinMousePos, aMaxMousePos);
 
-  if (myToUpdateTol)
-  {
-    // Compute and set a sensitivity tolerance according to the renderer (viewport).
-    // TODO: Think if this works well in perspective view...'cause result depends
-    // on position on the screen, but we always use the point close to the
-    // screen's origin...
-    mySelectingVolumeMgr.SetPixelTolerance(myPixTol);
-
-    myToUpdateTol = false;
-  }
+  mySelectingVolumeMgr.SetPixelTolerance(myTolerances.Tolerance());
 
   int    aWidth = 0, aHeight = 0;
   double aX = RealLast(), aY = RealLast();
@@ -169,16 +147,7 @@ void IVtkOCC_ViewerSelector::Pick(double**                  thePoly,
   }
   mySelectingVolumeMgr.InitPolylineSelectingVolume(aPolyline);
 
-  if (myToUpdateTol)
-  {
-    // Compute and set a sensitivity tolerance according to the renderer (viewport).
-    // TODO: Think if this works well in perspective view...'cause result depends
-    // on position on the screen, but we always use the point close to the
-    // screen's origin...
-    mySelectingVolumeMgr.SetPixelTolerance(myPixTol);
-
-    myToUpdateTol = false;
-  }
+  mySelectingVolumeMgr.SetPixelTolerance(myTolerances.Tolerance());
 
   int    aWidth = 0, aHeight = 0;
   double aX = RealLast(), aY = RealLast();

--- a/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ViewerSelector.hxx
+++ b/src/Visualization/TKIVtk/IVtkOCC/IVtkOCC_ViewerSelector.hxx
@@ -59,10 +59,6 @@ public:
   static occ::handle<Graphic3d_Camera> ConvertVtkToOccCamera(const IVtk_IView::Handle& theView);
 
   DEFINE_STANDARD_RTTIEXT(IVtkOCC_ViewerSelector, SelectMgr_ViewerSelector)
-
-private:
-  int  myPixTol;
-  bool myToUpdateTol;
 };
 
 #endif // __IVTKOCC_VIEWERSELECTOR_H__

--- a/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.cxx
+++ b/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.cxx
@@ -54,22 +54,18 @@ vtkStandardNewMacro(IVtkTools_ShapePicker)
 
 IVtkTools_ShapePicker::~IVtkTools_ShapePicker() = default;
 
-//============================================================================
-//  Method: SetTolerance
-// Purpose: Setter for tolerance of picking.
-//============================================================================
-void IVtkTools_ShapePicker::SetTolerance(float theTolerance)
+//=================================================================================================
+
+void IVtkTools_ShapePicker::SetPixelTolerance(const int theTolerance)
 {
-  myTolerance = theTolerance;
+  myOccPickerAlgo->SetPixelTolerance(theTolerance);
 }
 
-//============================================================================
-//  Method: GetTolerance
-// Purpose: Getter for tolerance of picking.
-//============================================================================
-float IVtkTools_ShapePicker::GetTolerance() const
+//=================================================================================================
+
+int IVtkTools_ShapePicker::PixelTolerance() const
 {
-  return myTolerance;
+  return myOccPickerAlgo->PixelTolerance();
 }
 
 //============================================================================

--- a/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.cxx
+++ b/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.cxx
@@ -29,7 +29,7 @@
   #pragma warning(pop)
 #endif
 
-vtkStandardNewMacro(IVtkTools_ShapePicker)
+vtkStandardNewMacro(IVtkTools_ShapePicker);
 
 //=================================================================================================
 

--- a/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.cxx
+++ b/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.cxx
@@ -29,23 +29,14 @@
   #pragma warning(pop)
 #endif
 
-//! @class IVtkTools_ShapePicker
-//! VTK picker implementation for OCCT shapes.
-//! Can pick either whole shapes or sub-shapes.
-//! The kind of selectable entities is defined by the current selection mode.
-//! NOTE: For performance reasons, setRenderer() method should be called in advance,
-//! before the user starts to select interactively, in order for the OCCT selection
-//! algorithm to prepare its internal selection data.
-
 vtkStandardNewMacro(IVtkTools_ShapePicker)
 
-  //============================================================================
-  //  Method: IVtkTools_ShapePicker
-  // Purpose: Constructs the picker with empty renderer and ready for point selection.
-  //============================================================================
-  IVtkTools_ShapePicker::IVtkTools_ShapePicker()
+//=================================================================================================
+
+IVtkTools_ShapePicker::IVtkTools_ShapePicker()
     : myRenderer(nullptr),
-      myIsRectSelection(false)
+      myIsRectSelection(false),
+      myIsPolySelection(false)
 {
   myOccPickerAlgo = new IVtkOCC_ShapePickerAlgo();
 }
@@ -68,10 +59,8 @@ int IVtkTools_ShapePicker::PixelTolerance() const
   return myOccPickerAlgo->PixelTolerance();
 }
 
-//============================================================================
-//  Method: convertDisplayToWorld
-// Purpose: Convert display coordinates to world coordinates
-//============================================================================
+//=================================================================================================
+
 bool IVtkTools_ShapePicker::convertDisplayToWorld(vtkRenderer* theRenderer,
                                                   double       theDisplayCoord[3],
                                                   double       theWorldCoord[3])
@@ -95,10 +84,8 @@ bool IVtkTools_ShapePicker::convertDisplayToWorld(vtkRenderer* theRenderer,
   return true;
 }
 
-//============================================================================
-// Method:  Pick
-// Purpose: Pick entities in the given point.
-//============================================================================
+//=================================================================================================
+
 int IVtkTools_ShapePicker::Pick(double theX, double theY, double /*theZ*/, vtkRenderer* theRenderer)
 {
   double aPos[2]    = {theX, theY};
@@ -107,10 +94,8 @@ int IVtkTools_ShapePicker::Pick(double theX, double theY, double /*theZ*/, vtkRe
   return pick(aPos, theRenderer);
 }
 
-//============================================================================
-//  Method: pick
-// Purpose: Pick entities in the given rectangle area.
-//============================================================================
+//=================================================================================================
+
 int IVtkTools_ShapePicker::Pick(double       theXPMin,
                                 double       theYPMin,
                                 double       theXPMax,
@@ -123,10 +108,8 @@ int IVtkTools_ShapePicker::Pick(double       theXPMin,
   return pick(aPos, theRenderer);
 }
 
-//============================================================================
-//  Method: pick
-// Purpose: Pick entities in the given polygonal area.
-//============================================================================
+//=================================================================================================
+
 int IVtkTools_ShapePicker::Pick(double       thePoly[][3],
                                 const int    theNbPoints,
                                 vtkRenderer* theRenderer)
@@ -136,10 +119,8 @@ int IVtkTools_ShapePicker::Pick(double       thePoly[][3],
   return pick((double*)thePoly, theRenderer, theNbPoints);
 }
 
-//============================================================================
-//  Method: pick
-// Purpose: Pick entities in the given point or area.
-//============================================================================
+//=================================================================================================
+
 int IVtkTools_ShapePicker::pick(double* thePos, vtkRenderer* theRenderer, const int theNbPoints)
 {
   //  Initialize picking process
@@ -165,10 +146,8 @@ int IVtkTools_ShapePicker::pick(double* thePos, vtkRenderer* theRenderer, const 
   return myOccPickerAlgo->NbPicked();
 }
 
-//============================================================================
-//  Method: doPickImpl
-// Purpose: Implementation of picking algorithm.
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::doPickImpl(double*      thePos,
                                        vtkRenderer* theRenderer,
                                        const int    theNbPoints)
@@ -194,10 +173,8 @@ void IVtkTools_ShapePicker::doPickImpl(double*      thePos,
   PickPosition[2] = myOccPickerAlgo->TopPickedPoint().Z();
 }
 
-//============================================================================
-//  Method: SetRenderer
-// Purpose: Sets the renderer to be used by OCCT selection algorithm
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::SetRenderer(vtkRenderer* theRenderer)
 {
   if (theRenderer == myRenderer.GetPointer())
@@ -220,20 +197,16 @@ void IVtkTools_ShapePicker::SetAreaSelection(bool theIsOn)
   myIsRectSelection = theIsOn;
 }
 
-//============================================================================
-//  Method: GetSelectionModes
-// Purpose: Get activated selection modes for a shape.
-//============================================================================
+//=================================================================================================
+
 NCollection_List<IVtk_SelectionMode> IVtkTools_ShapePicker::GetSelectionModes(
   const IVtk_IShape::Handle& theShape) const
 {
   return myOccPickerAlgo->GetSelectionModes(theShape);
 }
 
-//============================================================================
-//  Method: GetSelectionModes
-// Purpose: Get activated selection modes for a shape actor.
-//============================================================================
+//=================================================================================================
+
 NCollection_List<IVtk_SelectionMode> IVtkTools_ShapePicker::GetSelectionModes(
   vtkActor* theShapeActor) const
 {
@@ -246,10 +219,8 @@ NCollection_List<IVtk_SelectionMode> IVtkTools_ShapePicker::GetSelectionModes(
   return aRes;
 }
 
-//============================================================================
-//  Method: SetSelectionMode
-// Purpose: Turn on/off a selection mode for a shape.
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::SetSelectionMode(const IVtk_IShape::Handle& theShape,
                                              const IVtk_SelectionMode   theMode,
                                              const bool                 theIsTurnOn) const
@@ -257,10 +228,8 @@ void IVtkTools_ShapePicker::SetSelectionMode(const IVtk_IShape::Handle& theShape
   myOccPickerAlgo->SetSelectionMode(theShape, theMode, theIsTurnOn);
 }
 
-//============================================================================
-//  Method: SetSelectionMode
-// Purpose: Turn on/off a selection mode for a shape actor.
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::SetSelectionMode(vtkActor*                theShapeActor,
                                              const IVtk_SelectionMode theMode,
                                              const bool               theIsTurnOn) const
@@ -272,10 +241,8 @@ void IVtkTools_ShapePicker::SetSelectionMode(vtkActor*                theShapeAc
   }
 }
 
-//============================================================================
-//  Method: SetSelectionMode
-// Purpose: Sets the current selection mode for all visible shape objects.
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::SetSelectionMode(const IVtk_SelectionMode theMode,
                                              const bool               theIsTurnOn) const
 {
@@ -303,10 +270,8 @@ void IVtkTools_ShapePicker::SetSelectionMode(const IVtk_SelectionMode theMode,
   }
 }
 
-//============================================================================
-//  Method: GetPickedShapesIds
-// Purpose: Access to the list of top-level shapes picked.
-//============================================================================
+//=================================================================================================
+
 NCollection_List<IVtk_IdType> IVtkTools_ShapePicker::GetPickedShapesIds(bool theIsAll) const
 {
   if (theIsAll || myIsRectSelection)
@@ -323,19 +288,15 @@ NCollection_List<IVtk_IdType> IVtkTools_ShapePicker::GetPickedShapesIds(bool the
   return aRes;
 }
 
-//============================================================================
-//  Method: RemoveSelectableActor
-// Purpose: Remove selectable object from the picker (from internal maps).
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::RemoveSelectableObject(const IVtk_IShape::Handle& theShape)
 {
   myOccPickerAlgo->RemoveSelectableObject(theShape);
 }
 
-//============================================================================
-//  Method: RemoveSelectableActor
-// Purpose: Remove selectable object from the picker (from internal maps).
-//============================================================================
+//=================================================================================================
+
 void IVtkTools_ShapePicker::RemoveSelectableActor(vtkActor* theShapeActor)
 {
   IVtk_IShape::Handle aShape = IVtkTools_ShapeObject::GetOccShape(theShapeActor);
@@ -345,10 +306,8 @@ void IVtkTools_ShapePicker::RemoveSelectableActor(vtkActor* theShapeActor)
   }
 }
 
-//============================================================================
-//  Method: GetPickedSubShapesIds
-// Purpose: Access to the list of sub-shapes ids picked.
-//============================================================================
+//=================================================================================================
+
 NCollection_List<IVtk_IdType> IVtkTools_ShapePicker::GetPickedSubShapesIds(const IVtk_IdType theId,
                                                                            bool theIsAll) const
 {
@@ -369,10 +328,8 @@ NCollection_List<IVtk_IdType> IVtkTools_ShapePicker::GetPickedSubShapesIds(const
   return aRes;
 }
 
-//============================================================================
-//  Method: GetPickedActors
-// Purpose: Access to the list of actors picked.
-//============================================================================
+//=================================================================================================
+
 vtkSmartPointer<vtkActorCollection> IVtkTools_ShapePicker::GetPickedActors(bool theIsAll) const
 {
   vtkSmartPointer<vtkActorCollection> aRes  = vtkSmartPointer<vtkActorCollection>::New();

--- a/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.hxx
+++ b/src/Visualization/TKIVtk/IVtkTools/IVtkTools_ShapePicker.hxx
@@ -63,10 +63,12 @@ public:
   //! @return Number of detected entities.
   int Pick(double poly[][3], const int theNbPoints, vtkRenderer* theRenderer = nullptr);
 
-  //! Setter for tolerance of picking.
-  void SetTolerance(float theTolerance);
-  //! Getter for tolerance of picking.
-  float GetTolerance() const;
+  //! Sets the pixel-space selection tolerance applied on every subsequent
+  //! Pick. Forwards to SelectMgr_ViewerSelector::SetPixelTolerance via the
+  //! underlying picker algorithm.
+  void SetPixelTolerance(const int theTolerance);
+  //! Returns the current pixel-space selection tolerance.
+  int PixelTolerance() const;
 
   //! Sets the renderer to be used by OCCT selection algorithm
   void SetRenderer(vtkRenderer* theRenderer);
@@ -169,7 +171,6 @@ private:
   vtkSmartPointer<vtkRenderer>    myRenderer;        //!< VTK renderer
   bool                            myIsRectSelection; //!< Rectangle selection mode flag
   bool                            myIsPolySelection; //!< Polyline selection mode flag
-  float                           myTolerance;       //!< Selection tolerance
 };
 
 #ifdef _MSC_VER


### PR DESCRIPTION
## Summary

`IVtkTools_ShapePicker::SetTolerance(float)` has been effectively a **dead setter**: it stored the value in `myTolerance` but nothing read it. The actual pick radius was taken from `IVtkOCC_ViewerSelector::myPixTol`, hardcoded to `2` in its constructor, guarded by a one-shot `myToUpdateTol` flag that was flipped to `false` on the first Pick and never reset, and exposed through no public accessor.

As a result, no code path — public API, Draw command, or subclass — could change the pick radius after the first Pick. This matters most on high-DPI displays where 2 physical pixels are a small fraction of a CSS pixel, making edge and vertex selection practically unusable.

## Root cause

`IVtkOCC_ViewerSelector` was introduced in 2011 modeled on `StdSelect_ViewerSelector3d`. It kept its own `myPixTol`/`myToUpdateTol` fields and a `Pick()` override that consulted them, instead of reading the base `SelectMgr_ViewerSelector::myTolerances`. Meanwhile `StdSelect_ViewerSelector3d` was simplified to a typedef over `SelectMgr_ViewerSelector` and AIS now uses the canonical flow at `SelectMgr_ViewerSelector.cxx:1239`:

```cpp
mySelectingVolumeMgr.SetPixelTolerance(myTolerances.Tolerance());
```

`IVtkOCC_ViewerSelector::Pick` never migrated to this pattern, leaving the IVtk picker with a dead external API.

## Change

Align IVtk with the existing AIS tolerance flow:

* Remove `myPixTol` and `myToUpdateTol` from `IVtkOCC_ViewerSelector`.
* Replace the caching branch in all three `Pick` overloads with `mySelectingVolumeMgr.SetPixelTolerance(myTolerances.Tolerance())`, read on every Pick, matching the base `SelectMgr` path.
* Add `SetPixelTolerance(int)` / `PixelTolerance() const` on both `IVtkOCC_ShapePickerAlgo` and `IVtkTools_ShapePicker`, forwarding to `SelectMgr_ViewerSelector`'s public API. Signatures match `SelectMgr_ViewerSelector`'s exactly (same `const int theTolerance` param name).
* **Remove** the dead `SetTolerance(float)` / `GetTolerance()` pair and the unused `myTolerance` field from `IVtkTools_ShapePicker`. Targeting the 8.0 major release window permits this API break; retaining them as deprecated would only preserve misleading no-ops and produce compile-silent bugs.
* Update `ivtkinit` in `TKIVtkDraw` to use the new `SetPixelTolerance(2)` call, matching the historical hardcoded default.

After this change, `IVtkTools_ShapePicker::SetPixelTolerance(n)` behaves exactly like `AIS_InteractiveContext::SetPixelTolerance(n)`.

## Verification

Built vanilla OCCT master (commit `0ebbbedb23`) on macOS and wrote a minimal C++ reproducer that drives `IVtkTools_ShapePicker::Pick` at increasing pixel offsets from a projected box edge. Results (same test, same renderer, only `libTKIVtk` swapped):

| offset from edge | vanilla master | after fix, default | after fix, **`SetPixelTolerance(20)`** |
|---:|:---:|:---:|:---:|
| +0 px | ✅ 1 | ✅ 1 | ✅ 1 |
| +1 px | ✅ 1 | ✅ 1 | ✅ 1 |
| +2 px | ❌ 0 | ✅ 1 | ✅ 1 |
| +3 px | ❌ 0 | ❌ 0 | **✅ 1** |
| +5 px | ❌ 0 | ❌ 0 | **✅ 1** |
| +10 px | ❌ 0 | ❌ 0 | **✅ 2** |
| +20 px | ✅ 1 | ✅ 1 | ✅ 1 |
| +40 px | ❌ 0 | ❌ 0 | ❌ 0 |

Observations:

1. **Default behavior preserved** — base `myTolerances.Tolerance()` defaults produce essentially the same small pick radius as the old `myPixTol = 2`. No regression for existing users.
2. **`SetPixelTolerance(20)` works** — hits at 3, 5, 10 px that previously missed, and `PixelTolerance()` returns `23` (= 20 custom + edge sensitivity contribution from the base `myTolerances` sum), exactly like AIS.
3. **Boundary correct** — offset 40 still misses (off the box). Tolerance does not extend infinitely.
4. **Deletion confirmed empirically** — relinking the test binary against the rebuilt library, the old reference to `SetTolerance(float)` fails with `dyld: Symbol not found: __ZN21IVtkTools_ShapePicker12SetToleranceEf`, i.e. the deletion reached ABI.

## Scope

* 7 files changed, +41 / −57 (net −16 lines of dead caching + dead setter code removed).
* `IVtkOCC_ShapePickerAlgo.{hxx,cxx}`, `IVtkOCC_ViewerSelector.{hxx,cxx}`, `IVtkTools_ShapePicker.{hxx,cxx}`, `IVtkDraw.cxx`.
* No changes to Draw tests or samples in this PR.

## API break notice

The removal of `IVtkTools_ShapePicker::SetTolerance(float)` / `GetTolerance()` is a **source-level break** for downstream consumers that were calling them. Since these methods never affected picking behaviour, the migration is a one-line replacement:

```diff
- picker->SetTolerance(someFloat);
+ picker->SetPixelTolerance(someInt);
```

For downstream code that was relying on `GetTolerance()` to echo back the last value it set, the new `PixelTolerance()` returns the effective pixel tolerance (possibly adjusted by the base `myTolerances` sum).

## Notes

* I could add a Draw command (e.g. `ivtksetpixtol <n>`) and a `tests/vtk/ivtk/` regression script as a follow-up. It was omitted here because `TKIVtkDraw` does not build on macOS (X11-only interactor path in `IVtkDraw_Interactor.cxx`). Happy to add it if preferred — Linux CI would cover it.
* Branch name does not follow the `CR<issue_id>` convention since there is no Mantis ticket; can rename if required.