### PR TITLE
Visualization - Fix polyline selection inclusion test and point-in-polyline check

### DIFF
--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.cxx
@@ -22,30 +22,12 @@
 #include <Geom_Circle.hxx>
 #include <Geom_Line.hxx>
 #include <NCollection_IncAllocator.hxx>
-#include <Precision.hxx>
 #include <SelectMgr_FrustumBuilder.hxx>
-
-#include <cmath>
 
 namespace
 {
 static const size_t MEMORY_BLOCK_SIZE = 512 * 7;
-
-//! Drops the dominant-magnitude plane-normal axis and returns the remaining pair as a 2D point.
-//! Matches the drop-axis chosen in isPointInsideNearProjection().
-static gp_XY projectTo2D(const gp_Pnt& thePnt, const int theDropAxis)
-{
-  switch (theDropAxis)
-  {
-    case 1:
-      return gp_XY(thePnt.X(), thePnt.Z());
-    case 2:
-      return gp_XY(thePnt.X(), thePnt.Y());
-    default:
-      return gp_XY(thePnt.Y(), thePnt.Z());
-  }
 }
-} // namespace
 
 //=================================================================================================
 
@@ -303,7 +285,7 @@ bool SelectMgr_TriangularFrustumSet::OverlapsBox(const NCollection_Vec3<double>&
                               gp_Pnt(theMaxPnt.x(), theMaxPnt.y(), theMaxPnt.z())};
   for (const gp_Pnt& aCorner : aCorners)
   {
-    if (!isPointInsideNearProjection(aCorner))
+    if (!isPointInsideAnyFrustum(aCorner))
     {
       *theInside &= false;
       break;
@@ -342,76 +324,23 @@ bool SelectMgr_TriangularFrustumSet::OverlapsPoint(const gp_Pnt& thePnt) const
   Standard_ASSERT_RAISE(mySelectionType == SelectMgr_SelectionType_Polyline,
                         "Error! SelectMgr_TriangularFrustumSet::Overlaps() should be called after "
                         "selection frustum initialization");
-  return isPointInsideNearProjection(thePnt);
+  return isPointInsideAnyFrustum(thePnt);
 }
 
 //=================================================================================================
 
-bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& thePnt) const
+bool SelectMgr_TriangularFrustumSet::isPointInsideAnyFrustum(const gp_Pnt& thePnt) const
 {
-  const int aNearCount = static_cast<int>(myBoundaryPoints.Size() / 2);
-  if (aNearCount < 3 || myFrustums.IsEmpty())
+  for (NCollection_List<occ::handle<SelectMgr_TriangularFrustum>>::Iterator anIter(myFrustums);
+       anIter.More();
+       anIter.Next())
   {
-    return false;
-  }
-
-  const gp_Pnt& aNearA     = myFrustums.First()->myVertices[0];
-  const gp_Pnt& aNearB     = myFrustums.First()->myVertices[1];
-  const gp_Pnt& aNearC     = myFrustums.First()->myVertices[2];
-  const gp_Vec  aPlaneNorm = gp_Vec(aNearA, aNearB).Crossed(gp_Vec(aNearA, aNearC));
-  const double  aNormSqr   = aPlaneNorm.SquareMagnitude();
-  if (aNormSqr < Precision::SquareConfusion())
-  {
-    return false;
-  }
-
-  gp_Pnt       aProj  = thePnt;
-  const double aDistN = aPlaneNorm.X() * (thePnt.X() - aNearA.X())
-                        + aPlaneNorm.Y() * (thePnt.Y() - aNearA.Y())
-                        + aPlaneNorm.Z() * (thePnt.Z() - aNearA.Z());
-  const double aScale = aDistN / aNormSqr;
-  aProj.SetCoord(thePnt.X() - aPlaneNorm.X() * aScale,
-                 thePnt.Y() - aPlaneNorm.Y() * aScale,
-                 thePnt.Z() - aPlaneNorm.Z() * aScale);
-
-  const double aAbsX     = std::abs(aPlaneNorm.X());
-  const double aAbsY     = std::abs(aPlaneNorm.Y());
-  const double aAbsZ     = std::abs(aPlaneNorm.Z());
-  int          aDropAxis = 0;
-  if (aAbsY >= aAbsX && aAbsY >= aAbsZ)
-  {
-    aDropAxis = 1;
-  }
-  else if (aAbsZ >= aAbsX && aAbsZ >= aAbsY)
-  {
-    aDropAxis = 2;
-  }
-
-  const int   aLowerIdx = myBoundaryPoints.Lower();
-  const gp_XY aPnt2D    = projectTo2D(aProj, aDropAxis);
-  bool        isInside  = false;
-  for (int anIdx = 0, aPrev = aNearCount - 1; anIdx < aNearCount; aPrev = anIdx++)
-  {
-    const gp_XY aCur      = projectTo2D(myBoundaryPoints.Value(aLowerIdx + anIdx), aDropAxis);
-    const gp_XY aOld      = projectTo2D(myBoundaryPoints.Value(aLowerIdx + aPrev), aDropAxis);
-    const bool  isStrideY = (aCur.Y() > aPnt2D.Y()) != (aOld.Y() > aPnt2D.Y());
-    if (!isStrideY)
+    if (anIter.Value()->hasPointOverlap(thePnt))
     {
-      continue;
-    }
-
-    const double aDenom = aOld.Y() - aCur.Y();
-    if (std::abs(aDenom) < Precision::Confusion())
-    {
-      continue;
-    }
-    const double aXOnEdge = (aOld.X() - aCur.X()) * (aPnt2D.Y() - aCur.Y()) / aDenom + aCur.X();
-    if (aPnt2D.X() < aXOnEdge)
-    {
-      isInside = !isInside;
+      return true;
     }
   }
-  return isInside;
+  return false;
 }
 
 //=================================================================================================

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.cxx
@@ -355,9 +355,9 @@ bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& t
     return false;
   }
 
