### PR TITLE
Visualization - Fix AIS_ColorScale rectangle triangle winding

### DIFF
--- a/src/Visualization/TKV3d/AIS/AIS_ColorScale.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ColorScale.cxx
@@ -50,7 +50,7 @@ static void addColoredQuad(const occ::handle<Graphic3d_ArrayOfTriangles>& theTri
   theTris->AddVertex(gp_Pnt(theXLeft, theYBottom + theSizeY, 0.0), theColorTop);
   theTris->AddVertex(gp_Pnt(theXLeft + theSizeX, theYBottom + theSizeY, 0.0), theColorTop);
   theTris->AddEdges(aVertIndex, aVertIndex + 1, aVertIndex + 2);
-  theTris->AddEdges(aVertIndex + 1, aVertIndex + 2, aVertIndex + 3);
+  theTris->AddEdges(aVertIndex + 1, aVertIndex + 3, aVertIndex + 2);
 }
 
 //! Compute hue angle from specified value.


### PR DESCRIPTION
Swap the last two vertex indices in the second triangle of each color-scale rectangle so the two triangles share the same diagonal with consistent CCW orientation. Earlier indexing (v+1, v+2, v+3) built two overlapping triangles with opposite winding, producing visible seams and dropped vertices under back-face culling.