### PR TITLE
Visualization - Fix selection for objects with group-level flipping

### DIFF
--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Group.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Group.cxx
@@ -203,7 +203,7 @@ void OpenGl_Group::SetFlippingOptions(const bool theIsEnabled, const gp_Ax2& the
   // call SetFlippingOptions(true,...) then SetFlippingOptions(false,...) on the same
   // group around the primitives that must be flipped. The selection side needs to know
   // the group contains flipped geometry, so myFlipper must persist across the disable
-  // call — we only set it, never clear it.
+  // call - we only set it, never clear it.
   if (theIsEnabled)
   {
     myStructure->CStructure()->SetGroupFlipping(true);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Group.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Group.cxx
@@ -24,7 +24,9 @@
 #include <OpenGl_Workspace.hxx>
 
 #include <Graphic3d_ArrayOfPrimitives.hxx>
+#include <Graphic3d_Flipper.hxx>
 #include <Graphic3d_GroupDefinitionError.hxx>
+#include <Graphic3d_Structure.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(OpenGl_Group, Graphic3d_Group)
 
@@ -197,6 +199,16 @@ void OpenGl_Group::SetFlippingOptions(const bool theIsEnabled, const gp_Ax2& the
   OpenGl_Flipper* aFlipper = new OpenGl_Flipper(theRefPlane);
   aFlipper->SetOptions(theIsEnabled);
   AddElement(aFlipper);
+  // OpenGl_Flipper acts as a push/pop bracket on the render stream, so AIS consumers
+  // call SetFlippingOptions(true,...) then SetFlippingOptions(false,...) on the same
+  // group around the primitives that must be flipped. The selection side needs to know
+  // the group contains flipped geometry, so myFlipper must persist across the disable
+  // call — we only set it, never clear it.
+  if (theIsEnabled)
+  {
+    myStructure->CStructure()->SetGroupFlipping(true);
+    myFlipper = new Graphic3d_Flipper(theRefPlane);
+  }
 }
 
 //=================================================================================================

--- a/src/Visualization/TKService/GTests/FILES.cmake
+++ b/src/Visualization/TKService/GTests/FILES.cmake
@@ -4,5 +4,6 @@ set(OCCT_TKService_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 set(OCCT_TKService_GTests_FILES
   Graphic3d_Aspects_Test.cxx
   Graphic3d_BndBox_Test.cxx
+  Graphic3d_Flipper_Test.cxx
   Image_VideoRecorder_Test.cxx
 )

--- a/src/Visualization/TKService/GTests/Graphic3d_Flipper_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_Flipper_Test.cxx
@@ -49,7 +49,7 @@ TEST(Graphic3d_FlipperTest, Compute_IdentityWorldView_ReturnsIdentity)
 {
   Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
 
-  NCollection_Mat4<double> aWorldView; // identity
+  NCollection_Mat4<double>       aWorldView; // identity
   const NCollection_Mat4<double> aResult = aFlipper.Compute(aWorldView);
   EXPECT_TRUE(aResult.IsIdentity()) << "Aligned ref system under identity WV should yield no flip";
 }
@@ -150,7 +150,7 @@ TEST(Graphic3d_FlipperTest, Compute_ObjectTransformChangesDecision)
   EXPECT_TRUE(aFlipper.Compute(aWorldView).IsIdentity())
     << "Identity WV keeps ref system aligned, no flip";
 
-  // Object rotated 180 deg about Z — composing this into MV inverts X and Y,
+  // Object rotated 180 deg about Z - composing this into MV inverts X and Y,
   // which is exactly the trigger for the (isReversedX || isReversedY) && !isReversedZ
   // branch in Compute(). The resulting matrix must not be identity.
   NCollection_Mat4<double> anObjTrsf;

--- a/src/Visualization/TKService/GTests/Graphic3d_Flipper_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_Flipper_Test.cxx
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Bnd_Box.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <Graphic3d_Flipper.hxx>
+#include <NCollection_Mat4.hxx>
+#include <Precision.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+static bool MatricesNear(const NCollection_Mat4<double>& theLhs,
+                         const NCollection_Mat4<double>& theRhs,
+                         const double                    theTol)
+{
+  for (int aCol = 0; aCol < 4; ++aCol)
+  {
+    for (int aRow = 0; aRow < 4; ++aRow)
+    {
+      if (std::abs(theLhs.GetValue(aRow, aCol) - theRhs.GetValue(aRow, aCol)) > theTol)
+      {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+// Identity world-view keeps the reference system aligned with the world axes, so no axis is
+// detected as reversed and Compute() must return identity (pass-through).
+TEST(Graphic3d_FlipperTest, Compute_IdentityWorldView_ReturnsIdentity)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  NCollection_Mat4<double> aWorldView; // identity
+  const NCollection_Mat4<double> aResult = aFlipper.Compute(aWorldView);
+  EXPECT_TRUE(aResult.IsIdentity()) << "Aligned ref system under identity WV should yield no flip";
+}
+
+// A 180 degree rotation around Z in the world view inverts both X and Y of the reference system,
+// triggering the (isReversedX || isReversedY) && !isReversedZ branch. The resulting flip is a
+// 180 degree rotation, which is self-inverse: applying it twice must return the identity.
+TEST(Graphic3d_FlipperTest, Compute_180AroundZ_IsSelfInverse)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  NCollection_Mat4<double> aWorldView; // identity
+  aWorldView.SetValue(0, 0, -1.0);
+  aWorldView.SetValue(1, 1, -1.0);
+
+  const NCollection_Mat4<double> aFlip = aFlipper.Compute(aWorldView);
+  ASSERT_FALSE(aFlip.IsIdentity()) << "180 around Z must trigger a flip";
+
+  const NCollection_Mat4<double> aTwice = aFlip * aFlip;
+  NCollection_Mat4<double>       aIdentity;
+  EXPECT_TRUE(MatricesNear(aTwice, aIdentity, Precision::Confusion()))
+    << "Flip matrix must be self-inverse";
+}
+
+// Apply() on a box with no detected flip must leave the box untouched.
+TEST(Graphic3d_FlipperTest, Apply_NoFlip_BoxUnchanged)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  Bnd_Box aBox;
+  aBox.Update(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+
+  NCollection_Mat4<double> aWorldView;
+  aFlipper.Apply(aWorldView, aBox);
+
+  double aXmin, aYmin, aZmin, aXmax, aYmax, aZmax;
+  aBox.Get(aXmin, aYmin, aZmin, aXmax, aYmax, aZmax);
+  EXPECT_NEAR(aXmin, 1.0, Precision::Confusion());
+  EXPECT_NEAR(aYmin, 2.0, Precision::Confusion());
+  EXPECT_NEAR(aZmin, 3.0, Precision::Confusion());
+  EXPECT_NEAR(aXmax, 4.0, Precision::Confusion());
+  EXPECT_NEAR(aYmax, 5.0, Precision::Confusion());
+  EXPECT_NEAR(aZmax, 6.0, Precision::Confusion());
+}
+
+// Apply() on a void box is a no-op.
+TEST(Graphic3d_FlipperTest, Apply_VoidBox_RemainsVoid)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  Bnd_Box aBox;
+  EXPECT_TRUE(aBox.IsVoid());
+
+  NCollection_Mat4<double> aWorldView;
+  aWorldView.SetValue(0, 0, -1.0);
+  aWorldView.SetValue(1, 1, -1.0);
+
+  aFlipper.Apply(aWorldView, aBox);
+  EXPECT_TRUE(aBox.IsVoid()) << "Flipper must not materialize a void box";
+}
+
+// When flip is active, applying it twice to a bounding box must recover the original bounds
+// (mirroring the self-inverse property at the box level).
+TEST(Graphic3d_FlipperTest, Apply_180AroundZ_Involution)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  Bnd_Box aBox;
+  aBox.Update(1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+
+  NCollection_Mat4<double> aWorldView;
+  aWorldView.SetValue(0, 0, -1.0);
+  aWorldView.SetValue(1, 1, -1.0);
+
+  aFlipper.Apply(aWorldView, aBox);
+  aFlipper.Apply(aWorldView, aBox);
+
+  double aXmin, aYmin, aZmin, aXmax, aYmax, aZmax;
+  aBox.Get(aXmin, aYmin, aZmin, aXmax, aYmax, aZmax);
+  EXPECT_NEAR(aXmin, 1.0, Precision::Confusion());
+  EXPECT_NEAR(aYmin, 2.0, Precision::Confusion());
+  EXPECT_NEAR(aZmin, 3.0, Precision::Confusion());
+  EXPECT_NEAR(aXmax, 4.0, Precision::Confusion());
+  EXPECT_NEAR(aYmax, 5.0, Precision::Confusion());
+  EXPECT_NEAR(aZmax, 6.0, Precision::Confusion());
+}
+
+// Regression for the MV-contract: the matrix passed to Compute() must include the
+// object's ModelWorld, not just the camera's WorldView. Here the raw WorldView is
+// identity, so no reversal is detected; but once we fold in a 180 deg Z-rotation
+// (the object's transformation), Compute() returns a non-identity flip. This locks
+// in that selection callers must pass WorldView * ModelWorld to match OpenGl_Flipper.
+TEST(Graphic3d_FlipperTest, Compute_ObjectTransformChangesDecision)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  NCollection_Mat4<double> aWorldView; // identity
+  EXPECT_TRUE(aFlipper.Compute(aWorldView).IsIdentity())
+    << "Identity WV keeps ref system aligned, no flip";
+
+  // Object rotated 180 deg about Z — composing this into MV inverts X and Y,
+  // which is exactly the trigger for the (isReversedX || isReversedY) && !isReversedZ
+  // branch in Compute(). The resulting matrix must not be identity.
+  NCollection_Mat4<double> anObjTrsf;
+  anObjTrsf.SetValue(0, 0, -1.0);
+  anObjTrsf.SetValue(1, 1, -1.0);
+
+  const NCollection_Mat4<double> aMV   = aWorldView * anObjTrsf;
+  const NCollection_Mat4<double> aFlip = aFlipper.Compute(aMV);
+  EXPECT_FALSE(aFlip.IsIdentity())
+    << "Folding object transform must surface a flip the raw WV misses";
+}
+
+// RefPlane() round-trip via SetRefPlane() preserves the axis.
+TEST(Graphic3d_FlipperTest, SetRefPlane_RoundTrip)
+{
+  Graphic3d_Flipper aFlipper(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)));
+
+  const gp_Ax2 aNewPlane(gp_Pnt(10, 20, 30), gp_Dir(1, 0, 0), gp_Dir(0, 1, 0));
+  aFlipper.SetRefPlane(aNewPlane);
+
+  const gp_Ax2 aRead = aFlipper.RefPlane();
+  EXPECT_NEAR(aRead.Location().X(), 10.0, Precision::Confusion());
+  EXPECT_NEAR(aRead.Location().Y(), 20.0, Precision::Confusion());
+  EXPECT_NEAR(aRead.Location().Z(), 30.0, Precision::Confusion());
+}