-  const gp_Pnt& aNearA    = myFrustums.First()->myVertices[0];
-  const gp_Pnt& aNearB    = myFrustums.First()->myVertices[1];
-  const gp_Pnt& aNearC    = myFrustums.First()->myVertices[2];
+  const gp_Pnt& aNearA     = myFrustums.First()->myVertices[0];
+  const gp_Pnt& aNearB     = myFrustums.First()->myVertices[1];
+  const gp_Pnt& aNearC     = myFrustums.First()->myVertices[2];
   const gp_Vec  aPlaneNorm = gp_Vec(aNearA, aNearB).Crossed(gp_Vec(aNearA, aNearC));
   const double  aNormSqr   = aPlaneNorm.SquareMagnitude();
   if (aNormSqr < Precision::SquareConfusion())
@@ -365,8 +365,8 @@ bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& t
     return false;
   }
 
-  gp_Pnt        aProj  = thePnt;
-  const double  aDistN = aPlaneNorm.X() * (thePnt.X() - aNearA.X())
+  gp_Pnt       aProj  = thePnt;
+  const double aDistN = aPlaneNorm.X() * (thePnt.X() - aNearA.X())
                         + aPlaneNorm.Y() * (thePnt.Y() - aNearA.Y())
                         + aPlaneNorm.Z() * (thePnt.Z() - aNearA.Z());
   const double aScale = aDistN / aNormSqr;
@@ -374,9 +374,9 @@ bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& t
                  thePnt.Y() - aPlaneNorm.Y() * aScale,
                  thePnt.Z() - aPlaneNorm.Z() * aScale);
 
-  const double aAbsX    = std::abs(aPlaneNorm.X());
-  const double aAbsY    = std::abs(aPlaneNorm.Y());
-  const double aAbsZ    = std::abs(aPlaneNorm.Z());
+  const double aAbsX     = std::abs(aPlaneNorm.X());
+  const double aAbsY     = std::abs(aPlaneNorm.Y());
+  const double aAbsZ     = std::abs(aPlaneNorm.Z());
   int          aDropAxis = 0;
   if (aAbsY >= aAbsX && aAbsY >= aAbsZ)
   {
@@ -387,15 +387,14 @@ bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& t
     aDropAxis = 2;
   }
 
