### PR TITLE
Visualization - complete AIS_ColorScale face-culling fix

### DIFF
--- a/src/Visualization/TKV3d/AIS/AIS_ColorScale.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ColorScale.cxx
@@ -45,12 +45,11 @@ static void addColoredQuad(const occ::handle<Graphic3d_ArrayOfTriangles>& theTri
                            const Quantity_Color&                          theColorTop)
 {
   const int aVertIndex = theTris->VertexNumber() + 1;
+  theTris->AddVertex(gp_Pnt(theXLeft, theYBottom + theSizeY, 0.0), theColorTop);
   theTris->AddVertex(gp_Pnt(theXLeft, theYBottom, 0.0), theColorBottom);
   theTris->AddVertex(gp_Pnt(theXLeft + theSizeX, theYBottom, 0.0), theColorBottom);
-  theTris->AddVertex(gp_Pnt(theXLeft, theYBottom + theSizeY, 0.0), theColorTop);
   theTris->AddVertex(gp_Pnt(theXLeft + theSizeX, theYBottom + theSizeY, 0.0), theColorTop);
-  theTris->AddEdges(aVertIndex, aVertIndex + 1, aVertIndex + 2);
-  theTris->AddEdges(aVertIndex + 1, aVertIndex + 3, aVertIndex + 2);
+  theTris->AddQuadTriangleEdges(aVertIndex, aVertIndex + 1, aVertIndex + 2, aVertIndex + 3);
 }
 
 //! Compute hue angle from specified value.

--- a/tests/v3d/colorscale/colorscale_faceculling
+++ b/tests/v3d/colorscale/colorscale_faceculling
@@ -4,7 +4,6 @@ puts "============"
 puts ""
 
 pload VISUALIZATION
-dpiaware 0
 
 vclear
 vinit View1 -width 490 -height 409

--- a/tests/v3d/colorscale/colorscale_faceculling
+++ b/tests/v3d/colorscale/colorscale_faceculling
@@ -1,0 +1,18 @@
+puts "============"
+puts "AIS_ColorScale face-culling regression"
+puts "============"
+puts ""
+
+pload VISUALIZATION
+dpiaware 0
+
+vclear
+vinit View1 -width 490 -height 409
+vcolorscale cs -demo
+vaspects cs -faceCulling BACK
+
+if { [vreadpixel 20 25 -rgb -name] != "RED" } {
+  puts "Error: front face culled"
+}
+
+vdump ${imagedir}/${casename}.png


### PR DESCRIPTION
Complete the AIS_ColorScale rectangle winding fix by following the upstream patch revision from Kirill Gavrilov <kirill@sview.ru>, commit 9b8c6240d10ab709ac611503dcc40e45b83fb3d1.

Switch the rectangle helper from manual triangle edges to Graphic3d_ArrayOfPrimitives::AddQuadTriangleEdges() while preserving the top/bottom color layout. This keeps the quad in a consistent CCW orientation and avoids visible seam edge or front-face loss when BACK face culling is enabled.

Add DRAW regression test tests/v3d/colorscale/colorscale_faceculling using the original reproduction scenario and a pixel check for the front face.