### PR TITLE
Configuration - Only link TKIVtk against RenderingGL2PSOpenGL2 when VTK provides it

### DIFF
--- a/adm/cmake/occt_toolkit.cmake
+++ b/adm/cmake/occt_toolkit.cmake
@@ -277,7 +277,11 @@ if("${VTK_RENDERING_BACKEND}" STREQUAL "OpenGL2" OR IS_VTK_9XX)
       if (${VTK_EXCLUDE_LIBRARY} STREQUAL vtkRenderingOpenGL)
         list (APPEND USED_TOOLKITS_BY_CURRENT_PROJECT vtkRenderingOpenGL2)
         if(VTK_MAJOR_VERSION GREATER 6)
-          list (APPEND USED_TOOLKITS_BY_CURRENT_PROJECT vtkRenderingGL2PSOpenGL2)
+          # VTK omits RenderingGL2PSOpenGL2 on Android/iOS and under GLES (Emscripten);
+          # only add the dependency when the target is actually provided.
+          if (TARGET VTK::RenderingGL2PSOpenGL2 OR TARGET vtkRenderingGL2PSOpenGL2)
+            list (APPEND USED_TOOLKITS_BY_CURRENT_PROJECT vtkRenderingGL2PSOpenGL2)
+          endif()
         endif()
       endif()
     endif()


### PR DESCRIPTION
## Summary
`occt_toolkit.cmake` unconditionally appends `vtkRenderingGL2PSOpenGL2` to
`TKIVtk`'s link interface when VTK is 7+ and the OpenGL2 backend is active.
VTK, however, guards that module with `NOT ANDROID AND NOT APPLE_IOS AND NOT VTK_OPENGL_USE_GLES` (see `Rendering/GL2PSOpenGL2/vtk.module`),
so it is not emitted on Android/iOS or when building for GLES (e.g. Emscripten /
WebAssembly wasm32 or wasm64). Consuming such a VTK then fails at CMake
generate time:

```
CMake Error at adm/cmake/occt_toolkit.cmake:298 (target_link_libraries):
  Target "TKIVtk" links to:
    VTK::RenderingGL2PSOpenGL2
  but the target was not found.
```

## Fix
Guard the `list(APPEND ...)` call with `TARGET` existence checks for both the
VTK 9 namespaced name (`VTK::RenderingGL2PSOpenGL2`) and the legacy VTK 7/8
name (`vtkRenderingGL2PSOpenGL2`). No behavior change when the module is
present; TKIVtk simply drops the transitive dependency on platforms where
VTK chose not to ship it. GL2PS is a native-only PDF/PostScript exporter
with no runtime role on mobile or wasm targets.

## Test plan
- [x] Build OCCT with `USE_VTK=ON` against a VTK built with `VTK_OPENGL_USE_GLES=ON` (Emscripten wasm64) — TKIVtk now links cleanly.
- [ ] Build OCCT with `USE_VTK=ON` against a desktop VTK — `vtkRenderingGL2PSOpenGL2` still appears in the link interface (no regression).