### PR TITLE
Data Exchange - Segfault in CheckSRRReversesNAUO

### DIFF
--- a/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_Assembly.cxx
+++ b/src/DataExchange/TKDESTEP/STEPConstruct/STEPConstruct_Assembly.cxx
@@ -207,7 +207,13 @@ bool STEPConstruct_Assembly::CheckSRRReversesNAUO(
       occ::handle<StepShape_ShapeDefinitionRepresentation> SDR =
         occ::down_cast<StepShape_ShapeDefinitionRepresentation>(enti);
       if (SDR->UsedRepresentation() == rep1)
-        pd1 = SDR->Definition().PropertyDefinition()->Definition().ProductDefinition();
+      {
+        const occ::handle<StepRepr_PropertyDefinition> aPD = SDR->Definition().PropertyDefinition();
+        if (aPD)
+        {
+          pd1 = aPD->Definition().ProductDefinition();
+        }
+      }
     }
   }
 
@@ -220,7 +226,13 @@ bool STEPConstruct_Assembly::CheckSRRReversesNAUO(
       occ::handle<StepShape_ShapeDefinitionRepresentation> SDR =
         occ::down_cast<StepShape_ShapeDefinitionRepresentation>(enti);
       if (SDR->UsedRepresentation() == rep2)
-        pd2 = SDR->Definition().PropertyDefinition()->Definition().ProductDefinition();
+      {
+        const occ::handle<StepRepr_PropertyDefinition> aPD = SDR->Definition().PropertyDefinition();
+        if (aPD)
+        {
+          pd2 = aPD->Definition().ProductDefinition();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
STEPConstruct_Assembly::CheckSRRReversesNAUO() is now checks StepRepr_PropertyDefinition for nullptr before dereferencing it.
Closes https://github.com/Open-Cascade-SAS/OCCT/issues/1202