### PR TITLE
Data Exchange - Crash in XSControl_Reader::OneShape()

### DIFF
--- a/src/DataExchange/TKXSBase/XSControl/XSControl_Reader.cxx
+++ b/src/DataExchange/TKXSBase/XSControl/XSControl_Reader.cxx
@@ -225,8 +225,8 @@ int XSControl_Reader::TransferList(
   if (theList.IsNull())
     return 0;
 
-  int                                          aTransferedCount = 0;
-  const occ::handle<XSControl_TransferReader>& aTransferReader  = thesession->TransferReader();
+  int                                          aTransferredCount = 0;
+  const occ::handle<XSControl_TransferReader>& aTransferReader   = thesession->TransferReader();
   aTransferReader->BeginTransfer();
   InitializeMissingParameters();
   ClearShapes();
@@ -243,9 +243,9 @@ int XSControl_Reader::TransferList(
     // Null shapes are allowed intentionally.
     // SMH May 00: allow empty shapes (STEP CAX-IF, external references)
     theshapes.Append(aShape);
-    ++aTransferedCount;
+    ++aTransferredCount;
   }
-  return aTransferedCount;
+  return aTransferredCount;
 }
 
 //=================================================================================================
@@ -254,8 +254,8 @@ int XSControl_Reader::TransferRoots(const Message_ProgressRange& theProgress)
 {
   NbRootsForTransfer();
 
-  int                                          aTransferedCount = 0;
-  const occ::handle<XSControl_TransferReader>& aTransferReader  = thesession->TransferReader();
+  int                                          aTransferredCount = 0;
+  const occ::handle<XSControl_TransferReader>& aTransferReader   = thesession->TransferReader();
   aTransferReader->BeginTransfer();
   InitializeMissingParameters();
   ClearShapes();
@@ -272,9 +272,9 @@ int XSControl_Reader::TransferRoots(const Message_ProgressRange& theProgress)
     // Null shapes are allowed intentionally.
     // SMH May 00: allow empty shapes (STEP CAX-IF, external references)
     theshapes.Append(aShape);
-    ++aTransferedCount;
+    ++aTransferredCount;
   }
-  return aTransferedCount;
+  return aTransferredCount;
 }
 
 //=================================================================================================
@@ -321,14 +321,16 @@ TopoDS_Shape XSControl_Reader::OneShape() const
   BRep_Builder    aBuilder;
   TopoDS_Compound aResult;
   aBuilder.MakeCompound(aResult);
+  bool aNonNullShapeAdded = false;
   for (const auto& aCurrShape : theshapes)
   {
     if (!aCurrShape.IsNull())
     {
       aBuilder.Add(aResult, aCurrShape);
+      aNonNullShapeAdded = true;
     }
   }
-  return aResult;
+  return aNonNullShapeAdded ? aResult : TopoDS_Shape();
 }
 
 //=================================================================================================