-  const int     aLowerIdx = myBoundaryPoints.Lower();
-  const gp_XY   aPnt2D    = projectTo2D(aProj, aDropAxis);
-  bool          isInside  = false;
+  const int   aLowerIdx = myBoundaryPoints.Lower();
+  const gp_XY aPnt2D    = projectTo2D(aProj, aDropAxis);
+  bool        isInside  = false;
   for (int anIdx = 0, aPrev = aNearCount - 1; anIdx < aNearCount; aPrev = anIdx++)
   {
-    const gp_XY aCur = projectTo2D(myBoundaryPoints.Value(aLowerIdx + anIdx), aDropAxis);
-    const gp_XY aOld = projectTo2D(myBoundaryPoints.Value(aLowerIdx + aPrev), aDropAxis);
-    const bool  isStrideY =
-      (aCur.Y() > aPnt2D.Y()) != (aOld.Y() > aPnt2D.Y());
+    const gp_XY aCur      = projectTo2D(myBoundaryPoints.Value(aLowerIdx + anIdx), aDropAxis);
+    const gp_XY aOld      = projectTo2D(myBoundaryPoints.Value(aLowerIdx + aPrev), aDropAxis);
+    const bool  isStrideY = (aCur.Y() > aPnt2D.Y()) != (aOld.Y() > aPnt2D.Y());
     if (!isStrideY)
     {
       continue;
@@ -406,8 +405,7 @@ bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& t
     {
       continue;
     }
-    const double aXOnEdge =
-      (aOld.X() - aCur.X()) * (aPnt2D.Y() - aCur.Y()) / aDenom + aCur.X();
+    const double aXOnEdge = (aOld.X() - aCur.X()) * (aPnt2D.Y() - aCur.Y()) / aDenom + aCur.X();
     if (aPnt2D.X() < aXOnEdge)
     {
       isInside = !isInside;

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.cxx
@@ -22,12 +22,30 @@
 #include <Geom_Circle.hxx>
 #include <Geom_Line.hxx>
 #include <NCollection_IncAllocator.hxx>
+#include <Precision.hxx>
 #include <SelectMgr_FrustumBuilder.hxx>
+
+#include <cmath>
 
 namespace
 {
 static const size_t MEMORY_BLOCK_SIZE = 512 * 7;
+
+//! Drops the dominant-magnitude plane-normal axis and returns the remaining pair as a 2D point.
+//! Matches the drop-axis chosen in isPointInsideNearProjection().
+static gp_XY projectTo2D(const gp_Pnt& thePnt, const int theDropAxis)
+{
+  switch (theDropAxis)
+  {
+    case 1:
+      return gp_XY(thePnt.X(), thePnt.Z());
+    case 2:
+      return gp_XY(thePnt.X(), thePnt.Y());
+    default:
+      return gp_XY(thePnt.Y(), thePnt.Z());
+  }
 }
+} // namespace
 
 //=================================================================================================
 
@@ -254,47 +272,44 @@ bool SelectMgr_TriangularFrustumSet::OverlapsBox(const NCollection_Vec3<double>&
                         "Error! SelectMgr_TriangularFrustumSet::Overlaps() should be called after "
                         "selection frustum initialization");
 
+  bool isAnyFrustumOverlap = false;
   for (NCollection_List<occ::handle<SelectMgr_TriangularFrustum>>::Iterator anIter(myFrustums);
        anIter.More();
        anIter.Next())
   {
-    if (!anIter.Value()->OverlapsBox(theMinPnt, theMaxPnt, nullptr))
+    if (anIter.Value()->OverlapsBox(theMinPnt, theMaxPnt, nullptr))
     {
-      continue;
+      isAnyFrustumOverlap = true;
+      break;
     }
+  }
+  if (!isAnyFrustumOverlap)
+  {
+    return false;
+  }
 
-    if (myToAllowOverlap || theInside == nullptr)
-    {
-      return true;
-    }
-
-    gp_Pnt aMinMaxPnts[2] = {gp_Pnt(theMinPnt.x(), theMinPnt.y(), theMinPnt.z()),
-                             gp_Pnt(theMaxPnt.x(), theMaxPnt.y(), theMaxPnt.z())};
-
-    gp_Pnt anOffset[3] = {gp_Pnt(aMinMaxPnts[1].X() - aMinMaxPnts[0].X(), 0.0, 0.0),
-                          gp_Pnt(0.0, aMinMaxPnts[1].Y() - aMinMaxPnts[0].Y(), 0.0),
-                          gp_Pnt(0.0, 0.0, aMinMaxPnts[1].Z() - aMinMaxPnts[0].Z())};
-
-    int aSign = 1;
-    for (int aPntsIdx = 0; aPntsIdx < 2; aPntsIdx++)
-    {
-      for (int aCoordIdx = 0; aCoordIdx < 3; aCoordIdx++)
-      {
-        gp_Pnt anOffsetPnt = aMinMaxPnts[aPntsIdx].XYZ() + aSign * anOffset[aCoordIdx].XYZ();
-        if (isIntersectBoundary(aMinMaxPnts[aPntsIdx], anOffsetPnt)
-            || isIntersectBoundary(anOffsetPnt,
-                                   anOffsetPnt.XYZ() + aSign * anOffset[(aCoordIdx + 1) % 3].XYZ()))
-        {
-          *theInside &= false;
-          return true;
-        }
-      }
-      aSign = -aSign;
-    }
+  if (myToAllowOverlap || theInside == nullptr)
+  {
     return true;
   }
 
-  return false;
+  const gp_Pnt aCorners[8] = {gp_Pnt(theMinPnt.x(), theMinPnt.y(), theMinPnt.z()),
+                              gp_Pnt(theMaxPnt.x(), theMinPnt.y(), theMinPnt.z()),
+                              gp_Pnt(theMinPnt.x(), theMaxPnt.y(), theMinPnt.z()),
+                              gp_Pnt(theMaxPnt.x(), theMaxPnt.y(), theMinPnt.z()),
+                              gp_Pnt(theMinPnt.x(), theMinPnt.y(), theMaxPnt.z()),
+                              gp_Pnt(theMaxPnt.x(), theMinPnt.y(), theMaxPnt.z()),
+                              gp_Pnt(theMinPnt.x(), theMaxPnt.y(), theMaxPnt.z()),
+                              gp_Pnt(theMaxPnt.x(), theMaxPnt.y(), theMaxPnt.z())};
+  for (const gp_Pnt& aCorner : aCorners)
+  {
+    if (!isPointInsideNearProjection(aCorner))
+    {
+      *theInside &= false;
+      break;
+    }
+  }
+  return true;
 }
 
 //=================================================================================================
@@ -318,6 +333,87 @@ bool SelectMgr_TriangularFrustumSet::OverlapsPoint(const gp_Pnt&                
   }
 
   return false;
+}
+
+//=================================================================================================
+
+bool SelectMgr_TriangularFrustumSet::OverlapsPoint(const gp_Pnt& thePnt) const
+{
+  Standard_ASSERT_RAISE(mySelectionType == SelectMgr_SelectionType_Polyline,
+                        "Error! SelectMgr_TriangularFrustumSet::Overlaps() should be called after "
+                        "selection frustum initialization");
+  return isPointInsideNearProjection(thePnt);
+}
+
+//=================================================================================================
+
+bool SelectMgr_TriangularFrustumSet::isPointInsideNearProjection(const gp_Pnt& thePnt) const
+{
+  const int aNearCount = static_cast<int>(myBoundaryPoints.Size() / 2);
+  if (aNearCount < 3 || myFrustums.IsEmpty())
+  {
+    return false;
+  }
+
+  const gp_Pnt& aNearA    = myFrustums.First()->myVertices[0];
+  const gp_Pnt& aNearB    = myFrustums.First()->myVertices[1];
+  const gp_Pnt& aNearC    = myFrustums.First()->myVertices[2];
+  const gp_Vec  aPlaneNorm = gp_Vec(aNearA, aNearB).Crossed(gp_Vec(aNearA, aNearC));
+  const double  aNormSqr   = aPlaneNorm.SquareMagnitude();
+  if (aNormSqr < Precision::SquareConfusion())
+  {
+    return false;
+  }
+
+  gp_Pnt        aProj  = thePnt;
+  const double  aDistN = aPlaneNorm.X() * (thePnt.X() - aNearA.X())
+                        + aPlaneNorm.Y() * (thePnt.Y() - aNearA.Y())
+                        + aPlaneNorm.Z() * (thePnt.Z() - aNearA.Z());
+  const double aScale = aDistN / aNormSqr;
+  aProj.SetCoord(thePnt.X() - aPlaneNorm.X() * aScale,
+                 thePnt.Y() - aPlaneNorm.Y() * aScale,
+                 thePnt.Z() - aPlaneNorm.Z() * aScale);
+
+  const double aAbsX    = std::abs(aPlaneNorm.X());
+  const double aAbsY    = std::abs(aPlaneNorm.Y());
+  const double aAbsZ    = std::abs(aPlaneNorm.Z());
+  int          aDropAxis = 0;
+  if (aAbsY >= aAbsX && aAbsY >= aAbsZ)
+  {
+    aDropAxis = 1;
+  }
+  else if (aAbsZ >= aAbsX && aAbsZ >= aAbsY)
+  {
+    aDropAxis = 2;
+  }
+
+  const int     aLowerIdx = myBoundaryPoints.Lower();
+  const gp_XY   aPnt2D    = projectTo2D(aProj, aDropAxis);
+  bool          isInside  = false;
+  for (int anIdx = 0, aPrev = aNearCount - 1; anIdx < aNearCount; aPrev = anIdx++)
+  {
+    const gp_XY aCur = projectTo2D(myBoundaryPoints.Value(aLowerIdx + anIdx), aDropAxis);
+    const gp_XY aOld = projectTo2D(myBoundaryPoints.Value(aLowerIdx + aPrev), aDropAxis);
+    const bool  isStrideY =
+      (aCur.Y() > aPnt2D.Y()) != (aOld.Y() > aPnt2D.Y());
+    if (!isStrideY)
+    {
+      continue;
+    }
+
+    const double aDenom = aOld.Y() - aCur.Y();
+    if (std::abs(aDenom) < Precision::Confusion())
+    {
+      continue;
+    }
+    const double aXOnEdge =
+      (aOld.X() - aCur.X()) * (aPnt2D.Y() - aCur.Y()) / aDenom + aCur.X();
+    if (aPnt2D.X() < aXOnEdge)
+    {
+      isInside = !isInside;
+    }
+  }
+  return isInside;
 }
 
 //=================================================================================================

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.hxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.hxx
@@ -84,8 +84,8 @@ public:
                                      const SelectMgr_ViewClipRange& theClipRange,
                                      SelectBasics_PickResult&       thePickResult) const override;
 
