### PR TITLE
Modelling - Crash in BRepFill_PipeShell::MakeSolid()

### DIFF
--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
@@ -205,7 +205,9 @@ static bool IsSameOriented(const TopoDS_Shape& theFace, const TopoDS_Shape& theS
     }
   }
 
-  // No shared edge: orientation cannot be determined, leave the face unchanged.
+  // No shared edge found. Orientation cannot be determined reliably and this
+  // should not happen for valid input. Preserve the current face orientation
+  // instead of reporting an opposite orientation and forcing a reversal.
   return true;
 }
 

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
@@ -174,10 +174,7 @@ static bool PerformPlan(TopoDS_Shape& S)
   return Ok;
 }
 
-//=============================================================================
-// function :  IsSameOriented
-// purpose  : Checks whether aFace is oriented to the same side as aShell or not
-//=============================================================================
+//=================================================================================================
 
 static bool IsSameOriented(const TopoDS_Shape& theFace, const TopoDS_Shape& theShell)
 {
@@ -188,32 +185,28 @@ static bool IsSameOriented(const TopoDS_Shape& theFace, const TopoDS_Shape& theS
   for (TopExp_Explorer aFaceExplorer(theFace, TopAbs_EDGE); aFaceExplorer.More();
        aFaceExplorer.Next())
   {
-    // Find an edge of theFace that is also present in theShell.
-    const TopoDS_Shape       aCurrentEdge            = aFaceExplorer.Current();
-    const TopAbs_Orientation aCurrentEdgeOrientation = aCurrentEdge.Orientation();
+    const TopoDS_Shape& aCurrentEdge = aFaceExplorer.Current();
     if (!anEdgeFaceMap.Contains(aCurrentEdge))
     {
       continue;
     }
 
-    // Find a face that is adjacent to the edge and belongs to theShell.
-    const TopoDS_Shape& anAdjFace = anEdgeFaceMap.FindFromKey(aCurrentEdge).First();
+    const TopAbs_Orientation aCurrentEdgeOrientation = aCurrentEdge.Orientation();
+    const TopoDS_Shape&      anAdjFace = anEdgeFaceMap.FindFromKey(aCurrentEdge).First();
     for (TopExp_Explorer anAdjFaceExplorer(anAdjFace, TopAbs_EDGE); anAdjFaceExplorer.More();
          anAdjFaceExplorer.Next())
     {
-      // Find the same edge in the adjacent face and compare their orientations.
-      // The same means TShape and Location is same, but orientation may differ.
-      const TopoDS_Shape anAdjEdge = anAdjFaceExplorer.Current();
+      // IsSame compares TShape and Location only; orientation may differ.
+      const TopoDS_Shape& anAdjEdge = anAdjFaceExplorer.Current();
       if (anAdjEdge.IsSame(aCurrentEdge))
       {
-        const TopAbs_Orientation anAdjEdgeOrientation = anAdjEdge.Orientation();
-        return aCurrentEdgeOrientation != anAdjEdgeOrientation;
+        return aCurrentEdgeOrientation != anAdjEdge.Orientation();
       }
     }
   }
 
-  // No shared edge found. Should not happen for valid input.
-  return false;
+  // No shared edge: orientation cannot be determined, leave the face unchanged.
+  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_PipeShell.cxx
@@ -179,27 +179,41 @@ static bool PerformPlan(TopoDS_Shape& S)
 // purpose  : Checks whether aFace is oriented to the same side as aShell or not
 //=============================================================================
 
-static bool IsSameOriented(const TopoDS_Shape& aFace, const TopoDS_Shape& aShell)
+static bool IsSameOriented(const TopoDS_Shape& theFace, const TopoDS_Shape& theShell)
 {
-  TopExp_Explorer    Explo(aFace, TopAbs_EDGE);
-  TopoDS_Shape       anEdge = Explo.Current();
-  TopAbs_Orientation Or1    = anEdge.Orientation();
-
   NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
-    EFmap;
-  TopExp::MapShapesAndAncestors(aShell, TopAbs_EDGE, TopAbs_FACE, EFmap);
+    anEdgeFaceMap;
+  TopExp::MapShapesAndAncestors(theShell, TopAbs_EDGE, TopAbs_FACE, anEdgeFaceMap);
 
-  const TopoDS_Shape& AdjacentFace = EFmap.FindFromKey(anEdge).First();
-  TopoDS_Shape        theEdge;
-  for (Explo.Init(AdjacentFace, TopAbs_EDGE); Explo.More(); Explo.Next())
+  for (TopExp_Explorer aFaceExplorer(theFace, TopAbs_EDGE); aFaceExplorer.More();
+       aFaceExplorer.Next())
   {
-    theEdge = Explo.Current();
-    if (theEdge.IsSame(anEdge))
-      break;
+    // Find an edge of theFace that is also present in theShell.
+    const TopoDS_Shape       aCurrentEdge            = aFaceExplorer.Current();
+    const TopAbs_Orientation aCurrentEdgeOrientation = aCurrentEdge.Orientation();
+    if (!anEdgeFaceMap.Contains(aCurrentEdge))
+    {
+      continue;
+    }
+
+    // Find a face that is adjacent to the edge and belongs to theShell.
+    const TopoDS_Shape& anAdjFace = anEdgeFaceMap.FindFromKey(aCurrentEdge).First();
+    for (TopExp_Explorer anAdjFaceExplorer(anAdjFace, TopAbs_EDGE); anAdjFaceExplorer.More();
+         anAdjFaceExplorer.Next())
+    {
+      // Find the same edge in the adjacent face and compare their orientations.
+      // The same means TShape and Location is same, but orientation may differ.
+      const TopoDS_Shape anAdjEdge = anAdjFaceExplorer.Current();
+      if (anAdjEdge.IsSame(aCurrentEdge))
+      {
+        const TopAbs_Orientation anAdjEdgeOrientation = anAdjEdge.Orientation();
+        return aCurrentEdgeOrientation != anAdjEdgeOrientation;
+      }
+    }
   }
 
-  TopAbs_Orientation Or2 = theEdge.Orientation();
-  return Or1 != Or2;
+  // No shared edge found. Should not happen for valid input.
+  return false;
 }
 
 //=================================================================================================

--- a/src/ModelingAlgorithms/TKBool/GTests/BRepFill_PipeShell_Test.cxx
+++ b/src/ModelingAlgorithms/TKBool/GTests/BRepFill_PipeShell_Test.cxx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepFill_PipeShell.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Pnt.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+TopoDS_Wire MakeSquareProfile(const gp_Pnt& theCenter, const double theHalfSide)
+{
+  BRepBuilderAPI_MakePolygon aPolygon;
+  aPolygon.Add(gp_Pnt(theCenter.X() - theHalfSide, theCenter.Y() - theHalfSide, theCenter.Z()));
+  aPolygon.Add(gp_Pnt(theCenter.X() + theHalfSide, theCenter.Y() - theHalfSide, theCenter.Z()));
+  aPolygon.Add(gp_Pnt(theCenter.X() + theHalfSide, theCenter.Y() + theHalfSide, theCenter.Z()));
+  aPolygon.Add(gp_Pnt(theCenter.X() - theHalfSide, theCenter.Y() + theHalfSide, theCenter.Z()));
+  aPolygon.Close();
+  return aPolygon.Wire();
+}
+} // namespace
+
+TEST(BRepFill_PipeShellTest, MakeSolid_StraightSpineClosedProfile_ProducesClosedSolid)
+{
+  const TopoDS_Edge aSpineEdge =
+    BRepBuilderAPI_MakeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(0.0, 0.0, 10.0)).Edge();
+  const TopoDS_Wire aSpine = BRepBuilderAPI_MakeWire(aSpineEdge).Wire();
+
+  const TopoDS_Wire aProfile = MakeSquareProfile(gp_Pnt(0.0, 0.0, 0.0), 1.0);
+
+  BRepFill_PipeShell aPipe(aSpine);
+  aPipe.Add(aProfile);
+  ASSERT_TRUE(aPipe.IsReady());
+  ASSERT_TRUE(aPipe.Build());
+  ASSERT_TRUE(aPipe.MakeSolid());
+
+  const TopoDS_Shape& aResult = aPipe.Shape();
+  EXPECT_FALSE(aResult.IsNull());
+  EXPECT_TRUE(aResult.Closed());
+
+  BRepCheck_Analyzer anAnalyzer(aResult);
+  EXPECT_TRUE(anAnalyzer.IsValid());
+}
+
+TEST(BRepFill_PipeShellTest, MakeSolid_PolylineSpineClosedProfile_ProducesClosedSolid)
+{
+  BRepBuilderAPI_MakePolygon aSpinePolygon;
+  aSpinePolygon.Add(gp_Pnt(0.0, 0.0, 0.0));
+  aSpinePolygon.Add(gp_Pnt(0.0, 0.0, 5.0));
+  aSpinePolygon.Add(gp_Pnt(0.0, 5.0, 10.0));
+  const TopoDS_Wire aSpine = aSpinePolygon.Wire();
+
+  const TopoDS_Wire aProfile = MakeSquareProfile(gp_Pnt(0.0, 0.0, 0.0), 0.5);
+
+  BRepFill_PipeShell aPipe(aSpine);
+  aPipe.SetTransition(BRepFill_Right);
+  aPipe.Add(aProfile);
+  ASSERT_TRUE(aPipe.IsReady());
+  ASSERT_TRUE(aPipe.Build());
+  ASSERT_TRUE(aPipe.MakeSolid());
+
+  const TopoDS_Shape& aResult = aPipe.Shape();
+  EXPECT_FALSE(aResult.IsNull());
+  EXPECT_TRUE(aResult.Closed());
+}

--- a/src/ModelingAlgorithms/TKBool/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKBool/GTests/FILES.cmake
@@ -2,4 +2,5 @@
 set(OCCT_TKBool_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKBool_GTests_FILES
+  BRepFill_PipeShell_Test.cxx
 )


### PR DESCRIPTION
Fixed a crash when calling IsSameOriented() from
BRepFill_PipeShell::MakeSolid().
IsSameOriented() now checks that used edge of the face actually belongs to the shell.