--- a/src/DataExchange/TKXSBase/XSControl/XSControl_Reader.cxx
+++ b/src/DataExchange/TKXSBase/XSControl/XSControl_Reader.cxx
@@ -197,52 +197,55 @@ bool XSControl_Reader::TransferOne(const int num, const Message_ProgressRange& t
 
 //=================================================================================================
 
-bool XSControl_Reader::TransferEntity(const occ::handle<Standard_Transient>& start,
+bool XSControl_Reader::TransferEntity(const occ::handle<Standard_Transient>& theStart,
                                       const Message_ProgressRange&           theProgress)
 {
-  if (start.IsNull())
+  if (theStart.IsNull())
     return false;
-  const occ::handle<XSControl_TransferReader>& TR = thesession->TransferReader();
-  TR->BeginTransfer();
+
+  const occ::handle<XSControl_TransferReader>& aTransferReader = thesession->TransferReader();
+  aTransferReader->BeginTransfer();
   InitializeMissingParameters();
-  if (TR->TransferOne(start, true, theProgress) == 0)
+  if (aTransferReader->TransferOne(theStart, true, theProgress) == 0)
     return false;
-  TopoDS_Shape sh = TR->ShapeResult(start);
-  // ShapeExtend_Explorer STU;
+
+  const TopoDS_Shape aShape = aTransferReader->ShapeResult(theStart);
+  // Null shapes are allowed intentionally.
   // SMH May 00: allow empty shapes (STEP CAX-IF, external references)
-  // if (STU.ShapeType(sh,true) == TopAbs_SHAPE) return false;  // nulle-vide
-  theshapes.Append(sh);
+  theshapes.Append(aShape);
   return true;
 }
 
 //=================================================================================================
 
 int XSControl_Reader::TransferList(
-  const occ::handle<NCollection_HSequence<occ::handle<Standard_Transient>>>& list,
+  const occ::handle<NCollection_HSequence<occ::handle<Standard_Transient>>>& theList,
   const Message_ProgressRange&                                               theProgress)
 {
-  if (list.IsNull())
+  if (theList.IsNull())
     return 0;
-  int                                          nbt = 0;
-  int                                          i, nb = list->Length();
-  const occ::handle<XSControl_TransferReader>& TR = thesession->TransferReader();
-  TR->BeginTransfer();
+
+  int                                          aTransferedCount = 0;
+  const occ::handle<XSControl_TransferReader>& aTransferReader  = thesession->TransferReader();
+  aTransferReader->BeginTransfer();
   InitializeMissingParameters();
   ClearShapes();
-  ShapeExtend_Explorer  STU;
-  Message_ProgressScope PS(theProgress, nullptr, nb);
-  for (i = 1; i <= nb && PS.More(); i++)
+  Message_ProgressScope aProgressScope(theProgress, nullptr, theList->Size());
+  for (int i = 1; i <= theList->Size() && aProgressScope.More(); i++)
   {
-    occ::handle<Standard_Transient> start = list->Value(i);
-    if (TR->TransferOne(start, true, PS.Next()) == 0)
+    occ::handle<Standard_Transient> aStart = theList->Value(i);
+    if (aTransferReader->TransferOne(aStart, true, aProgressScope.Next()) == 0)
+    {
       continue;
-    TopoDS_Shape sh = TR->ShapeResult(start);
-    if (STU.ShapeType(sh, true) == TopAbs_SHAPE)
-      continue; // nulle-vide
-    theshapes.Append(sh);
-    nbt++;
+    }
+
+    const TopoDS_Shape aShape = aTransferReader->ShapeResult(aStart);
+    // Null shapes are allowed intentionally.
+    // SMH May 00: allow empty shapes (STEP CAX-IF, external references)
+    theshapes.Append(aShape);
+    ++aTransferedCount;
   }
-  return nbt;
+  return aTransferedCount;
 }
 
 //=================================================================================================
@@ -250,27 +253,28 @@ int XSControl_Reader::TransferList(
 int XSControl_Reader::TransferRoots(const Message_ProgressRange& theProgress)
 {
   NbRootsForTransfer();
-  int                                          nbt = 0;
-  int                                          i, nb = theroots.Length();
-  const occ::handle<XSControl_TransferReader>& TR = thesession->TransferReader();
 
-  TR->BeginTransfer();
+  int                                          aTransferedCount = 0;
+  const occ::handle<XSControl_TransferReader>& aTransferReader  = thesession->TransferReader();
+  aTransferReader->BeginTransfer();
   InitializeMissingParameters();
   ClearShapes();
-  ShapeExtend_Explorer  STU;
-  Message_ProgressScope PS(theProgress, "Root", nb);
-  for (i = 1; i <= nb && PS.More(); i++)
+  Message_ProgressScope aProgressScope(theProgress, "Root", theroots.Size());
+  for (int i = 1; i <= theroots.Size() && aProgressScope.More(); i++)
   {
-    occ::handle<Standard_Transient> start = theroots.Value(i);
-    if (TR->TransferOne(start, true, PS.Next()) == 0)
+    occ::handle<Standard_Transient> aStart = theroots.Value(i);
+    if (aTransferReader->TransferOne(aStart, true, aProgressScope.Next()) == 0)
+    {
       continue;
-    TopoDS_Shape sh = TR->ShapeResult(start);
-    if (STU.ShapeType(sh, true) == TopAbs_SHAPE)
-      continue; // nulle-vide
-    theshapes.Append(sh);
-    nbt++;
+    }
+
+    TopoDS_Shape aShape = aTransferReader->ShapeResult(aStart);
+    // Null shapes are allowed intentionally.
+    // SMH May 00: allow empty shapes (STEP CAX-IF, external references)
+    theshapes.Append(aShape);
+    ++aTransferedCount;
   }
-  return nbt;
+  return aTransferedCount;
 }
 
 //=================================================================================================
@@ -305,19 +309,26 @@ TopoDS_Shape XSControl_Reader::Shape(const int num) const
 
 TopoDS_Shape XSControl_Reader::OneShape() const
 {
-  TopoDS_Shape sh;
-  int          i, nb = theshapes.Length();
-  if (nb == 0)
-    return sh;
-  if (nb == 1)
-    return theshapes.Value(1);
-  TopoDS_Compound C;
-  BRep_Builder    B;
-  // pdn 26.02.99 testing S4133
-  B.MakeCompound(C);
-  for (i = 1; i <= nb; i++)
-    B.Add(C, theshapes.Value(i));
-  return C;
+  if (theshapes.IsEmpty())
+  {
+    return {};
+  }
+  if (theshapes.Length() == 1)
+  {
+    return theshapes.First();
+  }
+
+  BRep_Builder    aBuilder;
+  TopoDS_Compound aResult;
+  aBuilder.MakeCompound(aResult);
+  for (const auto& aCurrShape : theshapes)
+  {
+    if (!aCurrShape.IsNull())
+    {
+      aBuilder.Add(aResult, aCurrShape);
+    }
+  }
+  return aResult;
 }
 
 //=================================================================================================

--- a/src/DataExchange/TKXSBase/XSControl/XSControl_Reader.cxx
+++ b/src/DataExchange/TKXSBase/XSControl/XSControl_Reader.cxx
@@ -230,8 +230,8 @@ int XSControl_Reader::TransferList(
   aTransferReader->BeginTransfer();
   InitializeMissingParameters();
   ClearShapes();
-  Message_ProgressScope aProgressScope(theProgress, nullptr, theList->Size());
-  for (int i = 1; i <= theList->Size() && aProgressScope.More(); i++)
+  Message_ProgressScope aProgressScope(theProgress, nullptr, static_cast<double>(theList->Size()));
+  for (size_t i = 1; i <= theList->Size() && aProgressScope.More(); i++)
   {
     occ::handle<Standard_Transient> aStart = theList->Value(i);
     if (aTransferReader->TransferOne(aStart, true, aProgressScope.Next()) == 0)
@@ -259,8 +259,8 @@ int XSControl_Reader::TransferRoots(const Message_ProgressRange& theProgress)
   aTransferReader->BeginTransfer();
   InitializeMissingParameters();
   ClearShapes();
-  Message_ProgressScope aProgressScope(theProgress, "Root", theroots.Size());
-  for (int i = 1; i <= theroots.Size() && aProgressScope.More(); i++)
+  Message_ProgressScope aProgressScope(theProgress, "Root", static_cast<double>(theroots.Size()));
+  for (size_t i = 1; i <= theroots.Size() && aProgressScope.More(); i++)
   {
     occ::handle<Standard_Transient> aStart = theroots.Value(i);
     if (aTransferReader->TransferOne(aStart, true, aProgressScope.Next()) == 0)


### PR DESCRIPTION
Fixed a crash in XSControl_Reader::OneShape() that occured when one of the shapes in XSControl_Reader::theshapes was null. XSControl_Reader::TransferRoots() and XSControl_Reader::TransferList() can now add null shapes to XSControl_Reader::theshapes to make behavior consistant with XSControl_Reader::TransferEntity().