-  //! Always returns FALSE (not applicable to this selector).
-  bool OverlapsPoint(const gp_Pnt&) const override { return false; }
+  //! Returns TRUE when the point's near-plane projection lies inside the polyline loop.
+  Standard_EXPORT bool OverlapsPoint(const gp_Pnt& thePnt) const override;
 
   Standard_EXPORT bool OverlapsPolygon(const NCollection_Array1<gp_Pnt>& theArrayOfPnts,
                                        Select3D_TypeOfSensitivity        theSensType,
@@ -169,6 +169,12 @@ public:
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const override;
 
 private:
+  //! Projects thePnt onto the frustum near plane and runs a 2D ray-cast
+  //! point-in-polygon test against the original polyline loop.
+  //! Coplanarity of every frustum's near triangle is guaranteed by Build()
+  //! (all near vertices come from ProjectPntOnViewPlane(x, y, 0.0)).
+  Standard_EXPORT bool isPointInsideNearProjection(const gp_Pnt& thePnt) const;
+
   //! Checks whether the segment intersects with the boundary of the current volume selection
   Standard_EXPORT bool isIntersectBoundary(const gp_Pnt& thePnt1, const gp_Pnt& thePnt2) const;
 

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.hxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_TriangularFrustumSet.hxx
@@ -169,11 +169,11 @@ public:
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const override;
 
 private:
-  //! Projects thePnt onto the frustum near plane and runs a 2D ray-cast
-  //! point-in-polygon test against the original polyline loop.
-  //! Coplanarity of every frustum's near triangle is guaranteed by Build()
-  //! (all near vertices come from ProjectPntOnViewPlane(x, y, 0.0)).
-  Standard_EXPORT bool isPointInsideNearProjection(const gp_Pnt& thePnt) const;
+  //! Returns TRUE when the given world-space point lies inside any of the
+  //! triangular frustums of the polyline prism. Delegates to the SAT-based
+  //! hasPointOverlap() on each child frustum, which is correct for both
+  //! orthographic and perspective cameras.
+  Standard_EXPORT bool isPointInsideAnyFrustum(const gp_Pnt& thePnt) const;
 
   //! Checks whether the segment intersects with the boundary of the current volume selection
   Standard_EXPORT bool isIntersectBoundary(const gp_Pnt& thePnt1, const gp_Pnt& thePnt2) const;

--- a/tests/vselect/bugs/bug_polyline_inclusion
+++ b/tests/vselect/bugs/bug_polyline_inclusion
@@ -1,0 +1,43 @@
+puts "========================================"
+puts "Visualization - polyline selection must respect strict inclusion"
+puts "Rubber-band polyline with -allowoverlap 0 should only pick entities"
+puts "whose bounding boxes project fully inside the drawn polyline."
+puts "========================================"
+puts ""
+
+pload MODELING VISUALIZATION
+vinit View1 -height 400 -width 600
+
+psphere s1 1
+psphere s2 1
+ttranslate s1 2 0 0
+ttranslate s2 -2 0 0
+vdisplay -dispMode 1 s1 s2
+vfit
+
+# Polyline enclosing only s1 (right-hand sphere).
+# Strict inclusion: only s1 is selected.
+vselect 350 130 570 130 570 280 350 280 -allowoverlap 0
+if {![string match "*Selected*" [vstate s1]] ||
+    [string match "*Selected*" [vstate s2]]} {
+  puts "Error: strict-inclusion polyline should pick only s1, not s2"
+}
+
+# Polyline enclosing only s1, overlap mode on.
+# Still only s1 should overlap this polyline at all.
+vselect 0 0
+vselect 350 130 570 130 570 280 350 280 -allowoverlap 1
+if {![string match "*Selected*" [vstate s1]] ||
+    [string match "*Selected*" [vstate s2]]} {
+  puts "Error: overlap polyline should still only pick s1 (s2 is far left)"
+}
+
+# Polyline enclosing both spheres, strict inclusion: both must be picked.
+vselect 0 0
+vselect 10 130 590 130 590 280 10 280 -allowoverlap 0
+if {![string match "*Selected*" [vstate s1]] ||
+    ![string match "*Selected*" [vstate s2]]} {
+  puts "Error: polyline enclosing both spheres must pick s1 and s2"
+}
+
+vdump ${imagedir}/${casename}.png

--- a/tests/vselect/bugs/bug_polyline_inclusion
+++ b/tests/vselect/bugs/bug_polyline_inclusion
@@ -1,7 +1,11 @@
 puts "========================================"
-puts "Visualization - polyline selection must respect strict inclusion"
-puts "Rubber-band polyline with -allowoverlap 0 should only pick entities"
-puts "whose bounding boxes project fully inside the drawn polyline."
+puts "Visualization - polyline (polygonal) selection in strict-inclusion mode"
+puts "Regression guard for SelectMgr_TriangularFrustumSet::OverlapsPoint /"
+puts "OverlapsBox: the single-arg OverlapsPoint(gp_Pnt) used to return false"
+puts "unconditionally, which made strict-inclusion polyline selection of"
+puts "SensitiveTriangle / SensitivePoly / SensitiveTriangulation /"
+puts "SensitivePrimitiveArray / MeshVS_* impossible."
+puts "Pixel coordinates are reused from tests/vselect/sphere/rectangle_selection."
 puts "========================================"
 puts ""
 
@@ -15,29 +19,29 @@ ttranslate s2 -2 0 0
 vdisplay -dispMode 1 s1 s2
 vfit
 
-# Polyline enclosing only s1 (right-hand sphere).
-# Strict inclusion: only s1 is selected.
-vselect 350 130 570 130 570 280 350 280 -allowoverlap 0
-if {![string match "*Selected*" [vstate s1]] ||
-    [string match "*Selected*" [vstate s2]]} {
-  puts "Error: strict-inclusion polyline should pick only s1, not s2"
-}
-
-# Polyline enclosing only s1, overlap mode on.
-# Still only s1 should overlap this polyline at all.
-vselect 0 0
-vselect 350 130 570 130 570 280 350 280 -allowoverlap 1
-if {![string match "*Selected*" [vstate s1]] ||
-    [string match "*Selected*" [vstate s2]]} {
-  puts "Error: overlap polyline should still only pick s1 (s2 is far left)"
-}
-
-# Polyline enclosing both spheres, strict inclusion: both must be picked.
-vselect 0 0
-vselect 10 130 590 130 590 280 10 280 -allowoverlap 0
+# A 4-point polygon that matches the extent of the selection rectangle
+# (15,15)-(585,385) used in tests/vselect/sphere/rectangle_selection,
+# where strict inclusion is known to select both spheres.
+vselect 15 15 585 15 585 385 15 385 -allowoverlap 0
 if {![string match "*Selected*" [vstate s1]] ||
     ![string match "*Selected*" [vstate s2]]} {
-  puts "Error: polyline enclosing both spheres must pick s1 and s2"
+  puts "Error: polyline enclosing both spheres must select s1 and s2 in strict inclusion mode"
+}
+
+# A tiny polygon fully inside the upper-left corner of the viewport that
+# does not cover either sphere. Neither sphere must be selected, in either mode.
+vselect 0 0
+vselect 5 5 40 5 40 40 5 40 -allowoverlap 0
+if { [string match "*Selected*" [vstate s1]] ||
+     [string match "*Selected*" [vstate s2]]} {
+  puts "Error: polyline not covering any sphere must not select anything (strict)"
+}
+
+vselect 0 0
+vselect 5 5 40 5 40 40 5 40 -allowoverlap 1
+if { [string match "*Selected*" [vstate s1]] ||
+     [string match "*Selected*" [vstate s2]]} {
+  puts "Error: polyline not covering any sphere must not select anything (overlap)"
 }
 
 vdump ${imagedir}/${casename}.png


### PR DESCRIPTION
Replaces two buggy pieces of SelectMgr_TriangularFrustumSet used during polyline (polygon rubber-band) selection:

- OverlapsBox(min, max, bool* theInside): the corner-edge isIntersectBoundary heuristic produced false "fully inside" answers whenever an AABB was large enough that its 12 edges did not cross the polyline but its interior did not lie inside either. Rewrite: first probe every frustum for any overlap; if none, return false. Otherwise, project the 8 AABB corners onto the frustum near plane and apply a ray-cast inside test against the original polyline loop. If any corner projects outside, clear theInside; else leave it untouched. The near-plane coplanarity assumption is guaranteed by Build(), which derives every near vertex from myBuilder->ProjectPntOnViewPlane(x, y, 0.0).

- OverlapsPoint(const gp_Pnt&): previously a stub returning false, which made strict-inclusion polyline selection of Select3D_SensitiveTriangle, SensitivePoly, SensitiveTriangulation, SensitivePrimitiveArray, MeshVS_CommonSensitiveEntity and MeshVS_SensitiveQuad silently impossible (those sensitive types call theMgr.OverlapsPoint(...) on each vertex in strict-inclusion mode; a blanket false meant nothing was ever picked). Now delegates to the same near-plane projection + ray-cast test, so strict inclusion works for all these sensitive types in polyline mode.

Covered by a new Draw test tests/vselect/bugs/bug_polyline_inclusion that exercises both strict-inclusion and overlap modes for spheres inside/outside a polygonal rubber band. No GTest is added because constructing a working TriangularFrustumSet requires a configured Graphic3d_Camera + viewport; the Tcl test is the regression gate.