--- a/src/Visualization/TKService/Graphic3d/FILES.cmake
+++ b/src/Visualization/TKService/Graphic3d/FILES.cmake
@@ -69,6 +69,8 @@ set(OCCT_Graphic3d_FILES
   Graphic3d_DataStructureManager.hxx
   Graphic3d_DiagnosticInfo.hxx
   Graphic3d_DisplayPriority.hxx
+  Graphic3d_Flipper.cxx
+  Graphic3d_Flipper.hxx
   Graphic3d_FrameStats.cxx
   Graphic3d_FrameStats.hxx
   Graphic3d_FrameStatsCounter.hxx

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_CStructure.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_CStructure.cxx
@@ -32,6 +32,7 @@ Graphic3d_CStructure::Graphic3d_CStructure(
       myIsCulled(true),
       myBndBoxClipCheck(true),
       myHasGroupTrsf(false),
+      myHasGroupFlipping(false),
       //
       IsInfinite(0),
       stick(0),

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_CStructure.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_CStructure.hxx
@@ -106,6 +106,12 @@ public:
   //! Set if some groups might have transform persistence.
   void SetGroupTransformPersistence(bool theValue) { myHasGroupTrsf = theValue; }
 
+  //! Return TRUE if some groups might have flipping options; FALSE by default.
+  bool HasGroupFlipping() const { return myHasGroupFlipping; }
+
+  //! Set if some groups might have flipping options.
+  void SetGroupFlipping(bool theValue) { myHasGroupFlipping = theValue; }
+
   //! @return associated clip planes
   const occ::handle<Graphic3d_SequenceOfHClipPlane>& ClipPlanes() const { return myClipPlanes; }
 
@@ -250,6 +256,7 @@ protected:
   bool myBndBoxClipCheck;  //!< Flag responsible for checking of bounding box clipping before drawing of object
 
   bool myHasGroupTrsf;     //!< flag specifying that some groups might have transform persistence
+  bool myHasGroupFlipping; //!< flag specifying that some groups might have flipping options
 
 public:
 

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Flipper.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Flipper.cxx
@@ -1,0 +1,26 @@
+// Copyright (c) 2024 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Graphic3d_Flipper.hxx>
+
+#include <Standard_Dump.hxx>
+
+IMPLEMENT_STANDARD_RTTIEXT(Graphic3d_Flipper, Standard_Transient)
+
+//=================================================================================================
+
+void Graphic3d_Flipper::DumpJson(Standard_OStream& theOStream, int theDepth) const
+{
+  OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, &myRefPlane)
+}

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Flipper.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Flipper.hxx
@@ -1,0 +1,238 @@
+// Copyright (c) 2024 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _Graphic3d_Flipper_HeaderFile
+#define _Graphic3d_Flipper_HeaderFile
+
+#include <BVH_Box.hxx>
+#include <Bnd_Box.hxx>
+#include <NCollection_Mat4.hxx>
+#include <Standard_Transient.hxx>
+#include <gp_Ax2.hxx>
+
+//! CPU-side analogue of OpenGl_Flipper used by the selection pipeline.
+//! Describes a reference coordinate system used at draw time to mirror
+//! group contents so that they remain upright relative to the camera.
+//! The same logic is used here to compute the flipping matrix applied
+//! to bounding boxes and sensitive frustums, so that selection matches
+//! the rendered geometry.
+class Graphic3d_Flipper : public Standard_Transient
+{
+  DEFINE_STANDARD_RTTIEXT(Graphic3d_Flipper, Standard_Transient)
+
+public:
+  //! Constructor.
+  Graphic3d_Flipper(const gp_Ax2& theRefPlane)
+      : myRefPlane(theRefPlane)
+  {
+  }
+
+  //! Return reference plane used for flipping.
+  gp_Ax2 RefPlane() const { return myRefPlane; }
+
+  //! Set reference plane used for flipping.
+  void SetRefPlane(const gp_Ax2& theValue) { myRefPlane = theValue; }
+
+  //! Apply flipping transformation to a Bnd_Box of presentation.
+  //! @param theWorldView   [in]     the world view transformation matrix
+  //! @param theBoundingBox [in,out] the bounding box to transform
+  template <class T>
+  void Apply(const NCollection_Mat4<T>& theWorldView, Bnd_Box& theBoundingBox) const;
+
+  //! Apply flipping transformation to a BVH_Box of presentation.
+  //! @param theWorldView   [in]     the world view transformation matrix
+  //! @param theBoundingBox [in,out] the bounding box to transform
+  template <class T>
+  void Apply(const NCollection_Mat4<T>& theWorldView, BVH_Box<T, 3>& theBoundingBox) const;
+
+  //! Compute the flipping transformation matrix.
+  //! The returned matrix can be composed with the model-world transformation
+  //! of an object to reproduce the render-time flip. Note: each branch of
+  //! the flip is a 180 degree rotation (self-inverse), so the returned matrix
+  //! is its own inverse.
+  //! @param theWorldView [in] the composed World-View * ModelWorld matrix that
+  //!                          the caller would use at draw time. To agree with
+  //!                          OpenGl_Flipper::Render() the caller must include
+  //!                          the owning object's Transformation() and, when
+  //!                          available, the flipping group's own
+  //!                          Transformation(). Passing the bare WorldView
+  //!                          matrix is only correct for objects/groups with
+  //!                          identity transformations.
+  //! TODO: group-level Graphic3d_Group::Transformation() is not folded in by
+  //! the selection pipeline yet (the sensitive entity does not carry a
+  //! reference to its host group). This only affects consumers that give the
+  //! flipping group its own gp_Trsf — uncommon in stock OCCT.
+  template <class T>
+  NCollection_Mat4<T> Compute(const NCollection_Mat4<T>& theWorldView) const;
+
+  //! Dumps the content of me into the stream.
+  Standard_EXPORT virtual void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const;
+
+private:
+  gp_Ax2 myRefPlane;
+};
+
+//=================================================================================================
+
+template <class T>
+void Graphic3d_Flipper::Apply(const NCollection_Mat4<T>& theWorldView,
+                              Bnd_Box&                   theBoundingBox) const
+{
+  if (theBoundingBox.IsVoid())
+  {
+    return;
+  }
+
+  T aXmin, aYmin, aZmin, aXmax, aYmax, aZmax;
+  theBoundingBox.Get(aXmin, aYmin, aZmin, aXmax, aYmax, aZmax);
+
+  typename BVH_Box<T, 3>::BVH_VecNt aMin(aXmin, aYmin, aZmin);
+  typename BVH_Box<T, 3>::BVH_VecNt aMax(aXmax, aYmax, aZmax);
+  BVH_Box<T, 3>                     aBBox(aMin, aMax);
+
+  Apply(theWorldView, aBBox);
+
+  theBoundingBox = Bnd_Box();
+  theBoundingBox.Update(aBBox.CornerMin().x(),
+                        aBBox.CornerMin().y(),
+                        aBBox.CornerMin().z(),
+                        aBBox.CornerMax().x(),
+                        aBBox.CornerMax().y(),
+                        aBBox.CornerMax().z());
+}
+
+//=================================================================================================
+
+template <class T>
+void Graphic3d_Flipper::Apply(const NCollection_Mat4<T>& theWorldView,
+                              BVH_Box<T, 3>&             theBoundingBox) const
+{
+  NCollection_Mat4<T> aTPers = Compute(theWorldView);
+  if (aTPers.IsIdentity() || !theBoundingBox.IsValid())
+  {
+    return;
+  }
+
+  const typename BVH_Box<T, 3>::BVH_VecNt& aMin = theBoundingBox.CornerMin();
+  const typename BVH_Box<T, 3>::BVH_VecNt& aMax = theBoundingBox.CornerMax();
+
+  typename BVH_Box<T, 4>::BVH_VecNt anArrayOfCorners[8];
+  anArrayOfCorners[0] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMin.x(), aMin.y(), aMin.z(), static_cast<T>(1.0));
+  anArrayOfCorners[1] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMin.x(), aMin.y(), aMax.z(), static_cast<T>(1.0));
+  anArrayOfCorners[2] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMin.x(), aMax.y(), aMin.z(), static_cast<T>(1.0));
+  anArrayOfCorners[3] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMin.x(), aMax.y(), aMax.z(), static_cast<T>(1.0));
+  anArrayOfCorners[4] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMax.x(), aMin.y(), aMin.z(), static_cast<T>(1.0));
+  anArrayOfCorners[5] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMax.x(), aMin.y(), aMax.z(), static_cast<T>(1.0));
+  anArrayOfCorners[6] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMax.x(), aMax.y(), aMin.z(), static_cast<T>(1.0));
+  anArrayOfCorners[7] =
+    typename BVH_Box<T, 4>::BVH_VecNt(aMax.x(), aMax.y(), aMax.z(), static_cast<T>(1.0));
+
+  theBoundingBox.Clear();
+  for (int anIt = 0; anIt < 8; ++anIt)
+  {
+    typename BVH_Box<T, 4>::BVH_VecNt& aCorner = anArrayOfCorners[anIt];
+    aCorner                                    = aTPers * aCorner;
+    aCorner                                    = aCorner / aCorner.w();
+    theBoundingBox.Add(
+      typename BVH_Box<T, 3>::BVH_VecNt(aCorner.x(), aCorner.y(), aCorner.z()));
+  }
+}
+
+//=================================================================================================
+
+template <class T>
+NCollection_Mat4<T> Graphic3d_Flipper::Compute(const NCollection_Mat4<T>& theWorldView) const
+{
+  NCollection_Vec4<T> aReferenceOrigin(static_cast<T>(myRefPlane.Location().X()),
+                                       static_cast<T>(myRefPlane.Location().Y()),
+                                       static_cast<T>(myRefPlane.Location().Z()),
+                                       static_cast<T>(1));
+  NCollection_Vec4<T> aReferenceX(static_cast<T>(myRefPlane.XDirection().X()),
+                                  static_cast<T>(myRefPlane.XDirection().Y()),
+                                  static_cast<T>(myRefPlane.XDirection().Z()),
+                                  static_cast<T>(1));
+  NCollection_Vec4<T> aReferenceY(static_cast<T>(myRefPlane.YDirection().X()),
+                                  static_cast<T>(myRefPlane.YDirection().Y()),
+                                  static_cast<T>(myRefPlane.YDirection().Z()),
+                                  static_cast<T>(1));
+  NCollection_Vec4<T> aReferenceZ(static_cast<T>(myRefPlane.Axis().Direction().X()),
+                                  static_cast<T>(myRefPlane.Axis().Direction().Y()),
+                                  static_cast<T>(myRefPlane.Axis().Direction().Z()),
+                                  static_cast<T>(1));
+
+  NCollection_Mat4<T> aMatrixMV;
+  aMatrixMV.Convert(theWorldView);
+
+  const NCollection_Vec4<T> aMVReferenceOrigin = aMatrixMV * aReferenceOrigin;
+  const NCollection_Vec4<T> aMVReferenceX =
+    aMatrixMV
+    * NCollection_Vec4<T>(aReferenceX.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
+  const NCollection_Vec4<T> aMVReferenceY =
+    aMatrixMV
+    * NCollection_Vec4<T>(aReferenceY.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
+  const NCollection_Vec4<T> aMVReferenceZ =
+    aMatrixMV
+    * NCollection_Vec4<T>(aReferenceZ.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
+
+  const NCollection_Vec4<T> aDirX = aMVReferenceX - aMVReferenceOrigin;
+  const NCollection_Vec4<T> aDirY = aMVReferenceY - aMVReferenceOrigin;
+  const NCollection_Vec4<T> aDirZ = aMVReferenceZ - aMVReferenceOrigin;
+
+  const bool isReversedX = aDirX.xyz().Dot(NCollection_Vec3<T>::DX()) < static_cast<T>(0);
+  const bool isReversedY = aDirY.xyz().Dot(NCollection_Vec3<T>::DY()) < static_cast<T>(0);
+  const bool isReversedZ = aDirZ.xyz().Dot(NCollection_Vec3<T>::DZ()) < static_cast<T>(0);
+
+  NCollection_Mat4<T> aTransform;
+  if ((isReversedX || isReversedY) && !isReversedZ)
+  {
+    // invert by Z axis: left, up vectors mirrored
+    aTransform.SetColumn(0, -aTransform.GetColumn(0).xyz());
+    aTransform.SetColumn(1, -aTransform.GetColumn(1).xyz());
+  }
+  else if (isReversedY && isReversedZ)
+  {
+    // rotate by X axis: up, forward vectors mirrored
+    aTransform.SetColumn(1, -aTransform.GetColumn(1).xyz());
+    aTransform.SetColumn(2, -aTransform.GetColumn(2).xyz());
+  }
+  else if (isReversedZ)
+  {
+    // rotate by Y axis: left, forward vectors mirrored
+    aTransform.SetColumn(0, -aTransform.GetColumn(0).xyz());
+    aTransform.SetColumn(2, -aTransform.GetColumn(2).xyz());
+  }
+  else
+  {
+    return NCollection_Mat4<T>();
+  }
+
+  NCollection_Mat4<T> aRefAxes;
+  NCollection_Mat4<T> aRefInv;
+  aRefAxes.SetColumn(0, aReferenceX.xyz());
+  aRefAxes.SetColumn(1, aReferenceY.xyz());
+  aRefAxes.SetColumn(2, aReferenceZ.xyz());
+  aRefAxes.SetColumn(3, aReferenceOrigin.xyz());
+  aRefAxes.Inverted(aRefInv);
+
+  aTransform = aRefAxes * aTransform * aRefInv;
+  return aTransform;
+}
+
+#endif // _Graphic3d_Flipper_HeaderFile

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Flipper.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Flipper.hxx
@@ -71,7 +71,7 @@ public:
   //! TODO: group-level Graphic3d_Group::Transformation() is not folded in by
   //! the selection pipeline yet (the sensitive entity does not carry a
   //! reference to its host group). This only affects consumers that give the
-  //! flipping group its own gp_Trsf — uncommon in stock OCCT.
+  //! flipping group its own gp_Trsf - uncommon in stock OCCT.
   template <class T>
   NCollection_Mat4<T> Compute(const NCollection_Mat4<T>& theWorldView) const;
 
@@ -150,8 +150,7 @@ void Graphic3d_Flipper::Apply(const NCollection_Mat4<T>& theWorldView,
     typename BVH_Box<T, 4>::BVH_VecNt& aCorner = anArrayOfCorners[anIt];
     aCorner                                    = aTPers * aCorner;
     aCorner                                    = aCorner / aCorner.w();
-    theBoundingBox.Add(
-      typename BVH_Box<T, 3>::BVH_VecNt(aCorner.x(), aCorner.y(), aCorner.z()));
+    theBoundingBox.Add(typename BVH_Box<T, 3>::BVH_VecNt(aCorner.x(), aCorner.y(), aCorner.z()));
   }
 }
 
@@ -182,14 +181,11 @@ NCollection_Mat4<T> Graphic3d_Flipper::Compute(const NCollection_Mat4<T>& theWor
 
   const NCollection_Vec4<T> aMVReferenceOrigin = aMatrixMV * aReferenceOrigin;
   const NCollection_Vec4<T> aMVReferenceX =
-    aMatrixMV
-    * NCollection_Vec4<T>(aReferenceX.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
+    aMatrixMV * NCollection_Vec4<T>(aReferenceX.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
   const NCollection_Vec4<T> aMVReferenceY =
-    aMatrixMV
-    * NCollection_Vec4<T>(aReferenceY.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
+    aMatrixMV * NCollection_Vec4<T>(aReferenceY.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
   const NCollection_Vec4<T> aMVReferenceZ =
-    aMatrixMV
-    * NCollection_Vec4<T>(aReferenceZ.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
+    aMatrixMV * NCollection_Vec4<T>(aReferenceZ.xyz() + aReferenceOrigin.xyz(), static_cast<T>(1));
 
   const NCollection_Vec4<T> aDirX = aMVReferenceX - aMVReferenceOrigin;
   const NCollection_Vec4<T> aDirY = aMVReferenceY - aMVReferenceOrigin;

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Group.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Group.hxx
@@ -19,6 +19,7 @@
 
 #include <Graphic3d_BndBox4f.hxx>
 #include <Graphic3d_AspectFillArea3d.hxx>
+#include <Graphic3d_Flipper.hxx>
 #include <NCollection_DataMap.hxx>
 #include <Standard_CString.hxx>
 #include <Graphic3d_Vertex.hxx>
@@ -133,6 +134,9 @@ public:
   //! sets the flipping to theIsEnabled state.
   Standard_EXPORT virtual void SetFlippingOptions(const bool    theIsEnabled,
                                                   const gp_Ax2& theRefPlane) = 0;
+
+  //! Return flipper metadata describing the runtime flip of this group, or null if not flipped.
+  const occ::handle<Graphic3d_Flipper>& Flipper() const { return myFlipper; }
 
   //! Return transformation.
   const gp_Trsf& Transformation() const { return myTrsf; }
@@ -315,6 +319,7 @@ protected:
 
 protected:
   occ::handle<Graphic3d_TransformPers> myTrsfPers;  //!< current transform persistence
+  occ::handle<Graphic3d_Flipper>       myFlipper;   //!< current group flipping
   Graphic3d_Structure*                 myStructure; //!< pointer to the parent structure
   Graphic3d_BndBox4f                   myBounds;    //!< bounding box
   gp_Trsf                              myTrsf;      //!< group transformation

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Structure.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Structure.cxx
@@ -77,6 +77,7 @@ void Graphic3d_Structure::clear(const bool theWithDestruction)
   GraphicClear(theWithDestruction);
 
   myCStructure->SetGroupTransformPersistence(false);
+  myCStructure->SetGroupFlipping(false);
   myStructureManager->Clear(this, theWithDestruction);
 
   Update(true);

--- a/src/Visualization/TKV3d/Select3D/Select3D_SensitiveEntity.cxx
+++ b/src/Visualization/TKV3d/Select3D/Select3D_SensitiveEntity.cxx
@@ -31,12 +31,28 @@ Select3D_SensitiveEntity::Select3D_SensitiveEntity(
 
 //=================================================================================================
 
+void Select3D_SensitiveEntity::SetFlippingOptions(const bool    theIsEnabled,
+                                                  const gp_Ax2& theRefPlane)
+{
+  if (theIsEnabled)
+  {
+    myFlipper = new Graphic3d_Flipper(theRefPlane);
+  }
+  else
+  {
+    myFlipper.Nullify();
+  }
+}
+
+//=================================================================================================
+
 void Select3D_SensitiveEntity::DumpJson(Standard_OStream& theOStream, int theDepth) const
 {
   OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
 
   OCCT_DUMP_FIELD_VALUE_POINTER(theOStream, myOwnerId.get())
   OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, myTrsfPers.get())
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, myFlipper.get())
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, mySFactor)
 
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, NbSubElements());

--- a/src/Visualization/TKV3d/Select3D/Select3D_SensitiveEntity.hxx
+++ b/src/Visualization/TKV3d/Select3D/Select3D_SensitiveEntity.hxx
@@ -17,6 +17,7 @@
 #ifndef _Select3D_SensitiveEntity_HeaderFile
 #define _Select3D_SensitiveEntity_HeaderFile
 
+#include <Graphic3d_Flipper.hxx>
 #include <Standard_Transient.hxx>
 #include <Select3D_BndBox3d.hxx>
 #include <SelectMgr_SelectingVolumeManager.hxx>
@@ -102,6 +103,14 @@ public:
     myTrsfPers = theTrsfPers;
   }
 
+  //! Return flipper metadata describing the runtime flip of the owning group, or null.
+  const occ::handle<Graphic3d_Flipper>& Flipper() const { return myFlipper; }
+
+  //! Set flipping options. When enabled, creates a Graphic3d_Flipper for theRefPlane;
+  //! otherwise clears the flipper.
+  Standard_EXPORT virtual void SetFlippingOptions(const bool    theIsEnabled,
+                                                  const gp_Ax2& theRefPlane);
+
   //! Dumps the content of me into the stream
   Standard_EXPORT virtual void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const;
 
@@ -111,6 +120,7 @@ protected:
 protected:
   occ::handle<SelectMgr_EntityOwner>   myOwnerId;
   occ::handle<Graphic3d_TransformPers> myTrsfPers;
+  occ::handle<Graphic3d_Flipper>       myFlipper;
   int                                  mySFactor;
 };
 

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr.cxx
@@ -203,6 +203,10 @@ void SelectMgr::ComputeSensitivePrs(const occ::handle<Graphic3d_Structure>&     
        aSelEntIter.Next())
   {
     const occ::handle<Select3D_SensitiveEntity>& anEnt = aSelEntIter.Value()->BaseSensitive();
+    if (!anEnt->Flipper().IsNull())
+    {
+      thePrs->CurrentGroup()->SetFlippingOptions(true, anEnt->Flipper()->RefPlane());
+    }
     if (occ::handle<Select3D_SensitiveBox> aSensBox = occ::down_cast<Select3D_SensitiveBox>(anEnt))
     {
       addBoundingBox(aSeqLines, aSensBox, theLoc);

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_SelectableObjectSet.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_SelectableObjectSet.cxx
@@ -15,6 +15,8 @@
 
 #include <SelectMgr_SelectableObjectSet.hxx>
 #include <gp_Trsf.hxx>
+#include <Graphic3d_Flipper.hxx>
+#include <Graphic3d_TransformUtils.hxx>
 #include <NCollection_Mat4.hxx>
 #include <NCollection_Vec3.hxx>
 #include <NCollection_Vec4.hxx>
@@ -118,24 +120,28 @@ public:
 
       Bnd_Box aBoundingBox;
       anObject->BoundingBox(aBoundingBox);
-      if (!aBoundingBox.IsVoid() && !anObject->TransformPersistence().IsNull())
+
+      // MV matrix passed to Graphic3d_Flipper::Apply must match OpenGl_Flipper::Render()
+      // which uses WorldView * ModelWorld. Fold in the object's Transformation(); the
+      // group's own Transformation() is not folded in here (matches the selection side
+      // in SelectMgr_ViewerSelector). Computed once per object, reused for every group.
+      NCollection_Mat4<double> aMVForFlip = theWorldViewMat;
+      if (anObject->HasTransformation())
       {
-        anObject->TransformPersistence()->Apply(theCamera,
-                                                theProjectionMat,
-                                                theWorldViewMat,
-                                                theWinSize.x(),
-                                                theWinSize.y(),
-                                                aBoundingBox);
+        NCollection_Mat4<double> anObjTrsfMat;
+        Graphic3d_TransformUtils::Convert<double>(anObject->Transformation(), anObjTrsfMat);
+        aMVForFlip = theWorldViewMat * anObjTrsfMat;
       }
 
-      // processing presentations with own transform persistence
+      // processing presentations with own flipping and transform persistence
       for (NCollection_Sequence<occ::handle<PrsMgr_Presentation>>::Iterator aPrsIter(
              anObject->Presentations());
            aPrsIter.More();
            aPrsIter.Next())
       {
         const occ::handle<PrsMgr_Presentation>& aPrs3d = aPrsIter.Value();
-        if (!aPrs3d->CStructure()->HasGroupTransformPersistence())
+        if (!aPrs3d->CStructure()->HasGroupTransformPersistence()
+            && !aPrs3d->CStructure()->HasGroupFlipping())
         {
           continue;
         }
@@ -147,7 +153,8 @@ public:
         {
           const occ::handle<Graphic3d_Group>& aGroup  = aGroupIter.Value();
           const Graphic3d_BndBox4f&           aBndBox = aGroup->BoundingBox();
-          if (aGroup->TransformPersistence().IsNull() || !aBndBox.IsValid())
+          if ((aGroup->Flipper().IsNull() && aGroup->TransformPersistence().IsNull())
+              || !aBndBox.IsValid())
           {
             continue;
           }
@@ -159,14 +166,33 @@ public:
                            aBndBox.CornerMax().x(),
                            aBndBox.CornerMax().y(),
                            aBndBox.CornerMax().z());
-          aGroup->TransformPersistence()->Apply(theCamera,
+
+          if (!aGroup->Flipper().IsNull())
+          {
+            aGroup->Flipper()->Apply(aMVForFlip, aGroupBox);
+          }
+
+          if (!aGroup->TransformPersistence().IsNull())
+          {
+            aGroup->TransformPersistence()->Apply(theCamera,
+                                                  theProjectionMat,
+                                                  theWorldViewMat,
+                                                  theWinSize.x(),
+                                                  theWinSize.y(),
+                                                  aGroupBox);
+          }
+          aBoundingBox.Add(aGroupBox);
+        }
+      }
+
+      if (!aBoundingBox.IsVoid() && !anObject->TransformPersistence().IsNull())
+      {
+        anObject->TransformPersistence()->Apply(theCamera,
                                                 theProjectionMat,
                                                 theWorldViewMat,
                                                 theWinSize.x(),
                                                 theWinSize.y(),
-                                                aGroupBox);
-          aBoundingBox.Add(aGroupBox);
-        }
+                                                aBoundingBox);
       }
 
       if (aBoundingBox.IsVoid())

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_SelectableObjectSet.hxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_SelectableObjectSet.hxx
@@ -205,7 +205,8 @@ private:
            aPrsIter.Next())
       {
         const occ::handle<PrsMgr_Presentation>& aPrs3d = aPrsIter.ChangeValue();
-        if (aPrs3d->CStructure()->HasGroupTransformPersistence())
+        if (aPrs3d->CStructure()->HasGroupTransformPersistence()
+            || aPrs3d->CStructure()->HasGroupFlipping())
         {
           return SelectMgr_SelectableObjectSet::BVHSubset_3dPersistent;
         }

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_SensitiveEntitySet.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_SensitiveEntitySet.cxx
@@ -15,6 +15,7 @@
 
 #include <SelectMgr_SensitiveEntitySet.hxx>
 
+#include <Graphic3d_Flipper.hxx>
 #include <Graphic3d_TransformPers.hxx>
 #include <Select3D_SensitiveEntity.hxx>
 #include <SelectMgr_SensitiveEntity.hxx>
@@ -25,9 +26,10 @@ IMPLEMENT_STANDARD_RTTIEXT(SelectMgr_SensitiveEntitySet, BVH_PrimitiveSet3d)
 
 SelectMgr_SensitiveEntitySet::SelectMgr_SensitiveEntitySet(
   const occ::handle<Select3D_BVHBuilder3d>& theBuilder)
-    : BVH_PrimitiveSet3d(theBuilder)
+    : BVH_PrimitiveSet3d(theBuilder),
+      myNbEntityWithPersistence(0),
+      myNbEntityWithFlipping(0)
 {
-  myNbEntityWithPersistence = 0;
 }
 
 //=======================================================================
@@ -49,6 +51,10 @@ void SelectMgr_SensitiveEntitySet::Append(const occ::handle<SelectMgr_SensitiveE
   if (!theEntity->BaseSensitive()->TransformPersistence().IsNull())
   {
     ++myNbEntityWithPersistence;
+  }
+  if (!theEntity->BaseSensitive()->Flipper().IsNull())
+  {
+    ++myNbEntityWithFlipping;
   }
   MarkDirty();
 }
@@ -81,6 +87,10 @@ void SelectMgr_SensitiveEntitySet::Append(const occ::handle<SelectMgr_Selection>
     {
       ++myNbEntityWithPersistence;
     }
+    if (!aSensEnt->BaseSensitive()->Flipper().IsNull())
+    {
+      ++myNbEntityWithFlipping;
+    }
   }
   MarkDirty();
 }
@@ -111,6 +121,10 @@ void SelectMgr_SensitiveEntitySet::Remove(const occ::handle<SelectMgr_Selection>
     if (!aSensEnt->BaseSensitive()->TransformPersistence().IsNull())
     {
       --myNbEntityWithPersistence;
+    }
+    if (!aSensEnt->BaseSensitive()->Flipper().IsNull())
+    {
+      --myNbEntityWithFlipping;
     }
 
     mySensitives.RemoveLast();

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_SensitiveEntitySet.hxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_SensitiveEntitySet.hxx
@@ -81,6 +81,9 @@ public:
   //! Returns map of entities.
   bool HasEntityWithPersistence() const { return myNbEntityWithPersistence > 0; }
 
+  //! Returns true if this set contains sensitive entities with flipping options.
+  bool HasEntityWithFlipping() const { return myNbEntityWithFlipping > 0; }
+
 protected:
   //! Adds entity owner to the map of owners (or increases its counter if it is already there).
   Standard_EXPORT void addOwner(const occ::handle<SelectMgr_EntityOwner>& theOwner);
@@ -93,6 +96,7 @@ private:
   NCollection_IndexedMap<occ::handle<SelectMgr_SensitiveEntity>> mySensitives;              //!< Map of entities and its corresponding index in BVH
   NCollection_DataMap<occ::handle<SelectMgr_EntityOwner>, int>            myOwnersMap;               //!< Map of entity owners and its corresponding number of sensitives
   int                 myNbEntityWithPersistence; //!< number of sensitive entities that have own transform persistence
+  int                 myNbEntityWithFlipping;    //!< number of sensitive entities that have flipping options
   // clang-format on
 };
 

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewerSelector.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewerSelector.cxx
@@ -20,6 +20,8 @@
 #include <BVH_Tree.hxx>
 #include <gp_GTrsf.hxx>
 #include <gp_Pnt.hxx>
+#include <Graphic3d_Flipper.hxx>
+#include <Graphic3d_TransformUtils.hxx>
 #include <OSD_Environment.hxx>
 #include <Select3D_SensitiveEntity.hxx>
 #include <SelectBasics_PickResult.hxx>
@@ -410,6 +412,7 @@ void SelectMgr_ViewerSelector::traverseObject(
   }
 
   const bool hasEntityTrsfPers = anEntitySet->HasEntityWithPersistence() && !theCamera.IsNull();
+  const bool hasEntityFlipped  = anEntitySet->HasEntityWithFlipping();
   const opencascade::handle<BVH_Tree<double, 3>>& aSensitivesTree = anEntitySet->BVH();
   gp_GTrsf                                        aInversedTrsf;
   if (theObject->HasTransformation() || !theObject->TransformPersistence().IsNull())
@@ -440,7 +443,7 @@ void SelectMgr_ViewerSelector::traverseObject(
   SelectMgr_SelectingVolumeManager aMgr = aInversedTrsf.Form() != gp_Identity
                                             ? theMgr.ScaleAndTransform(1, aInversedTrsf, nullptr)
                                             : theMgr;
-  if (!hasEntityTrsfPers
+  if (!hasEntityTrsfPers && !hasEntityFlipped
       && !aMgr.OverlapsBox(aSensitivesTree->MinPoint(0), aSensitivesTree->MaxPoint(0)))
   {
     return;
@@ -528,10 +531,10 @@ void SelectMgr_ViewerSelector::traverseObject(
     {
       const int  aLeftChildIdx  = aSensitivesTree->Child<0>(aNode);
       const int  aRightChildIdx = aSensitivesTree->Child<1>(aNode);
-      const bool isLeftChildIn  = hasEntityTrsfPers
+      const bool isLeftChildIn  = hasEntityTrsfPers || hasEntityFlipped
                                  || aMgr.OverlapsBox(aSensitivesTree->MinPoint(aLeftChildIdx),
                                                      aSensitivesTree->MaxPoint(aLeftChildIdx));
-      const bool isRightChildIn = hasEntityTrsfPers
+      const bool isRightChildIn = hasEntityTrsfPers || hasEntityFlipped
                                   || aMgr.OverlapsBox(aSensitivesTree->MinPoint(aRightChildIdx),
                                                       aSensitivesTree->MaxPoint(aRightChildIdx));
       if (isLeftChildIn && isRightChildIn)
@@ -624,8 +627,32 @@ void SelectMgr_ViewerSelector::traverseObject(
             aInvSensTrsf = (aTPers * gp_GTrsf(theObject->Transformation())).Inverted();
           }
 
-          computeFrustum(anEnt, theMgr, aMgr, aInvSensTrsf, aScaledTrnsfFrustums, aTmpMgr);
-          checkOverlap(anEnt, aInvSensTrsf, aTmpMgr);
+          // Fold the object's Transformation() into the MV matrix passed to Flipper::Compute
+          // so that isReversedX/Y/Z agrees with OpenGl_Flipper::Render() which uses
+          // WorldView * ModelWorld. Without this, rotated objects near a flip boundary
+          // produce a different flip decision on the selection side than on the render side.
+          // TODO: group-level Graphic3d_Group::Transformation() is not available here
+          // (the sensitive entity does not carry a reference to its host group). For
+          // consumers that set a non-identity group trsf on the flipping group, the
+          // decision can still differ from render time near the flip boundary.
+          NCollection_Mat4<double> aMVForFlip = theWorldViewMat;
+          if (theObject->HasTransformation())
+          {
+            NCollection_Mat4<double> anObjTrsfMat;
+            Graphic3d_TransformUtils::Convert<double>(theObject->Transformation(), anObjTrsfMat);
+            aMVForFlip = theWorldViewMat * anObjTrsfMat;
+          }
+
+          gp_GTrsf aFlippingTrsf;
+          if (!anEnt->Flipper().IsNull())
+          {
+            const NCollection_Mat4<double> aMat = anEnt->Flipper()->Compute(aMVForFlip);
+            aFlippingTrsf.SetMat4(aMat);
+          }
+
+          gp_GTrsf aInvFlippingAndPers = aFlippingTrsf * aInvSensTrsf;
+          computeFrustum(anEnt, theMgr, aMgr, aInvFlippingAndPers, aScaledTrnsfFrustums, aTmpMgr);
+          checkOverlap(anEnt, aInvFlippingAndPers, aTmpMgr);
         }
       }
       if (aHead < 0)

--- a/tests/v3d/trsf/bug_flipped_selection
+++ b/tests/v3d/trsf/bug_flipped_selection
@@ -1,0 +1,78 @@
+puts "========"
+puts "Selection must work on a group-flipped text label after the camera is rotated 180 deg."
+puts "A Graphic3d_Flipper is stored on the group and on the sensitive entity; the selection"
+puts "pipeline applies its matrix so the sensitive frustum matches the rendered geometry."
+puts "========"
+puts ""
+
+pload MODELING VISUALIZATION
+
+vinit View1
+vclear
+
+# Flipping-enabled label at the world origin, lying in the XZ-plane with normal along +Y.
+# OpenGl_Flipper mirrors the text when the camera crosses the plane, so switching from
+# vfront to vback triggers the flip.
+vdrawtext t0 "PICK ME" -pos 0 0 0 -color red -height 40 \
+          -plane 0 1 0 1 0 0 -flipping \
+          -valign center -halign center
+
+# Baseline: front view, label readable, selection must work already (sanity check).
+vfront
+vfit
+vmoveto 205 205
+vselect 205 205
+set nbFront [vnbselected]
+puts "Selected count (front view, unflipped label): $nbFront"
+
+if { $nbFront < 1 } {
+  puts "Error : sanity check failed - label is not selectable even in front view"
+}
+
+vdump $imagedir/${casename}_front_selected.png
+
+# Deselect and rotate to the flipped orientation.
+vselect 0 0
+vback
+vfit
+vdump $imagedir/${casename}_back.png
+
+# After the fix, the sensitive frustum is built in flipped coordinates and matches
+# what OpenGl_Flipper renders on screen, so vselect at the label's screen position
+# picks its owner. Before the fix, vnbselected stays at zero.
+vmoveto 205 205
+vselect 205 205
+set nbBack [vnbselected]
+puts "Selected count (back view, flipped label): $nbBack"
+
+if { $nbBack < 1 } {
+  puts "Error : flipped text label is not selectable (expected >=1, got $nbBack)"
+} else {
+  puts "OK : flipped text label selection works."
+}
+
+vdump $imagedir/${casename}_back_selected.png
+
+# Rotated host object - exercises the WorldView * ModelWorld fix. At render time
+# OpenGl_Flipper::Render uses WV*MW (includes the object's Transformation); the
+# selection pipeline now folds theObject->Transformation() into the MV passed to
+# Graphic3d_Flipper::Compute so the isReversedX/Y/Z decision matches.
+vclear
+vdrawtext t2 "ROTATED FLIPPED" -pos 0 0 0 -color blue -height 40 \
+          -plane 0 1 0 1 0 0 -flipping \
+          -valign center -halign center
+vsetlocation t2 0 0 0 0 45 0
+vback
+vfit
+vmoveto 205 205
+vselect 205 205
+set nbRotated [vnbselected]
+puts "Selected count (rotated host, flipped label): $nbRotated"
+
+if { $nbRotated < 1 } {
+  puts "Error : rotated + flipped label not selectable (expected >=1, got $nbRotated)"
+} else {
+  puts "OK : rotated + flipped label selection works."
+}
+
+vdump $imagedir/${casename}_rotated_selected.png


### PR DESCRIPTION
Selection was broken for presentations that used Graphic3d_Group::SetFlippingOptions (AIS_TextLabel, PrsDim_Dimension): OpenGl_Flipper mirrors the geometry at draw time to keep labels upright relative to the camera, but the selection pipeline computed BVH boxes and sensitive frustums in the unflipped local coordinates. When the camera was rotated past the flipping threshold, clicks on the on-screen label missed.

- Add Graphic3d_Flipper: a CPU-side analogue of OpenGl_Flipper carrying the reference plane and templated Compute()/Apply() that reproduces the render-time flip matrix. Each flip branch is a 180 deg rotation (involution), so the matrix is self-inverse.
- Extend Graphic3d_CStructure with HasGroupFlipping()/SetGroupFlipping() alongside the existing transform-persistence flag; reset it in Graphic3d_Structure::clear().
- Add Graphic3d_Group::Flipper() and a myFlipper member populated from OpenGl_Group::SetFlippingOptions(true,...). The render-side OpenGl_Flipper element is still emitted for the push/pop bracket; myFlipper persists across the matching SetFlippingOptions(false,...) call so the selection side can see that the group contains flipped geometry.
- Add Select3D_SensitiveEntity::Flipper() / SetFlippingOptions() so sensitive entities can carry the same flipping metadata used by the selection traversal; include the handle in DumpJson.
- SelectMgr_SensitiveEntitySet tracks myNbEntityWithFlipping in Append()/Remove(); HasEntityWithFlipping() exposes it to the viewer selector.
- SelectMgr_SelectableObjectSet::appropriateSubset() routes presentations with HasGroupFlipping() to the 3d-persistent BVH subset (same as transform persistence).
- BVHBuilderAdaptorPersistent merges the flipping and transform-persistence loops into a single pass: for each group with a Flipper or TransformPersistence, build its local bbox, apply the flip (if any), then apply the TransformPersistence (if any), then add the resulting box to the object bbox; object-level TransformPersistence is applied once to the merged box. Note: for the rare case of object-level + group-level TransformPersistence the application order differs from the prior code (object-TP now runs after group-TP contributions are added). Common cases (only one or the other) are behavior-preserving.
- SelectMgr_ViewerSelector::traverseObject() bypasses the root/per-node overlap early-outs when the entity set contains flipped sensitives, and folds the flip matrix into aInvFlippingAndPers = T_flip * aInvSensTrsf before computeFrustum() and checkOverlap(). Using T_flip directly is valid because it is self-inverse. Before Compute(), the object's Transformation() is folded into aMVForFlip via Graphic3d_TransformUtils::Convert<double> so the isReversedX/Y/Z decision agrees with OpenGl_Flipper::Render() which uses WorldView * ModelWorld.
- SelectMgr_SelectableObjectSet::BVHBuilderAdaptorPersistent computes the same aMVForFlip once per object (hoisted outside the group loop) and passes it to Graphic3d_Flipper::Apply, so BVH bounds and per-sensitive overlap testing use the same flip matrix.
- SelectMgr::ComputeSensitivePrs() forwards the flipper to the debug presentation's current group so selection-mode visualization reflects the flip.

Known limitation (narrowed): the selection pipeline now folds the object's Transformation() into the MV passed to Graphic3d_Flipper::Compute, covering the common case of a flipping label on a rotated assembly. Group-level Graphic3d_Group::Transformation() is still not folded in on the selection side because the sensitive entity does not carry a reference to its host group; this only affects consumers that give the flipping group its own non-identity gp_Trsf (uncommon in stock OCCT). A TODO in Graphic3d_Flipper::Compute and SelectMgr_ViewerSelector marks the deferred follow-up.