### PR TITLE
Visualization - Add GetVertex accessor to Select3D_SensitivePrimitiveArray

### DIFF
--- a/src/Visualization/TKV3d/GTests/FILES.cmake
+++ b/src/Visualization/TKV3d/GTests/FILES.cmake
@@ -3,4 +3,5 @@ set(OCCT_TKV3d_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKV3d_GTests_FILES
   AIS_ColoredShape_Test.cxx
+  Select3D_SensitivePrimitiveArray_Test.cxx
 )

--- a/src/Visualization/TKV3d/GTests/Select3D_SensitivePrimitiveArray_Test.cxx
+++ b/src/Visualization/TKV3d/GTests/Select3D_SensitivePrimitiveArray_Test.cxx
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Graphic3d_ArrayOfTriangles.hxx>
+#include <Precision.hxx>
+#include <Select3D_SensitivePrimitiveArray.hxx>
+#include <SelectMgr_EntityOwner.hxx>
+#include <TopLoc_Location.hxx>
+
+#include <gtest/gtest.h>
+
+TEST(Select3D_SensitivePrimitiveArrayTest, GetVertex_ReturnsTriangleVertices)
+{
+  occ::handle<Graphic3d_ArrayOfTriangles> aTris = new Graphic3d_ArrayOfTriangles(3);
+  aTris->AddVertex(0.0, 0.0, 0.0);
+  aTris->AddVertex(1.0, 0.0, 0.0);
+  aTris->AddVertex(0.0, 1.0, 0.0);
+
+  occ::handle<SelectMgr_EntityOwner>            anOwner = new SelectMgr_EntityOwner();
+  occ::handle<Select3D_SensitivePrimitiveArray> aSens = new Select3D_SensitivePrimitiveArray(anOwner);
+  ASSERT_TRUE(aSens->InitTriangulation(aTris->Attributes(), aTris->Indices(), TopLoc_Location()));
+
+  const std::array<NCollection_Vec3<float>, 3> aVertices = aSens->GetVertex(0);
+  EXPECT_NEAR(aVertices[0].x(), 0.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[0].y(), 0.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[0].z(), 0.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[1].x(), 1.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[1].y(), 0.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[1].z(), 0.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[2].x(), 0.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[2].y(), 1.0f, float(Precision::Confusion()));
+  EXPECT_NEAR(aVertices[2].z(), 0.0f, float(Precision::Confusion()));
+}

--- a/src/Visualization/TKV3d/GTests/Select3D_SensitivePrimitiveArray_Test.cxx
+++ b/src/Visualization/TKV3d/GTests/Select3D_SensitivePrimitiveArray_Test.cxx
@@ -27,7 +27,8 @@ TEST(Select3D_SensitivePrimitiveArrayTest, GetVertex_ReturnsTriangleVertices)
   aTris->AddVertex(0.0, 1.0, 0.0);
 
   occ::handle<SelectMgr_EntityOwner>            anOwner = new SelectMgr_EntityOwner();
-  occ::handle<Select3D_SensitivePrimitiveArray> aSens = new Select3D_SensitivePrimitiveArray(anOwner);
+  occ::handle<Select3D_SensitivePrimitiveArray> aSens =
+    new Select3D_SensitivePrimitiveArray(anOwner);
   ASSERT_TRUE(aSens->InitTriangulation(aTris->Attributes(), aTris->Indices(), TopLoc_Location()));
 
   const std::array<NCollection_Vec3<float>, 3> aVertices = aSens->GetVertex(0);

--- a/src/Visualization/TKV3d/Select3D/Select3D_SensitivePrimitiveArray.cxx
+++ b/src/Visualization/TKV3d/Select3D/Select3D_SensitivePrimitiveArray.cxx
@@ -403,6 +403,16 @@ bool Select3D_SensitivePrimitiveArray::InitTriangulation(
 
 //=================================================================================================
 
+std::array<NCollection_Vec3<float>, 3> Select3D_SensitivePrimitiveArray::GetVertex(
+  const int theIndex) const
+{
+  int aTriNodes[3] = {0, 0, 0};
+  getTriIndices(myIndices, theIndex * 3, aTriNodes);
+  return {getPosVec3(aTriNodes[0]), getPosVec3(aTriNodes[1]), getPosVec3(aTriNodes[2])};
+}
+
+//=================================================================================================
+
 bool Select3D_SensitivePrimitiveArray::InitPoints(
   const occ::handle<Graphic3d_Buffer>&      theVerts,
   const occ::handle<Graphic3d_IndexBuffer>& theIndices,

--- a/src/Visualization/TKV3d/Select3D/Select3D_SensitivePrimitiveArray.hxx
+++ b/src/Visualization/TKV3d/Select3D/Select3D_SensitivePrimitiveArray.hxx
@@ -24,6 +24,8 @@
 #include <NCollection_Array1.hxx>
 #include <NCollection_Shared.hxx>
 
+#include <array>
+
 //! Sensitive for triangulation or point set defined by Primitive Array.
 //! The primitives can be optionally combined into patches within BVH tree
 //! to reduce its building time in expense of extra traverse time.
@@ -230,6 +232,11 @@ public:
 
   //! Return the second node of last topmost detected edge or -1 if undefined (axis picking).
   int LastDetectedEdgeNode2() const { return myDetectedEdgeNode2; }
+
+  //! Return the three vertex positions of the triangle at the given triangulation index.
+  //! Only meaningful for triangulation-based primitive arrays.
+  //! @param[in] theIndex zero-based triangle index within [0, triangle count)
+  Standard_EXPORT std::array<NCollection_Vec3<float>, 3> GetVertex(const int theIndex) const;
 
   //! Dumps the content of me into the stream
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const override;


### PR DESCRIPTION
Returns the three vertex positions of the triangle at the given index as a std::array<NCollection_Vec3<float>, 3>. Downstream selection consumers can now query the triangulation geometry of a picked primitive array without re-walking the underlying Graphic3d_Buffer/Graphic3d_IndexBuffer.

Uses the existing file-local getTriIndices helper and the private getPosVec3 member, so the implementation is a pure accessor. Returning std::array keeps the contract explicit (always three vertices, no heap allocation)

Adds a TKV3d GTest covering the happy path on a non-indexed triangle array.