### PR TITLE
Modeling - Refactor BRepGraph for uint32_t ids

### DIFF
--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph.cxx
@@ -360,8 +360,8 @@ void BRepGraph::invalidateSubgraphImpl(const BRepGraph_NodeId theNode)
 
   const uint32_t aNbNodes = aStorage.NbSolids() + aStorage.NbShells() + aStorage.NbFaces()
                             + aStorage.NbWires() + aStorage.NbEdges() + aStorage.NbVertices()
-                            + aStorage.NbCompounds() + aStorage.NbCompSolids() + aStorage.NbProducts()
-                            + aStorage.NbOccurrences();
+                            + aStorage.NbCompounds() + aStorage.NbCompSolids()
+                            + aStorage.NbProducts() + aStorage.NbOccurrences();
   const uint32_t                        aMaxDepth = aNbNodes > 0 ? aNbNodes : 1;
   occ::handle<NCollection_IncAllocator> anAlloc   = new NCollection_IncAllocator();
   NCollection_Vector<StackEntry>        aStack(64, anAlloc);

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph.cxx
@@ -355,20 +355,20 @@ void BRepGraph::invalidateSubgraphImpl(const BRepGraph_NodeId theNode)
   struct StackEntry
   {
     BRepGraph_NodeId Node;
-    int              Depth;
+    uint32_t         Depth;
   };
 
-  const int aNbNodes = aStorage.NbSolids() + aStorage.NbShells() + aStorage.NbFaces()
-                       + aStorage.NbWires() + aStorage.NbEdges() + aStorage.NbVertices()
-                       + aStorage.NbCompounds() + aStorage.NbCompSolids() + aStorage.NbProducts()
-                       + aStorage.NbOccurrences();
-  const int                             aMaxDepth = aNbNodes > 0 ? aNbNodes : 1;
+  const uint32_t aNbNodes = aStorage.NbSolids() + aStorage.NbShells() + aStorage.NbFaces()
+                            + aStorage.NbWires() + aStorage.NbEdges() + aStorage.NbVertices()
+                            + aStorage.NbCompounds() + aStorage.NbCompSolids() + aStorage.NbProducts()
+                            + aStorage.NbOccurrences();
+  const uint32_t                        aMaxDepth = aNbNodes > 0 ? aNbNodes : 1;
   occ::handle<NCollection_IncAllocator> anAlloc   = new NCollection_IncAllocator();
   NCollection_Vector<StackEntry>        aStack(64, anAlloc);
-  NCollection_Map<BRepGraph_NodeId>     aVisited(aNbNodes, anAlloc);
+  NCollection_Map<BRepGraph_NodeId>     aVisited(static_cast<size_t>(aNbNodes), anAlloc);
   aStack.Append({theNode, 0});
 
-  const auto aPushChild = [&](const BRepGraph_NodeId theChild, const int theDepth) {
+  const auto aPushChild = [&](const BRepGraph_NodeId theChild, const uint32_t theDepth) {
     if (!theChild.IsValid())
       return;
     aStack.Append({theChild, theDepth});
@@ -394,7 +394,7 @@ void BRepGraph::invalidateSubgraphImpl(const BRepGraph_NodeId theNode)
       ++anEntity->SubtreeGen;
     }
 
-    const int aNextDepth = aCurrent.Depth + 1;
+    const uint32_t aNextDepth = aCurrent.Depth + 1;
 
     switch (aCurrent.Node.NodeKind)
     {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ChildExplorer.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ChildExplorer.cxx
@@ -82,10 +82,9 @@ static BRepGraph_RefId childRefIdForStep(const BRepGraph&       theGraph,
   const BRepGraph_ProductId       aProductId = BRepGraph_ProductId::FromNodeId(theParent);
   const BRepGraphInc::ProductDef& aProduct   = aTopo.Products().Definition(aProductId);
 
-  int anActiveIndex = 0;
-  for (int anIndex = 0; anIndex < aProduct.OccurrenceRefIds.Length(); ++anIndex)
+  uint32_t anActiveIndex = 0;
+  for (const BRepGraph_OccurrenceRefId& anOccurrenceRefId : aProduct.OccurrenceRefIds)
   {
-    const BRepGraph_OccurrenceRefId    anOccurrenceRefId = aProduct.OccurrenceRefIds.Value(anIndex);
     const BRepGraphInc::OccurrenceRef& anOccurrenceRef =
       aRefs.Occurrences().Entry(anOccurrenceRefId);
     if (anOccurrenceRef.IsRemoved)
@@ -100,7 +99,7 @@ static BRepGraph_RefId childRefIdForStep(const BRepGraph&       theGraph,
       continue;
     }
 
-    if (anActiveIndex == theStep)
+    if (anActiveIndex == static_cast<uint32_t>(theStep))
     {
       return anOccurrenceRefId;
     }
@@ -356,8 +355,8 @@ void BRepGraph_ChildExplorer::advance()
 
   while (myStackTop >= 0)
   {
-    StackFrame& aFrame = topFrame();
-    const int   aIdx   = aFrame.NextChildIdx;
+    StackFrame&      aFrame = topFrame();
+    const uint32_t   aIdx   = aFrame.NextChildIdx;
 
     // Per-kind child iteration.
     // Each branch either yields a child (with step, loc, ori) and increments NextChildIdx,
@@ -365,7 +364,7 @@ void BRepGraph_ChildExplorer::advance()
     BRepGraph_NodeId   aChildNode;
     TopLoc_Location    aChildLoc = aFrame.AccLocation;
     TopAbs_Orientation aChildOri = aFrame.AccOrientation;
-    int                aStepIdx  = aIdx;
+    int                aStepIdx  = static_cast<int>(aIdx);
 
     switch (aFrame.Node.NodeKind)
     {
@@ -373,14 +372,15 @@ void BRepGraph_ChildExplorer::advance()
         const BRepGraphInc::CompoundDef& aComp =
           aDefs.Compounds().Definition(BRepGraph_CompoundId(aFrame.Node));
         // Skip removed refs.
-        int i = aIdx;
-        for (; i < aComp.ChildRefIds.Length(); ++i)
+        const uint32_t aNbChildren = static_cast<uint32_t>(aComp.ChildRefIds.Size());
+        uint32_t       i           = aIdx;
+        for (; i < aNbChildren; ++i)
         {
-          const BRepGraph_ChildRefId aRefId = aComp.ChildRefIds.Value(i);
+          const BRepGraph_ChildRefId aRefId = aComp.ChildRefIds.Value(static_cast<size_t>(i));
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aRefId);
             if (myConfig.AccumulateOrientation)
@@ -395,14 +395,15 @@ void BRepGraph_ChildExplorer::advance()
       case Kind::CompSolid: {
         const BRepGraphInc::CompSolidDef& aCS =
           aDefs.CompSolids().Definition(BRepGraph_CompSolidId(aFrame.Node));
-        int i = aIdx;
-        for (; i < aCS.SolidRefIds.Length(); ++i)
+        const uint32_t aNbSolids = static_cast<uint32_t>(aCS.SolidRefIds.Size());
+        uint32_t       i         = aIdx;
+        for (; i < aNbSolids; ++i)
         {
-          const BRepGraph_SolidRefId aRefId = aCS.SolidRefIds.Value(i);
+          const BRepGraph_SolidRefId aRefId = aCS.SolidRefIds.Value(static_cast<size_t>(i));
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aRefId);
             if (myConfig.AccumulateOrientation)
@@ -417,26 +418,26 @@ void BRepGraph_ChildExplorer::advance()
       case Kind::Solid: {
         const BRepGraphInc::SolidDef& aSolid =
           aDefs.Solids().Definition(BRepGraph_SolidId(aFrame.Node));
-        const int aNbShells = aSolid.ShellRefIds.Length();
-        const int aNbFree   = aSolid.AuxChildRefIds.Length();
-        int       i         = aIdx;
+        const uint32_t aNbShells = static_cast<uint32_t>(aSolid.ShellRefIds.Size());
+        const uint32_t aNbFree   = static_cast<uint32_t>(aSolid.AuxChildRefIds.Size());
+        uint32_t       i         = aIdx;
         for (; i < aNbShells + aNbFree; ++i)
         {
           BRepGraph_RefId aRefId;
           if (i < aNbShells)
           {
-            aRefId = aSolid.ShellRefIds.Value(i);
+            aRefId = aSolid.ShellRefIds.Value(static_cast<size_t>(i));
           }
           else
           {
-            const int aFreeIdx = i - aNbShells;
-            aRefId             = aSolid.AuxChildRefIds.Value(aFreeIdx);
+            const uint32_t aFreeIdx = i - aNbShells;
+            aRefId                  = aSolid.AuxChildRefIds.Value(static_cast<size_t>(aFreeIdx));
           }
 
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aRefId);
             if (myConfig.AccumulateOrientation)
@@ -451,26 +452,26 @@ void BRepGraph_ChildExplorer::advance()
       case Kind::Shell: {
         const BRepGraphInc::ShellDef& aShell =
           aDefs.Shells().Definition(BRepGraph_ShellId(aFrame.Node));
-        const int aNbFaces = aShell.FaceRefIds.Length();
-        const int aNbFree  = aShell.AuxChildRefIds.Length();
-        int       i        = aIdx;
+        const uint32_t aNbFaces = static_cast<uint32_t>(aShell.FaceRefIds.Size());
+        const uint32_t aNbFree  = static_cast<uint32_t>(aShell.AuxChildRefIds.Size());
+        uint32_t       i        = aIdx;
         for (; i < aNbFaces + aNbFree; ++i)
         {
           BRepGraph_RefId aRefId;
           if (i < aNbFaces)
           {
-            aRefId = aShell.FaceRefIds.Value(i);
+            aRefId = aShell.FaceRefIds.Value(static_cast<size_t>(i));
           }
           else
           {
-            const int aFreeIdx = i - aNbFaces;
-            aRefId             = aShell.AuxChildRefIds.Value(aFreeIdx);
+            const uint32_t aFreeIdx = i - aNbFaces;
+            aRefId                  = aShell.AuxChildRefIds.Value(static_cast<size_t>(aFreeIdx));
           }
 
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aRefId);
             if (myConfig.AccumulateOrientation)
@@ -485,26 +486,26 @@ void BRepGraph_ChildExplorer::advance()
       case Kind::Face: {
         const BRepGraphInc::FaceDef& aFace =
           aDefs.Faces().Definition(BRepGraph_FaceId(aFrame.Node));
-        const int aNbWires = aFace.WireRefIds.Length();
-        const int aNbVerts = aFace.VertexRefIds.Length();
-        int       i        = aIdx;
+        const uint32_t aNbWires = static_cast<uint32_t>(aFace.WireRefIds.Size());
+        const uint32_t aNbVerts = static_cast<uint32_t>(aFace.VertexRefIds.Size());
+        uint32_t       i        = aIdx;
         for (; i < aNbWires + aNbVerts; ++i)
         {
           BRepGraph_RefId aRefId;
           if (i < aNbWires)
           {
-            aRefId = aFace.WireRefIds.Value(i);
+            aRefId = aFace.WireRefIds.Value(static_cast<size_t>(i));
           }
           else
           {
-            const int aVIdx = i - aNbWires;
-            aRefId          = aFace.VertexRefIds.Value(aVIdx);
+            const uint32_t aVIdx = i - aNbWires;
+            aRefId               = aFace.VertexRefIds.Value(static_cast<size_t>(aVIdx));
           }
 
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aRefId);
             if (myConfig.AccumulateOrientation)
@@ -519,14 +520,16 @@ void BRepGraph_ChildExplorer::advance()
       case Kind::Wire: {
         const BRepGraphInc::WireDef& aWire =
           aDefs.Wires().Definition(BRepGraph_WireId(aFrame.Node));
-        int i = aIdx;
-        for (; i < aWire.CoEdgeRefIds.Length(); ++i)
+        const uint32_t aNbCoEdges = static_cast<uint32_t>(aWire.CoEdgeRefIds.Size());
+        uint32_t       i          = aIdx;
+        for (; i < aNbCoEdges; ++i)
         {
-          const BRepGraph_CoEdgeRefId aRefId = aWire.CoEdgeRefIds.Value(i);
+          const BRepGraph_CoEdgeRefId aRefId =
+            aWire.CoEdgeRefIds.Value(static_cast<size_t>(i));
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aRefId);
             if (myConfig.AccumulateOrientation)
@@ -542,9 +545,9 @@ void BRepGraph_ChildExplorer::advance()
         const BRepGraphInc::EdgeDef& anEdge =
           aDefs.Edges().Definition(BRepGraph_EdgeId(aFrame.Node));
         // Virtual concatenation: 0=Start, 1=End, 2+=Internal.
-        const int aNbIntern = anEdge.InternalVertexRefIds.Length();
-        const int aNbTotal  = 2 + aNbIntern;
-        int       i         = aIdx;
+        const uint32_t aNbIntern = static_cast<uint32_t>(anEdge.InternalVertexRefIds.Size());
+        const uint32_t aNbTotal  = 2 + aNbIntern;
+        uint32_t       i         = aIdx;
         for (; i < aNbTotal; ++i)
         {
           BRepGraph_VertexRefId aVRefId;
@@ -553,7 +556,7 @@ void BRepGraph_ChildExplorer::advance()
           else if (i == 1)
             aVRefId = anEdge.EndVertexRefId;
           else
-            aVRefId = anEdge.InternalVertexRefIds.Value(i - 2);
+            aVRefId = anEdge.InternalVertexRefIds.Value(static_cast<size_t>(i - 2));
 
           if (!aVRefId.IsValid())
           {
@@ -562,7 +565,7 @@ void BRepGraph_ChildExplorer::advance()
           if (!aRefs.IsRemoved(aVRefId))
           {
             aChildNode = aRefs.ChildNode(aVRefId);
-            aStepIdx   = i;
+            aStepIdx   = static_cast<int>(i);
             if (myConfig.AccumulateLocation)
               aChildLoc = aFrame.AccLocation * aRefs.LocalLocation(aVRefId);
             if (myConfig.AccumulateOrientation)
@@ -626,13 +629,14 @@ void BRepGraph_ChildExplorer::advance()
       case Kind::Product: {
         // All product children (shape roots and sub-products) go through occurrences.
         const BRepGraph_ProductId aProdId(aFrame.Node);
-        const int                 aNbComps = myGraph->Topo().Products().NbComponents(aProdId);
+        const uint32_t            aNbComps =
+          static_cast<uint32_t>(myGraph->Topo().Products().NbComponents(aProdId));
         if (aIdx < aNbComps)
         {
           const BRepGraph_OccurrenceId anOccId =
-            myGraph->Topo().Products().Component(aProdId, aIdx);
+            myGraph->Topo().Products().Component(aProdId, static_cast<int>(aIdx));
           aChildNode = anOccId;
-          aStepIdx   = aIdx;
+          aStepIdx   = static_cast<int>(aIdx);
         }
         aFrame.NextChildIdx = aIdx + 1;
         break;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ChildExplorer.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ChildExplorer.cxx
@@ -355,8 +355,8 @@ void BRepGraph_ChildExplorer::advance()
 
   while (myStackTop >= 0)
   {
-    StackFrame&      aFrame = topFrame();
-    const uint32_t   aIdx   = aFrame.NextChildIdx;
+    StackFrame&    aFrame = topFrame();
+    const uint32_t aIdx   = aFrame.NextChildIdx;
 
     // Per-kind child iteration.
     // Each branch either yields a child (with step, loc, ori) and increments NextChildIdx,
@@ -524,8 +524,7 @@ void BRepGraph_ChildExplorer::advance()
         uint32_t       i          = aIdx;
         for (; i < aNbCoEdges; ++i)
         {
-          const BRepGraph_CoEdgeRefId aRefId =
-            aWire.CoEdgeRefIds.Value(static_cast<size_t>(i));
+          const BRepGraph_CoEdgeRefId aRefId = aWire.CoEdgeRefIds.Value(static_cast<size_t>(i));
           if (!aRefs.IsRemoved(aRefId))
           {
             aChildNode = aRefs.ChildNode(aRefId);

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ChildExplorer.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ChildExplorer.hxx
@@ -262,7 +262,7 @@ private:
   struct StackFrame
   {
     BRepGraph_NodeId   Node;
-    int                NextChildIdx   = 0;
+    uint32_t           NextChildIdx   = 0;
     int                StepFromParent = -1;
     TopLoc_Location    AccLocation;
     TopAbs_Orientation AccOrientation = TopAbs_FORWARD;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
@@ -1120,9 +1120,11 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
     // Overwrite entries that have a mapping from the old graph.
     for (const auto& [anOldId, aNewId] : theMap.Items())
     {
-      if (anOldId.IsValidIn(theOldVec) && theOldVec.Value(static_cast<size_t>(anOldId.Index)).IsValid())
+      if (anOldId.IsValidIn(theOldVec)
+          && theOldVec.Value(static_cast<size_t>(anOldId.Index)).IsValid())
       {
-        theNewVec.ChangeValue(static_cast<size_t>(aNewId.Index)) = theOldVec.Value(static_cast<size_t>(anOldId.Index));
+        theNewVec.ChangeValue(static_cast<size_t>(aNewId.Index)) =
+          theOldVec.Value(static_cast<size_t>(anOldId.Index));
       }
     }
   };
@@ -1133,9 +1135,11 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
                              NCollection_Vector<BRepGraph_RefUID>&       theNewVec) {
     for (const auto& [anOldId, aNewId] : theMap.Items())
     {
-      if (anOldId.IsValidIn(theOldVec) && theOldVec.Value(static_cast<size_t>(anOldId.Index)).IsValid())
+      if (anOldId.IsValidIn(theOldVec)
+          && theOldVec.Value(static_cast<size_t>(anOldId.Index)).IsValid())
       {
-        theNewVec.ChangeValue(static_cast<size_t>(aNewId.Index)) = theOldVec.Value(static_cast<size_t>(anOldId.Index));
+        theNewVec.ChangeValue(static_cast<size_t>(aNewId.Index)) =
+          theOldVec.Value(static_cast<size_t>(anOldId.Index));
       }
     }
   };

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
@@ -44,7 +44,7 @@ void collectReachableNodesFromRootProducts(const BRepGraph&                   th
   for (BRepGraph_RootProductIterator aRootIt(theGraph); aRootIt.More(); aRootIt.Next())
   {
     const BRepGraph_ProductId aRootProductId = aRootIt.Current();
-    const int                 aRootNb        = theGraph.Topo().Products().Nb();
+    const uint32_t            aRootNb        = theGraph.Topo().Products().Nb();
     if (!aRootProductId.IsValid(aRootNb))
     {
       continue;
@@ -509,7 +509,7 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
 
     const NCollection_Vector<BRepGraph_CoEdgeRefId>& aNewCoEdgeRefs =
       aNewGraph.Topo().Wires().Definition(aNewWireId).CoEdgeRefIds;
-    for (int aRefIdx = 0; aRefIdx < anOldCoEdgeRefs.Length() && aRefIdx < aNewCoEdgeRefs.Length();
+    for (size_t aRefIdx = 0; aRefIdx < anOldCoEdgeRefs.Size() && aRefIdx < aNewCoEdgeRefs.Size();
          ++aRefIdx)
     {
       const BRepGraphInc::CoEdgeRef& anOldRef =
@@ -585,8 +585,8 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
       aWireRefMap.Bind(anOldOuterWireRef, aNewWireRefs.First());
     }
 
-    for (int anInnerIdx = 0;
-         anInnerIdx < anOldInnerWireRefs.Length() && anInnerIdx + 1 < aNewWireRefs.Length();
+    for (size_t anInnerIdx = 0;
+         anInnerIdx < anOldInnerWireRefs.Size() && anInnerIdx + 1 < aNewWireRefs.Size();
          ++anInnerIdx)
     {
       const BRepGraphInc::WireRef& anOldInnerRef =
@@ -838,7 +838,7 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
     {
       const NCollection_Vector<BRepGraph_ChildRefId>& aNewChildRefs =
         aNewGraph.Topo().Compounds().Definition(aNewCompoundId).ChildRefIds;
-      for (int aRefIdx = 0; aRefIdx < anOldChildRefs.Length() && aRefIdx < aNewChildRefs.Length();
+      for (size_t aRefIdx = 0; aRefIdx < anOldChildRefs.Size() && aRefIdx < aNewChildRefs.Size();
            ++aRefIdx)
       {
         const BRepGraphInc::ChildRef& anOldRef =
@@ -879,7 +879,7 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
     {
       const NCollection_Vector<BRepGraph_SolidRefId>& aNewSolidRefs =
         aNewGraph.Topo().CompSolids().Definition(aNewCompSolidId).SolidRefIds;
-      for (int aRefIdx = 0; aRefIdx < anOldSolidRefs.Length() && aRefIdx < aNewSolidRefs.Length();
+      for (size_t aRefIdx = 0; aRefIdx < anOldSolidRefs.Size() && aRefIdx < aNewSolidRefs.Size();
            ++aRefIdx)
       {
         const BRepGraphInc::SolidRef& anOldRef =
@@ -1120,9 +1120,9 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
     // Overwrite entries that have a mapping from the old graph.
     for (const auto& [anOldId, aNewId] : theMap.Items())
     {
-      if (anOldId.IsValidIn(theOldVec) && theOldVec.Value(anOldId.Index).IsValid())
+      if (anOldId.IsValidIn(theOldVec) && theOldVec.Value(static_cast<size_t>(anOldId.Index)).IsValid())
       {
-        theNewVec.ChangeValue(aNewId.Index) = theOldVec.Value(anOldId.Index);
+        theNewVec.ChangeValue(static_cast<size_t>(aNewId.Index)) = theOldVec.Value(static_cast<size_t>(anOldId.Index));
       }
     }
   };
@@ -1133,9 +1133,9 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
                              NCollection_Vector<BRepGraph_RefUID>&       theNewVec) {
     for (const auto& [anOldId, aNewId] : theMap.Items())
     {
-      if (anOldId.IsValidIn(theOldVec) && theOldVec.Value(anOldId.Index).IsValid())
+      if (anOldId.IsValidIn(theOldVec) && theOldVec.Value(static_cast<size_t>(anOldId.Index)).IsValid())
       {
-        theNewVec.ChangeValue(aNewId.Index) = theOldVec.Value(anOldId.Index);
+        theNewVec.ChangeValue(static_cast<size_t>(aNewId.Index)) = theOldVec.Value(static_cast<size_t>(anOldId.Index));
       }
     }
   };

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Copy.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Copy.cxx
@@ -334,7 +334,7 @@ BRepGraph BRepGraph_Copy::Perform(const BRepGraph& theGraph, const bool theCopyG
   // Phase 3: Transfer UIDs (identity mapping - direct vector copy).
   auto copyUIDs = [](const NCollection_Vector<BRepGraph_UID>& theSrc,
                      NCollection_Vector<BRepGraph_UID>&       theDst) {
-    NCollection_Vector<BRepGraph_UID>::Iterator       aDstIt(theDst);
+    NCollection_Vector<BRepGraph_UID>::Iterator aDstIt(theDst);
     NCollection_Vector<BRepGraph_UID>::Iterator anSrcIt(theSrc);
     for (; anSrcIt.More() && aDstIt.More(); anSrcIt.Next(), aDstIt.Next())
     {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Copy.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Copy.cxx
@@ -334,11 +334,12 @@ BRepGraph BRepGraph_Copy::Perform(const BRepGraph& theGraph, const bool theCopyG
   // Phase 3: Transfer UIDs (identity mapping - direct vector copy).
   auto copyUIDs = [](const NCollection_Vector<BRepGraph_UID>& theSrc,
                      NCollection_Vector<BRepGraph_UID>&       theDst) {
-    const int aNbToCopy = std::min(theSrc.Length(), theDst.Length());
-    for (int anIdx = 0; anIdx < aNbToCopy; ++anIdx)
+    NCollection_Vector<BRepGraph_UID>::Iterator       aDstIt(theDst);
+    NCollection_Vector<BRepGraph_UID>::Iterator anSrcIt(theSrc);
+    for (; anSrcIt.More() && aDstIt.More(); anSrcIt.Next(), aDstIt.Next())
     {
-      if (theSrc.Value(anIdx).IsValid())
-        theDst.ChangeValue(anIdx) = theSrc.Value(anIdx);
+      if (anSrcIt.Value().IsValid())
+        aDstIt.ChangeValue() = anSrcIt.Value();
     }
   };
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Deduplicate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Deduplicate.cxx
@@ -213,7 +213,7 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
     const double aTol = theOptions.HashTolerance;
 
     // Collect active vertices: (point, graph id) pairs.
-    const int aNbVertices = theGraph.Topo().Vertices().Nb();
+    const uint32_t aNbVertices = theGraph.Topo().Vertices().Nb();
     NCollection_Vector<std::pair<gp_Pnt, BRepGraph_VertexId>> aActiveVertices(256, aTmpAlloc);
     for (BRepGraph_FullVertexIterator aVertexIt(theGraph); aVertexIt.More(); aVertexIt.Next())
     {
@@ -226,10 +226,11 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
     }
 
     // Build KDTree from active vertex points - O(n log n).
-    const int                  aNbActive = aActiveVertices.Length();
+    const int                  aNbActive = static_cast<int>(aActiveVertices.Size());
     NCollection_Array1<gp_Pnt> aPointsArr(0, std::max(0, aNbActive - 1));
-    for (int i = 0; i < aNbActive; ++i)
-      aPointsArr.SetValue(i, aActiveVertices.Value(i).first);
+    int i = 0;
+    for (const auto& aVertex : aActiveVertices)
+      aPointsArr.SetValue(i++, aVertex.first);
 
     NCollection_KDTree<gp_Pnt, 3> aTree;
     if (!aPointsArr.IsEmpty())
@@ -237,10 +238,10 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
 
     // Canonical vertex map: old graph id -> canonical graph id.
     NCollection_DataMap<BRepGraph_VertexId, BRepGraph_VertexId> aCanonicalVertex(
-      std::max(1, aNbVertices),
+      static_cast<size_t>(std::max(1u, aNbVertices)),
       aTmpAlloc);
 
-    for (int aLocalIdx = 0; aLocalIdx < aNbActive; ++aLocalIdx)
+    for (size_t aLocalIdx = 0; aLocalIdx < aActiveVertices.Size(); ++aLocalIdx)
     {
       const BRepGraph_VertexId aBaseVtxId = aActiveVertices.Value(aLocalIdx).second;
       if (aCanonicalVertex.IsBound(aBaseVtxId))
@@ -250,7 +251,7 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
       const double aBaseVtxTol = BRepGraph_Tool::Vertex::Tolerance(theGraph, aBaseVtxId);
 
       aTree.ForEachInRange(aBaseVtxPnt, aTol, [&](size_t theResultIdx) {
-        const int anArrayIdx = static_cast<int>(theResultIdx) - 1;
+        const size_t anArrayIdx = theResultIdx - 1;
         if (anArrayIdx <= aLocalIdx)
           return; // skip self and already-processed
 
@@ -412,13 +413,13 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
          aGroupIter.Next())
     {
       const NCollection_Vector<BRepGraph_EdgeId>& aGroup = aGroupIter.Value();
-      if (aGroup.Length() < 2)
+      if (aGroup.Size() < 2)
         continue;
 
       const BRepGraph_EdgeId       aCanonEdgeId = aGroup.Value(0);
       const BRepGraphInc::EdgeDef& aCanonEdge   = theGraph.Topo().Edges().Definition(aCanonEdgeId);
 
-      for (int aCandIter = 1; aCandIter < aGroup.Length(); ++aCandIter)
+      for (size_t aCandIter = 1; aCandIter < aGroup.Size(); ++aCandIter)
       {
         const BRepGraph_EdgeId       aCandEdgeId = aGroup.Value(aCandIter);
         const BRepGraphInc::EdgeDef& aCandEdge   = theGraph.Topo().Edges().Definition(aCandEdgeId);
@@ -462,12 +463,9 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
         // Replace in wires.
         const NCollection_Vector<BRepGraph_WireId>& aWires =
           theGraph.Topo().Edges().Wires(anOldEdgeId);
-        for (int aWireIter = 0; aWireIter < aWires.Length(); ++aWireIter)
+        for (const BRepGraph_WireId& aWireId : aWires)
         {
-          theGraph.Editor().Wires().ReplaceEdge(aWires.Value(aWireIter),
-                                                anOldEdgeId,
-                                                aCanonEdgeId,
-                                                isReversed);
+          theGraph.Editor().Wires().ReplaceEdge(aWireId, anOldEdgeId, aCanonEdgeId, isReversed);
         }
 
         // ReplaceEdge() above rebinds all CoEdgeDef.EdgeDefId entries from anOldEdgeId
@@ -524,14 +522,16 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
         aWireBCoEdges.Append(theGraph.Refs().CoEdges().Entry(aCEIt.CurrentId()).CoEdgeDefId);
       }
 
-      if (aWireACoEdges.Length() != aWireBCoEdges.Length())
+      if (aWireACoEdges.Size() != aWireBCoEdges.Size())
         return false;
-      for (int anIdx = 0; anIdx < aWireACoEdges.Length(); ++anIdx)
+      NCollection_Vector<BRepGraph_CoEdgeId>::Iterator anItA(aWireACoEdges);
+      NCollection_Vector<BRepGraph_CoEdgeId>::Iterator anItB(aWireBCoEdges);
+      for (; anItA.More(); anItA.Next(), anItB.Next())
       {
         const BRepGraphInc::CoEdgeDef& aCoEdgeA =
-          theGraph.Topo().CoEdges().Definition(aWireACoEdges.Value(anIdx));
+          theGraph.Topo().CoEdges().Definition(anItA.Value());
         const BRepGraphInc::CoEdgeDef& aCoEdgeB =
-          theGraph.Topo().CoEdges().Definition(aWireBCoEdges.Value(anIdx));
+          theGraph.Topo().CoEdges().Definition(anItB.Value());
         if (aCoEdgeA.EdgeDefId != aCoEdgeB.EdgeDefId
             || aCoEdgeA.Orientation != aCoEdgeB.Orientation)
           return false;
@@ -565,13 +565,13 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
          aBucketIter.Next())
     {
       const NCollection_Vector<BRepGraph_WireId>& aBucket = aBucketIter.Value();
-      for (int aBaseIdx = 0; aBaseIdx < aBucket.Length(); ++aBaseIdx)
+      for (size_t aBaseIdx = 0; aBaseIdx < aBucket.Size(); ++aBaseIdx)
       {
         const BRepGraph_WireId aBaseWireId = aBucket.Value(aBaseIdx);
         if (aCanonicalWire.IsBound(aBaseWireId))
           continue;
 
-        for (int aCandIdx = aBaseIdx + 1; aCandIdx < aBucket.Length(); ++aCandIdx)
+        for (size_t aCandIdx = aBaseIdx + 1; aCandIdx < aBucket.Size(); ++aCandIdx)
         {
           const BRepGraph_WireId aCandWireId = aBucket.Value(aCandIdx);
           if (aCanonicalWire.IsBound(aCandWireId))
@@ -604,10 +604,9 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
             continue;
           }
 
-          for (int aWireRefIdx = 0; aWireRefIdx < aFaceDef.WireRefIds.Length(); ++aWireRefIdx)
+          for (const BRepGraph_WireRefId& aWireRefId : aFaceDef.WireRefIds)
           {
-            const BRepGraph_WireRefId    aWireRefId = aFaceDef.WireRefIds.Value(aWireRefIdx);
-            const BRepGraphInc::WireRef& aWireRef   = theGraph.Refs().Wires().Entry(aWireRefId);
+            const BRepGraphInc::WireRef& aWireRef = theGraph.Refs().Wires().Entry(aWireRefId);
             if (!aWireRef.IsRemoved && aWireRef.WireDefId == anOldWireId)
             {
               BRepGraph_MutGuard<BRepGraphInc::WireRef> aMutWireRef =
@@ -738,13 +737,13 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
          aGroupIter.Next())
     {
       const NCollection_Vector<BRepGraph_FaceId>& aGroup = aGroupIter.Value();
-      if (aGroup.Length() < 2)
+      if (aGroup.Size() < 2)
         continue;
 
       const BRepGraph_FaceId       aCanonFaceId = aGroup.Value(0);
       const BRepGraphInc::FaceDef& aCanonFace   = theGraph.Topo().Faces().Definition(aCanonFaceId);
 
-      for (int aCandIter = 1; aCandIter < aGroup.Length(); ++aCandIter)
+      for (size_t aCandIter = 1; aCandIter < aGroup.Size(); ++aCandIter)
       {
         const BRepGraph_FaceId       aCandFaceId = aGroup.Value(aCandIter);
         const BRepGraphInc::FaceDef& aCandFace   = theGraph.Topo().Faces().Definition(aCandFaceId);

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Deduplicate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Deduplicate.cxx
@@ -228,7 +228,7 @@ BRepGraph_Deduplicate::Result BRepGraph_Deduplicate::Perform(BRepGraph&     theG
     // Build KDTree from active vertex points - O(n log n).
     const int                  aNbActive = static_cast<int>(aActiveVertices.Size());
     NCollection_Array1<gp_Pnt> aPointsArr(0, std::max(0, aNbActive - 1));
-    int i = 0;
+    int                        i = 0;
     for (const auto& aVertex : aActiveVertices)
       aPointsArr.SetValue(i++, aVertex.first);
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_DefsIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_DefsIterator.hxx
@@ -462,7 +462,7 @@ public:
     }
 
     myRefIds = &TraitsT::RefIds(theGraph, theParent);
-    myLength = myRefIds->Length();
+    myLength = static_cast<uint32_t>(myRefIds->Size());
     skipRemoved();
   }
 
@@ -476,12 +476,12 @@ public:
 
   [[nodiscard]] ChildId CurrentId() const
   {
-    return TraitsT::ChildIdOf(myGraph, TraitsT::Ref(myGraph, myRefIds->Value(myIndex)));
+    return TraitsT::ChildIdOf(myGraph, TraitsT::Ref(myGraph, myRefIds->Value(static_cast<size_t>(myIndex))));
   }
 
   [[nodiscard]] const ChildDef& Current() const { return TraitsT::Child(myGraph, CurrentId()); }
 
-  [[nodiscard]] int Index() const { return myIndex; }
+  [[nodiscard]] uint32_t Index() const { return myIndex; }
 
   //! Returns an STL-compatible iterator for range-based for loops.
   NCollection_ForwardRangeIterator<DefsOfParent> begin()
@@ -497,7 +497,8 @@ private:
   {
     while (myRefIds != nullptr && myIndex < myLength)
     {
-      const typename TraitsT::RefEntry& aRef = TraitsT::Ref(myGraph, myRefIds->Value(myIndex));
+      const typename TraitsT::RefEntry& aRef =
+        TraitsT::Ref(myGraph, myRefIds->Value(static_cast<size_t>(myIndex)));
       if (!aRef.IsRemoved)
       {
         const BRepGraphInc::BaseDef* aChildDef =
@@ -513,8 +514,8 @@ private:
 
   const BRepGraph&                 myGraph;
   const NCollection_Vector<RefId>* myRefIds = nullptr;
-  int                              myIndex  = 0;
-  int                              myLength = 0;
+  uint32_t                         myIndex  = 0;
+  uint32_t                         myLength = 0;
 };
 
 //! @brief Direct active vertex children of an edge.
@@ -536,7 +537,7 @@ public:
     }
 
     myEdge   = &theGraph.Topo().Edges().Definition(theEdgeId);
-    myLength = 2 + myEdge->InternalVertexRefIds.Length();
+    myLength = 2u + static_cast<uint32_t>(myEdge->InternalVertexRefIds.Size());
     skipRemoved();
   }
 
@@ -558,7 +559,7 @@ public:
     return myGraph.Topo().Vertices().Definition(CurrentId());
   }
 
-  [[nodiscard]] int Index() const { return myIndex; }
+  [[nodiscard]] uint32_t Index() const { return myIndex; }
 
   //! Returns an STL-compatible iterator for range-based for loops.
   NCollection_ForwardRangeIterator<DefsVertexOfEdge> begin()
@@ -570,7 +571,7 @@ public:
   NCollection_ForwardRangeSentinel end() const { return NCollection_ForwardRangeSentinel{}; }
 
 private:
-  [[nodiscard]] BRepGraph_VertexRefId refIdAt(const int theIndex) const
+  [[nodiscard]] BRepGraph_VertexRefId refIdAt(const uint32_t theIndex) const
   {
     if (theIndex == 0)
     {
@@ -580,7 +581,7 @@ private:
     {
       return myEdge->EndVertexRefId;
     }
-    return myEdge->InternalVertexRefIds.Value(theIndex - 2);
+    return myEdge->InternalVertexRefIds.Value(static_cast<size_t>(theIndex - 2));
   }
 
   [[nodiscard]] BRepGraph_VertexRefId currentRefId() const { return refIdAt(myIndex); }
@@ -609,8 +610,8 @@ private:
 
   const BRepGraph&             myGraph;
   const BRepGraphInc::EdgeDef* myEdge   = nullptr;
-  int                          myIndex  = 0;
-  int                          myLength = 0;
+  uint32_t                     myIndex  = 0;
+  uint32_t                     myLength = 0;
 };
 
 } // namespace BRepGraph_DefsIterator

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_DefsIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_DefsIterator.hxx
@@ -476,7 +476,8 @@ public:
 
   [[nodiscard]] ChildId CurrentId() const
   {
-    return TraitsT::ChildIdOf(myGraph, TraitsT::Ref(myGraph, myRefIds->Value(static_cast<size_t>(myIndex))));
+    return TraitsT::ChildIdOf(myGraph,
+                              TraitsT::Ref(myGraph, myRefIds->Value(static_cast<size_t>(myIndex))));
   }
 
   [[nodiscard]] const ChildDef& Current() const { return TraitsT::Child(myGraph, CurrentId()); }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
@@ -1263,7 +1263,8 @@ void BRepGraph::EditorView::GenOps::RemoveSubgraph(const BRepGraph_NodeId theNod
         // Detach from parent product's OccurrenceRefIds.
         // Find the parent product by scanning OccurrenceRefs.
         for (BRepGraph_OccurrenceRefId aOccRefId = myGraph->Refs().Occurrences().StartId();
-             aOccRefId < myGraph->Refs().Occurrences().EndId(); ++aOccRefId)
+             aOccRefId < myGraph->Refs().Occurrences().EndId();
+             ++aOccRefId)
         {
           const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aOccRefId);
           if (aRef.IsRemoved || aRef.OccurrenceDefId != theNode)
@@ -1276,8 +1277,7 @@ void BRepGraph::EditorView::GenOps::RemoveSubgraph(const BRepGraph_NodeId theNod
           NCollection_Vector<BRepGraph_OccurrenceRefId>& aRefIds =
             myGraph->myData->myIncStorage.ChangeProduct(aParentProduct).OccurrenceRefIds;
           uint32_t anIdx = 0;
-          for (NCollection_Vector<BRepGraph_OccurrenceRefId>::Iterator anIt(aRefIds);
-               anIt.More();
+          for (NCollection_Vector<BRepGraph_OccurrenceRefId>::Iterator anIt(aRefIds); anIt.More();
                anIt.Next(), ++anIdx)
           {
             if (anIt.Value() == aOccRefId)
@@ -1641,7 +1641,8 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
         // Occurrence modifications propagate to the parent product.
         // Find the parent product via OccurrenceRef.ParentId.
         for (BRepGraph_OccurrenceRefId aOccRefId = myGraph->Refs().Occurrences().StartId();
-             aOccRefId < myGraph->Refs().Occurrences().EndId(); ++aOccRefId)
+             aOccRefId < myGraph->Refs().Occurrences().EndId();
+             ++aOccRefId)
         {
           const BRepGraphInc::OccurrenceRef& aRef =
             myGraph->myData->myIncStorage.OccurrenceRef(aOccRefId);
@@ -1763,12 +1764,12 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
   // Allocate SubA slot.
   const BRepGraph_EdgeId aSubAId(aMutStorage.NbEdges());
   aMutStorage.AppendEdge();
-  theSubA            = aSubAId;
+  theSubA = aSubAId;
 
   // Allocate SubB slot (note: Appended() may invalidate aSubADef reference - use index).
   const BRepGraph_EdgeId aSubBId(aMutStorage.NbEdges());
   aMutStorage.AppendEdge();
-  theSubB            = aSubBId;
+  theSubB = aSubBId;
 
   // Build vertex ref entries for the split vertex (no Location since split vertex is new).
   const BRepGraph_VertexId aSplitVertexDefId = theSplitVertex;
@@ -1787,10 +1788,10 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     const BRepGraph_VertexRefId aSubAStartRefId2(aMutStorage.NbVertexRefs());
     aMutStorage.AppendVertexRef();
     BRepGraphInc::VertexRef& aSubAStartRef = aMutStorage.ChangeVertexRef(aSubAStartRefId2);
-    aSubAStartRef.ParentId      = BRepGraph_NodeId(aSubAId);
-    aSubAStartRef.VertexDefId   = aOrigStartVertexId;
-    aSubAStartRef.Orientation   = aOrigStartOri;
-    aSubAStartRef.LocalLocation = aOrigStartLoc;
+    aSubAStartRef.ParentId                 = BRepGraph_NodeId(aSubAId);
+    aSubAStartRef.VertexDefId              = aOrigStartVertexId;
+    aSubAStartRef.Orientation              = aOrigStartOri;
+    aSubAStartRef.LocalLocation            = aOrigStartLoc;
     myGraph->allocateRefUID(aSubAStartRefId2);
     aSubAStartRefId = aSubAStartRefId2;
   }
@@ -1816,9 +1817,9 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     const BRepGraph_VertexRefId aSubBStartRefId2(aMutStorage.NbVertexRefs());
     aMutStorage.AppendVertexRef();
     BRepGraphInc::VertexRef& aSubBStartRef = aMutStorage.ChangeVertexRef(aSubBStartRefId2);
-    aSubBStartRef.ParentId    = BRepGraph_NodeId(aSubBId);
-    aSubBStartRef.VertexDefId = aSplitVertexDefId;
-    aSubBStartRef.Orientation = TopAbs_FORWARD;
+    aSubBStartRef.ParentId                 = BRepGraph_NodeId(aSubBId);
+    aSubBStartRef.VertexDefId              = aSplitVertexDefId;
+    aSubBStartRef.Orientation              = TopAbs_FORWARD;
     myGraph->allocateRefUID(aSubBStartRefId2);
     aSubBStartRefId = aSubBStartRefId2;
   }
@@ -1847,8 +1848,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
 
   // Set SubA: StartVertex -> SplitVertex, [ParamFirst, theSplitParam].
   {
-    BRepGraphInc::EdgeDef& aSubA =
-      myGraph->myData->myIncStorage.ChangeEdge(aSubAId);
+    BRepGraphInc::EdgeDef& aSubA = myGraph->myData->myIncStorage.ChangeEdge(aSubAId);
     initSubEdgeEntity(aSubA,
                       aOrigCurve3DRepId,
                       aOrigTolerance,
@@ -1861,8 +1861,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
 
   // Set SubB: SplitVertex -> EndVertex, [theSplitParam, ParamLast].
   {
-    BRepGraphInc::EdgeDef& aSubB =
-      myGraph->myData->myIncStorage.ChangeEdge(aSubBId);
+    BRepGraphInc::EdgeDef& aSubB = myGraph->myData->myIncStorage.ChangeEdge(aSubBId);
     initSubEdgeEntity(aSubB,
                       aOrigCurve3DRepId,
                       aOrigTolerance,
@@ -1982,8 +1981,10 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
         continue;
       int aJ = -1;
       aIdxOf.Find(aOldSeamPair, aJ);
-      aStorage.ChangeCoEdge(aNewACoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId = aNewACoEdgeIds.Value(aJ);
-      aStorage.ChangeCoEdge(aNewBCoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId = aNewBCoEdgeIds.Value(aJ);
+      aStorage.ChangeCoEdge(aNewACoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId =
+        aNewACoEdgeIds.Value(aJ);
+      aStorage.ChangeCoEdge(aNewBCoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId =
+        aNewBCoEdgeIds.Value(aJ);
     }
 
     // Step 4: rebuild wire CoEdgeRefIds (snapshot-before-mutate). For each

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
@@ -109,26 +109,32 @@ bool hasAnyActiveUsage(const BRepGraph& theGraph, const BRepGraph_NodeId theChil
 }
 
 template <typename RefIdT>
-int findOrderedRefIndex(const NCollection_Vector<RefIdT>& theRefIds, const RefIdT theRefId)
+RefIdT findOrderedRef(const NCollection_Vector<RefIdT>& theRefIds, const RefIdT theRefId)
 {
-  for (int anIndex = 0; anIndex < theRefIds.Length(); ++anIndex)
+  for (typename NCollection_Vector<RefIdT>::Iterator anIt(theRefIds); anIt.More(); anIt.Next())
   {
-    if (theRefIds.Value(anIndex) == theRefId)
-    {
-      return anIndex;
-    }
+    if (anIt.Value() == theRefId)
+      return theRefId;
   }
-  return -1;
+  return RefIdT();
 }
 
 template <typename RefIdT>
-void eraseOrderedRef(const int theRefIndex, NCollection_Vector<RefIdT>& theRefIds)
+void eraseOrderedRef(const RefIdT theRefId, NCollection_Vector<RefIdT>& theRefIds)
 {
-  for (int anIndex = theRefIndex; anIndex < theRefIds.Length() - 1; ++anIndex)
+  uint32_t anIndex = 0;
+  for (typename NCollection_Vector<RefIdT>::Iterator anIt(theRefIds); anIt.More();
+       anIt.Next(), ++anIndex)
   {
-    theRefIds.ChangeValue(anIndex) = theRefIds.Value(anIndex + 1);
+    if (anIt.Value() == theRefId)
+    {
+      for (uint32_t i = anIndex; i < static_cast<uint32_t>(theRefIds.Size()) - 1u; ++i)
+        theRefIds.ChangeValue(static_cast<size_t>(i)) =
+          theRefIds.Value(static_cast<size_t>(i + 1u));
+      theRefIds.EraseLast();
+      return;
+    }
   }
-  theRefIds.EraseLast();
 }
 
 template <typename RefIdT>
@@ -138,8 +144,7 @@ bool detachOrderedParentRef(BRepGraph&                  theGraph,
                             const BRepGraph_NodeId      theChildNode,
                             const bool                  theToPruneOrphanedChild)
 {
-  const int aRefIndex = findOrderedRefIndex(theParentRefIds, theRefId);
-  if (aRefIndex < 0)
+  if (!findOrderedRef(theParentRefIds, theRefId).IsValid())
   {
     return false;
   }
@@ -149,7 +154,7 @@ bool detachOrderedParentRef(BRepGraph&                  theGraph,
     return false;
   }
 
-  eraseOrderedRef(aRefIndex, theParentRefIds);
+  eraseOrderedRef(theRefId, theParentRefIds);
 
   if (theToPruneOrphanedChild && theChildNode.IsValid()
       && !hasAnyActiveUsage(theGraph, theChildNode))
@@ -321,14 +326,14 @@ static void rebindCoEdgesForEdgeReplacement(BRepGraphInc_Storage&  theStorage,
 {
   const NCollection_Vector<BRepGraph_CoEdgeId>& aCoEdgeIdxs =
     theStorage.ReverseIndex().CoEdgesOfEdgeRef(theSourceEdgeId);
-  const int                                      aNbCoEdges = aCoEdgeIdxs.Length();
+  const uint32_t aNbCoEdges = static_cast<uint32_t>(aCoEdgeIdxs.Size());
   NCollection_LocalArray<BRepGraph_CoEdgeId, 16> aCoEdgeSnapshot(aNbCoEdges);
-  for (int aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
+  for (uint32_t aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
   {
-    aCoEdgeSnapshot[aCoEdgeIdx] = aCoEdgeIdxs.Value(aCoEdgeIdx);
+    aCoEdgeSnapshot[aCoEdgeIdx] = aCoEdgeIdxs.Value(static_cast<size_t>(aCoEdgeIdx));
   }
 
-  for (int aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
+  for (uint32_t aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
   {
     const BRepGraph_CoEdgeId aCoEdgeId = aCoEdgeSnapshot[aCoEdgeIdx];
     if (!aCoEdgeId.IsValid(theStorage.NbCoEdges()))
@@ -351,14 +356,14 @@ static void unbindCoEdgesOfRemovedEdge(BRepGraphInc_Storage&  theStorage,
 {
   const NCollection_Vector<BRepGraph_CoEdgeId>& aCoEdgeIdxs =
     theStorage.ReverseIndex().CoEdgesOfEdgeRef(theEdgeId);
-  const int                                      aNbCoEdges = aCoEdgeIdxs.Length();
+  const uint32_t aNbCoEdges = static_cast<uint32_t>(aCoEdgeIdxs.Size());
   NCollection_LocalArray<BRepGraph_CoEdgeId, 16> aCoEdgeSnapshot(aNbCoEdges);
-  for (int aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
+  for (uint32_t aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
   {
-    aCoEdgeSnapshot[aCoEdgeIdx] = aCoEdgeIdxs.Value(aCoEdgeIdx);
+    aCoEdgeSnapshot[aCoEdgeIdx] = aCoEdgeIdxs.Value(static_cast<size_t>(aCoEdgeIdx));
   }
 
-  for (int aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
+  for (uint32_t aCoEdgeIdx = 0; aCoEdgeIdx < aNbCoEdges; ++aCoEdgeIdx)
   {
     const BRepGraph_CoEdgeId aCoEdgeId = aCoEdgeSnapshot[aCoEdgeIdx];
     if (!aCoEdgeId.IsValid(theStorage.NbCoEdges()))
@@ -1257,10 +1262,10 @@ void BRepGraph::EditorView::GenOps::RemoveSubgraph(const BRepGraph_NodeId theNod
         }
         // Detach from parent product's OccurrenceRefIds.
         // Find the parent product by scanning OccurrenceRefs.
-        for (int aRefIdx = 0; aRefIdx < aStorage.NbOccurrenceRefs(); ++aRefIdx)
+        for (BRepGraph_OccurrenceRefId aOccRefId = myGraph->Refs().Occurrences().StartId();
+             aOccRefId < myGraph->Refs().Occurrences().EndId(); ++aOccRefId)
         {
-          const BRepGraphInc::OccurrenceRef& aRef =
-            aStorage.OccurrenceRef(BRepGraph_OccurrenceRefId(aRefIdx));
+          const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aOccRefId);
           if (aRef.IsRemoved || aRef.OccurrenceDefId != theNode)
             continue;
 
@@ -1270,13 +1275,17 @@ void BRepGraph::EditorView::GenOps::RemoveSubgraph(const BRepGraph_NodeId theNod
 
           NCollection_Vector<BRepGraph_OccurrenceRefId>& aRefIds =
             myGraph->myData->myIncStorage.ChangeProduct(aParentProduct).OccurrenceRefIds;
-          for (int i = 0; i < aRefIds.Length(); ++i)
+          uint32_t anIdx = 0;
+          for (NCollection_Vector<BRepGraph_OccurrenceRefId>::Iterator anIt(aRefIds);
+               anIt.More();
+               anIt.Next(), ++anIdx)
           {
-            if (aRefIds.Value(i).Index == aRefIdx)
+            if (anIt.Value() == aOccRefId)
             {
-              myGraph->myData->myIncStorage.MarkRemovedRef(BRepGraph_OccurrenceRefId(aRefIdx));
-              if (i < aRefIds.Length() - 1)
-                aRefIds.ChangeValue(i) = aRefIds.Value(aRefIds.Length() - 1);
+              myGraph->myData->myIncStorage.MarkRemovedRef(aOccRefId);
+              if (anIdx < static_cast<uint32_t>(aRefIds.Size()) - 1u)
+                aRefIds.ChangeValue(static_cast<size_t>(anIdx)) =
+                  aRefIds.Value(aRefIds.Size() - 1u);
               aRefIds.EraseLast();
               myGraph->markModified(aParentProduct);
               break;
@@ -1484,7 +1493,7 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
   static constexpr int     THE_KIND_COUNT = BRepGraph_NodeId::THE_KIND_COUNT;
   NCollection_Array1<bool> aVisArrays[THE_KIND_COUNT];
   {
-    const int aKindCounts[THE_KIND_COUNT] = {
+    const uint32_t aKindCounts[THE_KIND_COUNT] = {
       aStorage.NbSolids(),     // Kind::Solid      = 0
       aStorage.NbShells(),     // Kind::Shell      = 1
       aStorage.NbFaces(),      // Kind::Face       = 2
@@ -1494,16 +1503,16 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
       aStorage.NbCompounds(),  // Kind::Compound   = 6
       aStorage.NbCompSolids(), // Kind::CompSolid  = 7
       aStorage.NbCoEdges(),    // Kind::CoEdge     = 8
-      0,                       // gap at 9
+      0u,                      // gap at 9
       aStorage.NbProducts(),   // Kind::Product    = 10
       aStorage.NbOccurrences() // Kind::Occurrence = 11
     };
     for (int aKindIdx = 0; aKindIdx < THE_KIND_COUNT; ++aKindIdx)
     {
-      const int aCount = aKindCounts[aKindIdx];
+      const uint32_t aCount = aKindCounts[aKindIdx];
       if (aCount > 0)
       {
-        aVisArrays[aKindIdx].Resize(0, aCount - 1, false);
+        aVisArrays[aKindIdx].Resize(0, static_cast<int>(aCount) - 1, false);
         aVisArrays[aKindIdx].Init(false);
       }
     }
@@ -1513,11 +1522,11 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
   const auto markVisited = [&aVisArrays](const BRepGraph_NodeId theNode) -> bool {
     const int                 aKindIdx = static_cast<int>(theNode.NodeKind);
     NCollection_Array1<bool>& aArr     = aVisArrays[aKindIdx];
-    if (aArr.IsEmpty() || theNode.Index > aArr.Upper())
+    if (aArr.IsEmpty() || static_cast<int>(theNode.Index) > aArr.Upper())
       return false;
-    if (aArr.Value(theNode.Index))
+    if (aArr.Value(static_cast<int>(theNode.Index)))
       return false;
-    aArr.SetValue(theNode.Index, true);
+    aArr.SetValue(static_cast<int>(theNode.Index), true);
     return true;
   };
 
@@ -1525,7 +1534,7 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
   // newly discovered parents at the end. The loop index advances through
   // the growing vector, so each node is visited exactly once.
   NCollection_Vector<BRepGraph_NodeId> aAllModified;
-  aAllModified.SetIncrement(aDeferredList.Length() * 2);
+  aAllModified.SetIncrement(aDeferredList.Size() * 2);
   int aModifiedKindsMask = 0;
 
   // Seed with directly modified nodes.
@@ -1541,7 +1550,7 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
   // Propagate upward level by level.
   // Process the list from front to back; newly appended parents will be
   // reached in subsequent iterations of the same loop.
-  for (int i = 0; i < aAllModified.Length(); ++i)
+  for (size_t i = 0; i < aAllModified.Size(); ++i)
   {
     const BRepGraph_NodeId aNodeId = aAllModified.Value(i);
 
@@ -1631,10 +1640,11 @@ void BRepGraph::EditorView::EndDeferredInvalidation() noexcept
       case BRepGraph_NodeId::Kind::Occurrence: {
         // Occurrence modifications propagate to the parent product.
         // Find the parent product via OccurrenceRef.ParentId.
-        for (int aRefIdx = 0; aRefIdx < myGraph->myData->myIncStorage.NbOccurrenceRefs(); ++aRefIdx)
+        for (BRepGraph_OccurrenceRefId aOccRefId = myGraph->Refs().Occurrences().StartId();
+             aOccRefId < myGraph->Refs().Occurrences().EndId(); ++aOccRefId)
         {
           const BRepGraphInc::OccurrenceRef& aRef =
-            myGraph->myData->myIncStorage.OccurrenceRef(BRepGraph_OccurrenceRefId(aRefIdx));
+            myGraph->myData->myIncStorage.OccurrenceRef(aOccRefId);
           if (!aRef.IsRemoved && aRef.OccurrenceDefId == aNodeId)
           {
             const BRepGraph_NodeId aParentId = aRef.ParentId;
@@ -1753,13 +1763,11 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
   // Allocate SubA slot.
   const BRepGraph_EdgeId aSubAId(aMutStorage.NbEdges());
   aMutStorage.AppendEdge();
-  const int aSubAIdx = aSubAId.Index;
   theSubA            = aSubAId;
 
   // Allocate SubB slot (note: Appended() may invalidate aSubADef reference - use index).
   const BRepGraph_EdgeId aSubBId(aMutStorage.NbEdges());
   aMutStorage.AppendEdge();
-  const int aSubBIdx = aSubBId.Index;
   theSubB            = aSubBId;
 
   // Build vertex ref entries for the split vertex (no Location since split vertex is new).
@@ -1779,7 +1787,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     const BRepGraph_VertexRefId aSubAStartRefId2(aMutStorage.NbVertexRefs());
     aMutStorage.AppendVertexRef();
     BRepGraphInc::VertexRef& aSubAStartRef = aMutStorage.ChangeVertexRef(aSubAStartRefId2);
-    aSubAStartRef.ParentId      = BRepGraph_NodeId(BRepGraph_NodeId::Kind::Edge, aSubAIdx);
+    aSubAStartRef.ParentId      = BRepGraph_NodeId(aSubAId);
     aSubAStartRef.VertexDefId   = aOrigStartVertexId;
     aSubAStartRef.Orientation   = aOrigStartOri;
     aSubAStartRef.LocalLocation = aOrigStartLoc;
@@ -1794,7 +1802,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     const BRepGraph_VertexRefId aSubAEndRefId2(aMutStorage.NbVertexRefs());
     aMutStorage.AppendVertexRef();
     BRepGraphInc::VertexRef& aSubAEndRef = aMutStorage.ChangeVertexRef(aSubAEndRefId2);
-    aSubAEndRef.ParentId                 = BRepGraph_NodeId(BRepGraph_NodeId::Kind::Edge, aSubAIdx);
+    aSubAEndRef.ParentId                 = BRepGraph_NodeId(aSubAId);
     aSubAEndRef.VertexDefId              = aSplitVertexDefId;
     aSubAEndRef.Orientation              = TopAbs_REVERSED;
     myGraph->allocateRefUID(aSubAEndRefId2);
@@ -1808,7 +1816,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     const BRepGraph_VertexRefId aSubBStartRefId2(aMutStorage.NbVertexRefs());
     aMutStorage.AppendVertexRef();
     BRepGraphInc::VertexRef& aSubBStartRef = aMutStorage.ChangeVertexRef(aSubBStartRefId2);
-    aSubBStartRef.ParentId    = BRepGraph_NodeId(BRepGraph_NodeId::Kind::Edge, aSubBIdx);
+    aSubBStartRef.ParentId    = BRepGraph_NodeId(aSubBId);
     aSubBStartRef.VertexDefId = aSplitVertexDefId;
     aSubBStartRef.Orientation = TopAbs_FORWARD;
     myGraph->allocateRefUID(aSubBStartRefId2);
@@ -1829,7 +1837,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     const BRepGraph_VertexRefId aSubBEndRefId2(aMutStorage.NbVertexRefs());
     aMutStorage.AppendVertexRef();
     BRepGraphInc::VertexRef& aSubBEndRef = aMutStorage.ChangeVertexRef(aSubBEndRefId2);
-    aSubBEndRef.ParentId                 = BRepGraph_NodeId(BRepGraph_NodeId::Kind::Edge, aSubBIdx);
+    aSubBEndRef.ParentId                 = BRepGraph_NodeId(aSubBId);
     aSubBEndRef.VertexDefId              = aOrigEndVertexId;
     aSubBEndRef.Orientation              = aOrigEndOri;
     aSubBEndRef.LocalLocation            = aOrigEndLoc;
@@ -1840,7 +1848,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
   // Set SubA: StartVertex -> SplitVertex, [ParamFirst, theSplitParam].
   {
     BRepGraphInc::EdgeDef& aSubA =
-      myGraph->myData->myIncStorage.ChangeEdge(BRepGraph_EdgeId(aSubAIdx));
+      myGraph->myData->myIncStorage.ChangeEdge(aSubAId);
     initSubEdgeEntity(aSubA,
                       aOrigCurve3DRepId,
                       aOrigTolerance,
@@ -1854,7 +1862,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
   // Set SubB: SplitVertex -> EndVertex, [theSplitParam, ParamLast].
   {
     BRepGraphInc::EdgeDef& aSubB =
-      myGraph->myData->myIncStorage.ChangeEdge(BRepGraph_EdgeId(aSubBIdx));
+      myGraph->myData->myIncStorage.ChangeEdge(aSubBId);
     initSubEdgeEntity(aSubB,
                       aOrigCurve3DRepId,
                       aOrigTolerance,
@@ -1889,16 +1897,16 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
       for (const BRepGraph_CoEdgeId& anId : *aSrc)
         anOrigCoEdgeIds.Append(anId);
     }
-    const int aNbOrig = anOrigCoEdgeIds.Length();
+    const uint32_t aNbOrig = static_cast<uint32_t>(anOrigCoEdgeIds.Size());
 
     // Step 2: allocate SubA-CE + SubB-CE per original with full payload.
     NCollection_DataMap<BRepGraph_CoEdgeId, int> aIdxOf;
     NCollection_Vector<BRepGraph_CoEdgeId>       aNewACoEdgeIds;
     NCollection_Vector<BRepGraph_CoEdgeId>       aNewBCoEdgeIds;
     const double                                 aParamRange = aOrigParamLast - aOrigParamFirst;
-    for (int i = 0; i < aNbOrig; ++i)
+    for (uint32_t i = 0; i < aNbOrig; ++i)
     {
-      const BRepGraph_CoEdgeId      aOldId = anOrigCoEdgeIds.Value(i);
+      const BRepGraph_CoEdgeId      aOldId = anOrigCoEdgeIds.Value(static_cast<size_t>(i));
       const BRepGraphInc::CoEdgeDef aOld   = aStorage.CoEdge(aOldId); // by-value snapshot
 
       double aPCSplit;
@@ -1966,16 +1974,16 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     // wire SubA<->partnerSubA and SubB<->partnerSubB; otherwise leave the
     // new CoEdges unpaired - an orphan SeamPairId would point into a dead
     // slot.
-    for (int i = 0; i < aNbOrig; ++i)
+    for (uint32_t i = 0; i < aNbOrig; ++i)
     {
-      const BRepGraph_CoEdgeId aOldId       = anOrigCoEdgeIds.Value(i);
+      const BRepGraph_CoEdgeId aOldId       = anOrigCoEdgeIds.Value(static_cast<size_t>(i));
       const BRepGraph_CoEdgeId aOldSeamPair = aStorage.CoEdge(aOldId).SeamPairId;
       if (!aOldSeamPair.IsValid() || !aIdxOf.IsBound(aOldSeamPair))
         continue;
       int aJ = -1;
       aIdxOf.Find(aOldSeamPair, aJ);
-      aStorage.ChangeCoEdge(aNewACoEdgeIds.Value(i)).SeamPairId = aNewACoEdgeIds.Value(aJ);
-      aStorage.ChangeCoEdge(aNewBCoEdgeIds.Value(i)).SeamPairId = aNewBCoEdgeIds.Value(aJ);
+      aStorage.ChangeCoEdge(aNewACoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId = aNewACoEdgeIds.Value(aJ);
+      aStorage.ChangeCoEdge(aNewBCoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId = aNewBCoEdgeIds.Value(aJ);
     }
 
     // Step 4: rebuild wire CoEdgeRefIds (snapshot-before-mutate). For each
@@ -1996,8 +2004,8 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
         }
       }
 
-      int anInsertOffset = 0;
-      for (int i = 0; i < aSnapshot.Length(); ++i)
+      size_t anInsertOffset = 0;
+      for (size_t i = 0; i < aSnapshot.Size(); ++i)
       {
         const BRepGraph_CoEdgeRefId    aRefId  = aSnapshot.Value(i);
         const BRepGraphInc::CoEdgeRef& aRefEnt = aStorage.CoEdgeRef(aRefId);
@@ -2027,9 +2035,9 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
         }
         myGraph->allocateRefUID(aNewRefId);
 
-        const int              aPos     = i + anInsertOffset;
+        const size_t           aPos     = i + anInsertOffset;
         BRepGraphInc::WireDef& aWireEnt = aStorage.ChangeWire(aWireId);
-        if (aPos >= 0 && aPos < aWireEnt.CoEdgeRefIds.Length())
+        if (aPos < aWireEnt.CoEdgeRefIds.Size())
           aWireEnt.CoEdgeRefIds.InsertAfter(aPos, aNewRefId);
         else
           aWireEnt.CoEdgeRefIds.Append(aNewRefId);
@@ -2043,11 +2051,11 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
 
     // Step 5: retire the original CoEdges and rebuild the Edge->CoEdge
     // reverse index so CoEdgesOfEdge(theSubA/B) resolves to the new pair.
-    for (int i = 0; i < aNbOrig; ++i)
+    for (uint32_t i = 0; i < aNbOrig; ++i)
     {
-      const BRepGraph_CoEdgeId aOldId = anOrigCoEdgeIds.Value(i);
-      const BRepGraph_CoEdgeId aNewA  = aNewACoEdgeIds.Value(i);
-      const BRepGraph_CoEdgeId aNewB  = aNewBCoEdgeIds.Value(i);
+      const BRepGraph_CoEdgeId aOldId = anOrigCoEdgeIds.Value(static_cast<size_t>(i));
+      const BRepGraph_CoEdgeId aNewA  = aNewACoEdgeIds.Value(static_cast<size_t>(i));
+      const BRepGraph_CoEdgeId aNewB  = aNewBCoEdgeIds.Value(static_cast<size_t>(i));
       aStorage.MarkRemoved(BRepGraph_NodeId(aOldId));
       aRevIdx.UnbindEdgeFromCoEdge(theEdgeEntity, aOldId);
       aRevIdx.BindEdgeToCoEdge(theSubA, aNewA);
@@ -2090,16 +2098,16 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
   for (const BRepGraph_WireId& aWireId : aOrigWires)
   {
     aRevIdx.UnbindEdgeFromWire(BRepGraph_EdgeId(theEdgeEntity), aWireId);
-    aRevIdx.BindEdgeToWire(BRepGraph_EdgeId(aSubAIdx), aWireId);
-    aRevIdx.BindEdgeToWire(BRepGraph_EdgeId(aSubBIdx), aWireId);
+    aRevIdx.BindEdgeToWire(aSubAId, aWireId);
+    aRevIdx.BindEdgeToWire(aSubBId, aWireId);
     myGraph->markModified(aWireId);
   }
 
   // Incremental vertex-to-edge updates: register sub-edge vertices.
   {
     const BRepGraphInc_Storage&  aStorageRef = myGraph->myData->myIncStorage;
-    const BRepGraphInc::EdgeDef& aSubAEnt    = aStorageRef.Edge(BRepGraph_EdgeId(aSubAIdx));
-    const BRepGraphInc::EdgeDef& aSubBEnt    = aStorageRef.Edge(BRepGraph_EdgeId(aSubBIdx));
+    const BRepGraphInc::EdgeDef& aSubAEnt    = aStorageRef.Edge(aSubAId);
+    const BRepGraphInc::EdgeDef& aSubBEnt    = aStorageRef.Edge(aSubBId);
     BRepGraphInc_ReverseIndex&   aRevIdxMut  = myGraph->myData->myIncStorage.ChangeReverseIndex();
 
     // Resolve vertex def ids from the sub-edge ref entries.
@@ -2108,26 +2116,26 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
       const BRepGraph_VertexId aVtxId =
         aStorageRef.VertexRef(aSubAEnt.StartVertexRefId).VertexDefId;
       if (aVtxId.IsValid())
-        aRevIdxMut.BindVertexToEdge(aVtxId, BRepGraph_EdgeId(aSubAIdx));
+        aRevIdxMut.BindVertexToEdge(aVtxId, aSubAId);
     }
     if (aSubAEnt.EndVertexRefId.IsValid())
     {
       const BRepGraph_VertexId aVtxId = aStorageRef.VertexRef(aSubAEnt.EndVertexRefId).VertexDefId;
       if (aVtxId.IsValid())
-        aRevIdxMut.BindVertexToEdge(aVtxId, BRepGraph_EdgeId(aSubAIdx));
+        aRevIdxMut.BindVertexToEdge(aVtxId, aSubAId);
     }
     if (aSubBEnt.StartVertexRefId.IsValid())
     {
       const BRepGraph_VertexId aVtxId =
         aStorageRef.VertexRef(aSubBEnt.StartVertexRefId).VertexDefId;
       if (aVtxId.IsValid())
-        aRevIdxMut.BindVertexToEdge(aVtxId, BRepGraph_EdgeId(aSubBIdx));
+        aRevIdxMut.BindVertexToEdge(aVtxId, aSubBId);
     }
     if (aSubBEnt.EndVertexRefId.IsValid())
     {
       const BRepGraph_VertexId aVtxId = aStorageRef.VertexRef(aSubBEnt.EndVertexRefId).VertexDefId;
       if (aVtxId.IsValid())
-        aRevIdxMut.BindVertexToEdge(aVtxId, BRepGraph_EdgeId(aSubBIdx));
+        aRevIdxMut.BindVertexToEdge(aVtxId, aSubBId);
     }
 
     // Remove old edge from vertex-to-edge index.
@@ -2143,8 +2151,8 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
     for (const BRepGraph_FaceId& aFaceId : aOrigFaces)
     {
       aRevIdxMut.UnbindEdgeFromFace(BRepGraph_EdgeId(theEdgeEntity), aFaceId);
-      aRevIdxMut.BindEdgeToFace(BRepGraph_EdgeId(aSubAIdx), aFaceId);
-      aRevIdxMut.BindEdgeToFace(BRepGraph_EdgeId(aSubBIdx), aFaceId);
+      aRevIdxMut.BindEdgeToFace(aSubAId, aFaceId);
+      aRevIdxMut.BindEdgeToFace(aSubBId, aFaceId);
     }
   }
 
@@ -3008,12 +3016,14 @@ BRepGraph_VertexRefId BRepGraph::EditorView::EdgeOps::ReplaceVertex(
   else
   {
     bool isFound = false;
-    for (int anIdx = 0; anIdx < anEdge.InternalVertexRefIds.Length(); ++anIdx)
+    for (NCollection_Vector<BRepGraph_VertexRefId>::Iterator anIt(anEdge.InternalVertexRefIds);
+         anIt.More();
+         anIt.Next())
     {
-      if (anEdge.InternalVertexRefIds.Value(anIdx) == theOldVertexRefId)
+      if (anIt.Value() == theOldVertexRefId)
       {
-        anEdge.InternalVertexRefIds.ChangeValue(anIdx) = aNewRefId;
-        isFound                                        = true;
+        anIt.ChangeValue() = aNewRefId;
+        isFound            = true;
         break;
       }
     }
@@ -3159,7 +3169,7 @@ bool BRepGraph::EditorView::ValidateMutationBoundary(
       const BRepGraph_OccurrenceId anOccId = anOccIt.CurrentId();
       BoundaryIssue                anIssue;
       TCollection_AsciiString aDesc("Storage occurrence child kind invalid at occurrence idx=");
-      aDesc += TCollection_AsciiString(anOccId.Index);
+      aDesc += TCollection_AsciiString(static_cast<int>(anOccId.Index));
       aDesc += ": child kind=";
       aDesc += TCollection_AsciiString(static_cast<int>(anOcc.ChildDefId.NodeKind));
       anIssue.NodeId      = BRepGraph_NodeId(anOccId);

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.cxx
@@ -53,7 +53,7 @@ void BRepGraph_History::Record(const TCollection_AsciiString&              theOp
   // Append a new history record.
   BRepGraph_HistoryRecord aRecord;
   aRecord.OperationName  = theOpLabel;
-  aRecord.SequenceNumber = myRecords.Length();
+  aRecord.SequenceNumber = myRecords.Size();
   if (!myAllocator.IsNull())
   {
     aRecord.Mapping =
@@ -100,20 +100,20 @@ void BRepGraph_History::RecordBatch(const TCollection_AsciiString&              
                                     const NCollection_Vector<BRepGraph_NodeId>& theReplacements,
                                     const TCollection_AsciiString&              theExtraInfo)
 {
-  Standard_ASSERT_VOID(theOriginals.Length() == theReplacements.Length(),
+  Standard_ASSERT_VOID(theOriginals.Size() == theReplacements.Size(),
                        "RecordBatch: mismatched vector lengths");
   if (!myEnabled || theOriginals.IsEmpty())
   {
     return;
   }
 
-  const int aNbPairs = theOriginals.Length();
+  const size_t aNbPairs = theOriginals.Size();
 
   // Create a single history record with all mappings.
   // Pre-size the Mapping to avoid DataMap rehashing.
   BRepGraph_HistoryRecord aRecord;
   aRecord.OperationName  = theOpLabel;
-  aRecord.SequenceNumber = myRecords.Length();
+  aRecord.SequenceNumber = myRecords.Size();
   if (!myAllocator.IsNull())
   {
     aRecord.Mapping =
@@ -127,15 +127,20 @@ void BRepGraph_History::RecordBatch(const TCollection_AsciiString&              
   aRecord.ExtraInfo = theExtraInfo;
 
   // Build mapping: each pair creates a 1-element replacement vector.
-  for (int i = 0; i < aNbPairs; ++i)
   {
-    const BRepGraph_NodeId& anOriginal   = theOriginals.Value(i);
-    const BRepGraph_NodeId& aReplacement = theReplacements.Value(i);
-    Standard_ASSERT_VOID(!aRecord.Mapping.IsBound(anOriginal),
-                         "RecordBatch: duplicate original node");
-    NCollection_Vector<BRepGraph_NodeId> aRepVec(THE_HISTORY_REPLACEMENT_BLOCK_SIZE, myAllocator);
-    aRepVec.Append(aReplacement);
-    aRecord.Mapping.Bind(anOriginal, std::move(aRepVec));
+    NCollection_Vector<BRepGraph_NodeId>::Iterator anOrigIt(theOriginals);
+    NCollection_Vector<BRepGraph_NodeId>::Iterator aReplIt(theReplacements);
+    for (; anOrigIt.More(); anOrigIt.Next(), aReplIt.Next())
+    {
+      const BRepGraph_NodeId& anOriginal   = anOrigIt.Value();
+      const BRepGraph_NodeId& aReplacement = aReplIt.Value();
+      Standard_ASSERT_VOID(!aRecord.Mapping.IsBound(anOriginal),
+                           "RecordBatch: duplicate original node");
+      NCollection_Vector<BRepGraph_NodeId> aRepVec(THE_HISTORY_REPLACEMENT_BLOCK_SIZE,
+                                                   myAllocator);
+      aRepVec.Append(aReplacement);
+      aRecord.Mapping.Bind(anOriginal, std::move(aRepVec));
+    }
   }
   myRecords.Append(std::move(aRecord));
 
@@ -144,26 +149,31 @@ void BRepGraph_History::RecordBatch(const TCollection_AsciiString&              
   myDerivedToOriginal.ReSize(myDerivedToOriginal.Extent() + aNbPairs);
   myOriginalToDerived.ReSize(myOriginalToDerived.Extent() + aNbPairs);
 
-  for (int i = 0; i < aNbPairs; ++i)
   {
-    const BRepGraph_NodeId& anOriginal   = theOriginals.Value(i);
-    const BRepGraph_NodeId& aReplacement = theReplacements.Value(i);
-    if (aReplacement == anOriginal)
+    NCollection_Vector<BRepGraph_NodeId>::Iterator anOrigIt(theOriginals);
+    NCollection_Vector<BRepGraph_NodeId>::Iterator aReplIt(theReplacements);
+    for (; anOrigIt.More(); anOrigIt.Next(), aReplIt.Next())
     {
-      continue;
-    }
+      const BRepGraph_NodeId& anOriginal   = anOrigIt.Value();
+      const BRepGraph_NodeId& aReplacement = aReplIt.Value();
+      if (aReplacement == anOriginal)
+      {
+        continue;
+      }
 
-    myDerivedToOriginal.Bind(aReplacement, anOriginal);
+      myDerivedToOriginal.Bind(aReplacement, anOriginal);
 
-    if (myOriginalToDerived.IsBound(anOriginal))
-    {
-      myOriginalToDerived.ChangeFind(anOriginal).Append(aReplacement);
-    }
-    else
-    {
-      NCollection_Vector<BRepGraph_NodeId> aDerVec(THE_HISTORY_REPLACEMENT_BLOCK_SIZE, myAllocator);
-      aDerVec.Append(aReplacement);
-      myOriginalToDerived.Bind(anOriginal, std::move(aDerVec));
+      if (myOriginalToDerived.IsBound(anOriginal))
+      {
+        myOriginalToDerived.ChangeFind(anOriginal).Append(aReplacement);
+      }
+      else
+      {
+        NCollection_Vector<BRepGraph_NodeId> aDerVec(THE_HISTORY_REPLACEMENT_BLOCK_SIZE,
+                                                     myAllocator);
+        aDerVec.Append(aReplacement);
+        myOriginalToDerived.Bind(anOriginal, std::move(aDerVec));
+      }
     }
   }
 }
@@ -202,9 +212,10 @@ NCollection_Vector<BRepGraph_NodeId> BRepGraph_History::FindDerived(
   aQueue.Append(theOriginal);
   aVisited.Add(theOriginal);
 
-  for (int aQueueIdx = 0; aQueueIdx < aQueue.Length(); ++aQueueIdx)
+  size_t aFront = 0;
+  while (aFront < aQueue.Size())
   {
-    const BRepGraph_NodeId aNode = aQueue.Value(aQueueIdx);
+    const BRepGraph_NodeId aNode = aQueue.Value(aFront++);
     if (!myOriginalToDerived.IsBound(aNode))
     {
       // Leaf node: only add if it is not the initial query node itself.
@@ -242,14 +253,14 @@ NCollection_Vector<BRepGraph_NodeId> BRepGraph_History::FindDerived(
 
 //=================================================================================================
 
-int BRepGraph_History::NbRecords() const
+size_t BRepGraph_History::NbRecords() const
 {
-  return myRecords.Length();
+  return myRecords.Size();
 }
 
 //=================================================================================================
 
-const BRepGraph_HistoryRecord& BRepGraph_History::Record(const int theRecordIdx) const
+const BRepGraph_HistoryRecord& BRepGraph_History::Record(const size_t theRecordIdx) const
 {
   return myRecords.Value(theRecordIdx);
 }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.cxx
@@ -136,8 +136,7 @@ void BRepGraph_History::RecordBatch(const TCollection_AsciiString&              
       const BRepGraph_NodeId& aReplacement = aReplIt.Value();
       Standard_ASSERT_VOID(!aRecord.Mapping.IsBound(anOriginal),
                            "RecordBatch: duplicate original node");
-      NCollection_Vector<BRepGraph_NodeId> aRepVec(THE_HISTORY_REPLACEMENT_BLOCK_SIZE,
-                                                   myAllocator);
+      NCollection_Vector<BRepGraph_NodeId> aRepVec(THE_HISTORY_REPLACEMENT_BLOCK_SIZE, myAllocator);
       aRepVec.Append(aReplacement);
       aRecord.Mapping.Bind(anOriginal, std::move(aRepVec));
     }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.hxx
@@ -79,7 +79,8 @@ public:
   //! Access a record by index (0-based).
   //! @param[in] theRecordIdx zero-based index into the records vector
   //! @return the history record at the given index
-  [[nodiscard]] Standard_EXPORT const BRepGraph_HistoryRecord& Record(const size_t theRecordIdx) const;
+  [[nodiscard]] Standard_EXPORT const BRepGraph_HistoryRecord& Record(
+    const size_t theRecordIdx) const;
 
   //! Enable or disable history recording.
   //! @param[in] theVal true to enable, false to disable

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_History.hxx
@@ -74,12 +74,12 @@ public:
 
   //! Number of recorded history events.
   //! @return record count
-  [[nodiscard]] Standard_EXPORT int NbRecords() const;
+  [[nodiscard]] Standard_EXPORT size_t NbRecords() const;
 
   //! Access a record by index (0-based).
   //! @param[in] theRecordIdx zero-based index into the records vector
   //! @return the history record at the given index
-  [[nodiscard]] Standard_EXPORT const BRepGraph_HistoryRecord& Record(const int theRecordIdx) const;
+  [[nodiscard]] Standard_EXPORT const BRepGraph_HistoryRecord& Record(const size_t theRecordIdx) const;
 
   //! Enable or disable history recording.
   //! @param[in] theVal true to enable, false to disable

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_HistoryRecord.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_HistoryRecord.hxx
@@ -35,7 +35,7 @@
 struct BRepGraph_HistoryRecord
 {
   TCollection_AsciiString OperationName;
-  int                     SequenceNumber = 0;
+  size_t                  SequenceNumber = 0;
 
   //! Key: original node id before the operation.
   //! Value: sequence of replacement node ids after the operation.

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.cxx
@@ -51,7 +51,7 @@ void removeVertex(NCollection_DataMap<KeyT, NCollection_Vector<BRepGraph_VertexI
     return;
 
   NCollection_Vector<BRepGraph_VertexId>& aVertices = theMap.ChangeFind(theKey);
-  uint32_t anIdx = 0;
+  uint32_t                                anIdx     = 0;
   for (NCollection_Vector<BRepGraph_VertexId>::Iterator anIt(aVertices); anIt.More();
        anIt.Next(), ++anIdx)
   {
@@ -322,8 +322,7 @@ void BRepGraph_LayerParam::SetPointOnSurface(const BRepGraph_VertexId theVertex,
                                              const double             theParameterV)
 {
   VertexParams& aParams = changeVertexParams(theVertex);
-  for (NCollection_Vector<PointOnSurfaceEntry>::Iterator anIt(aParams.PointsOnSurface);
-       anIt.More();
+  for (NCollection_Vector<PointOnSurfaceEntry>::Iterator anIt(aParams.PointsOnSurface); anIt.More();
        anIt.Next())
   {
     if (anIt.Value().FaceDefId != theFace)
@@ -370,8 +369,8 @@ void BRepGraph_LayerParam::removePointOnCurve(const BRepGraph_VertexId theVertex
   if (!myVertexParams.IsBound(theVertex))
     return;
 
-  VertexParams& aParams  = myVertexParams.ChangeFind(theVertex);
-  uint32_t      anIdx    = 0;
+  VertexParams& aParams = myVertexParams.ChangeFind(theVertex);
+  uint32_t      anIdx   = 0;
   for (NCollection_Vector<PointOnCurveEntry>::Iterator anIt(aParams.PointsOnCurve); anIt.More();
        anIt.Next(), ++anIdx)
   {
@@ -397,10 +396,9 @@ void BRepGraph_LayerParam::removePointOnSurface(const BRepGraph_VertexId theVert
   if (!myVertexParams.IsBound(theVertex))
     return;
 
-  VertexParams& aParams  = myVertexParams.ChangeFind(theVertex);
-  uint32_t      anIdx    = 0;
-  for (NCollection_Vector<PointOnSurfaceEntry>::Iterator anIt(aParams.PointsOnSurface);
-       anIt.More();
+  VertexParams& aParams = myVertexParams.ChangeFind(theVertex);
+  uint32_t      anIdx   = 0;
+  for (NCollection_Vector<PointOnSurfaceEntry>::Iterator anIt(aParams.PointsOnSurface); anIt.More();
        anIt.Next(), ++anIdx)
   {
     if (anIt.Value().FaceDefId != theFace)
@@ -425,8 +423,8 @@ void BRepGraph_LayerParam::removePointOnPCurve(const BRepGraph_VertexId theVerte
   if (!myVertexParams.IsBound(theVertex))
     return;
 
-  VertexParams& aParams  = myVertexParams.ChangeFind(theVertex);
-  uint32_t      anIdx    = 0;
+  VertexParams& aParams = myVertexParams.ChangeFind(theVertex);
+  uint32_t      anIdx   = 0;
   for (NCollection_Vector<PointOnPCurveEntry>::Iterator anIt(aParams.PointsOnPCurve); anIt.More();
        anIt.Next(), ++anIdx)
   {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.cxx
@@ -34,9 +34,9 @@ void appendUnique(NCollection_DataMap<KeyT, NCollection_Vector<BRepGraph_VertexI
   }
 
   NCollection_Vector<BRepGraph_VertexId>& aVertices = theMap.ChangeFind(theKey);
-  for (int anIdx = 0; anIdx < aVertices.Length(); ++anIdx)
+  for (const BRepGraph_VertexId& aVtx : aVertices)
   {
-    if (aVertices.Value(anIdx) == theVertex)
+    if (aVtx == theVertex)
       return;
   }
   aVertices.Append(theVertex);
@@ -51,12 +51,14 @@ void removeVertex(NCollection_DataMap<KeyT, NCollection_Vector<BRepGraph_VertexI
     return;
 
   NCollection_Vector<BRepGraph_VertexId>& aVertices = theMap.ChangeFind(theKey);
-  for (int anIdx = 0; anIdx < aVertices.Length(); ++anIdx)
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_VertexId>::Iterator anIt(aVertices); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aVertices.Value(anIdx) != theVertex)
+    if (anIt.Value() != theVertex)
       continue;
-    if (anIdx < aVertices.Length() - 1)
-      aVertices.ChangeValue(anIdx) = aVertices.Value(aVertices.Length() - 1);
+    if (anIdx < static_cast<uint32_t>(aVertices.Size()) - 1u)
+      aVertices.ChangeValue(static_cast<size_t>(anIdx)) = aVertices.Value(aVertices.Size() - 1u);
     aVertices.EraseLast();
     break;
   }
@@ -210,26 +212,26 @@ bool BRepGraph_LayerParam::FindPointOnPCurve(const BRepGraph_VertexId theVertex,
 
 //=================================================================================================
 
-int BRepGraph_LayerParam::NbPointsOnCurve(const BRepGraph_VertexId theVertex) const
+uint32_t BRepGraph_LayerParam::NbPointsOnCurve(const BRepGraph_VertexId theVertex) const
 {
   const VertexParams* aParams = FindVertexParams(theVertex);
-  return aParams == nullptr ? 0 : aParams->PointsOnCurve.Length();
+  return aParams == nullptr ? 0u : static_cast<uint32_t>(aParams->PointsOnCurve.Size());
 }
 
 //=================================================================================================
 
-int BRepGraph_LayerParam::NbPointsOnSurface(const BRepGraph_VertexId theVertex) const
+uint32_t BRepGraph_LayerParam::NbPointsOnSurface(const BRepGraph_VertexId theVertex) const
 {
   const VertexParams* aParams = FindVertexParams(theVertex);
-  return aParams == nullptr ? 0 : aParams->PointsOnSurface.Length();
+  return aParams == nullptr ? 0u : static_cast<uint32_t>(aParams->PointsOnSurface.Size());
 }
 
 //=================================================================================================
 
-int BRepGraph_LayerParam::NbPointsOnPCurve(const BRepGraph_VertexId theVertex) const
+uint32_t BRepGraph_LayerParam::NbPointsOnPCurve(const BRepGraph_VertexId theVertex) const
 {
   const VertexParams* aParams = FindVertexParams(theVertex);
-  return aParams == nullptr ? 0 : aParams->PointsOnPCurve.Length();
+  return aParams == nullptr ? 0u : static_cast<uint32_t>(aParams->PointsOnPCurve.Size());
 }
 
 //=================================================================================================
@@ -297,12 +299,12 @@ void BRepGraph_LayerParam::SetPointOnCurve(const BRepGraph_VertexId theVertex,
                                            const double             theParameter)
 {
   VertexParams& aParams = changeVertexParams(theVertex);
-  for (int anIdx = 0; anIdx < aParams.PointsOnCurve.Length(); ++anIdx)
+  for (NCollection_Vector<PointOnCurveEntry>::Iterator anIt(aParams.PointsOnCurve); anIt.More();
+       anIt.Next())
   {
-    PointOnCurveEntry& anEntry = aParams.PointsOnCurve.ChangeValue(anIdx);
-    if (anEntry.EdgeDefId != theEdge)
+    if (anIt.Value().EdgeDefId != theEdge)
       continue;
-    anEntry.Parameter = theParameter;
+    anIt.ChangeValue().Parameter = theParameter;
     return;
   }
 
@@ -320,13 +322,14 @@ void BRepGraph_LayerParam::SetPointOnSurface(const BRepGraph_VertexId theVertex,
                                              const double             theParameterV)
 {
   VertexParams& aParams = changeVertexParams(theVertex);
-  for (int anIdx = 0; anIdx < aParams.PointsOnSurface.Length(); ++anIdx)
+  for (NCollection_Vector<PointOnSurfaceEntry>::Iterator anIt(aParams.PointsOnSurface);
+       anIt.More();
+       anIt.Next())
   {
-    PointOnSurfaceEntry& anEntry = aParams.PointsOnSurface.ChangeValue(anIdx);
-    if (anEntry.FaceDefId != theFace)
+    if (anIt.Value().FaceDefId != theFace)
       continue;
-    anEntry.ParameterU = theParameterU;
-    anEntry.ParameterV = theParameterV;
+    anIt.ChangeValue().ParameterU = theParameterU;
+    anIt.ChangeValue().ParameterV = theParameterV;
     return;
   }
 
@@ -344,12 +347,12 @@ void BRepGraph_LayerParam::SetPointOnPCurve(const BRepGraph_VertexId theVertex,
                                             const double             theParameter)
 {
   VertexParams& aParams = changeVertexParams(theVertex);
-  for (int anIdx = 0; anIdx < aParams.PointsOnPCurve.Length(); ++anIdx)
+  for (NCollection_Vector<PointOnPCurveEntry>::Iterator anIt(aParams.PointsOnPCurve); anIt.More();
+       anIt.Next())
   {
-    PointOnPCurveEntry& anEntry = aParams.PointsOnPCurve.ChangeValue(anIdx);
-    if (anEntry.CoEdgeDefId != theCoEdge)
+    if (anIt.Value().CoEdgeDefId != theCoEdge)
       continue;
-    anEntry.Parameter = theParameter;
+    anIt.ChangeValue().Parameter = theParameter;
     return;
   }
 
@@ -367,14 +370,16 @@ void BRepGraph_LayerParam::removePointOnCurve(const BRepGraph_VertexId theVertex
   if (!myVertexParams.IsBound(theVertex))
     return;
 
-  VertexParams& aParams = myVertexParams.ChangeFind(theVertex);
-  for (int anIdx = 0; anIdx < aParams.PointsOnCurve.Length(); ++anIdx)
+  VertexParams& aParams  = myVertexParams.ChangeFind(theVertex);
+  uint32_t      anIdx    = 0;
+  for (NCollection_Vector<PointOnCurveEntry>::Iterator anIt(aParams.PointsOnCurve); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aParams.PointsOnCurve.Value(anIdx).EdgeDefId != theEdge)
+    if (anIt.Value().EdgeDefId != theEdge)
       continue;
-    if (anIdx < aParams.PointsOnCurve.Length() - 1)
-      aParams.PointsOnCurve.ChangeValue(anIdx) =
-        aParams.PointsOnCurve.Value(aParams.PointsOnCurve.Length() - 1);
+    if (anIdx < static_cast<uint32_t>(aParams.PointsOnCurve.Size()) - 1u)
+      aParams.PointsOnCurve.ChangeValue(static_cast<size_t>(anIdx)) =
+        aParams.PointsOnCurve.Value(aParams.PointsOnCurve.Size() - 1u);
     aParams.PointsOnCurve.EraseLast();
     unbindEdgeFromVertex(theEdge, theVertex);
     break;
@@ -392,16 +397,17 @@ void BRepGraph_LayerParam::removePointOnSurface(const BRepGraph_VertexId theVert
   if (!myVertexParams.IsBound(theVertex))
     return;
 
-  VertexParams& aParams = myVertexParams.ChangeFind(theVertex);
-  for (int anIdx = 0; anIdx < aParams.PointsOnSurface.Length(); ++anIdx)
+  VertexParams& aParams  = myVertexParams.ChangeFind(theVertex);
+  uint32_t      anIdx    = 0;
+  for (NCollection_Vector<PointOnSurfaceEntry>::Iterator anIt(aParams.PointsOnSurface);
+       anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aParams.PointsOnSurface.Value(anIdx).FaceDefId != theFace)
+    if (anIt.Value().FaceDefId != theFace)
       continue;
-    if (anIdx < aParams.PointsOnSurface.Length() - 1)
-    {
-      aParams.PointsOnSurface.ChangeValue(anIdx) =
-        aParams.PointsOnSurface.Value(aParams.PointsOnSurface.Length() - 1);
-    }
+    if (anIdx < static_cast<uint32_t>(aParams.PointsOnSurface.Size()) - 1u)
+      aParams.PointsOnSurface.ChangeValue(static_cast<size_t>(anIdx)) =
+        aParams.PointsOnSurface.Value(aParams.PointsOnSurface.Size() - 1u);
     aParams.PointsOnSurface.EraseLast();
     unbindFaceFromVertex(theFace, theVertex);
     break;
@@ -419,16 +425,16 @@ void BRepGraph_LayerParam::removePointOnPCurve(const BRepGraph_VertexId theVerte
   if (!myVertexParams.IsBound(theVertex))
     return;
 
-  VertexParams& aParams = myVertexParams.ChangeFind(theVertex);
-  for (int anIdx = 0; anIdx < aParams.PointsOnPCurve.Length(); ++anIdx)
+  VertexParams& aParams  = myVertexParams.ChangeFind(theVertex);
+  uint32_t      anIdx    = 0;
+  for (NCollection_Vector<PointOnPCurveEntry>::Iterator anIt(aParams.PointsOnPCurve); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aParams.PointsOnPCurve.Value(anIdx).CoEdgeDefId != theCoEdge)
+    if (anIt.Value().CoEdgeDefId != theCoEdge)
       continue;
-    if (anIdx < aParams.PointsOnPCurve.Length() - 1)
-    {
-      aParams.PointsOnPCurve.ChangeValue(anIdx) =
-        aParams.PointsOnPCurve.Value(aParams.PointsOnPCurve.Length() - 1);
-    }
+    if (anIdx < static_cast<uint32_t>(aParams.PointsOnPCurve.Size()) - 1u)
+      aParams.PointsOnPCurve.ChangeValue(static_cast<size_t>(anIdx)) =
+        aParams.PointsOnPCurve.Value(aParams.PointsOnPCurve.Size() - 1u);
     aParams.PointsOnPCurve.EraseLast();
     unbindCoEdgeFromVertex(theCoEdge, theVertex);
     break;
@@ -464,8 +470,8 @@ void BRepGraph_LayerParam::invalidateEdgeBindings(const BRepGraph_EdgeId theEdge
     return;
 
   const NCollection_Vector<BRepGraph_VertexId> aBoundVertices = *aVertices;
-  for (int anIdx = 0; anIdx < aBoundVertices.Length(); ++anIdx)
-    removePointOnCurve(aBoundVertices.Value(anIdx), theEdge);
+  for (const BRepGraph_VertexId& aVtx : aBoundVertices)
+    removePointOnCurve(aVtx, theEdge);
 }
 
 //=================================================================================================
@@ -477,8 +483,8 @@ void BRepGraph_LayerParam::invalidateFaceBindings(const BRepGraph_FaceId theFace
     return;
 
   const NCollection_Vector<BRepGraph_VertexId> aBoundVertices = *aVertices;
-  for (int anIdx = 0; anIdx < aBoundVertices.Length(); ++anIdx)
-    removePointOnSurface(aBoundVertices.Value(anIdx), theFace);
+  for (const BRepGraph_VertexId& aVtx : aBoundVertices)
+    removePointOnSurface(aVtx, theFace);
 }
 
 //=================================================================================================
@@ -490,8 +496,8 @@ void BRepGraph_LayerParam::invalidateCoEdgeBindings(const BRepGraph_CoEdgeId the
     return;
 
   const NCollection_Vector<BRepGraph_VertexId> aBoundVertices = *aVertices;
-  for (int anIdx = 0; anIdx < aBoundVertices.Length(); ++anIdx)
-    removePointOnPCurve(aBoundVertices.Value(anIdx), theCoEdge);
+  for (const BRepGraph_VertexId& aVtx : aBoundVertices)
+    removePointOnPCurve(aVtx, theCoEdge);
 }
 
 //=================================================================================================
@@ -530,13 +536,13 @@ void BRepGraph_LayerParam::migrateEdgeBindings(const BRepGraph_EdgeId theOldEdge
     return;
 
   const NCollection_Vector<BRepGraph_VertexId> aBoundVertices = *aVertices;
-  for (int anIdx = 0; anIdx < aBoundVertices.Length(); ++anIdx)
+  for (const BRepGraph_VertexId& aVtx : aBoundVertices)
   {
     double aParameter = 0.0;
-    if (!FindPointOnCurve(aBoundVertices.Value(anIdx), theOldEdge, &aParameter))
+    if (!FindPointOnCurve(aVtx, theOldEdge, &aParameter))
       continue;
-    removePointOnCurve(aBoundVertices.Value(anIdx), theOldEdge);
-    SetPointOnCurve(aBoundVertices.Value(anIdx), theNewEdge, aParameter);
+    removePointOnCurve(aVtx, theOldEdge);
+    SetPointOnCurve(aVtx, theNewEdge, aParameter);
   }
 }
 
@@ -550,13 +556,13 @@ void BRepGraph_LayerParam::migrateFaceBindings(const BRepGraph_FaceId theOldFace
     return;
 
   const NCollection_Vector<BRepGraph_VertexId> aBoundVertices = *aVertices;
-  for (int anIdx = 0; anIdx < aBoundVertices.Length(); ++anIdx)
+  for (const BRepGraph_VertexId& aVtx : aBoundVertices)
   {
     gp_Pnt2d aUV;
-    if (!FindPointOnSurface(aBoundVertices.Value(anIdx), theOldFace, &aUV))
+    if (!FindPointOnSurface(aVtx, theOldFace, &aUV))
       continue;
-    removePointOnSurface(aBoundVertices.Value(anIdx), theOldFace);
-    SetPointOnSurface(aBoundVertices.Value(anIdx), theNewFace, aUV.X(), aUV.Y());
+    removePointOnSurface(aVtx, theOldFace);
+    SetPointOnSurface(aVtx, theNewFace, aUV.X(), aUV.Y());
   }
 }
 
@@ -570,13 +576,13 @@ void BRepGraph_LayerParam::migrateCoEdgeBindings(const BRepGraph_CoEdgeId theOld
     return;
 
   const NCollection_Vector<BRepGraph_VertexId> aBoundVertices = *aVertices;
-  for (int anIdx = 0; anIdx < aBoundVertices.Length(); ++anIdx)
+  for (const BRepGraph_VertexId& aVtx : aBoundVertices)
   {
     double aParameter = 0.0;
-    if (!FindPointOnPCurve(aBoundVertices.Value(anIdx), theOldCoEdge, &aParameter))
+    if (!FindPointOnPCurve(aVtx, theOldCoEdge, &aParameter))
       continue;
-    removePointOnPCurve(aBoundVertices.Value(anIdx), theOldCoEdge);
-    SetPointOnPCurve(aBoundVertices.Value(anIdx), theNewCoEdge, aParameter);
+    removePointOnPCurve(aVtx, theOldCoEdge);
+    SetPointOnPCurve(aVtx, theNewCoEdge, aParameter);
   }
 }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.hxx
@@ -75,9 +75,9 @@ public:
                                          const BRepGraph_CoEdgeId theCoEdge,
                                          double* const            theParameter = nullptr) const;
 
-  Standard_EXPORT int NbPointsOnCurve(const BRepGraph_VertexId theVertex) const;
-  Standard_EXPORT int NbPointsOnSurface(const BRepGraph_VertexId theVertex) const;
-  Standard_EXPORT int NbPointsOnPCurve(const BRepGraph_VertexId theVertex) const;
+  Standard_EXPORT uint32_t NbPointsOnCurve(const BRepGraph_VertexId theVertex) const;
+  Standard_EXPORT uint32_t NbPointsOnSurface(const BRepGraph_VertexId theVertex) const;
+  Standard_EXPORT uint32_t NbPointsOnPCurve(const BRepGraph_VertexId theVertex) const;
 
   [[nodiscard]] bool HasBindings() const { return myVertexParams.Extent() != 0; }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegistry.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegistry.cxx
@@ -61,7 +61,7 @@ void BRepGraph_LayerRegistry::UnregisterLayer(const Standard_GUID& theGUID)
   {
     const occ::handle<BRepGraph_Layer>& aLastLayer = myLayers.Value(static_cast<size_t>(aLastSlot));
     myLayers.ChangeValue(static_cast<size_t>(aSlot)) = aLastLayer;
-    myGuidToSlot.ChangeFind(aLastLayer->ID())         = aSlot;
+    myGuidToSlot.ChangeFind(aLastLayer->ID())        = aSlot;
   }
 
   myLayers.EraseLast();
@@ -90,7 +90,8 @@ void BRepGraph_LayerRegistry::SetOwningGraph(BRepGraph* theGraph) noexcept
 occ::handle<BRepGraph_Layer> BRepGraph_LayerRegistry::FindLayer(const Standard_GUID& theGUID) const
 {
   const uint32_t* aSlot = myGuidToSlot.Seek(theGUID);
-  return aSlot != nullptr ? myLayers.Value(static_cast<size_t>(*aSlot)) : occ::handle<BRepGraph_Layer>();
+  return aSlot != nullptr ? myLayers.Value(static_cast<size_t>(*aSlot))
+                          : occ::handle<BRepGraph_Layer>();
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegistry.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegistry.cxx
@@ -23,45 +23,45 @@ int BRepGraph_LayerRegistry::RegisterLayer(const occ::handle<BRepGraph_Layer>& t
     return -1;
 
   const Standard_GUID& aGUID = theLayer->ID();
-  const int*           aSlot = myGuidToSlot.Seek(aGUID);
+  const uint32_t*      aSlot = myGuidToSlot.Seek(aGUID);
   if (aSlot != nullptr)
   {
-    const occ::handle<BRepGraph_Layer>& aPrev = myLayers.Value(*aSlot);
+    const occ::handle<BRepGraph_Layer>& aPrev = myLayers.Value(static_cast<size_t>(*aSlot));
     if (!aPrev.IsNull() && aPrev.get() != theLayer.get())
     {
       aPrev->setOwningGraph(nullptr);
     }
     theLayer->setOwningGraph(myOwningGraph);
-    myLayers.ChangeValue(*aSlot) = theLayer;
+    myLayers.ChangeValue(static_cast<size_t>(*aSlot)) = theLayer;
     recomputeSubscribedKindsMask();
-    return *aSlot;
+    return static_cast<int>(*aSlot);
   }
 
-  const int aNewSlot = myLayers.Length();
+  const uint32_t aNewSlot = static_cast<uint32_t>(myLayers.Size());
   theLayer->setOwningGraph(myOwningGraph);
   myLayers.Append(theLayer);
   myGuidToSlot.Bind(aGUID, aNewSlot);
   mySubscribedKindsMask |= theLayer->SubscribedKinds();
   mySubscribedRefKindsMask |= theLayer->SubscribedRefKinds();
-  return aNewSlot;
+  return static_cast<int>(aNewSlot);
 }
 
 //=================================================================================================
 
 void BRepGraph_LayerRegistry::UnregisterLayer(const Standard_GUID& theGUID)
 {
-  const int* aSlotPtr = myGuidToSlot.Seek(theGUID);
+  const uint32_t* aSlotPtr = myGuidToSlot.Seek(theGUID);
   if (aSlotPtr == nullptr)
     return;
 
-  const int                          aSlot     = *aSlotPtr;
-  const int                          aLastSlot = myLayers.Length() - 1;
-  const occ::handle<BRepGraph_Layer> aRemoved  = myLayers.Value(aSlot);
+  const uint32_t                     aSlot     = *aSlotPtr;
+  const uint32_t                     aLastSlot = static_cast<uint32_t>(myLayers.Size()) - 1;
+  const occ::handle<BRepGraph_Layer> aRemoved  = myLayers.Value(static_cast<size_t>(aSlot));
   if (aSlot != aLastSlot)
   {
-    const occ::handle<BRepGraph_Layer>& aLastLayer = myLayers.Value(aLastSlot);
-    myLayers.ChangeValue(aSlot)                    = aLastLayer;
-    myGuidToSlot.ChangeFind(aLastLayer->ID())      = aSlot;
+    const occ::handle<BRepGraph_Layer>& aLastLayer = myLayers.Value(static_cast<size_t>(aLastSlot));
+    myLayers.ChangeValue(static_cast<size_t>(aSlot)) = aLastLayer;
+    myGuidToSlot.ChangeFind(aLastLayer->ID())         = aSlot;
   }
 
   myLayers.EraseLast();
@@ -89,25 +89,25 @@ void BRepGraph_LayerRegistry::SetOwningGraph(BRepGraph* theGraph) noexcept
 
 occ::handle<BRepGraph_Layer> BRepGraph_LayerRegistry::FindLayer(const Standard_GUID& theGUID) const
 {
-  const int* aSlot = myGuidToSlot.Seek(theGUID);
-  return aSlot != nullptr ? myLayers.Value(*aSlot) : occ::handle<BRepGraph_Layer>();
+  const uint32_t* aSlot = myGuidToSlot.Seek(theGUID);
+  return aSlot != nullptr ? myLayers.Value(static_cast<size_t>(*aSlot)) : occ::handle<BRepGraph_Layer>();
 }
 
 //=================================================================================================
 
 int BRepGraph_LayerRegistry::FindSlot(const Standard_GUID& theGUID) const
 {
-  const int* aSlot = myGuidToSlot.Seek(theGUID);
-  return aSlot != nullptr ? *aSlot : -1;
+  const uint32_t* aSlot = myGuidToSlot.Seek(theGUID);
+  return aSlot != nullptr ? static_cast<int>(*aSlot) : -1;
 }
 
 //=================================================================================================
 
 const occ::handle<BRepGraph_Layer>& BRepGraph_LayerRegistry::Layer(const int theSlot) const
 {
-  Standard_OutOfRange_Raise_if(theSlot < 0 || theSlot >= myLayers.Length(),
+  Standard_OutOfRange_Raise_if(theSlot < 0 || static_cast<uint32_t>(theSlot) >= myLayers.Size(),
                                "BRepGraph_LayerRegistry::Layer() - invalid slot");
-  return myLayers.Value(theSlot);
+  return myLayers.Value(static_cast<size_t>(theSlot));
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegistry.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegistry.hxx
@@ -124,9 +124,9 @@ private:
 
 private:
   NCollection_Vector<occ::handle<BRepGraph_Layer>> myLayers;
-  NCollection_DataMap<Standard_GUID, int>          myGuidToSlot;
-  int                                              mySubscribedKindsMask    = 0;
-  int                                              mySubscribedRefKindsMask = 0;
+  NCollection_DataMap<Standard_GUID, uint32_t>     myGuidToSlot;
+  uint32_t                                         mySubscribedKindsMask    = 0;
+  uint32_t                                         mySubscribedRefKindsMask = 0;
   BRepGraph*                                       myOwningGraph            = nullptr;
 };
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
@@ -52,7 +52,7 @@ void removeEdge(NCollection_DataMap<BRepGraph_FaceId, NCollection_Vector<BRepGra
     return;
 
   NCollection_Vector<BRepGraph_EdgeId>& anEdges = theMap.ChangeFind(theFace);
-  uint32_t anIdx = 0;
+  uint32_t                              anIdx   = 0;
   for (NCollection_Vector<BRepGraph_EdgeId>::Iterator anIt(anEdges); anIt.More();
        anIt.Next(), ++anIdx)
   {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
@@ -36,9 +36,9 @@ void appendUnique(
   }
 
   NCollection_Vector<BRepGraph_EdgeId>& anEdges = theMap.ChangeFind(theFace);
-  for (int anIdx = 0; anIdx < anEdges.Length(); ++anIdx)
+  for (const BRepGraph_EdgeId& aEdge : anEdges)
   {
-    if (anEdges.Value(anIdx) == theEdge)
+    if (aEdge == theEdge)
       return;
   }
   anEdges.Append(theEdge);
@@ -52,12 +52,14 @@ void removeEdge(NCollection_DataMap<BRepGraph_FaceId, NCollection_Vector<BRepGra
     return;
 
   NCollection_Vector<BRepGraph_EdgeId>& anEdges = theMap.ChangeFind(theFace);
-  for (int anIdx = 0; anIdx < anEdges.Length(); ++anIdx)
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_EdgeId>::Iterator anIt(anEdges); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (anEdges.Value(anIdx) != theEdge)
+    if (anIt.Value() != theEdge)
       continue;
-    if (anIdx < anEdges.Length() - 1)
-      anEdges.ChangeValue(anIdx) = anEdges.Value(anEdges.Length() - 1);
+    if (anIdx < static_cast<uint32_t>(anEdges.Size()) - 1u)
+      anEdges.ChangeValue(static_cast<size_t>(anIdx)) = anEdges.Value(anEdges.Size() - 1u);
     anEdges.EraseLast();
     break;
   }
@@ -162,10 +164,10 @@ bool BRepGraph_LayerRegularity::FindContinuity(const BRepGraph_EdgeId theEdge,
 
 //=================================================================================================
 
-int BRepGraph_LayerRegularity::NbRegularities(const BRepGraph_EdgeId theEdge) const
+uint32_t BRepGraph_LayerRegularity::NbRegularities(const BRepGraph_EdgeId theEdge) const
 {
   const EdgeRegularities* aRegularities = FindEdgeRegularities(theEdge);
-  return aRegularities == nullptr ? 0 : aRegularities->Entries.Length();
+  return aRegularities == nullptr ? 0u : static_cast<uint32_t>(aRegularities->Entries.Size());
 }
 
 //=================================================================================================
@@ -223,12 +225,12 @@ void BRepGraph_LayerRegularity::SetRegularity(const BRepGraph_EdgeId theEdge,
   normalizeFacePair(aFace1, aFace2);
 
   EdgeRegularities& aRegularities = changeEdgeRegularities(theEdge);
-  for (int anIdx = 0; anIdx < aRegularities.Entries.Length(); ++anIdx)
+  for (NCollection_Vector<RegularityEntry>::Iterator anIt(aRegularities.Entries); anIt.More();
+       anIt.Next())
   {
-    RegularityEntry& anEntry = aRegularities.Entries.ChangeValue(anIdx);
-    if (anEntry.FaceEntity1 != aFace1 || anEntry.FaceEntity2 != aFace2)
+    if (anIt.Value().FaceEntity1 != aFace1 || anIt.Value().FaceEntity2 != aFace2)
       continue;
-    anEntry.Continuity = theContinuity;
+    anIt.ChangeValue().Continuity = theContinuity;
     return;
   }
 
@@ -255,14 +257,15 @@ void BRepGraph_LayerRegularity::removeRegularity(const BRepGraph_EdgeId theEdge,
 
   EdgeRegularities& aRegularities = myEdgeRegularities.ChangeFind(theEdge);
   bool              aFound        = false;
-  for (int anIdx = 0; anIdx < aRegularities.Entries.Length(); ++anIdx)
+  uint32_t          anIdx         = 0;
+  for (NCollection_Vector<RegularityEntry>::Iterator anIt(aRegularities.Entries); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    const RegularityEntry& anEntry = aRegularities.Entries.Value(anIdx);
-    if (anEntry.FaceEntity1 != aFace1 || anEntry.FaceEntity2 != aFace2)
+    if (anIt.Value().FaceEntity1 != aFace1 || anIt.Value().FaceEntity2 != aFace2)
       continue;
-    if (anIdx < aRegularities.Entries.Length() - 1)
-      aRegularities.Entries.ChangeValue(anIdx) =
-        aRegularities.Entries.Value(aRegularities.Entries.Length() - 1);
+    if (anIdx < static_cast<uint32_t>(aRegularities.Entries.Size()) - 1u)
+      aRegularities.Entries.ChangeValue(static_cast<size_t>(anIdx)) =
+        aRegularities.Entries.Value(aRegularities.Entries.Size() - 1u);
     aRegularities.Entries.EraseLast();
     aFound = true;
     break;
@@ -274,9 +277,8 @@ void BRepGraph_LayerRegularity::removeRegularity(const BRepGraph_EdgeId theEdge,
   // Only unbind a face if no remaining entry still references it on this edge.
   bool aFace1StillReferenced = false;
   bool aFace2StillReferenced = false;
-  for (int anIdx = 0; anIdx < aRegularities.Entries.Length(); ++anIdx)
+  for (const RegularityEntry& anEntry : aRegularities.Entries)
   {
-    const RegularityEntry& anEntry = aRegularities.Entries.Value(anIdx);
     if (anEntry.FaceEntity1 == aFace1 || anEntry.FaceEntity2 == aFace1)
       aFace1StillReferenced = true;
     if (anEntry.FaceEntity1 == aFace2 || anEntry.FaceEntity2 == aFace2)
@@ -316,17 +318,16 @@ void BRepGraph_LayerRegularity::invalidateFaceBindings(const BRepGraph_FaceId th
     return;
 
   const NCollection_Vector<BRepGraph_EdgeId> aBoundEdges = *anEdges;
-  for (int anIdx = 0; anIdx < aBoundEdges.Length(); ++anIdx)
+  for (const BRepGraph_EdgeId& aEdgeId : aBoundEdges)
   {
-    const EdgeRegularities* aRegularities = myEdgeRegularities.Seek(aBoundEdges.Value(anIdx));
+    const EdgeRegularities* aRegularities = myEdgeRegularities.Seek(aEdgeId);
     if (aRegularities == nullptr)
       continue;
     const EdgeRegularities aEntries = *aRegularities;
-    for (int aRegIdx = 0; aRegIdx < aEntries.Entries.Length(); ++aRegIdx)
+    for (const RegularityEntry& anEntry : aEntries.Entries)
     {
-      const RegularityEntry& anEntry = aEntries.Entries.Value(aRegIdx);
       if (anEntry.FaceEntity1 == theFace || anEntry.FaceEntity2 == theFace)
-        removeRegularity(aBoundEdges.Value(anIdx), anEntry.FaceEntity1, anEntry.FaceEntity2);
+        removeRegularity(aEdgeId, anEntry.FaceEntity1, anEntry.FaceEntity2);
     }
   }
 }
@@ -358,23 +359,22 @@ void BRepGraph_LayerRegularity::migrateFaceBindings(const BRepGraph_FaceId theOl
     return;
 
   const NCollection_Vector<BRepGraph_EdgeId> aBoundEdges = *anEdges;
-  for (int anIdx = 0; anIdx < aBoundEdges.Length(); ++anIdx)
+  for (const BRepGraph_EdgeId& aEdgeId : aBoundEdges)
   {
-    const EdgeRegularities* aRegularities = myEdgeRegularities.Seek(aBoundEdges.Value(anIdx));
+    const EdgeRegularities* aRegularities = myEdgeRegularities.Seek(aEdgeId);
     if (aRegularities == nullptr)
       continue;
     const EdgeRegularities aEntries = *aRegularities;
-    for (int aRegIdx = 0; aRegIdx < aEntries.Entries.Length(); ++aRegIdx)
+    for (const RegularityEntry& anEntry : aEntries.Entries)
     {
-      const RegularityEntry& anEntry = aEntries.Entries.Value(aRegIdx);
       if (anEntry.FaceEntity1 != theOldFace && anEntry.FaceEntity2 != theOldFace)
         continue;
-      removeRegularity(aBoundEdges.Value(anIdx), anEntry.FaceEntity1, anEntry.FaceEntity2);
+      removeRegularity(aEdgeId, anEntry.FaceEntity1, anEntry.FaceEntity2);
       const BRepGraph_FaceId aFace1 =
         anEntry.FaceEntity1 == theOldFace ? theNewFace : anEntry.FaceEntity1;
       const BRepGraph_FaceId aFace2 =
         anEntry.FaceEntity2 == theOldFace ? theNewFace : anEntry.FaceEntity2;
-      SetRegularity(aBoundEdges.Value(anIdx), aFace1, aFace2, anEntry.Continuity);
+      SetRegularity(aEdgeId, aFace1, aFace2, anEntry.Continuity);
     }
   }
 }
@@ -457,13 +457,13 @@ void BRepGraph_LayerRegularity::OnCompact(
 
       // Deduplicate: if same face pair already exists for this edge, update continuity.
       bool aDuplicate = false;
-      for (int aExIdx = 0; aExIdx < aRegularities.Entries.Length(); ++aExIdx)
+      for (NCollection_Vector<RegularityEntry>::Iterator anIt(aRegularities.Entries); anIt.More();
+           anIt.Next())
       {
-        RegularityEntry& anExisting = aRegularities.Entries.ChangeValue(aExIdx);
-        if (anExisting.FaceEntity1 == aNewFace1 && anExisting.FaceEntity2 == aNewFace2)
+        if (anIt.Value().FaceEntity1 == aNewFace1 && anIt.Value().FaceEntity2 == aNewFace2)
         {
-          anExisting.Continuity = anOldEntry.Continuity;
-          aDuplicate            = true;
+          anIt.ChangeValue().Continuity = anOldEntry.Continuity;
+          aDuplicate                    = true;
           break;
         }
       }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
@@ -52,7 +52,7 @@ public:
                                       const BRepGraph_FaceId theFace2,
                                       GeomAbs_Shape* const   theContinuity = nullptr) const;
 
-  Standard_EXPORT int           NbRegularities(const BRepGraph_EdgeId theEdge) const;
+  Standard_EXPORT uint32_t      NbRegularities(const BRepGraph_EdgeId theEdge) const;
   Standard_EXPORT GeomAbs_Shape MaxContinuity(const BRepGraph_EdgeId theEdge) const;
 
   [[nodiscard]] bool HasBindings() const { return myEdgeRegularities.Extent() != 0; }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_MeshCache.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_MeshCache.cxx
@@ -16,9 +16,9 @@
 //=================================================================================================
 
 template <typename T>
-void BRepGraph_MeshCacheStorage::ensureSize(NCollection_Vector<T>& theVec, const int theIndex)
+void BRepGraph_MeshCacheStorage::ensureSize(NCollection_Vector<T>& theVec, const size_t theIndex)
 {
-  while (theVec.Length() <= theIndex)
+  while (theVec.Size() <= theIndex)
   {
     theVec.Append(T());
   }
@@ -30,7 +30,7 @@ bool BRepGraph_MeshCacheStorage::HasFaceMesh(const BRepGraph_FaceId theFace) con
 {
   if (!theFace.IsValidIn(myFaceMeshes))
     return false;
-  return myFaceMeshes.Value(theFace.Index).IsPresent();
+  return myFaceMeshes.Value(static_cast<size_t>(theFace.Index)).IsPresent();
 }
 
 //=================================================================================================
@@ -40,7 +40,7 @@ const BRepGraph_MeshCache::FaceMeshEntry* BRepGraph_MeshCacheStorage::FindFaceMe
 {
   if (!theFace.IsValidIn(myFaceMeshes))
     return nullptr;
-  const BRepGraph_MeshCache::FaceMeshEntry& anEntry = myFaceMeshes.Value(theFace.Index);
+  const BRepGraph_MeshCache::FaceMeshEntry& anEntry = myFaceMeshes.Value(static_cast<size_t>(theFace.Index));
   if (!anEntry.IsPresent())
     return nullptr;
   return &anEntry;
@@ -51,8 +51,8 @@ const BRepGraph_MeshCache::FaceMeshEntry* BRepGraph_MeshCacheStorage::FindFaceMe
 BRepGraph_MeshCache::FaceMeshEntry& BRepGraph_MeshCacheStorage::ChangeFaceMesh(
   const BRepGraph_FaceId theFace)
 {
-  ensureSize(myFaceMeshes, theFace.Index);
-  return myFaceMeshes.ChangeValue(theFace.Index);
+  ensureSize(myFaceMeshes, static_cast<size_t>(theFace.Index));
+  return myFaceMeshes.ChangeValue(static_cast<size_t>(theFace.Index));
 }
 
 //=================================================================================================
@@ -61,7 +61,7 @@ void BRepGraph_MeshCacheStorage::ClearFaceMesh(const BRepGraph_FaceId theFace)
 {
   if (theFace.IsValidIn(myFaceMeshes))
   {
-    myFaceMeshes.ChangeValue(theFace.Index).Reset();
+    myFaceMeshes.ChangeValue(static_cast<size_t>(theFace.Index)).Reset();
   }
 }
 
@@ -71,7 +71,7 @@ bool BRepGraph_MeshCacheStorage::HasCoEdgeMesh(const BRepGraph_CoEdgeId theCoEdg
 {
   if (!theCoEdge.IsValidIn(myCoEdgeMeshes))
     return false;
-  return myCoEdgeMeshes.Value(theCoEdge.Index).IsPresent();
+  return myCoEdgeMeshes.Value(static_cast<size_t>(theCoEdge.Index)).IsPresent();
 }
 
 //=================================================================================================
@@ -81,7 +81,7 @@ const BRepGraph_MeshCache::CoEdgeMeshEntry* BRepGraph_MeshCacheStorage::FindCoEd
 {
   if (!theCoEdge.IsValidIn(myCoEdgeMeshes))
     return nullptr;
-  const BRepGraph_MeshCache::CoEdgeMeshEntry& anEntry = myCoEdgeMeshes.Value(theCoEdge.Index);
+  const BRepGraph_MeshCache::CoEdgeMeshEntry& anEntry = myCoEdgeMeshes.Value(static_cast<size_t>(theCoEdge.Index));
   if (!anEntry.IsPresent())
     return nullptr;
   return &anEntry;
@@ -92,8 +92,8 @@ const BRepGraph_MeshCache::CoEdgeMeshEntry* BRepGraph_MeshCacheStorage::FindCoEd
 BRepGraph_MeshCache::CoEdgeMeshEntry& BRepGraph_MeshCacheStorage::ChangeCoEdgeMesh(
   const BRepGraph_CoEdgeId theCoEdge)
 {
-  ensureSize(myCoEdgeMeshes, theCoEdge.Index);
-  return myCoEdgeMeshes.ChangeValue(theCoEdge.Index);
+  ensureSize(myCoEdgeMeshes, static_cast<size_t>(theCoEdge.Index));
+  return myCoEdgeMeshes.ChangeValue(static_cast<size_t>(theCoEdge.Index));
 }
 
 //=================================================================================================
@@ -102,7 +102,7 @@ void BRepGraph_MeshCacheStorage::ClearCoEdgeMesh(const BRepGraph_CoEdgeId theCoE
 {
   if (theCoEdge.IsValidIn(myCoEdgeMeshes))
   {
-    myCoEdgeMeshes.ChangeValue(theCoEdge.Index).Reset();
+    myCoEdgeMeshes.ChangeValue(static_cast<size_t>(theCoEdge.Index)).Reset();
   }
 }
 
@@ -112,7 +112,7 @@ bool BRepGraph_MeshCacheStorage::HasEdgeMesh(const BRepGraph_EdgeId theEdge) con
 {
   if (!theEdge.IsValidIn(myEdgeMeshes))
     return false;
-  return myEdgeMeshes.Value(theEdge.Index).IsPresent();
+  return myEdgeMeshes.Value(static_cast<size_t>(theEdge.Index)).IsPresent();
 }
 
 //=================================================================================================
@@ -122,7 +122,7 @@ const BRepGraph_MeshCache::EdgeMeshEntry* BRepGraph_MeshCacheStorage::FindEdgeMe
 {
   if (!theEdge.IsValidIn(myEdgeMeshes))
     return nullptr;
-  const BRepGraph_MeshCache::EdgeMeshEntry& anEntry = myEdgeMeshes.Value(theEdge.Index);
+  const BRepGraph_MeshCache::EdgeMeshEntry& anEntry = myEdgeMeshes.Value(static_cast<size_t>(theEdge.Index));
   if (!anEntry.IsPresent())
     return nullptr;
   return &anEntry;
@@ -133,8 +133,8 @@ const BRepGraph_MeshCache::EdgeMeshEntry* BRepGraph_MeshCacheStorage::FindEdgeMe
 BRepGraph_MeshCache::EdgeMeshEntry& BRepGraph_MeshCacheStorage::ChangeEdgeMesh(
   const BRepGraph_EdgeId theEdge)
 {
-  ensureSize(myEdgeMeshes, theEdge.Index);
-  return myEdgeMeshes.ChangeValue(theEdge.Index);
+  ensureSize(myEdgeMeshes, static_cast<size_t>(theEdge.Index));
+  return myEdgeMeshes.ChangeValue(static_cast<size_t>(theEdge.Index));
 }
 
 //=================================================================================================
@@ -143,7 +143,7 @@ void BRepGraph_MeshCacheStorage::ClearEdgeMesh(const BRepGraph_EdgeId theEdge)
 {
   if (theEdge.IsValidIn(myEdgeMeshes))
   {
-    myEdgeMeshes.ChangeValue(theEdge.Index).Reset();
+    myEdgeMeshes.ChangeValue(static_cast<size_t>(theEdge.Index)).Reset();
   }
 }
 
@@ -175,11 +175,11 @@ void BRepGraph_MeshCacheStorage::OnCompact(
       const BRepGraph_FaceId anOldFaceId(anOldId);
       if (!anOldFaceId.IsValidIn(myFaceMeshes))
         continue;
-      const BRepGraph_MeshCache::FaceMeshEntry& anOldEntry = myFaceMeshes.Value(anOldFaceId.Index);
+      const BRepGraph_MeshCache::FaceMeshEntry& anOldEntry = myFaceMeshes.Value(static_cast<size_t>(anOldFaceId.Index));
       if (!anOldEntry.IsPresent())
         continue;
-      ensureSize(aNewFaces, aNewId.Index);
-      aNewFaces.ChangeValue(aNewId.Index) = anOldEntry;
+      ensureSize(aNewFaces, static_cast<size_t>(aNewId.Index));
+      aNewFaces.ChangeValue(static_cast<size_t>(aNewId.Index)) = anOldEntry;
     }
     myFaceMeshes = std::move(aNewFaces);
   }
@@ -199,11 +199,11 @@ void BRepGraph_MeshCacheStorage::OnCompact(
       if (!anOldCoEdgeId.IsValidIn(myCoEdgeMeshes))
         continue;
       const BRepGraph_MeshCache::CoEdgeMeshEntry& anOldEntry =
-        myCoEdgeMeshes.Value(anOldCoEdgeId.Index);
+        myCoEdgeMeshes.Value(static_cast<size_t>(anOldCoEdgeId.Index));
       if (!anOldEntry.IsPresent())
         continue;
-      ensureSize(aNewCoEdges, aNewId.Index);
-      aNewCoEdges.ChangeValue(aNewId.Index) = anOldEntry;
+      ensureSize(aNewCoEdges, static_cast<size_t>(aNewId.Index));
+      aNewCoEdges.ChangeValue(static_cast<size_t>(aNewId.Index)) = anOldEntry;
     }
     myCoEdgeMeshes = std::move(aNewCoEdges);
   }
@@ -222,11 +222,11 @@ void BRepGraph_MeshCacheStorage::OnCompact(
       const BRepGraph_EdgeId anOldEdgeId(anOldId);
       if (!anOldEdgeId.IsValidIn(myEdgeMeshes))
         continue;
-      const BRepGraph_MeshCache::EdgeMeshEntry& anOldEntry = myEdgeMeshes.Value(anOldEdgeId.Index);
+      const BRepGraph_MeshCache::EdgeMeshEntry& anOldEntry = myEdgeMeshes.Value(static_cast<size_t>(anOldEdgeId.Index));
       if (!anOldEntry.IsPresent())
         continue;
-      ensureSize(aNewEdges, aNewId.Index);
-      aNewEdges.ChangeValue(aNewId.Index) = anOldEntry;
+      ensureSize(aNewEdges, static_cast<size_t>(aNewId.Index));
+      aNewEdges.ChangeValue(static_cast<size_t>(aNewId.Index)) = anOldEntry;
     }
     myEdgeMeshes = std::move(aNewEdges);
   }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_MeshCache.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_MeshCache.cxx
@@ -40,7 +40,8 @@ const BRepGraph_MeshCache::FaceMeshEntry* BRepGraph_MeshCacheStorage::FindFaceMe
 {
   if (!theFace.IsValidIn(myFaceMeshes))
     return nullptr;
-  const BRepGraph_MeshCache::FaceMeshEntry& anEntry = myFaceMeshes.Value(static_cast<size_t>(theFace.Index));
+  const BRepGraph_MeshCache::FaceMeshEntry& anEntry =
+    myFaceMeshes.Value(static_cast<size_t>(theFace.Index));
   if (!anEntry.IsPresent())
     return nullptr;
   return &anEntry;
@@ -81,7 +82,8 @@ const BRepGraph_MeshCache::CoEdgeMeshEntry* BRepGraph_MeshCacheStorage::FindCoEd
 {
   if (!theCoEdge.IsValidIn(myCoEdgeMeshes))
     return nullptr;
-  const BRepGraph_MeshCache::CoEdgeMeshEntry& anEntry = myCoEdgeMeshes.Value(static_cast<size_t>(theCoEdge.Index));
+  const BRepGraph_MeshCache::CoEdgeMeshEntry& anEntry =
+    myCoEdgeMeshes.Value(static_cast<size_t>(theCoEdge.Index));
   if (!anEntry.IsPresent())
     return nullptr;
   return &anEntry;
@@ -122,7 +124,8 @@ const BRepGraph_MeshCache::EdgeMeshEntry* BRepGraph_MeshCacheStorage::FindEdgeMe
 {
   if (!theEdge.IsValidIn(myEdgeMeshes))
     return nullptr;
-  const BRepGraph_MeshCache::EdgeMeshEntry& anEntry = myEdgeMeshes.Value(static_cast<size_t>(theEdge.Index));
+  const BRepGraph_MeshCache::EdgeMeshEntry& anEntry =
+    myEdgeMeshes.Value(static_cast<size_t>(theEdge.Index));
   if (!anEntry.IsPresent())
     return nullptr;
   return &anEntry;
@@ -175,7 +178,8 @@ void BRepGraph_MeshCacheStorage::OnCompact(
       const BRepGraph_FaceId anOldFaceId(anOldId);
       if (!anOldFaceId.IsValidIn(myFaceMeshes))
         continue;
-      const BRepGraph_MeshCache::FaceMeshEntry& anOldEntry = myFaceMeshes.Value(static_cast<size_t>(anOldFaceId.Index));
+      const BRepGraph_MeshCache::FaceMeshEntry& anOldEntry =
+        myFaceMeshes.Value(static_cast<size_t>(anOldFaceId.Index));
       if (!anOldEntry.IsPresent())
         continue;
       ensureSize(aNewFaces, static_cast<size_t>(aNewId.Index));
@@ -222,7 +226,8 @@ void BRepGraph_MeshCacheStorage::OnCompact(
       const BRepGraph_EdgeId anOldEdgeId(anOldId);
       if (!anOldEdgeId.IsValidIn(myEdgeMeshes))
         continue;
-      const BRepGraph_MeshCache::EdgeMeshEntry& anOldEntry = myEdgeMeshes.Value(static_cast<size_t>(anOldEdgeId.Index));
+      const BRepGraph_MeshCache::EdgeMeshEntry& anOldEntry =
+        myEdgeMeshes.Value(static_cast<size_t>(anOldEdgeId.Index));
       if (!anOldEntry.IsPresent())
         continue;
       ensureSize(aNewEdges, static_cast<size_t>(aNewId.Index));

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_MeshCache.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_MeshCache.hxx
@@ -178,7 +178,7 @@ public:
 private:
   //! Ensure vector has at least theIndex+1 elements.
   template <typename T>
-  static void ensureSize(NCollection_Vector<T>& theVec, const int theIndex);
+  static void ensureSize(NCollection_Vector<T>& theVec, const size_t theIndex);
 
   NCollection_Vector<BRepGraph_MeshCache::FaceMeshEntry>   myFaceMeshes;
   NCollection_Vector<BRepGraph_MeshCache::CoEdgeMeshEntry> myCoEdgeMeshes;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_NodeId.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_NodeId.hxx
@@ -18,13 +18,15 @@
 #include <Standard_HashUtils.hxx>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <limits>
 #include <utility>
 
 //! Lightweight typed index into a per-kind node vector inside BRepGraph.
 //!
 //! The pair (NodeKind, Index) forms a unique node identifier within one graph
-//! instance.  Default-constructed NodeId has Index = -1 (invalid).
+//! instance.  Default-constructed NodeId has Index = UINT32_MAX (invalid).
 //!
 //! NodeId is a value type: cheap to copy, compare, hash.  It carries no
 //! pointer back to the owning graph; the caller is responsible for using
@@ -62,22 +64,21 @@ struct BRepGraph_NodeId
   template <Kind TheKind>
   struct Typed
   {
-    static constexpr int THE_START_INDEX   = 0;
-    static constexpr int THE_INVALID_INDEX = -1;
+    static constexpr uint32_t THE_START_INDEX   = 0u;
+    static constexpr uint32_t THE_INVALID_INDEX = std::numeric_limits<uint32_t>::max();
 
-    int Index;
+    uint32_t Index;
 
-    //! Default: invalid (Index = -1).
+    //! Default: invalid (Index = UINT32_MAX).
     Typed()
         : Index(THE_INVALID_INDEX)
     {
     }
 
     //! Construct from index.
-    explicit Typed(const int theIdx)
+    explicit Typed(const uint32_t theIdx)
         : Index(theIdx)
     {
-      Standard_ASSERT_VOID(theIdx >= THE_INVALID_INDEX, "index must be >= -1");
     }
 
     //! Construct from an untyped node id of the same kind.
@@ -96,14 +97,11 @@ struct BRepGraph_NodeId
     [[nodiscard]] static Typed Invalid() { return Typed(); }
 
     //! True if this id points to an allocated node slot.
-    [[nodiscard]] bool IsValid() const { return Index > THE_INVALID_INDEX; }
+    [[nodiscard]] bool IsValid() const { return Index != THE_INVALID_INDEX; }
 
     //! True if this id points to an allocated slot within [0, theMaxCount).
-    [[nodiscard]] bool IsValid(const int theMaxCount) const
-    {
-      Standard_ASSERT_RETURN(theMaxCount >= 0, "max count must be non-negative", false);
-      return IsValid() && Index < theMaxCount;
-    }
+    //! UINT32_MAX (invalid sentinel) always fails this check for any realistic count.
+    [[nodiscard]] bool IsValid(const uint32_t theMaxCount) const { return Index < theMaxCount; }
 
     //! True if this id is within the dense range exposed by a provider with Nb().
     template <typename CountProviderT>
@@ -113,12 +111,12 @@ struct BRepGraph_NodeId
       return IsValid(theProvider.Nb());
     }
 
-    //! True if this id is within the dense range exposed by a provider with Length().
+    //! True if this id is within the dense range exposed by a provider with Size().
     template <typename CountProviderT>
     [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
-      -> decltype(theProvider.Length(), bool())
+      -> decltype(theProvider.Size(), bool())
     {
-      return IsValid(theProvider.Length());
+      return IsValid(static_cast<uint32_t>(theProvider.Size()));
     }
 
     //! Implicit conversion to untyped NodeId.
@@ -148,7 +146,7 @@ struct BRepGraph_NodeId
     //! Pre-increment (++id).
     Typed& operator++()
     {
-      Standard_ASSERT_VOID(Index >= 0, "pre-increment on invalid id");
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "pre-increment on invalid id");
       ++Index;
       return *this;
     }
@@ -156,17 +154,25 @@ struct BRepGraph_NodeId
     //! Post-increment (id++).
     Typed operator++(int)
     {
-      Standard_ASSERT_VOID(Index >= 0, "post-increment on invalid id");
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "post-increment on invalid id");
       Typed aPrev = *this;
       ++Index;
       return aPrev;
     }
 
     //! Advance by offset.
-    [[nodiscard]] Typed operator+(const int theOffset) const { return Typed(Index + theOffset); }
+    [[nodiscard]] Typed operator+(const uint32_t theOffset) const
+    {
+      return Typed(Index + theOffset);
+    }
 
     //! Retreat by offset.
-    [[nodiscard]] Typed operator-(const int theOffset) const { return Typed(Index - theOffset); }
+    [[nodiscard]] Typed operator-(const uint32_t theOffset) const
+    {
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX && Index >= theOffset,
+                           "retreat underflows index");
+      return Typed(Index - theOffset);
+    }
 
     //! Comparison with untyped NodeId (checks both Kind and Index).
     bool operator==(const BRepGraph_NodeId& theOther) const
@@ -199,14 +205,14 @@ struct BRepGraph_NodeId
 
   //! Total number of dense kind slots used by per-kind arrays.
   //! Includes the reserved gap at enum value 9.
-  static constexpr int THE_KIND_COUNT    = static_cast<int>(Kind::Occurrence) + 1;
-  static constexpr int THE_START_INDEX   = 0;
-  static constexpr int THE_INVALID_INDEX = -1;
+  static constexpr int      THE_KIND_COUNT    = static_cast<int>(Kind::Occurrence) + 1;
+  static constexpr uint32_t THE_START_INDEX   = 0u;
+  static constexpr uint32_t THE_INVALID_INDEX = std::numeric_limits<uint32_t>::max();
 
-  Kind NodeKind;
-  int  Index;
+  Kind     NodeKind;
+  uint32_t Index;
 
-  //! Default: invalid NodeId (Index = -1).
+  //! Default: invalid NodeId (Index = UINT32_MAX).
   //! NodeKind is set to Kind::Solid but is meaningless when !IsValid().
   BRepGraph_NodeId()
       : NodeKind(Kind::Solid),
@@ -214,11 +220,10 @@ struct BRepGraph_NodeId
   {
   }
 
-  BRepGraph_NodeId(const Kind theKind, const int theIdx)
+  BRepGraph_NodeId(const Kind theKind, const uint32_t theIdx)
       : NodeKind(theKind),
         Index(theIdx)
   {
-    Standard_ASSERT_VOID(theIdx >= THE_INVALID_INDEX, "BRepGraph_NodeId: index must be >= -1");
   }
 
   //! First valid id in a dense sequence for the specified kind.
@@ -234,14 +239,11 @@ struct BRepGraph_NodeId
   }
 
   //! True if this id points to an allocated node slot.
-  [[nodiscard]] bool IsValid() const { return Index > THE_INVALID_INDEX; }
+  [[nodiscard]] bool IsValid() const { return Index != THE_INVALID_INDEX; }
 
   //! True if this id points to an allocated slot within [0, theMaxCount).
-  [[nodiscard]] bool IsValid(const int theMaxCount) const
-  {
-    Standard_ASSERT_RETURN(theMaxCount >= 0, "max count must be non-negative", false);
-    return IsValid() && Index < theMaxCount;
-  }
+  //! UINT32_MAX (invalid sentinel) always fails this check for any realistic count.
+  [[nodiscard]] bool IsValid(const uint32_t theMaxCount) const { return Index < theMaxCount; }
 
   //! True if this id is within the dense range exposed by a provider with Nb().
   template <typename CountProviderT>
@@ -251,12 +253,12 @@ struct BRepGraph_NodeId
     return IsValid(theProvider.Nb());
   }
 
-  //! True if this id is within the dense range exposed by a provider with Length().
+  //! True if this id is within the dense range exposed by a provider with Size().
   template <typename CountProviderT>
   [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
-    -> decltype(theProvider.Length(), bool())
+    -> decltype(theProvider.Size(), bool())
   {
-    return IsValid(theProvider.Length());
+    return IsValid(static_cast<uint32_t>(theProvider.Size()));
   }
 
   bool operator==(const BRepGraph_NodeId& theOther) const
@@ -276,7 +278,7 @@ struct BRepGraph_NodeId
   //! Pre-increment (++id).
   BRepGraph_NodeId& operator++()
   {
-    Standard_ASSERT_VOID(Index >= 0, "pre-increment on invalid id");
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "pre-increment on invalid id");
     ++Index;
     return *this;
   }
@@ -284,21 +286,23 @@ struct BRepGraph_NodeId
   //! Post-increment (id++).
   BRepGraph_NodeId operator++(int)
   {
-    Standard_ASSERT_VOID(Index >= 0, "post-increment on invalid id");
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "post-increment on invalid id");
     BRepGraph_NodeId aPrev = *this;
     ++Index;
     return aPrev;
   }
 
   //! Advance by offset.
-  [[nodiscard]] BRepGraph_NodeId operator+(const int theOffset) const
+  [[nodiscard]] BRepGraph_NodeId operator+(const uint32_t theOffset) const
   {
     return BRepGraph_NodeId(NodeKind, Index + theOffset);
   }
 
   //! Retreat by offset.
-  [[nodiscard]] BRepGraph_NodeId operator-(const int theOffset) const
+  [[nodiscard]] BRepGraph_NodeId operator-(const uint32_t theOffset) const
   {
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX && Index >= theOffset,
+                         "retreat underflows index");
     return BRepGraph_NodeId(NodeKind, Index - theOffset);
   }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ParentExplorer.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ParentExplorer.cxx
@@ -392,14 +392,14 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
 
   for (;;)
   {
-    const int aParentIdx = theChild.NextParentIdx++;
+    const uint32_t aParentIdx = theChild.NextParentIdx++;
 
     switch (theChild.Node.NodeKind)
     {
       case Kind::Vertex: {
         const BRepGraph_VertexId      aVertexId(theChild.Node);
         const BRepGraph_EdgesOfVertex aParents(*myGraph, aTopo.Vertices().Edges(aVertexId));
-        if (aParentIdx >= aParents.Length())
+        if (aParentIdx >= aParents.Size())
         {
           return false;
         }
@@ -426,10 +426,12 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
       case Kind::Edge: {
         const BRepGraph_EdgeId        aEdgeId(theChild.Node);
         const BRepGraph_CoEdgesOfEdge aParents(*myGraph, aTopo.Edges().CoEdges(aEdgeId));
-        if (aParentIdx >= aParents.Length())
+        if (aParentIdx >= static_cast<uint32_t>(aParents.Size()))
         {
           BRepGraph_ProductId aProductId;
-          if (!findNthProductWrapper(theChild.Node, aParentIdx - aParents.Length(), aProductId))
+          if (!findNthProductWrapper(theChild.Node,
+                                     aParentIdx - static_cast<uint32_t>(aParents.Size()),
+                                     aProductId))
           {
             return false;
           }
@@ -456,10 +458,12 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
       case Kind::Wire: {
         const BRepGraph_WireId      aWireId(theChild.Node);
         const BRepGraph_FacesOfWire aParents(*myGraph, aTopo.Wires().Faces(aWireId));
-        if (aParentIdx >= aParents.Length())
+        if (aParentIdx >= static_cast<uint32_t>(aParents.Size()))
         {
           BRepGraph_ProductId aProductId;
-          if (!findNthProductWrapper(theChild.Node, aParentIdx - aParents.Length(), aProductId))
+          if (!findNthProductWrapper(theChild.Node,
+                                     aParentIdx - static_cast<uint32_t>(aParents.Size()),
+                                     aProductId))
           {
             return false;
           }
@@ -493,8 +497,8 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
         const BRepGraph_FaceId          aFaceId(theChild.Node);
         const BRepGraph_ShellsOfFace    aShells(*myGraph, aTopo.Faces().Shells(aFaceId));
         const BRepGraph_CompoundsOfFace aCompounds(*myGraph, aTopo.Faces().Compounds(aFaceId));
-        const int                       aNbShells    = aShells.Length();
-        const int                       aNbCompounds = aCompounds.Length();
+        const uint32_t                  aNbShells    = static_cast<uint32_t>(aShells.Size());
+        const uint32_t                  aNbCompounds = static_cast<uint32_t>(aCompounds.Size());
         if (aParentIdx < aNbShells)
         {
           const BRepGraph_ShellId       aShellId = aShells.Value(aParentIdx);
@@ -554,8 +558,8 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
         const BRepGraph_ShellId          aShellId = BRepGraph_ShellId(theChild.Node);
         const BRepGraph_SolidsOfShell    aSolids(*myGraph, aTopo.Shells().Solids(aShellId));
         const BRepGraph_CompoundsOfShell aCompounds(*myGraph, aTopo.Shells().Compounds(aShellId));
-        const int                        aNbSolids    = aSolids.Length();
-        const int                        aNbCompounds = aCompounds.Length();
+        const uint32_t                   aNbSolids    = static_cast<uint32_t>(aSolids.Size());
+        const uint32_t                   aNbCompounds = static_cast<uint32_t>(aCompounds.Size());
         if (aParentIdx < aNbSolids)
         {
           const BRepGraph_SolidId       aSolidId = aSolids.Value(aParentIdx);
@@ -616,8 +620,8 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
         const BRepGraph_CompSolidsOfSolid aCompSolids(*myGraph,
                                                       aTopo.Solids().CompSolids(aSolidId));
         const BRepGraph_CompoundsOfSolid  aCompounds(*myGraph, aTopo.Solids().Compounds(aSolidId));
-        const int                         aNbCompSolids = aCompSolids.Length();
-        const int                         aNbCompounds  = aCompounds.Length();
+        const uint32_t                    aNbCompSolids = static_cast<uint32_t>(aCompSolids.Size());
+        const uint32_t                    aNbCompounds  = static_cast<uint32_t>(aCompounds.Size());
         if (aParentIdx < aNbCompSolids)
         {
           const BRepGraph_CompSolidId       aCompSolidId = aCompSolids.Value(aParentIdx);
@@ -679,7 +683,7 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
         const BRepGraph_CompoundsOfCompound aParents(
           *myGraph,
           aTopo.Compounds().ParentCompounds(aCompoundId));
-        const int aNbParents = aParents.Length();
+        const uint32_t aNbParents = static_cast<uint32_t>(aParents.Size());
         if (aParentIdx < aNbParents)
         {
           const BRepGraph_CompoundId       aParentCompoundId = aParents.Value(aParentIdx);
@@ -718,7 +722,7 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
         const BRepGraph_CompSolidId          aCompSolidId(theChild.Node);
         const BRepGraph_CompoundsOfCompSolid aParents(*myGraph,
                                                       aTopo.CompSolids().Compounds(aCompSolidId));
-        const int                            aNbParents = aParents.Length();
+        const uint32_t                       aNbParents = static_cast<uint32_t>(aParents.Size());
         if (aParentIdx < aNbParents)
         {
           const BRepGraph_CompoundId       aParentCompoundId = aParents.Value(aParentIdx);
@@ -756,7 +760,7 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
       case Kind::CoEdge: {
         const BRepGraph_CoEdgeId      aCoEdgeId(theChild.Node);
         const BRepGraph_WiresOfCoEdge aWires(*myGraph, aTopo.CoEdges().Wires(aCoEdgeId));
-        const int                     aNbWires = aWires.Length();
+        const uint32_t                aNbWires = static_cast<uint32_t>(aWires.Size());
         if (aParentIdx >= aNbWires)
         {
           return false;
@@ -785,13 +789,13 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
         const BRepGraph_ProductId                         aProductId(theChild.Node);
         const NCollection_Vector<BRepGraph_OccurrenceId>& anOccurrences =
           aTopo.Products().Instances(aProductId);
-        const int aNbOccurrences = anOccurrences.Length();
+        const uint32_t aNbOccurrences = static_cast<uint32_t>(anOccurrences.Size());
         if (aParentIdx >= aNbOccurrences)
         {
           return false;
         }
 
-        const BRepGraph_OccurrenceId       anOccurrenceId = anOccurrences.Value(aParentIdx);
+        const BRepGraph_OccurrenceId       anOccurrenceId = anOccurrences.Value(static_cast<size_t>(aParentIdx));
         const BRepGraphInc::OccurrenceDef& anOccurrence =
           aTopo.Occurrences().Definition(anOccurrenceId);
         if (anOccurrence.IsRemoved)
@@ -896,13 +900,12 @@ void BRepGraph_ParentExplorer::applyTransition(const BRepGraph_NodeId theParent,
       {
         return;
       }
-      const BRepGraph::RefsView&                           aRefs = myGraph->Refs();
-      const NCollection_Vector<BRepGraph_OccurrenceRefId>& aRefIds =
-        aRefs.Occurrences().IdsOf(aParentProductId);
-      for (int i = 0; i < aRefIds.Length(); ++i)
+      const BRepGraph::RefsView& aRefs = myGraph->Refs();
+      for (BRepGraph_RefsOccurrenceOfProduct anOccIt(*myGraph, aParentProductId); anOccIt.More();
+           anOccIt.Next())
       {
-        const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(aRefIds.Value(i));
-        if (!aRef.IsRemoved && aRef.OccurrenceDefId == anOccId)
+        const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(anOccIt.CurrentId());
+        if (aRef.OccurrenceDefId == anOccId)
         {
           theLocation = theLocation * aRef.LocalLocation;
           return;
@@ -928,19 +931,14 @@ void BRepGraph_ParentExplorer::applyTransition(const BRepGraph_NodeId theParent,
       {
         return;
       }
-      const BRepGraph::RefsView&                           aRefs = myGraph->Refs();
-      const NCollection_Vector<BRepGraph_OccurrenceRefId>& aRefIds =
-        aRefs.Occurrences().IdsOf(aProductId);
-      for (int i = 0; i < aRefIds.Length(); ++i)
+      const BRepGraph::RefsView& aRefs = myGraph->Refs();
+      for (BRepGraph_RefsOccurrenceOfProduct anOccIt(*myGraph, aProductId); anOccIt.More();
+           anOccIt.Next())
       {
-        const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(aRefIds.Value(i));
-        if (aRef.IsRemoved)
-        {
-          continue;
-        }
+        const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(anOccIt.CurrentId());
         const BRepGraphInc::OccurrenceDef& anOccDef =
           aTopo.Occurrences().Definition(aRef.OccurrenceDefId);
-        if (!anOccDef.IsRemoved && anOccDef.ChildDefId == theChild)
+        if (anOccDef.ChildDefId == theChild)
         {
           theLocation = theLocation * aRef.LocalLocation;
           return;
@@ -974,36 +972,26 @@ int BRepGraph_ParentExplorer::branchRootFrame() const
 //=================================================================================================
 
 bool BRepGraph_ParentExplorer::findNthProductWrapper(const BRepGraph_NodeId theNode,
-                                                     const int              theOrdinal,
+                                                     const uint32_t         theOrdinal,
                                                      BRepGraph_ProductId&   theProduct) const
 {
-  if (theOrdinal < 0)
-  {
-    return false;
-  }
-
   const BRepGraph::TopoView& aTopo  = myGraph->Topo();
   const BRepGraph::RefsView& aRefs  = myGraph->Refs();
-  int                        aCount = 0;
+  uint32_t                   aCount = 0;
   for (int aPass = 0; aPass < 2; ++aPass)
   {
     for (BRepGraph_ProductIterator aProdIt(*myGraph); aProdIt.More(); aProdIt.Next())
     {
       const BRepGraph_ProductId aProductId = aProdIt.CurrentId();
 
-      bool                                                 aHasChild = false;
-      const NCollection_Vector<BRepGraph_OccurrenceRefId>& aRefIds =
-        aRefs.Occurrences().IdsOf(aProductId);
-      for (int i = 0; i < aRefIds.Length(); ++i)
+      bool aHasChild = false;
+      for (BRepGraph_RefsOccurrenceOfProduct anOccIt(*myGraph, aProductId); anOccIt.More();
+           anOccIt.Next())
       {
-        const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(aRefIds.Value(i));
-        if (aRef.IsRemoved)
-        {
-          continue;
-        }
+        const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(anOccIt.CurrentId());
         const BRepGraphInc::OccurrenceDef& anOccDef =
           aTopo.Occurrences().Definition(aRef.OccurrenceDefId);
-        if (!anOccDef.IsRemoved && anOccDef.ChildDefId == theNode)
+        if (anOccDef.ChildDefId == theNode)
         {
           aHasChild = true;
           break;
@@ -1040,12 +1028,11 @@ bool BRepGraph_ParentExplorer::findParentProduct(const BRepGraph_OccurrenceId th
   for (BRepGraph_ProductIterator aProdIt(*myGraph); aProdIt.More(); aProdIt.Next())
   {
     const BRepGraph_ProductId                            aProductId = aProdIt.CurrentId();
-    const NCollection_Vector<BRepGraph_OccurrenceRefId>& aRefIds =
-      aRefs.Occurrences().IdsOf(aProductId);
-    for (int i = 0; i < aRefIds.Length(); ++i)
+    for (BRepGraph_RefsOccurrenceOfProduct anOccIt(*myGraph, aProductId); anOccIt.More();
+         anOccIt.Next())
     {
-      const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(aRefIds.Value(i));
-      if (!aRef.IsRemoved && aRef.OccurrenceDefId == theOccurrence)
+      const BRepGraphInc::OccurrenceRef& aRef = aRefs.Occurrences().Entry(anOccIt.CurrentId());
+      if (aRef.OccurrenceDefId == theOccurrence)
       {
         theProduct = aProductId;
         return true;
@@ -1129,12 +1116,13 @@ int BRepGraph_ParentExplorer::findSolidChildStep(const BRepGraph_SolidId thePare
     return -1;
   }
 
-  for (int aRefIdx = 0; aRefIdx < aSolid.AuxChildRefIds.Length(); ++aRefIdx)
   {
-    const BRepGraph_ChildRefId aRefId = aSolid.AuxChildRefIds.Value(aRefIdx);
-    if (!aRefs.IsRemoved(aRefId) && aRefs.ChildNode(aRefId) == theChild)
+    uint32_t aRefIdx = 0;
+    for (const BRepGraph_ChildRefId& aRefId : aSolid.AuxChildRefIds)
     {
-      return aSolid.ShellRefIds.Length() + aRefIdx;
+      if (!aRefs.IsRemoved(aRefId) && aRefs.ChildNode(aRefId) == theChild)
+        return aSolid.ShellRefIds.Length() + static_cast<int>(aRefIdx);
+      ++aRefIdx;
     }
   }
   return -1;
@@ -1162,12 +1150,13 @@ int BRepGraph_ParentExplorer::findShellChildStep(const BRepGraph_ShellId thePare
     return -1;
   }
 
-  for (int aRefIdx = 0; aRefIdx < aShell.AuxChildRefIds.Length(); ++aRefIdx)
   {
-    const BRepGraph_ChildRefId aRefId = aShell.AuxChildRefIds.Value(aRefIdx);
-    if (!aRefs.IsRemoved(aRefId) && aRefs.ChildNode(aRefId) == theChild)
+    uint32_t aRefIdx = 0;
+    for (const BRepGraph_ChildRefId& aRefId : aShell.AuxChildRefIds)
     {
-      return aShell.FaceRefIds.Length() + aRefIdx;
+      if (!aRefs.IsRemoved(aRefId) && aRefs.ChildNode(aRefId) == theChild)
+        return aShell.FaceRefIds.Length() + static_cast<int>(aRefIdx);
+      ++aRefIdx;
     }
   }
   return -1;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ParentExplorer.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ParentExplorer.cxx
@@ -795,7 +795,8 @@ bool BRepGraph_ParentExplorer::nextParentFrame(StackFrame& theChild, StackFrame&
           return false;
         }
 
-        const BRepGraph_OccurrenceId       anOccurrenceId = anOccurrences.Value(static_cast<size_t>(aParentIdx));
+        const BRepGraph_OccurrenceId anOccurrenceId =
+          anOccurrences.Value(static_cast<size_t>(aParentIdx));
         const BRepGraphInc::OccurrenceDef& anOccurrence =
           aTopo.Occurrences().Definition(anOccurrenceId);
         if (anOccurrence.IsRemoved)
@@ -1027,7 +1028,7 @@ bool BRepGraph_ParentExplorer::findParentProduct(const BRepGraph_OccurrenceId th
   const BRepGraph::RefsView& aRefs = myGraph->Refs();
   for (BRepGraph_ProductIterator aProdIt(*myGraph); aProdIt.More(); aProdIt.Next())
   {
-    const BRepGraph_ProductId                            aProductId = aProdIt.CurrentId();
+    const BRepGraph_ProductId aProductId = aProdIt.CurrentId();
     for (BRepGraph_RefsOccurrenceOfProduct anOccIt(*myGraph, aProductId); anOccIt.More();
          anOccIt.Next())
     {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ParentExplorer.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ParentExplorer.hxx
@@ -194,7 +194,7 @@ private:
   struct StackFrame
   {
     BRepGraph_NodeId   Node;
-    int                NextParentIdx = 0;
+    uint32_t           NextParentIdx = 0;
     int                StepToChild   = -1;
     TopLoc_Location    AccLocation;
     TopAbs_Orientation AccOrientation = TopAbs_FORWARD;
@@ -215,7 +215,7 @@ private:
   [[nodiscard]] Standard_EXPORT int branchRootFrame() const;
 
   Standard_EXPORT bool findNthProductWrapper(const BRepGraph_NodeId theNode,
-                                             const int              theOrdinal,
+                                             const uint32_t         theOrdinal,
                                              BRepGraph_ProductId&   theProduct) const;
 
   Standard_EXPORT bool findParentProduct(const BRepGraph_OccurrenceId theOccurrence,

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RefId.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RefId.hxx
@@ -18,13 +18,15 @@
 #include <Standard_HashUtils.hxx>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <limits>
 #include <utility>
 
 //! Lightweight typed index into a per-kind reference vector inside BRepGraph.
 //!
 //! The pair (Kind, Index) forms a unique reference identifier within one graph
-//! instance. Default-constructed RefId has Index = -1 (invalid).
+//! instance. Default-constructed RefId has Index = UINT32_MAX (invalid).
 struct BRepGraph_RefId
 {
   //! Enumeration of supported topology reference kinds.
@@ -46,20 +48,19 @@ struct BRepGraph_RefId
   template <Kind TheKind>
   struct Typed
   {
-    static constexpr int THE_START_INDEX   = 0;
-    static constexpr int THE_INVALID_INDEX = -1;
+    static constexpr uint32_t THE_START_INDEX   = 0u;
+    static constexpr uint32_t THE_INVALID_INDEX = std::numeric_limits<uint32_t>::max();
 
-    int Index;
+    uint32_t Index;
 
     Typed()
         : Index(THE_INVALID_INDEX)
     {
     }
 
-    explicit Typed(const int theIdx)
+    explicit Typed(const uint32_t theIdx)
         : Index(theIdx)
     {
-      Standard_ASSERT_VOID(theIdx >= THE_INVALID_INDEX, "index must be >= -1");
     }
 
     //! Construct from an untyped reference id of the same kind.
@@ -77,13 +78,11 @@ struct BRepGraph_RefId
     //! Invalid sentinel id.
     [[nodiscard]] static Typed Invalid() { return Typed(); }
 
-    [[nodiscard]] bool IsValid() const { return Index > THE_INVALID_INDEX; }
+    [[nodiscard]] bool IsValid() const { return Index != THE_INVALID_INDEX; }
 
-    [[nodiscard]] bool IsValid(const int theMaxCount) const
-    {
-      Standard_ASSERT_RETURN(theMaxCount >= 0, "max count must be non-negative", false);
-      return IsValid() && Index < theMaxCount;
-    }
+    //! True if this id points to an allocated slot within [0, theMaxCount).
+    //! UINT32_MAX (invalid sentinel) always fails this check for any realistic count.
+    [[nodiscard]] bool IsValid(const uint32_t theMaxCount) const { return Index < theMaxCount; }
 
     template <typename CountProviderT>
     [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
@@ -94,9 +93,9 @@ struct BRepGraph_RefId
 
     template <typename CountProviderT>
     [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
-      -> decltype(theProvider.Length(), bool())
+      -> decltype(theProvider.Size(), bool())
     {
-      return IsValid(theProvider.Length());
+      return IsValid(static_cast<uint32_t>(theProvider.Size()));
     }
 
     operator BRepGraph_RefId() const { return BRepGraph_RefId(TheKind, Index); }
@@ -122,7 +121,7 @@ struct BRepGraph_RefId
     //! Pre-increment (++id).
     Typed& operator++()
     {
-      Standard_ASSERT_VOID(Index >= 0, "pre-increment on invalid id");
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "pre-increment on invalid id");
       ++Index;
       return *this;
     }
@@ -130,17 +129,25 @@ struct BRepGraph_RefId
     //! Post-increment (id++).
     Typed operator++(int)
     {
-      Standard_ASSERT_VOID(Index >= 0, "post-increment on invalid id");
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "post-increment on invalid id");
       Typed aPrev = *this;
       ++Index;
       return aPrev;
     }
 
     //! Advance by offset.
-    [[nodiscard]] Typed operator+(const int theOffset) const { return Typed(Index + theOffset); }
+    [[nodiscard]] Typed operator+(const uint32_t theOffset) const
+    {
+      return Typed(Index + theOffset);
+    }
 
     //! Retreat by offset.
-    [[nodiscard]] Typed operator-(const int theOffset) const { return Typed(Index - theOffset); }
+    [[nodiscard]] Typed operator-(const uint32_t theOffset) const
+    {
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX && Index >= theOffset,
+                           "retreat underflows index");
+      return Typed(Index - theOffset);
+    }
 
     bool operator==(const BRepGraph_RefId& theOther) const
     {
@@ -166,11 +173,11 @@ struct BRepGraph_RefId
            && static_cast<int>(theKind) <= static_cast<int>(Kind::Child);
   }
 
-  static constexpr int THE_START_INDEX   = 0;
-  static constexpr int THE_INVALID_INDEX = -1;
+  static constexpr uint32_t THE_START_INDEX   = 0u;
+  static constexpr uint32_t THE_INVALID_INDEX = std::numeric_limits<uint32_t>::max();
 
-  Kind RefKind;
-  int  Index;
+  Kind     RefKind;
+  uint32_t Index;
 
   BRepGraph_RefId()
       : RefKind(Kind::Shell),
@@ -178,11 +185,10 @@ struct BRepGraph_RefId
   {
   }
 
-  BRepGraph_RefId(const Kind theKind, const int theIdx)
+  BRepGraph_RefId(const Kind theKind, const uint32_t theIdx)
       : RefKind(theKind),
         Index(theIdx)
   {
-    Standard_ASSERT_VOID(theIdx >= THE_INVALID_INDEX, "BRepGraph_RefId: index must be >= -1");
   }
 
   //! First valid id in a dense sequence for the specified kind.
@@ -197,13 +203,11 @@ struct BRepGraph_RefId
     return BRepGraph_RefId(theKind, THE_INVALID_INDEX);
   }
 
-  [[nodiscard]] bool IsValid() const { return Index > THE_INVALID_INDEX; }
+  [[nodiscard]] bool IsValid() const { return Index != THE_INVALID_INDEX; }
 
-  [[nodiscard]] bool IsValid(const int theMaxCount) const
-  {
-    Standard_ASSERT_RETURN(theMaxCount >= 0, "max count must be non-negative", false);
-    return IsValid() && Index < theMaxCount;
-  }
+  //! True if this id points to an allocated slot within [0, theMaxCount).
+  //! UINT32_MAX (invalid sentinel) always fails this check for any realistic count.
+  [[nodiscard]] bool IsValid(const uint32_t theMaxCount) const { return Index < theMaxCount; }
 
   template <typename CountProviderT>
   [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
@@ -214,9 +218,9 @@ struct BRepGraph_RefId
 
   template <typename CountProviderT>
   [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
-    -> decltype(theProvider.Length(), bool())
+    -> decltype(theProvider.Size(), bool())
   {
-    return IsValid(theProvider.Length());
+    return IsValid(static_cast<uint32_t>(theProvider.Size()));
   }
 
   bool operator==(const BRepGraph_RefId& theOther) const
@@ -236,7 +240,7 @@ struct BRepGraph_RefId
   //! Pre-increment (++id).
   BRepGraph_RefId& operator++()
   {
-    Standard_ASSERT_VOID(Index >= 0, "pre-increment on invalid id");
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "pre-increment on invalid id");
     ++Index;
     return *this;
   }
@@ -244,21 +248,23 @@ struct BRepGraph_RefId
   //! Post-increment (id++).
   BRepGraph_RefId operator++(int)
   {
-    Standard_ASSERT_VOID(Index >= 0, "post-increment on invalid id");
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "post-increment on invalid id");
     BRepGraph_RefId aPrev = *this;
     ++Index;
     return aPrev;
   }
 
   //! Advance by offset.
-  [[nodiscard]] BRepGraph_RefId operator+(const int theOffset) const
+  [[nodiscard]] BRepGraph_RefId operator+(const uint32_t theOffset) const
   {
     return BRepGraph_RefId(RefKind, Index + theOffset);
   }
 
   //! Retreat by offset.
-  [[nodiscard]] BRepGraph_RefId operator-(const int theOffset) const
+  [[nodiscard]] BRepGraph_RefId operator-(const uint32_t theOffset) const
   {
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX && Index >= theOffset,
+                         "retreat underflows index");
     return BRepGraph_RefId(RefKind, Index - theOffset);
   }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RefTransientCache.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RefTransientCache.cxx
@@ -35,11 +35,11 @@ BRepGraph_RefTransientCache::CacheSlot& BRepGraph_RefTransientCache::changeSlot(
                        "BRepGraph_RefTransientCache: RefKind out of range");
   NCollection_Vector<CacheSlot>& aVec =
     myKinds.ChangeValue(theKindSlot).myRefKinds[aRefKindIdx].mySlots;
-  if (theRef.Index >= aVec.Length())
+  if (theRef.Index >= aVec.Size())
   {
-    return aVec.SetValue(theRef.Index, CacheSlot());
+    return aVec.SetValue(static_cast<size_t>(theRef.Index), CacheSlot());
   }
-  return aVec.ChangeValue(theRef.Index);
+  return aVec.ChangeValue(static_cast<size_t>(theRef.Index));
 }
 
 //=================================================================================================
@@ -62,7 +62,7 @@ const BRepGraph_RefTransientCache::CacheSlot* BRepGraph_RefTransientCache::seekS
   {
     return nullptr;
   }
-  return &aVec.Value(theRef.Index);
+  return &aVec.Value(static_cast<size_t>(theRef.Index));
 }
 
 //=================================================================================================
@@ -132,9 +132,9 @@ void BRepGraph_RefTransientCache::Set(const BRepGraph_RefId                    t
     const int                      aRefKindIdx = static_cast<int>(theRef.RefKind);
     NCollection_Vector<CacheSlot>& aVec =
       myKinds.ChangeValue(theKindSlot).myRefKinds[aRefKindIdx].mySlots;
-    if (theRef.Index < aVec.Length())
+    if (theRef.Index < aVec.Size())
     {
-      CacheSlot& aSlot   = aVec.ChangeValue(theRef.Index);
+      CacheSlot& aSlot   = aVec.ChangeValue(static_cast<size_t>(theRef.Index));
       aSlot.Value        = theValue;
       aSlot.StoredOwnGen = theCurrentOwnGen;
       return;
@@ -185,9 +185,9 @@ occ::handle<BRepGraph_CacheValue> BRepGraph_RefTransientCache::Get(
     const int                            aRefKindIdx = static_cast<int>(theRef.RefKind);
     const NCollection_Vector<CacheSlot>& aVec =
       myKinds.Value(theKindSlot).myRefKinds[aRefKindIdx].mySlots;
-    if (theRef.Index < aVec.Length())
+    if (theRef.Index < aVec.Size())
     {
-      const CacheSlot& aSlot = aVec.Value(theRef.Index);
+      const CacheSlot& aSlot = aVec.Value(static_cast<size_t>(theRef.Index));
       if (aSlot.Value.IsNull())
       {
         return occ::handle<BRepGraph_CacheValue>();
@@ -250,12 +250,12 @@ bool BRepGraph_RefTransientCache::Remove(const BRepGraph_RefId theRef, const int
   const int                      aRefKindIdx = static_cast<int>(theRef.RefKind);
   NCollection_Vector<CacheSlot>& aVec =
     myKinds.ChangeValue(theKindSlot).myRefKinds[aRefKindIdx].mySlots;
-  if (theRef.Index >= aVec.Length())
+  if (theRef.Index >= aVec.Size())
   {
     return false;
   }
 
-  CacheSlot& aSlot = aVec.ChangeValue(theRef.Index);
+  CacheSlot& aSlot = aVec.ChangeValue(static_cast<size_t>(theRef.Index));
   if (aSlot.Value.IsNull())
   {
     return false;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RefsIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RefsIterator.hxx
@@ -497,7 +497,7 @@ public:
     }
 
     myRefIds = &TraitsT::RefIds(theGraph, theParent);
-    myLength = myRefIds->Length();
+    myLength = static_cast<uint32_t>(myRefIds->Size());
     skipRemoved();
   }
 
@@ -509,9 +509,9 @@ public:
     skipRemoved();
   }
 
-  [[nodiscard]] RefId CurrentId() const { return myRefIds->Value(myIndex); }
+  [[nodiscard]] RefId CurrentId() const { return myRefIds->Value(static_cast<size_t>(myIndex)); }
 
-  [[nodiscard]] int Index() const { return myIndex; }
+  [[nodiscard]] uint32_t Index() const { return myIndex; }
 
   //! Returns an STL-compatible iterator for range-based for loops.
   NCollection_ForwardRangeIterator<RefsOfParent> begin()
@@ -527,7 +527,8 @@ private:
   {
     while (myRefIds != nullptr && myIndex < myLength)
     {
-      const typename TraitsT::RefEntry& aRef = TraitsT::Ref(myGraph, myRefIds->Value(myIndex));
+      const typename TraitsT::RefEntry& aRef =
+        TraitsT::Ref(myGraph, myRefIds->Value(static_cast<size_t>(myIndex)));
       if (!aRef.IsRemoved)
       {
         const BRepGraphInc::BaseDef* aChildDef =
@@ -543,8 +544,8 @@ private:
 
   const BRepGraph&                 myGraph;
   const NCollection_Vector<RefId>* myRefIds = nullptr;
-  int                              myIndex  = 0;
-  int                              myLength = 0;
+  uint32_t                         myIndex  = 0;
+  uint32_t                         myLength = 0;
 };
 
 //! @brief Direct active vertex reference ids of an edge.
@@ -565,7 +566,7 @@ public:
     }
 
     myEdge   = &theGraph.Topo().Edges().Definition(theEdgeId);
-    myLength = 2 + myEdge->InternalVertexRefIds.Length();
+    myLength = 2u + static_cast<uint32_t>(myEdge->InternalVertexRefIds.Size());
     skipRemoved();
   }
 
@@ -579,7 +580,7 @@ public:
 
   [[nodiscard]] RefId CurrentId() const { return refIdAt(myIndex); }
 
-  [[nodiscard]] int Index() const { return myIndex; }
+  [[nodiscard]] uint32_t Index() const { return myIndex; }
 
   //! Returns an STL-compatible iterator for range-based for loops.
   NCollection_ForwardRangeIterator<RefsVertexOfEdge> begin()
@@ -591,7 +592,7 @@ public:
   NCollection_ForwardRangeSentinel end() const { return NCollection_ForwardRangeSentinel{}; }
 
 private:
-  [[nodiscard]] RefId refIdAt(const int theIndex) const
+  [[nodiscard]] RefId refIdAt(const uint32_t theIndex) const
   {
     if (theIndex == 0)
     {
@@ -601,7 +602,7 @@ private:
     {
       return myEdge->EndVertexRefId;
     }
-    return myEdge->InternalVertexRefIds.Value(theIndex - 2);
+    return myEdge->InternalVertexRefIds.Value(static_cast<size_t>(theIndex - 2));
   }
 
   void skipRemoved()
@@ -628,8 +629,8 @@ private:
 
   const BRepGraph&             myGraph;
   const BRepGraphInc::EdgeDef* myEdge   = nullptr;
-  int                          myIndex  = 0;
-  int                          myLength = 0;
+  uint32_t                     myIndex  = 0;
+  uint32_t                     myLength = 0;
 };
 
 } // namespace BRepGraph_RefsIterator

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RelatedIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RelatedIterator.hxx
@@ -188,9 +188,9 @@ private:
 
         const NCollection_Vector<BRepGraph_FaceId>& aFaces =
           myGraph->Topo().Edges().Faces(aCoEdgeIt.Current().EdgeDefId);
-        for (; myDeepIndex < aFaces.Length(); ++myDeepIndex)
+        for (; myDeepIndex < static_cast<uint32_t>(aFaces.Size()); ++myDeepIndex)
         {
-          const BRepGraph_FaceId anAdjacentFaceId = aFaces.Value(myDeepIndex);
+          const BRepGraph_FaceId anAdjacentFaceId = aFaces.Value(static_cast<size_t>(myDeepIndex));
           if (anAdjacentFaceId == aFaceId)
           {
             continue;
@@ -372,9 +372,9 @@ private:
   BRepGraph_NodeId myCurrent;
   RelationKind     myRelation   = RelationKind::BoundaryEdge;
   Stage            myStage      = Stage::First;
-  int              myIndex      = 0;
-  int              myInnerIndex = 0;
-  int              myDeepIndex  = 0;
+  uint32_t         myIndex      = 0;
+  uint32_t         myInnerIndex = 0;
+  uint32_t         myDeepIndex  = 0;
   bool             myHasCurrent = false;
 };
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RepId.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_RepId.hxx
@@ -18,13 +18,15 @@
 #include <Standard_HashUtils.hxx>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <limits>
 #include <utility>
 
 //! Lightweight typed index into a per-kind representation vector inside BRepGraph.
 //!
 //! The pair (Kind, Index) forms a unique representation identifier within one
-//! graph instance.  Default-constructed RepId has Index = -1 (invalid).
+//! graph instance.  Default-constructed RepId has Index = UINT32_MAX (invalid).
 //!
 //! Representations are NOT topology nodes - they hold geometry or mesh data
 //! referenced by topology entities.  They do not participate in BFS traversal,
@@ -74,22 +76,21 @@ struct BRepGraph_RepId
   template <Kind TheKind>
   struct Typed
   {
-    static constexpr int THE_START_INDEX   = 0;
-    static constexpr int THE_INVALID_INDEX = -1;
+    static constexpr uint32_t THE_START_INDEX   = 0u;
+    static constexpr uint32_t THE_INVALID_INDEX = std::numeric_limits<uint32_t>::max();
 
-    int Index;
+    uint32_t Index;
 
-    //! Default: invalid (Index = -1).
+    //! Default: invalid (Index = UINT32_MAX).
     Typed()
         : Index(THE_INVALID_INDEX)
     {
     }
 
     //! Construct from index.
-    explicit Typed(const int theIdx)
+    explicit Typed(const uint32_t theIdx)
         : Index(theIdx)
     {
-      Standard_ASSERT_VOID(theIdx >= THE_INVALID_INDEX, "index must be >= -1");
     }
 
     //! Construct from an untyped representation id of the same kind.
@@ -108,14 +109,11 @@ struct BRepGraph_RepId
     [[nodiscard]] static Typed Invalid() { return Typed(); }
 
     //! True if this id points to an allocated representation slot.
-    [[nodiscard]] bool IsValid() const { return Index > THE_INVALID_INDEX; }
+    [[nodiscard]] bool IsValid() const { return Index != THE_INVALID_INDEX; }
 
     //! True if this id points to an allocated slot within [0, theMaxCount).
-    [[nodiscard]] bool IsValid(const int theMaxCount) const
-    {
-      Standard_ASSERT_RETURN(theMaxCount >= 0, "max count must be non-negative", false);
-      return IsValid() && Index < theMaxCount;
-    }
+    //! UINT32_MAX (invalid sentinel) always fails this check for any realistic count.
+    [[nodiscard]] bool IsValid(const uint32_t theMaxCount) const { return Index < theMaxCount; }
 
     //! True if this id is within the dense range exposed by a provider with Nb().
     template <typename CountProviderT>
@@ -128,9 +126,9 @@ struct BRepGraph_RepId
     //! True if this id is within the dense range exposed by a provider with Length().
     template <typename CountProviderT>
     [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
-      -> decltype(theProvider.Length(), bool())
+      -> decltype(theProvider.Size(), bool())
     {
-      return IsValid(theProvider.Length());
+      return IsValid(static_cast<uint32_t>(theProvider.Size()));
     }
 
     //! Implicit conversion to untyped RepId.
@@ -160,7 +158,7 @@ struct BRepGraph_RepId
     //! Pre-increment (++id).
     Typed& operator++()
     {
-      Standard_ASSERT_VOID(Index >= 0, "pre-increment on invalid id");
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "pre-increment on invalid id");
       ++Index;
       return *this;
     }
@@ -168,17 +166,25 @@ struct BRepGraph_RepId
     //! Post-increment (id++).
     Typed operator++(int)
     {
-      Standard_ASSERT_VOID(Index >= 0, "post-increment on invalid id");
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "post-increment on invalid id");
       Typed aPrev = *this;
       ++Index;
       return aPrev;
     }
 
     //! Advance by offset.
-    [[nodiscard]] Typed operator+(const int theOffset) const { return Typed(Index + theOffset); }
+    [[nodiscard]] Typed operator+(const uint32_t theOffset) const
+    {
+      return Typed(Index + theOffset);
+    }
 
     //! Retreat by offset.
-    [[nodiscard]] Typed operator-(const int theOffset) const { return Typed(Index - theOffset); }
+    [[nodiscard]] Typed operator-(const uint32_t theOffset) const
+    {
+      Standard_ASSERT_VOID(Index != THE_INVALID_INDEX && Index >= theOffset,
+                           "retreat underflows index");
+      return Typed(Index - theOffset);
+    }
 
     //! Comparison with untyped RepId (checks both Kind and Index).
     bool operator==(const BRepGraph_RepId& theOther) const
@@ -200,13 +206,13 @@ struct BRepGraph_RepId
     }
   };
 
-  static constexpr int THE_START_INDEX   = 0;
-  static constexpr int THE_INVALID_INDEX = -1;
+  static constexpr uint32_t THE_START_INDEX   = 0u;
+  static constexpr uint32_t THE_INVALID_INDEX = std::numeric_limits<uint32_t>::max();
 
-  Kind RepKind;
-  int  Index;
+  Kind     RepKind;
+  uint32_t Index;
 
-  //! Default: invalid RepId (Index = -1).
+  //! Default: invalid RepId (Index = UINT32_MAX).
   //! RepKind is set to Kind::Surface but is meaningless when !IsValid().
   BRepGraph_RepId()
       : RepKind(Kind::Surface),
@@ -214,11 +220,10 @@ struct BRepGraph_RepId
   {
   }
 
-  BRepGraph_RepId(const Kind theKind, const int theIdx)
+  BRepGraph_RepId(const Kind theKind, const uint32_t theIdx)
       : RepKind(theKind),
         Index(theIdx)
   {
-    Standard_ASSERT_VOID(theIdx >= THE_INVALID_INDEX, "BRepGraph_RepId: index must be >= -1");
   }
 
   //! First valid id in a dense sequence for the specified kind.
@@ -234,14 +239,11 @@ struct BRepGraph_RepId
   }
 
   //! True if this id points to an allocated representation slot.
-  [[nodiscard]] bool IsValid() const { return Index > THE_INVALID_INDEX; }
+  [[nodiscard]] bool IsValid() const { return Index != THE_INVALID_INDEX; }
 
   //! True if this id points to an allocated slot within [0, theMaxCount).
-  [[nodiscard]] bool IsValid(const int theMaxCount) const
-  {
-    Standard_ASSERT_RETURN(theMaxCount >= 0, "max count must be non-negative", false);
-    return IsValid() && Index < theMaxCount;
-  }
+  //! UINT32_MAX (invalid sentinel) always fails this check for any realistic count.
+  [[nodiscard]] bool IsValid(const uint32_t theMaxCount) const { return Index < theMaxCount; }
 
   //! True if this id is within the dense range exposed by a provider with Nb().
   template <typename CountProviderT>
@@ -251,45 +253,12 @@ struct BRepGraph_RepId
     return IsValid(theProvider.Nb());
   }
 
-  //! True if this id is within the dense range exposed by a provider with Length().
+  //! True if this id is within the dense range exposed by a provider with Size().
   template <typename CountProviderT>
   [[nodiscard]] auto IsValidIn(const CountProviderT& theProvider) const
-    -> decltype(theProvider.Length(), bool())
+    -> decltype(theProvider.Size(), bool())
   {
-    return IsValid(theProvider.Length());
-  }
-
-  //! Creates a typed surface representation id from the given index.
-  static Typed<Kind::Surface> Surface(const int theIdx) { return Typed<Kind::Surface>(theIdx); }
-
-  //! Creates a typed 3D curve representation id from the given index.
-  static Typed<Kind::Curve3D> Curve3D(const int theIdx) { return Typed<Kind::Curve3D>(theIdx); }
-
-  //! Creates a typed 2D curve representation id from the given index.
-  static Typed<Kind::Curve2D> Curve2D(const int theIdx) { return Typed<Kind::Curve2D>(theIdx); }
-
-  //! Creates a typed triangulation representation id from the given index.
-  static Typed<Kind::Triangulation> Triangulation(const int theIdx)
-  {
-    return Typed<Kind::Triangulation>(theIdx);
-  }
-
-  //! Creates a typed 3D polygon representation id from the given index.
-  static Typed<Kind::Polygon3D> Polygon3D(const int theIdx)
-  {
-    return Typed<Kind::Polygon3D>(theIdx);
-  }
-
-  //! Creates a typed 2D polygon representation id from the given index.
-  static Typed<Kind::Polygon2D> Polygon2D(const int theIdx)
-  {
-    return Typed<Kind::Polygon2D>(theIdx);
-  }
-
-  //! Creates a typed polygon-on-triangulation representation id from the given index.
-  static Typed<Kind::PolygonOnTri> PolygonOnTri(const int theIdx)
-  {
-    return Typed<Kind::PolygonOnTri>(theIdx);
+    return IsValid(static_cast<uint32_t>(theProvider.Size()));
   }
 
   bool operator==(const BRepGraph_RepId& theOther) const
@@ -309,7 +278,7 @@ struct BRepGraph_RepId
   //! Pre-increment (++id).
   BRepGraph_RepId& operator++()
   {
-    Standard_ASSERT_VOID(Index >= 0, "pre-increment on invalid id");
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "pre-increment on invalid id");
     ++Index;
     return *this;
   }
@@ -317,21 +286,23 @@ struct BRepGraph_RepId
   //! Post-increment (id++).
   BRepGraph_RepId operator++(int)
   {
-    Standard_ASSERT_VOID(Index >= 0, "post-increment on invalid id");
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX, "post-increment on invalid id");
     BRepGraph_RepId aPrev = *this;
     ++Index;
     return aPrev;
   }
 
   //! Advance by offset.
-  [[nodiscard]] BRepGraph_RepId operator+(const int theOffset) const
+  [[nodiscard]] BRepGraph_RepId operator+(const uint32_t theOffset) const
   {
     return BRepGraph_RepId(RepKind, Index + theOffset);
   }
 
   //! Retreat by offset.
-  [[nodiscard]] BRepGraph_RepId operator-(const int theOffset) const
+  [[nodiscard]] BRepGraph_RepId operator-(const uint32_t theOffset) const
   {
+    Standard_ASSERT_VOID(Index != THE_INVALID_INDEX && Index >= theOffset,
+                         "retreat underflows index");
     return BRepGraph_RepId(RepKind, Index - theOffset);
   }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ReverseIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ReverseIterator.hxx
@@ -192,7 +192,7 @@ public:
   //! Skips to the first non-removed entry at or after theStartIndex.
   ParentsOf(const BRepGraph&                    theGraph,
             const NCollection_Vector<TypedIdT>& theParents,
-            const int                           theStartIndex)
+            const uint32_t                      theStartIndex)
       : myGraph(&theGraph),
         myParents(&theParents),
         myIndex(theStartIndex)
@@ -200,7 +200,7 @@ public:
     skipRemoved();
   }
 
-  [[nodiscard]] bool More() const { return myIndex < myParents->Size(); }
+  [[nodiscard]] bool More() const { return myIndex < static_cast<uint32_t>(myParents->Size()); }
 
   void Next()
   {
@@ -208,7 +208,10 @@ public:
     skipRemoved();
   }
 
-  [[nodiscard]] TypedIdT CurrentId() const { return myParents->Value(myIndex); }
+  [[nodiscard]] TypedIdT CurrentId() const
+  {
+    return myParents->Value(static_cast<size_t>(myIndex));
+  }
 
   //! Alias for CurrentId(), enables range-for via NCollection_ForwardRange Current() priority.
   [[nodiscard]] TypedIdT Current() const { return CurrentId(); }
@@ -219,7 +222,7 @@ public:
     return DefTraits<TypedIdT>::Get(*myGraph, CurrentId());
   }
 
-  [[nodiscard]] int Index() const { return myIndex; }
+  [[nodiscard]] uint32_t Index() const { return myIndex; }
 
   //! Returns the total number of parent entries (including removed).
   [[nodiscard]] int Length() const { return myParents->Length(); }
@@ -241,10 +244,10 @@ public:
 private:
   void skipRemoved()
   {
-    while (myIndex < myParents->Length())
+    while (myIndex < static_cast<uint32_t>(myParents->Length()))
     {
       const BRepGraphInc::BaseDef* aDef =
-        myGraph->Topo().Gen().TopoEntity(BRepGraph_NodeId(myParents->Value(myIndex)));
+        myGraph->Topo().Gen().TopoEntity(myParents->Value(static_cast<size_t>(myIndex)));
       if (aDef != nullptr && !aDef->IsRemoved)
       {
         return;
@@ -255,7 +258,7 @@ private:
 
   const BRepGraph*                    myGraph   = nullptr;
   const NCollection_Vector<TypedIdT>* myParents = nullptr;
-  int                                 myIndex   = 0;
+  uint32_t                            myIndex   = 0;
 };
 
 //! Result pair returned by RefsParentsOf: parent definition ID + the RefId
@@ -305,7 +308,7 @@ public:
 
   [[nodiscard]] RefIdType CurrentRefId() const { return myCurrent.Ref; }
 
-  [[nodiscard]] int Index() const { return myIndex; }
+  [[nodiscard]] uint32_t Index() const { return myIndex; }
 
   //! Returns an STL-compatible iterator for range-based for loops.
   NCollection_ForwardRangeIterator<RefsParentsOf> begin()
@@ -320,9 +323,9 @@ private:
   void advance()
   {
     myHasCurrent = false;
-    while (myIndex < myParents->Length())
+    while (myIndex < static_cast<uint32_t>(myParents->Size()))
     {
-      const ParentIdType           aParentId = myParents->Value(myIndex);
+      const ParentIdType           aParentId = myParents->Value(static_cast<size_t>(myIndex));
       const BRepGraphInc::BaseDef* aDef =
         myGraph->Topo().Gen().TopoEntity(BRepGraph_NodeId(aParentId));
       if (aDef != nullptr && !aDef->IsRemoved)
@@ -343,7 +346,7 @@ private:
   const NCollection_Vector<ParentIdType>* myParents = nullptr;
   ChildIdType                             myChild;
   ResultType                              myCurrent;
-  int                                     myIndex      = 0;
+  uint32_t                                myIndex      = 0;
   bool                                    myHasCurrent = false;
 };
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ReverseIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ReverseIterator.hxx
@@ -222,8 +222,9 @@ public:
   [[nodiscard]] int Index() const { return myIndex; }
 
   //! Returns the total number of parent entries (including removed).
-  [[nodiscard]] int    Length() const { return myParents->Length(); }
-  [[nodiscard]] size_t Size()   const { return myParents->Size(); }
+  [[nodiscard]] int Length() const { return myParents->Length(); }
+
+  [[nodiscard]] size_t Size() const { return myParents->Size(); }
 
   //! Returns the parent ID at the given index (does NOT check IsRemoved).
   [[nodiscard]] TypedIdT Value(const size_t theIndex) const { return myParents->Value(theIndex); }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ReverseIterator.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ReverseIterator.hxx
@@ -200,7 +200,7 @@ public:
     skipRemoved();
   }
 
-  [[nodiscard]] bool More() const { return myIndex < myParents->Length(); }
+  [[nodiscard]] bool More() const { return myIndex < myParents->Size(); }
 
   void Next()
   {
@@ -222,10 +222,11 @@ public:
   [[nodiscard]] int Index() const { return myIndex; }
 
   //! Returns the total number of parent entries (including removed).
-  [[nodiscard]] int Length() const { return myParents->Length(); }
+  [[nodiscard]] int    Length() const { return myParents->Length(); }
+  [[nodiscard]] size_t Size()   const { return myParents->Size(); }
 
   //! Returns the parent ID at the given index (does NOT check IsRemoved).
-  [[nodiscard]] TypedIdT Value(const int theIndex) const { return myParents->Value(theIndex); }
+  [[nodiscard]] TypedIdT Value(const size_t theIndex) const { return myParents->Value(theIndex); }
 
   //! Returns an STL-compatible iterator for range-based for loops.
   NCollection_ForwardRangeIterator<ParentsOf> begin()

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ShapesView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_ShapesView.cxx
@@ -103,16 +103,11 @@ static TopoDS_Shape reconstructProductLocal(BRepGraph_ReconstructionContext& the
   TopoDS_Shape     aResult;
   BRepGraph_NodeId aShapeRootNode;
   TopLoc_Location  aRootLocation;
-  for (int i = 0; i < aProduct.OccurrenceRefIds.Length(); ++i)
+  for (BRepGraph_RefsOccurrenceOfProduct anOccIt(*theContext.Graph, theProduct); anOccIt.More();
+       anOccIt.Next())
   {
-    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aProduct.OccurrenceRefIds(i));
-    if (aRef.IsRemoved)
-      continue;
-    if (!aRef.OccurrenceDefId.IsValid(aStorage.NbOccurrences()))
-      continue;
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(anOccIt.CurrentId());
     const BRepGraphInc::OccurrenceDef& aDef = aStorage.Occurrence(aRef.OccurrenceDefId);
-    if (aDef.IsRemoved)
-      continue;
     if (aDef.ChildDefId.IsValid() && aDef.ChildDefId.NodeKind != BRepGraph_NodeId::Kind::Product)
     {
       aShapeRootNode = aDef.ChildDefId;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
@@ -328,9 +328,9 @@ double BRepGraph_Tool::Vertex::PCurveParameter(const BRepGraph&         theGraph
 
 //=================================================================================================
 
-int BRepGraph_Tool::Vertex::NbEdges(const BRepGraph& theGraph, const BRepGraph_VertexId theVertex)
+uint32_t BRepGraph_Tool::Vertex::NbEdges(const BRepGraph& theGraph, const BRepGraph_VertexId theVertex)
 {
-  return theGraph.Topo().Vertices().Edges(theVertex).Length();
+  return static_cast<uint32_t>(theGraph.Topo().Vertices().Edges(theVertex).Size());
 }
 
 //=================================================================================================
@@ -374,7 +374,7 @@ GeomAbs_Shape BRepGraph_Tool::Edge::MaxContinuity(const BRepGraph&       theGrap
 
 //=================================================================================================
 
-int BRepGraph_Tool::Edge::NbFaces(const BRepGraph& theGraph, const BRepGraph_EdgeId theEdge)
+uint32_t BRepGraph_Tool::Edge::NbFaces(const BRepGraph& theGraph, const BRepGraph_EdgeId theEdge)
 {
   return theGraph.Topo().Edges().NbFaces(theEdge);
 }
@@ -729,9 +729,9 @@ const occ::handle<Poly_Triangulation>& BRepGraph_Tool::Face::Triangulation(
 
 //=================================================================================================
 
-int BRepGraph_Tool::Face::NbWires(const BRepGraph& theGraph, const BRepGraph_FaceId theFace)
+uint32_t BRepGraph_Tool::Face::NbWires(const BRepGraph& theGraph, const BRepGraph_FaceId theFace)
 {
-  return theGraph.Topo().Faces().Definition(theFace).WireRefIds.Length();
+  return static_cast<uint32_t>(theGraph.Topo().Faces().Definition(theFace).WireRefIds.Size());
 }
 
 //=================================================================================================
@@ -789,9 +789,9 @@ bool BRepGraph_Tool::Wire::IsClosed(const BRepGraph& theGraph, const BRepGraph_W
 
 //=================================================================================================
 
-int BRepGraph_Tool::Wire::NbCoEdges(const BRepGraph& theGraph, const BRepGraph_WireId theWire)
+uint32_t BRepGraph_Tool::Wire::NbCoEdges(const BRepGraph& theGraph, const BRepGraph_WireId theWire)
 {
-  return theGraph.Topo().Wires().Definition(theWire).CoEdgeRefIds.Length();
+  return static_cast<uint32_t>(theGraph.Topo().Wires().Definition(theWire).CoEdgeRefIds.Size());
 }
 
 //=================================================================================================
@@ -834,9 +834,9 @@ bool BRepGraph_Tool::Shell::IsClosed(const BRepGraph& theGraph, const BRepGraph_
 
 //=================================================================================================
 
-int BRepGraph_Tool::Shell::NbFaces(const BRepGraph& theGraph, const BRepGraph_ShellId theShell)
+uint32_t BRepGraph_Tool::Shell::NbFaces(const BRepGraph& theGraph, const BRepGraph_ShellId theShell)
 {
-  return theGraph.Topo().Shells().Definition(theShell).FaceRefIds.Length();
+  return static_cast<uint32_t>(theGraph.Topo().Shells().Definition(theShell).FaceRefIds.Size());
 }
 
 //=================================================================================================
@@ -928,18 +928,16 @@ void BRepGraph_Tool::Mesh::ClearFaceCache(BRepGraph& theGraph, const BRepGraph_F
   if (!theFace.IsValid(aStorage.NbFaces()))
     return;
   const BRepGraphInc::FaceDef& aFace = aStorage.Face(theFace);
-  for (int aWireIdx = 0; aWireIdx < aFace.WireRefIds.Length(); ++aWireIdx)
+  for (const BRepGraph_WireRefId& aWireRefId : aFace.WireRefIds)
   {
-    const BRepGraph_WireRefId aWireRefId = aFace.WireRefIds.Value(aWireIdx);
     if (!aWireRefId.IsValid(aStorage.NbWireRefs()))
       continue;
     const BRepGraph_WireId aWireId = aStorage.WireRef(aWireRefId).WireDefId;
     if (!aWireId.IsValid(aStorage.NbWires()))
       continue;
     const BRepGraphInc::WireDef& aWire = aStorage.Wire(aWireId);
-    for (int aCERefIdx = 0; aCERefIdx < aWire.CoEdgeRefIds.Length(); ++aCERefIdx)
+    for (const BRepGraph_CoEdgeRefId& aCERefId : aWire.CoEdgeRefIds)
     {
-      const BRepGraph_CoEdgeRefId aCERefId = aWire.CoEdgeRefIds.Value(aCERefIdx);
       if (!aCERefId.IsValid(aStorage.NbCoEdgeRefs()))
         continue;
       const BRepGraph_CoEdgeId aCoEdgeId = aStorage.CoEdgeRef(aCERefId).CoEdgeDefId;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
@@ -328,7 +328,8 @@ double BRepGraph_Tool::Vertex::PCurveParameter(const BRepGraph&         theGraph
 
 //=================================================================================================
 
-uint32_t BRepGraph_Tool::Vertex::NbEdges(const BRepGraph& theGraph, const BRepGraph_VertexId theVertex)
+uint32_t BRepGraph_Tool::Vertex::NbEdges(const BRepGraph&         theGraph,
+                                         const BRepGraph_VertexId theVertex)
 {
   return static_cast<uint32_t>(theGraph.Topo().Vertices().Edges(theVertex).Size());
 }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
@@ -613,7 +613,7 @@ public:
     //! @param[in] theWire  typed wire definition identifier
     //! @return number of coedge entries
     [[nodiscard]] Standard_EXPORT static uint32_t NbCoEdges(const BRepGraph&       theGraph,
-                                                             const BRepGraph_WireId theWire);
+                                                            const BRepGraph_WireId theWire);
 
     //! Returns the first owning face for this wire via the reverse-index table.
     //! Returns an invalid id if the wire has no owning face (free wire).
@@ -651,7 +651,7 @@ public:
     //! @param[in] theShell typed shell definition identifier
     //! @return number of face entries (including removed)
     [[nodiscard]] Standard_EXPORT static uint32_t NbFaces(const BRepGraph&        theGraph,
-                                                           const BRepGraph_ShellId theShell);
+                                                          const BRepGraph_ShellId theShell);
   };
 
   //! @brief Mesh cache writes and representation creation.

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
@@ -121,8 +121,8 @@ public:
     //! @param[in] theGraph  source graph
     //! @param[in] theVertex typed vertex definition identifier
     //! @return edge count
-    [[nodiscard]] Standard_EXPORT static int NbEdges(const BRepGraph&         theGraph,
-                                                     const BRepGraph_VertexId theVertex);
+    [[nodiscard]] Standard_EXPORT static uint32_t NbEdges(const BRepGraph&         theGraph,
+                                                          const BRepGraph_VertexId theVertex);
   };
 
   //! @brief Edge geometry, curve, polygon, and continuity accessors.
@@ -292,8 +292,8 @@ public:
     //! @param[in] theGraph source graph
     //! @param[in] theEdge  typed edge definition identifier
     //! @return face count
-    [[nodiscard]] Standard_EXPORT static int NbFaces(const BRepGraph&       theGraph,
-                                                     const BRepGraph_EdgeId theEdge);
+    [[nodiscard]] Standard_EXPORT static uint32_t NbFaces(const BRepGraph&       theGraph,
+                                                          const BRepGraph_EdgeId theEdge);
 
     //! Returns true if the edge is shared by exactly two faces (manifold).
     //! @param[in] theGraph source graph
@@ -572,8 +572,8 @@ public:
     //! @param[in] theGraph source graph
     //! @param[in] theFace  typed face definition identifier
     //! @return wire count (includes removed refs)
-    [[nodiscard]] Standard_EXPORT static int NbWires(const BRepGraph&       theGraph,
-                                                     const BRepGraph_FaceId theFace);
+    [[nodiscard]] Standard_EXPORT static uint32_t NbWires(const BRepGraph&       theGraph,
+                                                          const BRepGraph_FaceId theFace);
 
     //! Returns the UV parameter bounds of the face surface.
     //! For faces with NaturalRestriction the bounds come directly from the surface.
@@ -612,8 +612,8 @@ public:
     //! @param[in] theGraph source graph
     //! @param[in] theWire  typed wire definition identifier
     //! @return number of coedge entries
-    [[nodiscard]] Standard_EXPORT static int NbCoEdges(const BRepGraph&       theGraph,
-                                                       const BRepGraph_WireId theWire);
+    [[nodiscard]] Standard_EXPORT static uint32_t NbCoEdges(const BRepGraph&       theGraph,
+                                                             const BRepGraph_WireId theWire);
 
     //! Returns the first owning face for this wire via the reverse-index table.
     //! Returns an invalid id if the wire has no owning face (free wire).
@@ -650,8 +650,8 @@ public:
     //! @param[in] theGraph source graph
     //! @param[in] theShell typed shell definition identifier
     //! @return number of face entries (including removed)
-    [[nodiscard]] Standard_EXPORT static int NbFaces(const BRepGraph&        theGraph,
-                                                     const BRepGraph_ShellId theShell);
+    [[nodiscard]] Standard_EXPORT static uint32_t NbFaces(const BRepGraph&        theGraph,
+                                                           const BRepGraph_ShellId theShell);
   };
 
   //! @brief Mesh cache writes and representation creation.

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.cxx
@@ -315,7 +315,7 @@ const BRepGraphInc::EdgeDef& BRepGraph::TopoView::EdgeOps::Definition(
 
 //=================================================================================================
 
-int BRepGraph::TopoView::EdgeOps::NbFaces(const BRepGraph_EdgeId theEdge) const
+uint32_t BRepGraph::TopoView::EdgeOps::NbFaces(const BRepGraph_EdgeId theEdge) const
 {
   return myGraph->myData->myIncStorage.ReverseIndex().NbFacesOfEdge(theEdge);
 }
@@ -929,10 +929,9 @@ BRepGraph_NodeId BRepGraph::TopoView::ProductOps::ShapeRoot(
   }
 
   // Scan occurrences to find the first with a topology ChildDefId.
-  for (int i = 0; i < aProductDef.OccurrenceRefIds.Length(); ++i)
+  for (const BRepGraph_OccurrenceRefId& aRefId : aProductDef.OccurrenceRefIds)
   {
-    const BRepGraph_OccurrenceRefId    aRefId = aProductDef.OccurrenceRefIds.Value(i);
-    const BRepGraphInc::OccurrenceRef& aRef   = aStorage.OccurrenceRef(aRefId);
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (aRef.IsRemoved)
       continue;
     const BRepGraphInc::OccurrenceDef& anOccDef = aStorage.Occurrence(aRef.OccurrenceDefId);
@@ -966,10 +965,9 @@ bool BRepGraph::TopoView::ProductOps::IsAssembly(const BRepGraph_ProductId thePr
   }
 
   // Assembly if any active occurrence references a product child.
-  for (int i = 0; i < aProductDef.OccurrenceRefIds.Length(); ++i)
+  for (const BRepGraph_OccurrenceRefId& aRefId : aProductDef.OccurrenceRefIds)
   {
-    const BRepGraph_OccurrenceRefId    aRefId = aProductDef.OccurrenceRefIds.Value(i);
-    const BRepGraphInc::OccurrenceRef& aRef   = aStorage.OccurrenceRef(aRefId);
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (aRef.IsRemoved)
       continue;
     const BRepGraphInc::OccurrenceDef& anOccDef = aStorage.Occurrence(aRef.OccurrenceDefId);
@@ -1000,10 +998,9 @@ bool BRepGraph::TopoView::ProductOps::IsPart(const BRepGraph_ProductId theProduc
   }
 
   // Part if any active occurrence references a topology child.
-  for (int i = 0; i < aProductDef.OccurrenceRefIds.Length(); ++i)
+  for (const BRepGraph_OccurrenceRefId& aRefId : aProductDef.OccurrenceRefIds)
   {
-    const BRepGraph_OccurrenceRefId    aRefId = aProductDef.OccurrenceRefIds.Value(i);
-    const BRepGraphInc::OccurrenceRef& aRef   = aStorage.OccurrenceRef(aRefId);
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (aRef.IsRemoved)
       continue;
     const BRepGraphInc::OccurrenceDef& anOccDef = aStorage.Occurrence(aRef.OccurrenceDefId);
@@ -1036,10 +1033,9 @@ BRepGraph_NodeId BRepGraph::TopoView::ProductOps::ShapeRootNode(
   }
 
   // Find the first occurrence with a topology ChildDefId.
-  for (int i = 0; i < aProductDef.OccurrenceRefIds.Length(); ++i)
+  for (const BRepGraph_OccurrenceRefId& aRefId : aProductDef.OccurrenceRefIds)
   {
-    const BRepGraph_OccurrenceRefId    aRefId = aProductDef.OccurrenceRefIds.Value(i);
-    const BRepGraphInc::OccurrenceRef& aRef   = aStorage.OccurrenceRef(aRefId);
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (aRef.IsRemoved)
       continue;
     const BRepGraphInc::OccurrenceDef& anOccDef = aStorage.Occurrence(aRef.OccurrenceDefId);
@@ -1185,10 +1181,10 @@ BRepGraph_ProductId BRepGraph::TopoView::OccurrenceOps::ParentProduct(
   }
 
   // Find the OccurrenceRef that owns this OccurrenceDef to get ParentId.
-  const int aNbOccRefs = aStorage.NbOccurrenceRefs();
-  for (int i = 0; i < aNbOccRefs; ++i)
+  for (BRepGraph_OccurrenceRefId aRefId = myGraph->Refs().Occurrences().StartId();
+       aRefId < myGraph->Refs().Occurrences().EndId(); ++aRefId)
   {
-    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(BRepGraph_OccurrenceRefId(i));
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (aRef.IsRemoved || aRef.OccurrenceDefId != theOccurrence)
       continue;
 
@@ -1217,10 +1213,10 @@ TopLoc_Location BRepGraph::TopoView::OccurrenceOps::OccurrenceLocation(
 
   // Placement is now on OccurrenceRef::LocalLocation.
   // Find the OccurrenceRef that owns this OccurrenceDef.
-  const int aNbOccRefs = aStorage.NbOccurrenceRefs();
-  for (int i = 0; i < aNbOccRefs; ++i)
+  for (BRepGraph_OccurrenceRefId aRefId = myGraph->Refs().Occurrences().StartId();
+       aRefId < myGraph->Refs().Occurrences().EndId(); ++aRefId)
   {
-    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(BRepGraph_OccurrenceRefId(i));
+    const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (!aRef.IsRemoved && aRef.OccurrenceDefId == theOccurrence)
     {
       return aRef.LocalLocation;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.cxx
@@ -1182,7 +1182,8 @@ BRepGraph_ProductId BRepGraph::TopoView::OccurrenceOps::ParentProduct(
 
   // Find the OccurrenceRef that owns this OccurrenceDef to get ParentId.
   for (BRepGraph_OccurrenceRefId aRefId = myGraph->Refs().Occurrences().StartId();
-       aRefId < myGraph->Refs().Occurrences().EndId(); ++aRefId)
+       aRefId < myGraph->Refs().Occurrences().EndId();
+       ++aRefId)
   {
     const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (aRef.IsRemoved || aRef.OccurrenceDefId != theOccurrence)
@@ -1214,7 +1215,8 @@ TopLoc_Location BRepGraph::TopoView::OccurrenceOps::OccurrenceLocation(
   // Placement is now on OccurrenceRef::LocalLocation.
   // Find the OccurrenceRef that owns this OccurrenceDef.
   for (BRepGraph_OccurrenceRefId aRefId = myGraph->Refs().Occurrences().StartId();
-       aRefId < myGraph->Refs().Occurrences().EndId(); ++aRefId)
+       aRefId < myGraph->Refs().Occurrences().EndId();
+       ++aRefId)
   {
     const BRepGraphInc::OccurrenceRef& aRef = aStorage.OccurrenceRef(aRefId);
     if (!aRef.IsRemoved && aRef.OccurrenceDefId == theOccurrence)

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.hxx
@@ -107,7 +107,7 @@ public:
 
     [[nodiscard]] Standard_EXPORT const BRepGraphInc::EdgeDef& Definition(
       const BRepGraph_EdgeId theEdge) const;
-    [[nodiscard]] Standard_EXPORT int   NbFaces(const BRepGraph_EdgeId theEdge) const;
+    [[nodiscard]] Standard_EXPORT uint32_t NbFaces(const BRepGraph_EdgeId theEdge) const;
     [[nodiscard]] Standard_EXPORT const NCollection_Vector<BRepGraph_WireId>& Wires(
       const BRepGraph_EdgeId theEdge) const;
     [[nodiscard]] Standard_EXPORT const NCollection_Vector<BRepGraph_CoEdgeId>& CoEdges(

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TransientCache.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TransientCache.cxx
@@ -165,11 +165,11 @@ BRepGraph_TransientCache::CacheSlot& BRepGraph_TransientCache::changeSlot(
                        "BRepGraph_TransientCache: NodeKind out of range");
   NCollection_Vector<CacheSlot>& aVec =
     myKinds.ChangeValue(theKindSlot).myNodeKinds[aKindIdx].mySlots;
-  if (theNode.Index >= aVec.Length())
+  if (theNode.Index >= aVec.Size())
   {
-    return aVec.SetValue(theNode.Index, CacheSlot());
+    return aVec.SetValue(static_cast<size_t>(theNode.Index), CacheSlot());
   }
-  return aVec.ChangeValue(theNode.Index);
+  return aVec.ChangeValue(static_cast<size_t>(theNode.Index));
 }
 
 //=================================================================================================
@@ -192,7 +192,7 @@ const BRepGraph_TransientCache::CacheSlot* BRepGraph_TransientCache::seekSlot(
   {
     return nullptr;
   }
-  return &aVec.Value(theNode.Index);
+  return &aVec.Value(static_cast<size_t>(theNode.Index));
 }
 
 //=================================================================================================
@@ -261,9 +261,9 @@ void BRepGraph_TransientCache::Set(const BRepGraph_NodeId                   theN
     const int                      aKindIdx = static_cast<int>(theNode.NodeKind);
     NCollection_Vector<CacheSlot>& aVec =
       myKinds.ChangeValue(theKindSlot).myNodeKinds[aKindIdx].mySlots;
-    if (theNode.Index < aVec.Length())
+    if (theNode.Index < aVec.Size())
     {
-      CacheSlot& aSlot       = aVec.ChangeValue(theNode.Index);
+      CacheSlot& aSlot       = aVec.ChangeValue(static_cast<size_t>(theNode.Index));
       aSlot.Value            = theValue;
       aSlot.StoredSubtreeGen = theCurrentSubtreeGen;
       return;
@@ -314,9 +314,9 @@ occ::handle<BRepGraph_CacheValue> BRepGraph_TransientCache::Get(
     const int                            aKindIdx = static_cast<int>(theNode.NodeKind);
     const NCollection_Vector<CacheSlot>& aVec =
       myKinds.Value(theKindSlot).myNodeKinds[aKindIdx].mySlots;
-    if (theNode.Index < aVec.Length())
+    if (theNode.Index < aVec.Size())
     {
-      const CacheSlot& aSlot = aVec.Value(theNode.Index);
+      const CacheSlot& aSlot = aVec.Value(static_cast<size_t>(theNode.Index));
       if (aSlot.Value.IsNull())
       {
         return occ::handle<BRepGraph_CacheValue>();
@@ -371,7 +371,7 @@ bool BRepGraph_TransientCache::Remove(const BRepGraph_NodeId theNode, const int 
   }
 
   std::unique_lock<std::shared_mutex> aLock(myMutex);
-  if (theKindSlot >= myKinds.Length())
+  if (static_cast<size_t>(theKindSlot) >= myKinds.Size())
   {
     return false;
   }
@@ -379,12 +379,12 @@ bool BRepGraph_TransientCache::Remove(const BRepGraph_NodeId theNode, const int 
   const int                      aKindIdx = static_cast<int>(theNode.NodeKind);
   NCollection_Vector<CacheSlot>& aVec =
     myKinds.ChangeValue(theKindSlot).myNodeKinds[aKindIdx].mySlots;
-  if (theNode.Index >= aVec.Length())
+  if (theNode.Index >= aVec.Size())
   {
     return false;
   }
 
-  CacheSlot& aSlot = aVec.ChangeValue(theNode.Index);
+  CacheSlot& aSlot = aVec.ChangeValue(static_cast<size_t>(theNode.Index));
   if (aSlot.Value.IsNull())
   {
     return false;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_UIDsView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_UIDsView.cxx
@@ -26,7 +26,7 @@ void appendRefUIDReverseIndex(BRepGraph_Data& theData, const BRepGraph_RefId::Ki
   const NCollection_Vector<BRepGraph_RefUID>& aUIDs = theData.myIncStorage.RefUIDs(theKind);
   for (BRepGraph_RefId aRefId = BRepGraph_RefId::Start(theKind); aRefId.IsValidIn(aUIDs); ++aRefId)
   {
-    const BRepGraph_RefUID aUID = aUIDs.Value(aRefId.Index);
+    const BRepGraph_RefUID aUID = aUIDs.Value(static_cast<size_t>(aRefId.Index));
     if (aUID.IsValid())
     {
       theData.myRefUIDToRefId.Bind(aUID, aRefId);
@@ -42,7 +42,7 @@ void appendUIDReverseIndex(BRepGraph_Data& theData, const BRepGraph_NodeId::Kind
   for (BRepGraph_NodeId aNodeId = BRepGraph_NodeId::Start(theKind); aNodeId.IsValidIn(aUIDs);
        ++aNodeId)
   {
-    const BRepGraph_UID aUID = aUIDs.Value(aNodeId.Index);
+    const BRepGraph_UID aUID = aUIDs.Value(static_cast<size_t>(aNodeId.Index));
     if (aUID.IsValid())
     {
       theData.myUIDToNodeId.Bind(aUID, aNodeId);
@@ -134,7 +134,7 @@ BRepGraph_UID BRepGraph::UIDsView::Of(const BRepGraph_NodeId theNode) const
     myGraph->myData->myIncStorage.UIDs(theNode.NodeKind);
   if (!theNode.IsValidIn(aVec))
     return BRepGraph_UID();
-  return aVec.Value(theNode.Index);
+  return aVec.Value(static_cast<size_t>(theNode.Index));
 }
 
 //=================================================================================================
@@ -153,7 +153,7 @@ BRepGraph_RefUID BRepGraph::UIDsView::Of(const BRepGraph_RefId theRefId) const
   if (aBase.IsRemoved)
     return BRepGraph_RefUID();
 
-  return aVec.Value(theRefId.Index);
+  return aVec.Value(static_cast<size_t>(theRefId.Index));
 }
 
 //=================================================================================================
@@ -244,7 +244,7 @@ BRepGraph_VersionStamp BRepGraph::UIDsView::StampOf(const BRepGraph_NodeId theNo
   if (!theNode.IsValidIn(aVec))
     return BRepGraph_VersionStamp();
 
-  const BRepGraph_UID          aUID = aVec.Value(theNode.Index);
+  const BRepGraph_UID          aUID = aVec.Value(static_cast<size_t>(theNode.Index));
   const BRepGraphInc::BaseDef* aDef = myGraph->topoEntity(theNode);
   if (aDef == nullptr || aDef->IsRemoved)
     return BRepGraph_VersionStamp();
@@ -268,7 +268,7 @@ BRepGraph_VersionStamp BRepGraph::UIDsView::StampOf(const BRepGraph_RefId theRef
   if (aBase.IsRemoved)
     return BRepGraph_VersionStamp();
 
-  return BRepGraph_VersionStamp(aUIDs.Value(theRefId.Index),
+  return BRepGraph_VersionStamp(aUIDs.Value(static_cast<size_t>(theRefId.Index)),
                                 aBase.OwnGen,
                                 myGraph->myData->myGeneration.load());
 }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
@@ -432,12 +432,12 @@ void checkReverseIndexFaceCountCache(const BRepGraph&                           
       aUniqueFaces.Add(aCoEdge.FaceDefId);
     }
 
-    const int aCachedCount  = aDefs.Edges().NbFaces(anEdgeId);
-    const int anActualCount = aUniqueFaces.Extent();
-    if (aCachedCount != anActualCount)
+    const uint32_t aCachedCount  = aDefs.Edges().NbFaces(anEdgeId);
+    const int      anActualCount = aUniqueFaces.Extent();
+    if (static_cast<int>(aCachedCount) != anActualCount)
     {
       TCollection_AsciiString aDesc("Reverse index face-count cache mismatch: cached=");
-      aDesc += TCollection_AsciiString(aCachedCount);
+      aDesc += TCollection_AsciiString(static_cast<int>(aCachedCount));
       aDesc += " actual=";
       aDesc += TCollection_AsciiString(anActualCount);
       theIssues.Append(Issue{Severity::Error, anEdgeId, aDesc});
@@ -568,10 +568,8 @@ void checkGeometryReferences(const BRepGraph&                               theG
       theGraph.Mesh().Faces().CachedMesh(aFaceIt.CurrentId());
     if (aCachedFace != nullptr)
     {
-      for (int aCIdx = 0; aCIdx < aCachedFace->TriangulationRepIds.Length(); ++aCIdx)
+      for (const BRepGraph_TriangulationRepId& aCTriRepId : aCachedFace->TriangulationRepIds)
       {
-        const BRepGraph_TriangulationRepId aCTriRepId =
-          aCachedFace->TriangulationRepIds.Value(aCIdx);
         if (!aCTriRepId.IsValid(theGraph.Mesh().Poly().NbTriangulations()))
         {
           theIssues.Append(Issue{Severity::Error,
@@ -1012,7 +1010,7 @@ BRepGraph_Validate::Result BRepGraph_Validate::Perform(const BRepGraph& theGraph
     // exponential blowup on DAGs. A cycle exists if we re-encounter aProdIdx.
     NCollection_Map<BRepGraph_ProductId>    aVisited;
     NCollection_Vector<BRepGraph_ProductId> aQueue;
-    int                                     aHead = 0;
+    size_t                                  aHead = 0;
 
     // Seed with direct children.
     for (BRepGraph_RefsOccurrenceOfProduct anOccIt(theGraph, aProdId); anOccIt.More();
@@ -1040,7 +1038,7 @@ BRepGraph_Validate::Result BRepGraph_Validate::Perform(const BRepGraph& theGraph
     }
 
     bool aCycleFound = false;
-    while (aHead < aQueue.Length() && !aCycleFound)
+    while (aHead < aQueue.Size() && !aCycleFound)
     {
       const BRepGraph_ProductId aChildProdId = aQueue.Value(aHead);
       ++aHead;
@@ -1108,7 +1106,7 @@ BRepGraph_Validate::Result BRepGraph_Validate::Perform(const BRepGraph& theGraph
     }
 
     bool aCycleFound = false;
-    while (aHead < aQueue.Length() && !aCycleFound)
+    while (aHead < aQueue.Size() && !aCycleFound)
     {
       const BRepGraph_CompoundId aChildCompoundId = aQueue.Value(aHead);
       ++aHead;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
@@ -1081,7 +1081,7 @@ BRepGraph_Validate::Result BRepGraph_Validate::Perform(const BRepGraph& theGraph
     const BRepGraph_CompoundId               aRootCompoundId = aCompIt.CurrentId();
     NCollection_Map<BRepGraph_CompoundId>    aVisited;
     NCollection_Vector<BRepGraph_CompoundId> aQueue;
-    int                                      aHead = 0;
+    size_t                                   aHead = 0;
 
     for (BRepGraph_RefsChildOfCompound anIt(theGraph, aRootCompoundId); anIt.More(); anIt.Next())
     {

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
@@ -76,7 +76,7 @@ void appendFaceRef(BRepGraphInc_Storage&             theStorage,
 {
   const BRepGraph_FaceRefId aRefId  = theStorage.AppendFaceRef();
   BRepGraphInc::FaceRef&    anEntry = theStorage.ChangeFaceRef(aRefId);
-  anEntry.ParentId                  = BRepGraph_ShellId(theParentShellId.Index);
+  anEntry.ParentId                  = theParentShellId;
   anEntry.FaceDefId                 = theRef.DefId;
   anEntry.Orientation               = theRef.Orientation;
   anEntry.LocalLocation             = theRef.Location;
@@ -91,7 +91,7 @@ void appendWireRef(BRepGraphInc_Storage&             theStorage,
 {
   const BRepGraph_WireRefId aRefId  = theStorage.AppendWireRef();
   BRepGraphInc::WireRef&    anEntry = theStorage.ChangeWireRef(aRefId);
-  anEntry.ParentId                  = BRepGraph_FaceId(theParentFaceId.Index);
+  anEntry.ParentId                  = theParentFaceId;
   anEntry.WireDefId                 = theRef.DefId;
   anEntry.IsOuter                   = theRef.IsOuter;
   anEntry.Orientation               = theRef.Orientation;
@@ -107,7 +107,7 @@ void appendCoEdgeRef(BRepGraphInc_Storage&               theStorage,
 {
   const BRepGraph_CoEdgeRefId aRefId  = theStorage.AppendCoEdgeRef();
   BRepGraphInc::CoEdgeRef&    anEntry = theStorage.ChangeCoEdgeRef(aRefId);
-  anEntry.ParentId                    = BRepGraph_WireId(theParentWireId.Index);
+  anEntry.ParentId                    = theParentWireId;
   anEntry.CoEdgeDefId                 = theRef.DefId;
   anEntry.LocalLocation               = theRef.Location;
   theStorage.ChangeWire(theParentWireId).CoEdgeRefIds.Append(aRefId);
@@ -136,7 +136,7 @@ void appendShellRef(BRepGraphInc_Storage&              theStorage,
 {
   const BRepGraph_ShellRefId aRefId  = theStorage.AppendShellRef();
   BRepGraphInc::ShellRef&    anEntry = theStorage.ChangeShellRef(aRefId);
-  anEntry.ParentId                   = BRepGraph_SolidId(theParentSolidId.Index);
+  anEntry.ParentId                   = theParentSolidId;
   anEntry.ShellDefId                 = theRef.DefId;
   anEntry.Orientation                = theRef.Orientation;
   anEntry.LocalLocation              = theRef.Location;
@@ -151,7 +151,7 @@ void appendSolidRef(BRepGraphInc_Storage&              theStorage,
 {
   const BRepGraph_SolidRefId aRefId  = theStorage.AppendSolidRef();
   BRepGraphInc::SolidRef&    anEntry = theStorage.ChangeSolidRef(aRefId);
-  anEntry.ParentId                   = BRepGraph_CompSolidId(theParentCompSolidId.Index);
+  anEntry.ParentId                   = theParentCompSolidId;
   anEntry.SolidDefId                 = theRef.DefId;
   anEntry.Orientation                = theRef.Orientation;
   anEntry.LocalLocation              = theRef.Location;
@@ -171,7 +171,7 @@ BRepGraph_ChildRefId appendChildRef(BRepGraphInc_Storage&             theStorage
   anEntry.Orientation                = theRef.Orientation;
   anEntry.LocalLocation              = theRef.Location;
   if (theParentId.NodeKind == BRepGraph_NodeId::Kind::Compound)
-    theStorage.ChangeCompound(BRepGraph_CompoundId(theParentId.Index)).ChildRefIds.Append(aRefId);
+    theStorage.ChangeCompound(BRepGraph_CompoundId(theParentId)).ChildRefIds.Append(aRefId);
   return aRefId;
 }
 
@@ -238,7 +238,7 @@ struct FaceLocalData
   // Phase 1 context.
   TopoDS_Face     Face;
   TopLoc_Location ParentGlobalLoc;
-  int             ParentShellIdx = -1;
+  BRepGraph_ShellId ParentShellId;
 
   // Phase 2 extracted geometry.
   occ::handle<Geom_Surface>         Surface;
@@ -452,23 +452,23 @@ const BRepGraph_NodeId* findExistingNode(const BRepGraphInc_Storage& theStorage,
   return nullptr;
 }
 
-//! Register a vertex entity by TShape dedup, or return the existing index.
+//! Register a vertex entity by TShape dedup, or return the existing VertexId.
 //! @param[in,out] theStorage   incidence storage
 //! @param[in]     theVertex    original TopoDS_Vertex
 //! @param[in]     thePoint     3D point (pre-extracted)
 //! @param[in]     theTolerance vertex tolerance (pre-extracted)
-//! @return index into the vertex entity vector, or -1 if theVertex is null
-int registerOrReuseVertex(BRepGraphInc_Storage& theStorage,
-                          const TopoDS_Vertex&  theVertex,
-                          const gp_Pnt&         thePoint,
-                          const double          theTolerance)
+//! @return typed VertexId, or default-constructed (invalid) if theVertex is null
+BRepGraph_VertexId registerOrReuseVertex(BRepGraphInc_Storage& theStorage,
+                                         const TopoDS_Vertex&  theVertex,
+                                         const gp_Pnt&         thePoint,
+                                         const double          theTolerance)
 {
   if (theVertex.IsNull())
-    return -1;
+    return BRepGraph_VertexId();
   const BRepGraph_NodeId* anExisting =
     findExistingNode(theStorage, theVertex, BRepGraph_NodeId::Kind::Vertex);
   if (anExisting != nullptr)
-    return anExisting->Index;
+    return BRepGraph_VertexId(*anExisting);
 
   const BRepGraph_VertexId aVtxId  = theStorage.AppendVertex();
   BRepGraphInc::VertexDef& aVtxEnt = theStorage.ChangeVertex(aVtxId);
@@ -476,14 +476,15 @@ int registerOrReuseVertex(BRepGraphInc_Storage& theStorage,
   aVtxEnt.Tolerance                = theTolerance;
   theStorage.BindTShapeToNode(theVertex.TShape().get(), aVtxId);
   theStorage.BindOriginal(aVtxId, theVertex);
-  return aVtxId.Index;
+  return aVtxId;
 }
 
 //! Convenience overload: extracts point and tolerance from the vertex.
-int registerOrReuseVertex(BRepGraphInc_Storage& theStorage, const TopoDS_Vertex& theVertex)
+BRepGraph_VertexId registerOrReuseVertex(BRepGraphInc_Storage& theStorage,
+                                         const TopoDS_Vertex&  theVertex)
 {
   if (theVertex.IsNull())
-    return -1;
+    return BRepGraph_VertexId();
   return registerOrReuseVertex(theStorage,
                                theVertex,
                                rawVertexPoint(theVertex),
@@ -542,154 +543,156 @@ static occ::handle<Poly_Polygon3D> applyRepLocationToPolygon3D(
 //! Keyed by raw Handle pointer - same underlying geometry object -> same rep entity.
 struct RepDedup
 {
-  NCollection_DataMap<const Geom_Surface*, int>                Surfaces;
-  NCollection_DataMap<const Geom_Curve*, int>                  Curves3D;
-  NCollection_DataMap<const Geom2d_Curve*, int>                Curves2D;
-  NCollection_DataMap<const Poly_Triangulation*, int>          Triangulations;
-  NCollection_DataMap<const Poly_Polygon3D*, int>              Polygons3D;
-  NCollection_DataMap<const Poly_Polygon2D*, int>              Polygons2D;
-  NCollection_DataMap<const Poly_PolygonOnTriangulation*, int> PolygonsOnTri;
+  NCollection_DataMap<const Geom_Surface*, BRepGraph_SurfaceRepId>                     Surfaces;
+  NCollection_DataMap<const Geom_Curve*, BRepGraph_Curve3DRepId>                       Curves3D;
+  NCollection_DataMap<const Geom2d_Curve*, BRepGraph_Curve2DRepId>                     Curves2D;
+  NCollection_DataMap<const Poly_Triangulation*, BRepGraph_TriangulationRepId>         Triangulations;
+  NCollection_DataMap<const Poly_Polygon3D*, BRepGraph_Polygon3DRepId>                 Polygons3D;
+  NCollection_DataMap<const Poly_Polygon2D*, BRepGraph_Polygon2DRepId>                 Polygons2D;
+  NCollection_DataMap<const Poly_PolygonOnTriangulation*, BRepGraph_PolygonOnTriRepId> PolygonsOnTri;
 };
 
 //! Create or reuse a SurfaceRep for the given surface handle.
-int getOrCreateSurfaceRep(BRepGraphInc_Storage&            theStorage,
-                          RepDedup&                        theDedup,
-                          const occ::handle<Geom_Surface>& theSurface)
+BRepGraph_SurfaceRepId getOrCreateSurfaceRep(BRepGraphInc_Storage&            theStorage,
+                                             RepDedup&                        theDedup,
+                                             const occ::handle<Geom_Surface>& theSurface)
 {
   if (theSurface.IsNull())
-    return -1;
-  const Geom_Surface* aPtr       = theSurface.get();
-  const int*          anExisting = theDedup.Surfaces.Seek(aPtr);
+    return BRepGraph_SurfaceRepId();
+  const Geom_Surface*            aPtr       = theSurface.get();
+  const BRepGraph_SurfaceRepId*  anExisting = theDedup.Surfaces.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_SurfaceRepId aRepId = theStorage.AppendSurfaceRep();
   BRepGraphInc::SurfaceRep&    aRep   = theStorage.ChangeSurfaceRep(aRepId);
   aRep.Surface                        = theSurface;
-  theDedup.Surfaces.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  theDedup.Surfaces.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Create or reuse a Curve3DRep for the given 3D curve handle.
-int getOrCreateCurve3DRep(BRepGraphInc_Storage&          theStorage,
-                          RepDedup&                      theDedup,
-                          const occ::handle<Geom_Curve>& theCurve)
+BRepGraph_Curve3DRepId getOrCreateCurve3DRep(BRepGraphInc_Storage&          theStorage,
+                                             RepDedup&                      theDedup,
+                                             const occ::handle<Geom_Curve>& theCurve)
 {
   if (theCurve.IsNull())
-    return -1;
-  const Geom_Curve* aPtr       = theCurve.get();
-  const int*        anExisting = theDedup.Curves3D.Seek(aPtr);
+    return BRepGraph_Curve3DRepId();
+  const Geom_Curve*              aPtr       = theCurve.get();
+  const BRepGraph_Curve3DRepId*  anExisting = theDedup.Curves3D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Curve3DRepId aRepId = theStorage.AppendCurve3DRep();
   BRepGraphInc::Curve3DRep&    aRep   = theStorage.ChangeCurve3DRep(aRepId);
   aRep.Curve                          = theCurve;
-  theDedup.Curves3D.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  theDedup.Curves3D.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Create or reuse a Curve2DRep for the given 2D curve handle.
-int getOrCreateCurve2DRep(BRepGraphInc_Storage&            theStorage,
-                          RepDedup&                        theDedup,
-                          const occ::handle<Geom2d_Curve>& theCurve)
+BRepGraph_Curve2DRepId getOrCreateCurve2DRep(BRepGraphInc_Storage&            theStorage,
+                                             RepDedup&                        theDedup,
+                                             const occ::handle<Geom2d_Curve>& theCurve)
 {
   if (theCurve.IsNull())
-    return -1;
-  const Geom2d_Curve* aPtr       = theCurve.get();
-  const int*          anExisting = theDedup.Curves2D.Seek(aPtr);
+    return BRepGraph_Curve2DRepId();
+  const Geom2d_Curve*            aPtr       = theCurve.get();
+  const BRepGraph_Curve2DRepId*  anExisting = theDedup.Curves2D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Curve2DRepId aRepId = theStorage.AppendCurve2DRep();
   BRepGraphInc::Curve2DRep&    aRep   = theStorage.ChangeCurve2DRep(aRepId);
   aRep.Curve                          = theCurve;
-  theDedup.Curves2D.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  theDedup.Curves2D.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Create or reuse a TriangulationRep for the given triangulation handle.
-int getOrCreateTriangulationRep(BRepGraphInc_Storage&                  theStorage,
-                                RepDedup&                              theDedup,
-                                const occ::handle<Poly_Triangulation>& theTriangulation)
+BRepGraph_TriangulationRepId getOrCreateTriangulationRep(
+  BRepGraphInc_Storage&                  theStorage,
+  RepDedup&                              theDedup,
+  const occ::handle<Poly_Triangulation>& theTriangulation)
 {
   if (theTriangulation.IsNull())
-    return -1;
-  const Poly_Triangulation* aPtr       = theTriangulation.get();
-  const int*                anExisting = theDedup.Triangulations.Seek(aPtr);
+    return BRepGraph_TriangulationRepId();
+  const Poly_Triangulation*              aPtr       = theTriangulation.get();
+  const BRepGraph_TriangulationRepId*    anExisting = theDedup.Triangulations.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_TriangulationRepId aRepId = theStorage.AppendTriangulationRep();
   BRepGraphInc::TriangulationRep&    aRep   = theStorage.ChangeTriangulationRep(aRepId);
   aRep.Triangulation                        = theTriangulation;
-  theDedup.Triangulations.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  theDedup.Triangulations.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Create or reuse a Polygon3DRep for the given polygon handle.
-int getOrCreatePolygon3DRep(BRepGraphInc_Storage&              theStorage,
-                            RepDedup&                          theDedup,
-                            const occ::handle<Poly_Polygon3D>& thePolygon)
+BRepGraph_Polygon3DRepId getOrCreatePolygon3DRep(BRepGraphInc_Storage&              theStorage,
+                                                 RepDedup&                          theDedup,
+                                                 const occ::handle<Poly_Polygon3D>& thePolygon)
 {
   if (thePolygon.IsNull())
-    return -1;
-  const Poly_Polygon3D* aPtr       = thePolygon.get();
-  const int*            anExisting = theDedup.Polygons3D.Seek(aPtr);
+    return BRepGraph_Polygon3DRepId();
+  const Poly_Polygon3D*            aPtr       = thePolygon.get();
+  const BRepGraph_Polygon3DRepId*  anExisting = theDedup.Polygons3D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Polygon3DRepId aRepId = theStorage.AppendPolygon3DRep();
   BRepGraphInc::Polygon3DRep&    aRep   = theStorage.ChangePolygon3DRep(aRepId);
   aRep.Polygon                          = thePolygon;
-  theDedup.Polygons3D.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  theDedup.Polygons3D.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Create or reuse a Polygon2DRep for the given polygon-on-surface handle.
-int getOrCreatePolygon2DRep(BRepGraphInc_Storage&              theStorage,
-                            RepDedup&                          theDedup,
-                            const occ::handle<Poly_Polygon2D>& thePolygon)
+BRepGraph_Polygon2DRepId getOrCreatePolygon2DRep(BRepGraphInc_Storage&              theStorage,
+                                                 RepDedup&                          theDedup,
+                                                 const occ::handle<Poly_Polygon2D>& thePolygon)
 {
   if (thePolygon.IsNull())
-    return -1;
-  const Poly_Polygon2D* aPtr       = thePolygon.get();
-  const int*            anExisting = theDedup.Polygons2D.Seek(aPtr);
+    return BRepGraph_Polygon2DRepId();
+  const Poly_Polygon2D*            aPtr       = thePolygon.get();
+  const BRepGraph_Polygon2DRepId*  anExisting = theDedup.Polygons2D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Polygon2DRepId aRepId = theStorage.AppendPolygon2DRep();
   BRepGraphInc::Polygon2DRep&    aRep   = theStorage.ChangePolygon2DRep(aRepId);
   aRep.Polygon                          = thePolygon;
-  theDedup.Polygons2D.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  theDedup.Polygons2D.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Create or reuse a PolygonOnTriRep for the given polygon-on-triangulation handle.
-//! theTriRepIdx is the global TriangulationRep index (not face-local).
-int getOrCreatePolygonOnTriRep(BRepGraphInc_Storage&                           theStorage,
-                               RepDedup&                                       theDedup,
-                               const occ::handle<Poly_PolygonOnTriangulation>& thePolygon,
-                               const int                                       theTriRepIdx)
+//! theTriRepId is the global TriangulationRepId (not face-local).
+BRepGraph_PolygonOnTriRepId getOrCreatePolygonOnTriRep(
+  BRepGraphInc_Storage&                           theStorage,
+  RepDedup&                                       theDedup,
+  const occ::handle<Poly_PolygonOnTriangulation>& thePolygon,
+  const BRepGraph_TriangulationRepId              theTriRepId)
 {
   if (thePolygon.IsNull())
-    return -1;
-  const Poly_PolygonOnTriangulation* aPtr       = thePolygon.get();
-  const int*                         anExisting = theDedup.PolygonsOnTri.Seek(aPtr);
+    return BRepGraph_PolygonOnTriRepId();
+  const Poly_PolygonOnTriangulation*  aPtr       = thePolygon.get();
+  const BRepGraph_PolygonOnTriRepId*  anExisting = theDedup.PolygonsOnTri.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_PolygonOnTriRepId aRepId = theStorage.AppendPolygonOnTriRep();
   BRepGraphInc::PolygonOnTriRep&    aRep   = theStorage.ChangePolygonOnTriRep(aRepId);
   aRep.Polygon                             = thePolygon;
-  aRep.TriangulationRepId                  = BRepGraph_TriangulationRepId(theTriRepIdx);
-  theDedup.PolygonsOnTri.Bind(aPtr, aRepId.Index);
-  return aRepId.Index;
+  aRep.TriangulationRepId                  = theTriRepId;
+  theDedup.PolygonsOnTri.Bind(aPtr, aRepId);
+  return aRepId;
 }
 
 //! Register an edge entity from pre-extracted data, with TShape dedup.
-//! Creates the entity (with vertices) if new, returns the index in both cases.
-int registerExtractedEdge(BRepGraphInc_Storage& theStorage,
-                          const ExtractedEdge&  theEdgeData,
-                          RepDedup&             theRepDedup)
+//! Creates the entity (with vertices) if new, returns the EdgeId in both cases.
+BRepGraph_EdgeId registerExtractedEdge(BRepGraphInc_Storage& theStorage,
+                                       const ExtractedEdge&  theEdgeData,
+                                       RepDedup&             theRepDedup)
 {
   const BRepGraph_NodeId* anExisting =
     findExistingNode(theStorage, theEdgeData.Shape, BRepGraph_NodeId::Kind::Edge);
   if (anExisting != nullptr)
-    return anExisting->Index;
+    return BRepGraph_EdgeId(*anExisting);
 
   const BRepGraph_EdgeId anEdgeId  = theStorage.AppendEdge();
   BRepGraphInc::EdgeDef& anEdgeEnt = theStorage.ChangeEdge(anEdgeId);
@@ -703,8 +706,7 @@ int registerExtractedEdge(BRepGraphInc_Storage& theStorage,
 
   if (!theEdgeData.Curve3d.IsNull())
   {
-    anEdgeEnt.Curve3DRepId =
-      BRepGraph_Curve3DRepId(getOrCreateCurve3DRep(theStorage, theRepDedup, theEdgeData.Curve3d));
+    anEdgeEnt.Curve3DRepId = getOrCreateCurve3DRep(theStorage, theRepDedup, theEdgeData.Curve3d);
   }
 
   // Vertex registration (boundary vertices stored as VertexRefId into Ref table).
@@ -712,10 +714,10 @@ int registerExtractedEdge(BRepGraphInc_Storage& theStorage,
   if (!theEdgeData.StartVertex.Shape.IsNull())
   {
     BRepGraphInc::VertexInstance aVR;
-    aVR.DefId                  = BRepGraph_VertexId(registerOrReuseVertex(theStorage,
-                                                         theEdgeData.StartVertex.Shape,
-                                                         theEdgeData.StartVertex.Point,
-                                                         theEdgeData.StartVertex.Tolerance));
+    aVR.DefId                  = registerOrReuseVertex(theStorage,
+                                                       theEdgeData.StartVertex.Shape,
+                                                       theEdgeData.StartVertex.Point,
+                                                       theEdgeData.StartVertex.Tolerance);
     aVR.Orientation            = TopAbs_FORWARD;
     aVR.Location               = theEdgeData.StartVertex.Shape.Location();
     anEdgeEnt.StartVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -723,10 +725,10 @@ int registerExtractedEdge(BRepGraphInc_Storage& theStorage,
   if (!theEdgeData.EndVertex.Shape.IsNull())
   {
     BRepGraphInc::VertexInstance aVR;
-    aVR.DefId                = BRepGraph_VertexId(registerOrReuseVertex(theStorage,
-                                                         theEdgeData.EndVertex.Shape,
-                                                         theEdgeData.EndVertex.Point,
-                                                         theEdgeData.EndVertex.Tolerance));
+    aVR.DefId                = registerOrReuseVertex(theStorage,
+                                                     theEdgeData.EndVertex.Shape,
+                                                     theEdgeData.EndVertex.Point,
+                                                     theEdgeData.EndVertex.Tolerance);
     aVR.Orientation          = TopAbs_REVERSED;
     aVR.Location             = theEdgeData.EndVertex.Shape.Location();
     anEdgeEnt.EndVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -735,12 +737,12 @@ int registerExtractedEdge(BRepGraphInc_Storage& theStorage,
   // Register internal/external vertices.
   for (const ExtractedInternalVertex& anIntVtx : theEdgeData.InternalVertices)
   {
-    const int anIntVtxIdx =
+    const BRepGraph_VertexId anIntVtxId =
       registerOrReuseVertex(theStorage, anIntVtx.Shape, anIntVtx.Point, anIntVtx.Tolerance);
-    if (anIntVtxIdx >= 0)
+    if (anIntVtxId.IsValid())
     {
       BRepGraphInc::VertexInstance aVR;
-      aVR.DefId       = BRepGraph_VertexId(anIntVtxIdx);
+      aVR.DefId       = anIntVtxId;
       aVR.Orientation = anIntVtx.Orientation;
       aVR.Location    = anIntVtx.Shape.Location();
       anEdgeEnt.InternalVertexRefIds.Append(appendVertexRef(theStorage, anEdgeId, aVR));
@@ -749,7 +751,7 @@ int registerExtractedEdge(BRepGraphInc_Storage& theStorage,
 
   theStorage.BindTShapeToNode(theEdgeData.Shape.TShape().get(), anEdgeId);
   theStorage.BindOriginal(anEdgeId, theEdgeData.Shape);
-  return anEdgeId.Index;
+  return anEdgeId;
 }
 
 //! Create a NodeInstance from a child shape, resolving its index via TShape lookup.
@@ -1050,27 +1052,25 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
     const BRepGraph_NodeId* anExistingFace =
       findExistingNode(theStorage, aCurFace, BRepGraph_NodeId::Kind::Face);
 
-    int  aFaceIdx      = -1;
-    bool aIsNewFaceDef = false;
+    BRepGraph_FaceId aFaceId;
+    bool             aIsNewFaceDef = false;
     if (anExistingFace != nullptr)
     {
-      aFaceIdx = anExistingFace->Index;
+      aFaceId = BRepGraph_FaceId(*anExistingFace);
     }
     else
     {
       aIsNewFaceDef                  = true;
-      const BRepGraph_FaceId aFaceId = theStorage.AppendFace();
-      aFaceIdx                       = aFaceId.Index;
+      aFaceId                        = theStorage.AppendFace();
       BRepGraphInc::FaceDef& aFace   = theStorage.ChangeFace(aFaceId);
       aFace.Tolerance                = aData.Tolerance;
       aFace.NaturalRestriction       = aData.NaturalRestriction;
-      aFace.SurfaceRepId =
-        BRepGraph_SurfaceRepId(getOrCreateSurfaceRep(theStorage, theRepDedup, aData.Surface));
+      aFace.SurfaceRepId             = getOrCreateSurfaceRep(theStorage, theRepDedup, aData.Surface);
 
       if (!aData.ActiveTriangulation.IsNull())
       {
-        aFace.TriangulationRepId = BRepGraph_TriangulationRepId(
-          getOrCreateTriangulationRep(theStorage, theRepDedup, aData.ActiveTriangulation));
+        aFace.TriangulationRepId =
+          getOrCreateTriangulationRep(theStorage, theRepDedup, aData.ActiveTriangulation);
       }
 
       theStorage.BindTShapeToNode(aCurFace.TShape().get(), aFaceId);
@@ -1078,18 +1078,17 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
     }
 
     // Link face to parent shell (with per-instance location for shared TShapes).
-    if (aData.ParentShellIdx >= 0)
+    if (aData.ParentShellId.IsValid())
     {
       BRepGraphInc::FaceInstance aRef;
-      aRef.DefId       = BRepGraph_FaceId(aFaceIdx);
+      aRef.DefId       = aFaceId;
       aRef.Orientation = aData.Orientation;
       aRef.Location    = aCurFace.Location();
-      const BRepGraph_ShellId aShellId(aData.ParentShellIdx);
-      appendFaceRef(theStorage, aShellId, aRef);
+      appendFaceRef(theStorage, aData.ParentShellId, aRef);
     }
 
     // Pre-fetch face entity for triangulation access in edge loop.
-    BRepGraphInc::FaceDef&       aFaceMut = theStorage.ChangeFace(BRepGraph_FaceId(aFaceIdx));
+    BRepGraphInc::FaceDef&       aFaceMut = theStorage.ChangeFace(aFaceId);
     const BRepGraphInc::FaceDef& aFaceDef = aFaceMut;
 
     // Process wires - only for newly created face definitions.
@@ -1105,17 +1104,16 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
       const BRepGraph_NodeId* anExistingWire =
         findExistingNode(theStorage, aWireData.Shape, BRepGraph_NodeId::Kind::Wire);
 
-      int  aWireIdx      = -1;
-      bool aIsNewWireDef = false;
+      BRepGraph_WireId aWireId;
+      bool             aIsNewWireDef = false;
 
       if (anExistingWire != nullptr)
       {
-        aWireIdx = anExistingWire->Index;
+        aWireId = BRepGraph_WireId(*anExistingWire);
       }
       else
       {
-        const BRepGraph_WireId aWireId = theStorage.AppendWire();
-        aWireIdx                       = aWireId.Index;
+        aWireId = theStorage.AppendWire();
         theStorage.BindTShapeToNode(aWireData.Shape.TShape().get(), aWireId);
         theStorage.BindOriginal(aWireId, aWireData.Shape);
         aIsNewWireDef = true;
@@ -1124,80 +1122,72 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
       // Link wire to face.
       {
         BRepGraphInc::WireInstance aWireRef;
-        aWireRef.DefId       = BRepGraph_WireId(aWireIdx);
+        aWireRef.DefId       = aWireId;
         aWireRef.Orientation = aWireData.Shape.Orientation();
         aWireRef.Location    = aWireData.Shape.Location();
         aWireRef.IsOuter     = aWireData.IsOuter;
-        const BRepGraph_FaceId aFaceId(aFaceIdx);
         appendWireRef(theStorage, aFaceId, aWireRef);
       }
 
       for (const ExtractedEdge& anEdgeData : aWireData.Edges)
       {
-        int anEdgeIdx = registerExtractedEdge(theStorage, anEdgeData, theRepDedup);
+        const BRepGraph_EdgeId anEdgeIdx = registerExtractedEdge(theStorage, anEdgeData, theRepDedup);
 
         // Cache mutable edge reference for subsequent PCurve/Polygon appends.
         // Safe: no new edges are appended within this scope.
-        BRepGraphInc::EdgeDef& anEdgeMut = theStorage.ChangeEdge(BRepGraph_EdgeId(anEdgeIdx));
+        BRepGraphInc::EdgeDef& anEdgeMut = theStorage.ChangeEdge(anEdgeIdx);
 
         // Create CoEdge entity for this edge-face binding and add CoEdgeUsage to wire.
-        int aFwdCoEdgeIdx  = -1;
-        int aSeamCoEdgeIdx = -1;
+        BRepGraph_CoEdgeId aFwdCoEdgeId;
+        BRepGraph_CoEdgeId aSeamCoEdgeId;
         if (aIsNewWireDef)
         {
           // Create the forward CoEdge.
-          const BRepGraph_CoEdgeId aCoEdgeId  = theStorage.AppendCoEdge();
-          aFwdCoEdgeIdx                       = aCoEdgeId.Index;
-          const int                aCoEdgeIdx = aFwdCoEdgeIdx;
-          BRepGraphInc::CoEdgeDef& aCoEdge    = theStorage.ChangeCoEdge(aCoEdgeId);
-          aCoEdge.EdgeDefId                   = BRepGraph_EdgeId(anEdgeIdx);
-          aCoEdge.FaceDefId                   = BRepGraph_FaceId(aFaceIdx);
+          aFwdCoEdgeId                        = theStorage.AppendCoEdge();
+          BRepGraphInc::CoEdgeDef& aCoEdge    = theStorage.ChangeCoEdge(aFwdCoEdgeId);
+          aCoEdge.EdgeDefId                   = anEdgeIdx;
+          aCoEdge.FaceDefId                   = aFaceId;
           aCoEdge.Orientation                 = anEdgeData.OrientationInWire;
 
           // Populate CoEdge with PCurve and polygon data for this face context.
           if (!anEdgeData.PCurve2d.IsNull())
           {
-            aCoEdge.Curve2DRepId = BRepGraph_Curve2DRepId(
-              getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2d));
+            aCoEdge.Curve2DRepId = getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2d);
             aCoEdge.ParamFirst = anEdgeData.PCFirst;
             aCoEdge.ParamLast  = anEdgeData.PCLast;
             aCoEdge.Continuity = anEdgeData.PCurveContinuity;
             aCoEdge.UV1        = anEdgeData.PCUV1;
             aCoEdge.UV2        = anEdgeData.PCUV2;
           }
-          aCoEdge.Polygon2DRepId = BRepGraph_Polygon2DRepId(
-            getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurf));
+          aCoEdge.Polygon2DRepId = getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurf);
 
           // Handle seam edge: create a second CoEdge for the reversed sense.
           if (!anEdgeData.PCurve2dReversed.IsNull())
           {
-            const BRepGraph_CoEdgeId aSeamCoEdgeId = theStorage.AppendCoEdge();
-            aSeamCoEdgeIdx                         = aSeamCoEdgeId.Index;
+            aSeamCoEdgeId                          = theStorage.AppendCoEdge();
             BRepGraphInc::CoEdgeDef& aSeamCoEdge   = theStorage.ChangeCoEdge(aSeamCoEdgeId);
-            aSeamCoEdge.EdgeDefId                  = BRepGraph_EdgeId(anEdgeIdx);
-            aSeamCoEdge.FaceDefId                  = BRepGraph_FaceId(aFaceIdx);
+            aSeamCoEdge.EdgeDefId                  = anEdgeIdx;
+            aSeamCoEdge.FaceDefId                  = aFaceId;
             aSeamCoEdge.Orientation                = TopAbs_REVERSED;
-            aSeamCoEdge.Curve2DRepId               = BRepGraph_Curve2DRepId(
-              getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2dReversed));
+            aSeamCoEdge.Curve2DRepId =
+              getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2dReversed);
             aSeamCoEdge.ParamFirst     = anEdgeData.PCFirstReversed;
             aSeamCoEdge.ParamLast      = anEdgeData.PCLastReversed;
             aSeamCoEdge.Continuity     = anEdgeData.PCurveContinuity;
             aSeamCoEdge.SeamContinuity = anEdgeData.SeamContinuity;
-            aSeamCoEdge.Polygon2DRepId = BRepGraph_Polygon2DRepId(
-              getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurfReversed));
+            aSeamCoEdge.Polygon2DRepId =
+              getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurfReversed);
 
             // Link seam pair.
             // Note: aCoEdge ref may be invalidated by AppendCoEdge, re-fetch.
-            theStorage.ChangeCoEdge(BRepGraph_CoEdgeId(aCoEdgeIdx)).SeamPairId =
-              BRepGraph_CoEdgeId(aSeamCoEdgeIdx);
-            aSeamCoEdge.SeamPairId = BRepGraph_CoEdgeId(aCoEdgeIdx);
+            theStorage.ChangeCoEdge(aFwdCoEdgeId).SeamPairId = aSeamCoEdgeId;
+            aSeamCoEdge.SeamPairId                           = aFwdCoEdgeId;
           }
 
           // Add CoEdgeUsage to wire with edge-in-wire Location.
           BRepGraphInc::CoEdgeInstance aCoEdgeRef;
-          aCoEdgeRef.DefId    = BRepGraph_CoEdgeId(aCoEdgeIdx);
+          aCoEdgeRef.DefId    = aFwdCoEdgeId;
           aCoEdgeRef.Location = anEdgeData.Shape.Location();
-          const BRepGraph_WireId aWireId(aWireIdx);
           appendCoEdgeRef(theStorage, aWireId, aCoEdgeRef);
 
           // Note: seam coedge (if any) is NOT added to wire CoEdgeRefs --
@@ -1209,15 +1199,15 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
         // Polygon3D (once per edge).
         if (!anEdgeData.Polygon3D.IsNull() && !anEdgeMut.Polygon3DRepId.IsValid())
         {
-          anEdgeMut.Polygon3DRepId = BRepGraph_Polygon3DRepId(
-            getOrCreatePolygon3DRep(theStorage, theRepDedup, anEdgeData.Polygon3D));
+          anEdgeMut.Polygon3DRepId =
+            getOrCreatePolygon3DRep(theStorage, theRepDedup, anEdgeData.Polygon3D);
         }
 
         // Polygon-on-triangulation: extract directly into CoEdge entities.
-        if (aFwdCoEdgeIdx >= 0)
+        if (aFwdCoEdgeId.IsValid())
         {
           TopLoc_Location aPolyTriLoc;
-          const bool      hasSeamCoEdge = aSeamCoEdgeIdx >= 0;
+          const bool      hasSeamCoEdge = aSeamCoEdgeId.IsValid();
           TopoDS_Edge     aRevEdge;
           if (hasSeamCoEdge)
             aRevEdge = TopoDS::Edge(anEdgeData.Shape.Reversed());
@@ -1232,7 +1222,7 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
                 BRep_Tool::PolygonOnTriangulation(anEdgeData.Shape, aTri, aPolyTriLoc);
               if (!aPolyOnTri.IsNull())
               {
-                int aTriRepIdx = aFaceDef.TriangulationRepId.Index;
+                BRepGraph_TriangulationRepId aTriRepId = aFaceDef.TriangulationRepId;
                 if (!aPolyTriLoc.IsIdentity())
                 {
                   const TopLoc_Location aRepLoc =
@@ -1243,16 +1233,15 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
                     const gp_Trsf&                  aTrsf    = aRepLoc.Transformation();
                     for (int aNodeIdx = 1; aNodeIdx <= aTriCopy->NbNodes(); ++aNodeIdx)
                       aTriCopy->SetNode(aNodeIdx, aTriCopy->Node(aNodeIdx).Transformed(aTrsf));
-                    aTriRepIdx = getOrCreateTriangulationRep(theStorage, theRepDedup, aTriCopy);
-                    aFaceMut.TriangulationRepId = BRepGraph_TriangulationRepId(aTriRepIdx);
+                    aTriRepId                   = getOrCreateTriangulationRep(theStorage, theRepDedup, aTriCopy);
+                    aFaceMut.TriangulationRepId = aTriRepId;
                   }
                 }
 
-                const int aPolyOnTriRepIdx =
-                  getOrCreatePolygonOnTriRep(theStorage, theRepDedup, aPolyOnTri, aTriRepIdx);
+                const BRepGraph_PolygonOnTriRepId aPolyOnTriRepId =
+                  getOrCreatePolygonOnTriRep(theStorage, theRepDedup, aPolyOnTri, aTriRepId);
 
-                theStorage.ChangeCoEdge(BRepGraph_CoEdgeId(aFwdCoEdgeIdx)).PolygonOnTriRepId =
-                  BRepGraph_PolygonOnTriRepId(aPolyOnTriRepIdx);
+                theStorage.ChangeCoEdge(aFwdCoEdgeId).PolygonOnTriRepId = aPolyOnTriRepId;
 
                 // Seam polygon-on-triangulation.
                 if (hasSeamCoEdge)
@@ -1261,13 +1250,10 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
                     BRep_Tool::PolygonOnTriangulation(aRevEdge, aTri, aPolyTriLoc);
                   if (!aPolyOnTriRev.IsNull() && aPolyOnTriRev != aPolyOnTri)
                   {
-                    const int aSeamPolyRepIdx = getOrCreatePolygonOnTriRep(theStorage,
-                                                                           theRepDedup,
-                                                                           aPolyOnTriRev,
-                                                                           aTriRepIdx);
+                    const BRepGraph_PolygonOnTriRepId aSeamPolyRepId = getOrCreatePolygonOnTriRep(
+                      theStorage, theRepDedup, aPolyOnTriRev, aTriRepId);
 
-                    theStorage.ChangeCoEdge(BRepGraph_CoEdgeId(aSeamCoEdgeIdx)).PolygonOnTriRepId =
-                      BRepGraph_PolygonOnTriRepId(aSeamPolyRepIdx);
+                    theStorage.ChangeCoEdge(aSeamCoEdgeId).PolygonOnTriRepId = aSeamPolyRepId;
                   }
                 }
               }
@@ -1279,24 +1265,23 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
       // Wire closure: copy directly from the original shape.
       if (aIsNewWireDef)
       {
-        theStorage.ChangeWire(BRepGraph_WireId(aWireIdx)).IsClosed = aWireData.Shape.Closed();
+        theStorage.ChangeWire(aWireId).IsClosed = aWireData.Shape.Closed();
       }
     }
 
     // Register direct vertex children of the face (INTERNAL/EXTERNAL).
     for (const ExtractedInternalVertex& aDirVtx : aData.DirectVertices)
     {
-      const int aVtxIdx =
+      const BRepGraph_VertexId aVtxId =
         registerOrReuseVertex(theStorage, aDirVtx.Shape, aDirVtx.Point, aDirVtx.Tolerance);
-      if (aVtxIdx >= 0)
+      if (aVtxId.IsValid())
       {
         BRepGraphInc::VertexInstance aVR;
-        aVR.DefId       = BRepGraph_VertexId(aVtxIdx);
+        aVR.DefId       = aVtxId;
         aVR.Orientation = aDirVtx.Orientation;
         aVR.Location    = aDirVtx.Shape.Location();
-        const BRepGraph_FaceId aFaceId(aFaceIdx);
         theStorage.ChangeFace(aFaceId).VertexRefIds.Append(
-          appendVertexRef(theStorage, BRepGraph_FaceId(aFaceId.Index), aVR));
+          appendVertexRef(theStorage, aFaceId, aVR));
       }
     }
   }
@@ -1321,9 +1306,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       if (findExistingNode(theStorage, aCompound, BRepGraph_NodeId::Kind::Compound))
         break;
 
-      theStorage.AppendCompound();
-      int                        aCompIdx = theStorage.NbCompounds() - 1;
-      const BRepGraph_CompoundId aCompId(aCompIdx);
+      const BRepGraph_CompoundId aCompId = theStorage.AppendCompound();
       theStorage.BindTShapeToNode(aCompound.TShape().get(), aCompId);
       theStorage.BindOriginal(aCompId, aCompound);
 
@@ -1339,9 +1322,9 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         if (aChild.ShapeType() != TopAbs_SHAPE)
         {
           // Resolve child index via TShape lookup (handles dedup correctly).
-          // Face indices are deferred (-1) because faces are registered in Phase 3;
+          // Face indices are deferred (invalid) because faces are registered in Phase 3;
           // resolved in the Phase 3a fixup pass after registerFaceData().
-          int aChildIdx = -1;
+          uint32_t aChildIdx = BRepGraph_NodeId::THE_INVALID_INDEX;
           if (aChild.ShapeType() != TopAbs_FACE)
           {
             const BRepGraph_NodeId* aChildNodeId =
@@ -1354,8 +1337,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           aRef.DefId       = BRepGraph_NodeId(aChildKind, aChildIdx);
           aRef.Orientation = aChild.Orientation();
           aRef.Location    = aChild.Location();
-          const BRepGraph_CompoundId aCompId(aCompIdx);
-          appendChildRef(theStorage, BRepGraph_CompoundId(aCompId.Index), aRef);
+          appendChildRef(theStorage, aCompId, aRef);
         }
       }
       break;
@@ -1366,9 +1348,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       if (findExistingNode(theStorage, aCompSolid, BRepGraph_NodeId::Kind::CompSolid))
         break;
 
-      theStorage.AppendCompSolid();
-      int                         aCSolidIdx = theStorage.NbCompSolids() - 1;
-      const BRepGraph_CompSolidId aCSolidId(aCSolidIdx);
+      const BRepGraph_CompSolidId aCSolidId = theStorage.AppendCompSolid();
       theStorage.BindTShapeToNode(aCompSolid.TShape().get(), aCSolidId);
       theStorage.BindOriginal(aCSolidId, aCompSolid);
 
@@ -1389,8 +1369,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         aRef.DefId       = BRepGraph_SolidId::FromNodeId(*aSolidNodeId);
         aRef.Orientation = aChildIt.Value().Orientation();
         aRef.Location    = aChildIt.Value().Location();
-        const BRepGraph_CompSolidId aCompSolidId(aCSolidIdx);
-        appendSolidRef(theStorage, aCompSolidId, aRef);
+        appendSolidRef(theStorage, aCSolidId, aRef);
       }
       break;
     }
@@ -1400,9 +1379,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       if (findExistingNode(theStorage, aSolid, BRepGraph_NodeId::Kind::Solid))
         break;
 
-      theStorage.AppendSolid();
-      int                     aSolidIdx = theStorage.NbSolids() - 1;
-      const BRepGraph_SolidId aSolidId(aSolidIdx);
+      const BRepGraph_SolidId aSolidId = theStorage.AppendSolid();
       theStorage.BindTShapeToNode(aSolid.TShape().get(), aSolidId);
       theStorage.BindOriginal(aSolidId, aSolid);
 
@@ -1423,7 +1400,6 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           aRef.DefId       = BRepGraph_ShellId::FromNodeId(*aShellNodeId);
           aRef.Orientation = aChild.Orientation();
           aRef.Location    = aChild.Location();
-          const BRepGraph_SolidId aSolidId(aSolidIdx);
           appendShellRef(theStorage, aSolidId, aRef);
         }
         else if (aChild.ShapeType() == TopAbs_EDGE || aChild.ShapeType() == TopAbs_VERTEX)
@@ -1431,9 +1407,8 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           BRepGraphInc::NodeInstance aCR;
           if (makeAuxChildRef(theStorage, aChild, aCR))
           {
-            const BRepGraph_SolidId    aSolidId(aSolidIdx);
             const BRepGraph_ChildRefId aChildRefId =
-              appendChildRef(theStorage, BRepGraph_SolidId(aSolidId.Index), aCR);
+              appendChildRef(theStorage, aSolidId, aCR);
             theStorage.ChangeSolid(aSolidId).AuxChildRefIds.Append(aChildRefId);
           }
         }
@@ -1447,7 +1422,6 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         break;
 
       const BRepGraph_ShellId aShellId  = theStorage.AppendShell();
-      const int               aShellIdx = aShellId.Index;
       BRepGraphInc::ShellDef& aShellEnt = theStorage.ChangeShell(aShellId);
       aShellEnt.IsClosed                = aShell.Closed();
       theStorage.BindTShapeToNode(aShell.TShape().get(), aShellId);
@@ -1463,7 +1437,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           FaceLocalData& aData  = theFaceData.Appended();
           aData.Face            = TopoDS::Face(aChild);
           aData.ParentGlobalLoc = aGlobalLoc;
-          aData.ParentShellIdx  = aShellIdx;
+          aData.ParentShellId   = aShellId;
         }
         else if (aChild.ShapeType() == TopAbs_WIRE || aChild.ShapeType() == TopAbs_EDGE)
         {
@@ -1472,9 +1446,8 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           BRepGraphInc::NodeInstance aCR;
           if (makeAuxChildRef(theStorage, aChild, aCR))
           {
-            const BRepGraph_ShellId    aShellId(aShellIdx);
             const BRepGraph_ChildRefId aChildRefId =
-              appendChildRef(theStorage, BRepGraph_ShellId(aShellId.Index), aCR);
+              appendChildRef(theStorage, aShellId, aCR);
             theStorage.ChangeShell(aShellId).AuxChildRefIds.Append(aChildRefId);
           }
         }
@@ -1486,7 +1459,6 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       FaceLocalData& aData  = theFaceData.Appended();
       aData.Face            = TopoDS::Face(theCurrentShape);
       aData.ParentGlobalLoc = theParentGlobalLoc;
-      aData.ParentShellIdx  = -1;
       break;
     }
 
@@ -1496,7 +1468,6 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         break;
 
       const BRepGraph_WireId aWireId  = theStorage.AppendWire();
-      const int              aWireIdx = aWireId.Index;
       BRepGraphInc::WireDef& aWireEnt = theStorage.ChangeWire(aWireId);
       aWireEnt.IsClosed               = aWire.Closed();
       theStorage.BindTShapeToNode(aWire.TShape().get(), aWireId);
@@ -1516,18 +1487,16 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         if (anEdgeNodeId != nullptr && anEdgeNodeId->NodeKind == BRepGraph_NodeId::Kind::Edge)
         {
           // Create CoEdge for free wire (no face context).
-          const BRepGraph_CoEdgeId aCoEdgeId  = theStorage.AppendCoEdge();
-          const int                aCoEdgeIdx = aCoEdgeId.Index;
-          BRepGraphInc::CoEdgeDef& aCoEdge    = theStorage.ChangeCoEdge(aCoEdgeId);
-          aCoEdge.EdgeDefId                   = BRepGraph_EdgeId::FromNodeId(*anEdgeNodeId);
-          aCoEdge.Orientation                 = anEdge.Orientation();
+          const BRepGraph_CoEdgeId aCoEdgeId = theStorage.AppendCoEdge();
+          BRepGraphInc::CoEdgeDef& aCoEdge   = theStorage.ChangeCoEdge(aCoEdgeId);
+          aCoEdge.EdgeDefId                  = BRepGraph_EdgeId::FromNodeId(*anEdgeNodeId);
+          aCoEdge.Orientation                = anEdge.Orientation();
           // FaceDefId left invalid for free wires.
           // Curve2d left null for free wires.
 
           BRepGraphInc::CoEdgeInstance aCoEdgeRef;
-          aCoEdgeRef.DefId    = BRepGraph_CoEdgeId(aCoEdgeIdx);
+          aCoEdgeRef.DefId    = aCoEdgeId;
           aCoEdgeRef.Location = anEdge.Location();
-          const BRepGraph_WireId aWireId(aWireIdx);
           appendCoEdgeRef(theStorage, aWireId, aCoEdgeRef);
         }
       }
@@ -1557,8 +1526,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         anEdgeEnt.ParamLast  = aLast;
         aCurve3d =
           applyRepresentationLocation<Geom_Curve>(aCurve3d, anEdge.Location(), aCurveCombinedLoc);
-        anEdgeEnt.Curve3DRepId =
-          BRepGraph_Curve3DRepId(getOrCreateCurve3DRep(theStorage, theRepDedup, aCurve3d));
+        anEdgeEnt.Curve3DRepId = getOrCreateCurve3DRep(theStorage, theRepDedup, aCurve3d);
       }
 
       // Extract vertices.
@@ -1571,10 +1539,10 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       if (!aVFirst.IsNull())
       {
         BRepGraphInc::VertexInstance aVR;
-        aVR.DefId                  = BRepGraph_VertexId(registerOrReuseVertex(theStorage,
-                                                             aVFirst,
-                                                             rawVertexPoint(aVFirst),
-                                                             BRep_Tool::Tolerance(aVFirst)));
+        aVR.DefId                  = registerOrReuseVertex(theStorage,
+                                                           aVFirst,
+                                                           rawVertexPoint(aVFirst),
+                                                           BRep_Tool::Tolerance(aVFirst));
         aVR.Orientation            = TopAbs_FORWARD;
         aVR.Location               = aVFirst.Location();
         anEdgeEnt.StartVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -1582,10 +1550,10 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       if (!aVLast.IsNull())
       {
         BRepGraphInc::VertexInstance aVR;
-        aVR.DefId                = BRepGraph_VertexId(registerOrReuseVertex(theStorage,
-                                                             aVLast,
-                                                             rawVertexPoint(aVLast),
-                                                             BRep_Tool::Tolerance(aVLast)));
+        aVR.DefId                = registerOrReuseVertex(theStorage,
+                                                         aVLast,
+                                                         rawVertexPoint(aVLast),
+                                                         BRep_Tool::Tolerance(aVLast));
         aVR.Orientation          = TopAbs_REVERSED;
         aVR.Location             = aVLast.Location();
         anEdgeEnt.EndVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -1593,12 +1561,12 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
 
       for (const ExtractedInternalVertex& anIntVtx : anInternalVerts)
       {
-        const int anIntVtxIdx =
+        const BRepGraph_VertexId anIntVtxId =
           registerOrReuseVertex(theStorage, anIntVtx.Shape, anIntVtx.Point, anIntVtx.Tolerance);
-        if (anIntVtxIdx >= 0)
+        if (anIntVtxId.IsValid())
         {
           BRepGraphInc::VertexInstance aVR;
-          aVR.DefId       = BRepGraph_VertexId(anIntVtxIdx);
+          aVR.DefId       = anIntVtxId;
           aVR.Orientation = anIntVtx.Orientation;
           aVR.Location    = anIntVtx.Shape.Location();
           anEdgeEnt.InternalVertexRefIds.Append(appendVertexRef(theStorage, anEdgeId, aVR));
@@ -1610,8 +1578,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
         TopLoc_Location             aPoly3DLoc;
         occ::handle<Poly_Polygon3D> aPolygon3D = BRep_Tool::Polygon3D(anEdge, aPoly3DLoc);
         aPolygon3D = applyRepLocationToPolygon3D(aPolygon3D, anEdge.Location(), aPoly3DLoc);
-        anEdgeEnt.Polygon3DRepId =
-          BRepGraph_Polygon3DRepId(getOrCreatePolygon3DRep(theStorage, theRepDedup, aPolygon3D));
+        anEdgeEnt.Polygon3DRepId = getOrCreatePolygon3DRep(theStorage, theRepDedup, aPolygon3D);
       }
 
       theStorage.BindTShapeToNode(anEdge.TShape().get(), anEdgeId);
@@ -1679,7 +1646,6 @@ void flattenForAppend(BRepGraphInc_Storage&                 theStorage,
       FaceLocalData& aData  = theFaceData.Appended();
       aData.Face            = TopoDS::Face(theCurrentShape);
       aData.ParentGlobalLoc = theParentGlobalLoc;
-      aData.ParentShellIdx  = -1;
       break;
     }
     case TopAbs_WIRE:
@@ -1707,7 +1673,7 @@ void flattenForAppend(BRepGraphInc_Storage&                 theStorage,
 void populateRegularityLayer(BRepGraphInc_Storage&                         theStorage,
                              BRepGraph_LayerRegularity*                    theRegularityLayer,
                              const bool                                    theExtractRegularities,
-                             const int                                     theOldNbEdges,
+                             const uint32_t                                theOldNbEdges,
                              const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   if (theRegularityLayer == nullptr)
@@ -1719,9 +1685,9 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
     return;
 
   // Surface-to-face map covers all faces (new edges may reference old faces).
-  NCollection_DataMap<const Geom_Surface*, int> aSurfToFaceIdx(1, theTmpAlloc);
-  const int                                     aNbFaces = theStorage.NbFaces();
-  for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaces); ++aFaceId)
+  NCollection_DataMap<const Geom_Surface*, BRepGraph_FaceId> aSurfToFaceIdx(1, theTmpAlloc);
+  const uint32_t                                             aNbFaces = theStorage.NbFaces();
+  for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start(); aFaceId.IsValid(aNbFaces); ++aFaceId)
   {
     const TopoDS_Shape* anOrigFace = theStorage.FindOriginal(aFaceId);
     if (anOrigFace == nullptr || anOrigFace->IsNull())
@@ -1730,11 +1696,11 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
     TopLoc_Location           aLoc;
     occ::handle<Geom_Surface> aRawSurf = BRep_Tool::Surface(TopoDS::Face(*anOrigFace), aLoc);
     if (!aRawSurf.IsNull())
-      aSurfToFaceIdx.TryBind(aRawSurf.get(), aFaceId.Index);
+      aSurfToFaceIdx.TryBind(aRawSurf.get(), aFaceId);
   }
 
   // Only process new edges in incremental mode.
-  const int aNbEdges = theStorage.NbEdges();
+  const uint32_t aNbEdges = theStorage.NbEdges();
   for (BRepGraph_EdgeId anEdgeId(theOldNbEdges); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
     const TopoDS_Shape* anOrigShape = theStorage.FindOriginal(anEdgeId);
@@ -1761,14 +1727,14 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
       if (aSurf1Ptr == nullptr || aSurf2Ptr == nullptr)
         continue;
 
-      const int* aFaceIdx1 = aSurfToFaceIdx.Seek(aSurf1Ptr);
-      const int* aFaceIdx2 = aSurfToFaceIdx.Seek(aSurf2Ptr);
+      const BRepGraph_FaceId* aFaceIdx1 = aSurfToFaceIdx.Seek(aSurf1Ptr);
+      const BRepGraph_FaceId* aFaceIdx2 = aSurfToFaceIdx.Seek(aSurf2Ptr);
       if (aFaceIdx1 == nullptr || aFaceIdx2 == nullptr)
         continue;
 
       theRegularityLayer->SetRegularity(anEdgeId,
-                                        BRepGraph_FaceId(*aFaceIdx1),
-                                        BRepGraph_FaceId(*aFaceIdx2),
+                                        *aFaceIdx1,
+                                        *aFaceIdx2,
                                         aCon2S->Continuity());
     }
   }
@@ -1779,7 +1745,7 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
 void populateParamLayer(BRepGraphInc_Storage&                         theStorage,
                         BRepGraph_LayerParam*                         theParamLayer,
                         const bool                                    theExtractVertexPointReps,
-                        const int                                     theOldNbVertices,
+                        const uint32_t                                theOldNbVertices,
                         const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   if (theParamLayer == nullptr)
@@ -1791,8 +1757,8 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
     return;
 
   NCollection_DataMap<const Geom_Curve*, BRepGraph_NodeId> aCurveToEdgeDef(1, theTmpAlloc);
-  const int                                                aNbEdges = theStorage.NbEdges();
-  for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
+  const uint32_t                                           aNbEdges = theStorage.NbEdges();
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start(); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
     const TopoDS_Shape* anOrigEdge = theStorage.FindOriginal(anEdgeId);
     if (anOrigEdge == nullptr || anOrigEdge->IsNull())
@@ -1809,8 +1775,8 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
 
   NCollection_DataMap<const Geom_Surface*, BRepGraph_NodeId> aSurfToFaceDef(1, theTmpAlloc);
   NCollection_Vector<const Geom_Surface*>                    aFaceRawSurfaces(1, theTmpAlloc);
-  const int                                                  aNbFaces = theStorage.NbFaces();
-  for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaces); ++aFaceId)
+  const uint32_t                                             aNbFaces = theStorage.NbFaces();
+  for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start(); aFaceId.IsValid(aNbFaces); ++aFaceId)
   {
     const TopoDS_Shape* anOrigFace  = theStorage.FindOriginal(aFaceId);
     const Geom_Surface* aRawSurfPtr = nullptr;
@@ -1830,7 +1796,7 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
   NCollection_DataMap<const Geom2d_Curve*, NCollection_Vector<BRepGraph_CoEdgeId>> aPCurveToCoEdges(
     1,
     theTmpAlloc);
-  const int aNbCoEdges = theStorage.NbCoEdges();
+  const uint32_t aNbCoEdges = theStorage.NbCoEdges();
   for (BRepGraph_CoEdgeId aCoEdgeId(0); aCoEdgeId.IsValid(aNbCoEdges); ++aCoEdgeId)
   {
     const BRepGraphInc::CoEdgeDef& aCoEdge = theStorage.CoEdge(aCoEdgeId);
@@ -1855,7 +1821,7 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
   }
 
   // Only process new vertices in incremental mode.
-  const int aNbVertices = theStorage.NbVertices();
+  const uint32_t aNbVertices = theStorage.NbVertices();
   for (BRepGraph_VertexId aVertexId(theOldNbVertices); aVertexId.IsValid(aNbVertices); ++aVertexId)
   {
     const TopoDS_Shape* aVtxShape = theStorage.FindOriginal(aVertexId);
@@ -1893,9 +1859,9 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
         for (const BRepGraph_CoEdgeId& aCoEdgeId : *aCandidates)
         {
           const BRepGraphInc::CoEdgeDef& aCoEdge = theStorage.CoEdge(aCoEdgeId);
-          if (!aCoEdge.FaceDefId.IsValid(aFaceRawSurfaces.Length()))
+          if (!aCoEdge.FaceDefId.IsValidIn(aFaceRawSurfaces))
             continue;
-          if (aFaceRawSurfaces.Value(aCoEdge.FaceDefId.Index) == aSurfacePtr)
+          if (aFaceRawSurfaces.Value(static_cast<size_t>(aCoEdge.FaceDefId.Index)) == aSurfacePtr)
           {
             aMatchedCoEdge = aCoEdgeId;
             break;
@@ -1927,8 +1893,8 @@ void populateOptionalLayers(BRepGraphInc_Storage&                         theSto
                             BRepGraph_LayerParam*                         theParamLayer,
                             BRepGraph_LayerRegularity*                    theRegularityLayer,
                             const BRepGraphInc_Populate::Options&         theOptions,
-                            const int                                     theOldNbEdges,
-                            const int                                     theOldNbVertices,
+                            const uint32_t                                theOldNbEdges,
+                            const uint32_t                                theOldNbVertices,
                             const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   populateRegularityLayer(theStorage,
@@ -1989,7 +1955,7 @@ void BRepGraphInc_Populate::Perform(BRepGraphInc_Storage&      theStorage,
   // Phase 3a: Fix compound Face ChildRefs (face indices were unknown during Phase 1,
   // resolved now after registerFaceData). All other child types were resolved
   // immediately in traverseShape via FindNodeByTShape.
-  const int aNbCompounds = theStorage.myCompounds.Nb();
+  const uint32_t aNbCompounds = theStorage.myCompounds.Nb();
   for (BRepGraph_CompoundId aCompoundId(0); aCompoundId.IsValid(aNbCompounds); ++aCompoundId)
   {
     const BRepGraph_NodeId aParentId(aCompoundId);
@@ -1997,13 +1963,15 @@ void BRepGraphInc_Populate::Perform(BRepGraphInc_Storage&      theStorage,
     if (aCompOrig == nullptr)
       continue;
 
-    int aRefOrd = 0;
+    uint32_t aRefOrd = 0;
     for (TopoDS_Iterator aChildIt(*aCompOrig, false, false); aChildIt.More(); aChildIt.Next())
     {
-      BRepGraphInc::ChildRef* aRef         = nullptr;
-      int                     aCurrentOrd  = 0;
-      const int               aNbChildRefs = theStorage.NbChildRefs();
-      for (BRepGraph_ChildRefId aChildRefId(0); aChildRefId.IsValid(aNbChildRefs); ++aChildRefId)
+      BRepGraphInc::ChildRef* aRef              = nullptr;
+      uint32_t                aCurrentOrd       = 0;
+      const uint32_t          aNbChildRefs      = theStorage.NbChildRefs();
+      for (BRepGraph_ChildRefId aChildRefId = BRepGraph_ChildRefId::Start();
+           aChildRefId.IsValid(aNbChildRefs);
+           ++aChildRefId)
       {
         BRepGraphInc::ChildRef& aCandidate = theStorage.ChangeChildRef(aChildRefId);
         if (aCandidate.ParentId != aParentId || aCandidate.IsRemoved)
@@ -2067,16 +2035,16 @@ void BRepGraphInc_Populate::AppendFlattened(
   const int aParallelWorkers = theParallel ? BRepGraph_ParallelPolicy::WorkerCount() : 1;
 
   // Snapshot entity counts before appending, for incremental updates.
-  const int anOldNbEdges      = theStorage.NbEdges();
-  const int anOldNbWires      = theStorage.NbWires();
-  const int anOldNbFaces      = theStorage.NbFaces();
-  const int anOldNbShells     = theStorage.NbShells();
-  const int anOldNbSolids     = theStorage.NbSolids();
-  const int anOldNbCompounds  = theStorage.NbCompounds();
-  const int anOldNbCompSolids = theStorage.NbCompSolids();
-  const int anOldNbVertices   = theStorage.NbVertices();
-  const int anOldNbChildRefs  = theStorage.NbChildRefs();
-  const int anOldNbSolidRefs  = theStorage.NbSolidRefs();
+  const uint32_t anOldNbEdges      = theStorage.NbEdges();
+  const uint32_t anOldNbWires      = theStorage.NbWires();
+  const uint32_t anOldNbFaces      = theStorage.NbFaces();
+  const uint32_t anOldNbShells     = theStorage.NbShells();
+  const uint32_t anOldNbSolids     = theStorage.NbSolids();
+  const uint32_t anOldNbCompounds  = theStorage.NbCompounds();
+  const uint32_t anOldNbCompSolids = theStorage.NbCompSolids();
+  const uint32_t anOldNbVertices   = theStorage.NbVertices();
+  const uint32_t anOldNbChildRefs  = theStorage.NbChildRefs();
+  const uint32_t anOldNbSolidRefs  = theStorage.NbSolidRefs();
 
   // Collect face contexts by flattening hierarchy.
   NCollection_Vector<FaceLocalData> aFaceData(256, aTmpAlloc);
@@ -2153,16 +2121,16 @@ void BRepGraphInc_Populate::Append(BRepGraphInc_Storage&                        
   const int aParallelWorkers = theParallel ? BRepGraph_ParallelPolicy::WorkerCount() : 1;
 
   // Snapshot entity counts before appending, for incremental updates.
-  const int anOldNbEdges      = theStorage.NbEdges();
-  const int anOldNbWires      = theStorage.NbWires();
-  const int anOldNbFaces      = theStorage.NbFaces();
-  const int anOldNbShells     = theStorage.NbShells();
-  const int anOldNbSolids     = theStorage.NbSolids();
-  const int anOldNbVertices   = theStorage.NbVertices();
-  const int anOldNbCompounds  = theStorage.NbCompounds();
-  const int anOldNbCompSolids = theStorage.NbCompSolids();
-  const int anOldNbChildRefs  = theStorage.NbChildRefs();
-  const int anOldNbSolidRefs  = theStorage.NbSolidRefs();
+  const uint32_t anOldNbEdges      = theStorage.NbEdges();
+  const uint32_t anOldNbWires      = theStorage.NbWires();
+  const uint32_t anOldNbFaces      = theStorage.NbFaces();
+  const uint32_t anOldNbShells     = theStorage.NbShells();
+  const uint32_t anOldNbSolids     = theStorage.NbSolids();
+  const uint32_t anOldNbVertices   = theStorage.NbVertices();
+  const uint32_t anOldNbCompounds  = theStorage.NbCompounds();
+  const uint32_t anOldNbCompSolids = theStorage.NbCompSolids();
+  const uint32_t anOldNbChildRefs  = theStorage.NbChildRefs();
+  const uint32_t anOldNbSolidRefs  = theStorage.NbSolidRefs();
 
   // Phase 1 (sequential): Traverse the full hierarchy.
   // Existing shapes are deduplicated via findExistingNode; only new shapes are added.
@@ -2191,18 +2159,18 @@ void BRepGraphInc_Populate::Append(BRepGraphInc_Storage&                        
   // Cost is O(total children across new compounds). Earlier versions rescanned every
   // ChildRef in the storage for each child (O(children x total refs)); the new compound's
   // own ChildRefIds vector is already in order, so we iterate it directly.
-  const int aNbCompounds = theStorage.myCompounds.Nb();
-  for (int aCompIdx = anOldNbCompounds; aCompIdx < aNbCompounds; ++aCompIdx)
+  for (BRepGraph_CompoundId aCompoundId(anOldNbCompounds);
+       aCompoundId.IsValid(theStorage.myCompounds.Nb()); ++aCompoundId)
   {
-    const BRepGraph_NodeId aCompoundNode = BRepGraph_CompoundId(aCompIdx);
+    const BRepGraph_NodeId aCompoundNode = BRepGraph_NodeId(aCompoundId);
     const TopoDS_Shape*    aCompOrig     = theStorage.myOriginalShapes.Seek(aCompoundNode);
     if (aCompOrig == nullptr)
       continue;
 
-    const BRepGraphInc::CompoundDef& aCompDef = theStorage.Compound(BRepGraph_CompoundId(aCompIdx));
-    const int                        aNbOwnedRefs = aCompDef.ChildRefIds.Length();
+    const BRepGraphInc::CompoundDef& aCompDef = theStorage.Compound(aCompoundId);
+    const size_t aNbOwnedRefs = aCompDef.ChildRefIds.Size();
 
-    int aRefOrd = 0;
+    size_t aRefOrd = 0;
     for (TopoDS_Iterator aChildIt(*aCompOrig, false, false); aChildIt.More(); aChildIt.Next())
     {
       if (aRefOrd >= aNbOwnedRefs)

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
@@ -236,8 +236,8 @@ struct ExtractedWire
 struct FaceLocalData
 {
   // Phase 1 context.
-  TopoDS_Face     Face;
-  TopLoc_Location ParentGlobalLoc;
+  TopoDS_Face       Face;
+  TopLoc_Location   ParentGlobalLoc;
   BRepGraph_ShellId ParentShellId;
 
   // Phase 2 extracted geometry.
@@ -543,13 +543,14 @@ static occ::handle<Poly_Polygon3D> applyRepLocationToPolygon3D(
 //! Keyed by raw Handle pointer - same underlying geometry object -> same rep entity.
 struct RepDedup
 {
-  NCollection_DataMap<const Geom_Surface*, BRepGraph_SurfaceRepId>                     Surfaces;
-  NCollection_DataMap<const Geom_Curve*, BRepGraph_Curve3DRepId>                       Curves3D;
-  NCollection_DataMap<const Geom2d_Curve*, BRepGraph_Curve2DRepId>                     Curves2D;
-  NCollection_DataMap<const Poly_Triangulation*, BRepGraph_TriangulationRepId>         Triangulations;
-  NCollection_DataMap<const Poly_Polygon3D*, BRepGraph_Polygon3DRepId>                 Polygons3D;
-  NCollection_DataMap<const Poly_Polygon2D*, BRepGraph_Polygon2DRepId>                 Polygons2D;
-  NCollection_DataMap<const Poly_PolygonOnTriangulation*, BRepGraph_PolygonOnTriRepId> PolygonsOnTri;
+  NCollection_DataMap<const Geom_Surface*, BRepGraph_SurfaceRepId>             Surfaces;
+  NCollection_DataMap<const Geom_Curve*, BRepGraph_Curve3DRepId>               Curves3D;
+  NCollection_DataMap<const Geom2d_Curve*, BRepGraph_Curve2DRepId>             Curves2D;
+  NCollection_DataMap<const Poly_Triangulation*, BRepGraph_TriangulationRepId> Triangulations;
+  NCollection_DataMap<const Poly_Polygon3D*, BRepGraph_Polygon3DRepId>         Polygons3D;
+  NCollection_DataMap<const Poly_Polygon2D*, BRepGraph_Polygon2DRepId>         Polygons2D;
+  NCollection_DataMap<const Poly_PolygonOnTriangulation*, BRepGraph_PolygonOnTriRepId>
+    PolygonsOnTri;
 };
 
 //! Create or reuse a SurfaceRep for the given surface handle.
@@ -559,8 +560,8 @@ BRepGraph_SurfaceRepId getOrCreateSurfaceRep(BRepGraphInc_Storage&            th
 {
   if (theSurface.IsNull())
     return BRepGraph_SurfaceRepId();
-  const Geom_Surface*            aPtr       = theSurface.get();
-  const BRepGraph_SurfaceRepId*  anExisting = theDedup.Surfaces.Seek(aPtr);
+  const Geom_Surface*           aPtr       = theSurface.get();
+  const BRepGraph_SurfaceRepId* anExisting = theDedup.Surfaces.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_SurfaceRepId aRepId = theStorage.AppendSurfaceRep();
@@ -577,8 +578,8 @@ BRepGraph_Curve3DRepId getOrCreateCurve3DRep(BRepGraphInc_Storage&          theS
 {
   if (theCurve.IsNull())
     return BRepGraph_Curve3DRepId();
-  const Geom_Curve*              aPtr       = theCurve.get();
-  const BRepGraph_Curve3DRepId*  anExisting = theDedup.Curves3D.Seek(aPtr);
+  const Geom_Curve*             aPtr       = theCurve.get();
+  const BRepGraph_Curve3DRepId* anExisting = theDedup.Curves3D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Curve3DRepId aRepId = theStorage.AppendCurve3DRep();
@@ -595,8 +596,8 @@ BRepGraph_Curve2DRepId getOrCreateCurve2DRep(BRepGraphInc_Storage&            th
 {
   if (theCurve.IsNull())
     return BRepGraph_Curve2DRepId();
-  const Geom2d_Curve*            aPtr       = theCurve.get();
-  const BRepGraph_Curve2DRepId*  anExisting = theDedup.Curves2D.Seek(aPtr);
+  const Geom2d_Curve*           aPtr       = theCurve.get();
+  const BRepGraph_Curve2DRepId* anExisting = theDedup.Curves2D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Curve2DRepId aRepId = theStorage.AppendCurve2DRep();
@@ -614,8 +615,8 @@ BRepGraph_TriangulationRepId getOrCreateTriangulationRep(
 {
   if (theTriangulation.IsNull())
     return BRepGraph_TriangulationRepId();
-  const Poly_Triangulation*              aPtr       = theTriangulation.get();
-  const BRepGraph_TriangulationRepId*    anExisting = theDedup.Triangulations.Seek(aPtr);
+  const Poly_Triangulation*           aPtr       = theTriangulation.get();
+  const BRepGraph_TriangulationRepId* anExisting = theDedup.Triangulations.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_TriangulationRepId aRepId = theStorage.AppendTriangulationRep();
@@ -632,8 +633,8 @@ BRepGraph_Polygon3DRepId getOrCreatePolygon3DRep(BRepGraphInc_Storage&          
 {
   if (thePolygon.IsNull())
     return BRepGraph_Polygon3DRepId();
-  const Poly_Polygon3D*            aPtr       = thePolygon.get();
-  const BRepGraph_Polygon3DRepId*  anExisting = theDedup.Polygons3D.Seek(aPtr);
+  const Poly_Polygon3D*           aPtr       = thePolygon.get();
+  const BRepGraph_Polygon3DRepId* anExisting = theDedup.Polygons3D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Polygon3DRepId aRepId = theStorage.AppendPolygon3DRep();
@@ -650,8 +651,8 @@ BRepGraph_Polygon2DRepId getOrCreatePolygon2DRep(BRepGraphInc_Storage&          
 {
   if (thePolygon.IsNull())
     return BRepGraph_Polygon2DRepId();
-  const Poly_Polygon2D*            aPtr       = thePolygon.get();
-  const BRepGraph_Polygon2DRepId*  anExisting = theDedup.Polygons2D.Seek(aPtr);
+  const Poly_Polygon2D*           aPtr       = thePolygon.get();
+  const BRepGraph_Polygon2DRepId* anExisting = theDedup.Polygons2D.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_Polygon2DRepId aRepId = theStorage.AppendPolygon2DRep();
@@ -671,8 +672,8 @@ BRepGraph_PolygonOnTriRepId getOrCreatePolygonOnTriRep(
 {
   if (thePolygon.IsNull())
     return BRepGraph_PolygonOnTriRepId();
-  const Poly_PolygonOnTriangulation*  aPtr       = thePolygon.get();
-  const BRepGraph_PolygonOnTriRepId*  anExisting = theDedup.PolygonsOnTri.Seek(aPtr);
+  const Poly_PolygonOnTriangulation* aPtr       = thePolygon.get();
+  const BRepGraph_PolygonOnTriRepId* anExisting = theDedup.PolygonsOnTri.Seek(aPtr);
   if (anExisting != nullptr)
     return *anExisting;
   const BRepGraph_PolygonOnTriRepId aRepId = theStorage.AppendPolygonOnTriRep();
@@ -715,9 +716,9 @@ BRepGraph_EdgeId registerExtractedEdge(BRepGraphInc_Storage& theStorage,
   {
     BRepGraphInc::VertexInstance aVR;
     aVR.DefId                  = registerOrReuseVertex(theStorage,
-                                                       theEdgeData.StartVertex.Shape,
-                                                       theEdgeData.StartVertex.Point,
-                                                       theEdgeData.StartVertex.Tolerance);
+                                      theEdgeData.StartVertex.Shape,
+                                      theEdgeData.StartVertex.Point,
+                                      theEdgeData.StartVertex.Tolerance);
     aVR.Orientation            = TopAbs_FORWARD;
     aVR.Location               = theEdgeData.StartVertex.Shape.Location();
     anEdgeEnt.StartVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -726,9 +727,9 @@ BRepGraph_EdgeId registerExtractedEdge(BRepGraphInc_Storage& theStorage,
   {
     BRepGraphInc::VertexInstance aVR;
     aVR.DefId                = registerOrReuseVertex(theStorage,
-                                                     theEdgeData.EndVertex.Shape,
-                                                     theEdgeData.EndVertex.Point,
-                                                     theEdgeData.EndVertex.Tolerance);
+                                      theEdgeData.EndVertex.Shape,
+                                      theEdgeData.EndVertex.Point,
+                                      theEdgeData.EndVertex.Tolerance);
     aVR.Orientation          = TopAbs_REVERSED;
     aVR.Location             = theEdgeData.EndVertex.Shape.Location();
     anEdgeEnt.EndVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -1060,12 +1061,12 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
     }
     else
     {
-      aIsNewFaceDef                  = true;
-      aFaceId                        = theStorage.AppendFace();
-      BRepGraphInc::FaceDef& aFace   = theStorage.ChangeFace(aFaceId);
-      aFace.Tolerance                = aData.Tolerance;
-      aFace.NaturalRestriction       = aData.NaturalRestriction;
-      aFace.SurfaceRepId             = getOrCreateSurfaceRep(theStorage, theRepDedup, aData.Surface);
+      aIsNewFaceDef                = true;
+      aFaceId                      = theStorage.AppendFace();
+      BRepGraphInc::FaceDef& aFace = theStorage.ChangeFace(aFaceId);
+      aFace.Tolerance              = aData.Tolerance;
+      aFace.NaturalRestriction     = aData.NaturalRestriction;
+      aFace.SurfaceRepId           = getOrCreateSurfaceRep(theStorage, theRepDedup, aData.Surface);
 
       if (!aData.ActiveTriangulation.IsNull())
       {
@@ -1131,7 +1132,8 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
 
       for (const ExtractedEdge& anEdgeData : aWireData.Edges)
       {
-        const BRepGraph_EdgeId anEdgeIdx = registerExtractedEdge(theStorage, anEdgeData, theRepDedup);
+        const BRepGraph_EdgeId anEdgeIdx =
+          registerExtractedEdge(theStorage, anEdgeData, theRepDedup);
 
         // Cache mutable edge reference for subsequent PCurve/Polygon appends.
         // Safe: no new edges are appended within this scope.
@@ -1143,32 +1145,34 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
         if (aIsNewWireDef)
         {
           // Create the forward CoEdge.
-          aFwdCoEdgeId                        = theStorage.AppendCoEdge();
-          BRepGraphInc::CoEdgeDef& aCoEdge    = theStorage.ChangeCoEdge(aFwdCoEdgeId);
-          aCoEdge.EdgeDefId                   = anEdgeIdx;
-          aCoEdge.FaceDefId                   = aFaceId;
-          aCoEdge.Orientation                 = anEdgeData.OrientationInWire;
+          aFwdCoEdgeId                     = theStorage.AppendCoEdge();
+          BRepGraphInc::CoEdgeDef& aCoEdge = theStorage.ChangeCoEdge(aFwdCoEdgeId);
+          aCoEdge.EdgeDefId                = anEdgeIdx;
+          aCoEdge.FaceDefId                = aFaceId;
+          aCoEdge.Orientation              = anEdgeData.OrientationInWire;
 
           // Populate CoEdge with PCurve and polygon data for this face context.
           if (!anEdgeData.PCurve2d.IsNull())
           {
-            aCoEdge.Curve2DRepId = getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2d);
+            aCoEdge.Curve2DRepId =
+              getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2d);
             aCoEdge.ParamFirst = anEdgeData.PCFirst;
             aCoEdge.ParamLast  = anEdgeData.PCLast;
             aCoEdge.Continuity = anEdgeData.PCurveContinuity;
             aCoEdge.UV1        = anEdgeData.PCUV1;
             aCoEdge.UV2        = anEdgeData.PCUV2;
           }
-          aCoEdge.Polygon2DRepId = getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurf);
+          aCoEdge.Polygon2DRepId =
+            getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurf);
 
           // Handle seam edge: create a second CoEdge for the reversed sense.
           if (!anEdgeData.PCurve2dReversed.IsNull())
           {
-            aSeamCoEdgeId                          = theStorage.AppendCoEdge();
-            BRepGraphInc::CoEdgeDef& aSeamCoEdge   = theStorage.ChangeCoEdge(aSeamCoEdgeId);
-            aSeamCoEdge.EdgeDefId                  = anEdgeIdx;
-            aSeamCoEdge.FaceDefId                  = aFaceId;
-            aSeamCoEdge.Orientation                = TopAbs_REVERSED;
+            aSeamCoEdgeId                        = theStorage.AppendCoEdge();
+            BRepGraphInc::CoEdgeDef& aSeamCoEdge = theStorage.ChangeCoEdge(aSeamCoEdgeId);
+            aSeamCoEdge.EdgeDefId                = anEdgeIdx;
+            aSeamCoEdge.FaceDefId                = aFaceId;
+            aSeamCoEdge.Orientation              = TopAbs_REVERSED;
             aSeamCoEdge.Curve2DRepId =
               getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2dReversed);
             aSeamCoEdge.ParamFirst     = anEdgeData.PCFirstReversed;
@@ -1233,7 +1237,7 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
                     const gp_Trsf&                  aTrsf    = aRepLoc.Transformation();
                     for (int aNodeIdx = 1; aNodeIdx <= aTriCopy->NbNodes(); ++aNodeIdx)
                       aTriCopy->SetNode(aNodeIdx, aTriCopy->Node(aNodeIdx).Transformed(aTrsf));
-                    aTriRepId                   = getOrCreateTriangulationRep(theStorage, theRepDedup, aTriCopy);
+                    aTriRepId = getOrCreateTriangulationRep(theStorage, theRepDedup, aTriCopy);
                     aFaceMut.TriangulationRepId = aTriRepId;
                   }
                 }
@@ -1250,8 +1254,8 @@ void registerFaceData(BRepGraphInc_Storage&                    theStorage,
                     BRep_Tool::PolygonOnTriangulation(aRevEdge, aTri, aPolyTriLoc);
                   if (!aPolyOnTriRev.IsNull() && aPolyOnTriRev != aPolyOnTri)
                   {
-                    const BRepGraph_PolygonOnTriRepId aSeamPolyRepId = getOrCreatePolygonOnTriRep(
-                      theStorage, theRepDedup, aPolyOnTriRev, aTriRepId);
+                    const BRepGraph_PolygonOnTriRepId aSeamPolyRepId =
+                      getOrCreatePolygonOnTriRep(theStorage, theRepDedup, aPolyOnTriRev, aTriRepId);
 
                     theStorage.ChangeCoEdge(aSeamCoEdgeId).PolygonOnTriRepId = aSeamPolyRepId;
                   }
@@ -1407,8 +1411,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           BRepGraphInc::NodeInstance aCR;
           if (makeAuxChildRef(theStorage, aChild, aCR))
           {
-            const BRepGraph_ChildRefId aChildRefId =
-              appendChildRef(theStorage, aSolidId, aCR);
+            const BRepGraph_ChildRefId aChildRefId = appendChildRef(theStorage, aSolidId, aCR);
             theStorage.ChangeSolid(aSolidId).AuxChildRefIds.Append(aChildRefId);
           }
         }
@@ -1446,8 +1449,7 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
           BRepGraphInc::NodeInstance aCR;
           if (makeAuxChildRef(theStorage, aChild, aCR))
           {
-            const BRepGraph_ChildRefId aChildRefId =
-              appendChildRef(theStorage, aShellId, aCR);
+            const BRepGraph_ChildRefId aChildRefId = appendChildRef(theStorage, aShellId, aCR);
             theStorage.ChangeShell(aShellId).AuxChildRefIds.Append(aChildRefId);
           }
         }
@@ -1540,9 +1542,9 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       {
         BRepGraphInc::VertexInstance aVR;
         aVR.DefId                  = registerOrReuseVertex(theStorage,
-                                                           aVFirst,
-                                                           rawVertexPoint(aVFirst),
-                                                           BRep_Tool::Tolerance(aVFirst));
+                                          aVFirst,
+                                          rawVertexPoint(aVFirst),
+                                          BRep_Tool::Tolerance(aVFirst));
         aVR.Orientation            = TopAbs_FORWARD;
         aVR.Location               = aVFirst.Location();
         anEdgeEnt.StartVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -1551,9 +1553,9 @@ void traverseHierarchy(BRepGraphInc_Storage&              theStorage,
       {
         BRepGraphInc::VertexInstance aVR;
         aVR.DefId                = registerOrReuseVertex(theStorage,
-                                                         aVLast,
-                                                         rawVertexPoint(aVLast),
-                                                         BRep_Tool::Tolerance(aVLast));
+                                          aVLast,
+                                          rawVertexPoint(aVLast),
+                                          BRep_Tool::Tolerance(aVLast));
         aVR.Orientation          = TopAbs_REVERSED;
         aVR.Location             = aVLast.Location();
         anEdgeEnt.EndVertexRefId = appendVertexRef(theStorage, anEdgeId, aVR);
@@ -1732,10 +1734,7 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
       if (aFaceIdx1 == nullptr || aFaceIdx2 == nullptr)
         continue;
 
-      theRegularityLayer->SetRegularity(anEdgeId,
-                                        *aFaceIdx1,
-                                        *aFaceIdx2,
-                                        aCon2S->Continuity());
+      theRegularityLayer->SetRegularity(anEdgeId, *aFaceIdx1, *aFaceIdx2, aCon2S->Continuity());
     }
   }
 }
@@ -1758,7 +1757,8 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
 
   NCollection_DataMap<const Geom_Curve*, BRepGraph_NodeId> aCurveToEdgeDef(1, theTmpAlloc);
   const uint32_t                                           aNbEdges = theStorage.NbEdges();
-  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start(); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start(); anEdgeId.IsValid(aNbEdges);
+       ++anEdgeId)
   {
     const TopoDS_Shape* anOrigEdge = theStorage.FindOriginal(anEdgeId);
     if (anOrigEdge == nullptr || anOrigEdge->IsNull())
@@ -1966,9 +1966,9 @@ void BRepGraphInc_Populate::Perform(BRepGraphInc_Storage&      theStorage,
     uint32_t aRefOrd = 0;
     for (TopoDS_Iterator aChildIt(*aCompOrig, false, false); aChildIt.More(); aChildIt.Next())
     {
-      BRepGraphInc::ChildRef* aRef              = nullptr;
-      uint32_t                aCurrentOrd       = 0;
-      const uint32_t          aNbChildRefs      = theStorage.NbChildRefs();
+      BRepGraphInc::ChildRef* aRef         = nullptr;
+      uint32_t                aCurrentOrd  = 0;
+      const uint32_t          aNbChildRefs = theStorage.NbChildRefs();
       for (BRepGraph_ChildRefId aChildRefId = BRepGraph_ChildRefId::Start();
            aChildRefId.IsValid(aNbChildRefs);
            ++aChildRefId)
@@ -2160,15 +2160,16 @@ void BRepGraphInc_Populate::Append(BRepGraphInc_Storage&                        
   // ChildRef in the storage for each child (O(children x total refs)); the new compound's
   // own ChildRefIds vector is already in order, so we iterate it directly.
   for (BRepGraph_CompoundId aCompoundId(anOldNbCompounds);
-       aCompoundId.IsValid(theStorage.myCompounds.Nb()); ++aCompoundId)
+       aCompoundId.IsValid(theStorage.myCompounds.Nb());
+       ++aCompoundId)
   {
     const BRepGraph_NodeId aCompoundNode = BRepGraph_NodeId(aCompoundId);
     const TopoDS_Shape*    aCompOrig     = theStorage.myOriginalShapes.Seek(aCompoundNode);
     if (aCompOrig == nullptr)
       continue;
 
-    const BRepGraphInc::CompoundDef& aCompDef = theStorage.Compound(aCompoundId);
-    const size_t aNbOwnedRefs = aCompDef.ChildRefIds.Size();
+    const BRepGraphInc::CompoundDef& aCompDef     = theStorage.Compound(aCompoundId);
+    const size_t                     aNbOwnedRefs = aCompDef.ChildRefIds.Size();
 
     size_t aRefOrd = 0;
     for (TopoDS_Iterator aChildIt(*aCompOrig, false, false); aChildIt.More(); aChildIt.Next())

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
@@ -273,7 +273,8 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::Face: {
-      aResult = FaceWithCache(theStorage, BRepGraph_FaceId(theNode), theCache, theParams, theRegularities);
+      aResult =
+        FaceWithCache(theStorage, BRepGraph_FaceId(theNode), theCache, theParams, theRegularities);
       break;
     }
 
@@ -353,9 +354,8 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::Compound: {
-      const BRepGraphInc::CompoundDef& aComp =
-        theStorage.Compound(BRepGraph_CompoundId(theNode));
-      TopoDS_Compound aNewComp;
+      const BRepGraphInc::CompoundDef& aComp = theStorage.Compound(BRepGraph_CompoundId(theNode));
+      TopoDS_Compound                  aNewComp;
       aBB.MakeCompound(aNewComp);
       for (const BRepGraph_ChildRefId& aChildRefId : aComp.ChildRefIds)
       {
@@ -377,9 +377,8 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::CompSolid: {
-      const BRepGraphInc::CompSolidDef& aCS =
-        theStorage.CompSolid(BRepGraph_CompSolidId(theNode));
-      TopoDS_CompSolid aNewCS;
+      const BRepGraphInc::CompSolidDef& aCS = theStorage.CompSolid(BRepGraph_CompSolidId(theNode));
+      TopoDS_CompSolid                  aNewCS;
       aBB.MakeCompSolid(aNewCS);
       for (const BRepGraph_SolidRefId& aSolidRefId : aCS.SolidRefIds)
       {

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
@@ -161,7 +161,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
   switch (theNode.NodeKind)
   {
     case BRepGraph_NodeId::Kind::Vertex: {
-      const BRepGraphInc::VertexDef& aVtx = theStorage.Vertex(BRepGraph_VertexId(theNode.Index));
+      const BRepGraphInc::VertexDef& aVtx = theStorage.Vertex(BRepGraph_VertexId(theNode));
       TopoDS_Vertex                  aNewVtx;
       aBB.MakeVertex(aNewVtx, aVtx.Point, aVtx.Tolerance);
       aResult = aNewVtx;
@@ -169,7 +169,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::Edge: {
-      const BRepGraphInc::EdgeDef& anEdge = theStorage.Edge(BRepGraph_EdgeId(theNode.Index));
+      const BRepGraphInc::EdgeDef& anEdge = theStorage.Edge(BRepGraph_EdgeId(theNode));
       TopoDS_Edge                  aNewEdge;
       if (anEdge.IsDegenerate)
       {
@@ -245,7 +245,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::Wire: {
-      const BRepGraphInc::WireDef& aWire = theStorage.Wire(BRepGraph_WireId(theNode.Index));
+      const BRepGraphInc::WireDef& aWire = theStorage.Wire(BRepGraph_WireId(theNode));
       TopoDS_Wire                  aNewWire;
       aBB.MakeWire(aNewWire);
       for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId : aWire.CoEdgeRefIds)
@@ -254,7 +254,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
         if (aCoEdgeRef.IsRemoved || !aCoEdgeRef.CoEdgeDefId.IsValid(theStorage.NbCoEdges()))
           continue;
         const BRepGraphInc::CoEdgeDef& aCoEdge =
-          theStorage.CoEdge(BRepGraph_CoEdgeId(aCoEdgeRef.CoEdgeDefId.Index));
+          theStorage.CoEdge(BRepGraph_CoEdgeId(aCoEdgeRef.CoEdgeDefId));
         if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid(theStorage.NbEdges()))
           continue;
         TopoDS_Shape anEdge = Node(theStorage, aCoEdge.EdgeDefId, theCache);
@@ -273,12 +273,12 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::Face: {
-      aResult = FaceWithCache(theStorage, theNode.Index, theCache, theParams, theRegularities);
+      aResult = FaceWithCache(theStorage, BRepGraph_FaceId(theNode), theCache, theParams, theRegularities);
       break;
     }
 
     case BRepGraph_NodeId::Kind::Shell: {
-      const BRepGraphInc::ShellDef& aShell = theStorage.Shell(BRepGraph_ShellId(theNode.Index));
+      const BRepGraphInc::ShellDef& aShell = theStorage.Shell(BRepGraph_ShellId(theNode));
       TopoDS_Shell                  aNewShell;
       aBB.MakeShell(aNewShell);
       for (const BRepGraph_FaceRefId& aFaceRefId : aShell.FaceRefIds)
@@ -287,7 +287,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
         if (aRef.IsRemoved || !aRef.FaceDefId.IsValid(theStorage.NbFaces()))
           continue;
         TopoDS_Shape aFace =
-          FaceWithCache(theStorage, aRef.FaceDefId.Index, theCache, theParams, theRegularities);
+          FaceWithCache(theStorage, aRef.FaceDefId, theCache, theParams, theRegularities);
         if (!aFace.IsNull())
         {
           aFace.Orientation(aRef.Orientation);
@@ -317,7 +317,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
     }
 
     case BRepGraph_NodeId::Kind::Solid: {
-      const BRepGraphInc::SolidDef& aSolid = theStorage.Solid(BRepGraph_SolidId(theNode.Index));
+      const BRepGraphInc::SolidDef& aSolid = theStorage.Solid(BRepGraph_SolidId(theNode));
       TopoDS_Solid                  aNewSolid;
       aBB.MakeSolid(aNewSolid);
       for (const BRepGraph_ShellRefId& aShellRefId : aSolid.ShellRefIds)
@@ -354,7 +354,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
 
     case BRepGraph_NodeId::Kind::Compound: {
       const BRepGraphInc::CompoundDef& aComp =
-        theStorage.Compound(BRepGraph_CompoundId(theNode.Index));
+        theStorage.Compound(BRepGraph_CompoundId(theNode));
       TopoDS_Compound aNewComp;
       aBB.MakeCompound(aNewComp);
       for (const BRepGraph_ChildRefId& aChildRefId : aComp.ChildRefIds)
@@ -378,7 +378,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
 
     case BRepGraph_NodeId::Kind::CompSolid: {
       const BRepGraphInc::CompSolidDef& aCS =
-        theStorage.CompSolid(BRepGraph_CompSolidId(theNode.Index));
+        theStorage.CompSolid(BRepGraph_CompSolidId(theNode));
       TopoDS_CompSolid aNewCS;
       aBB.MakeCompSolid(aNewCS);
       for (const BRepGraph_SolidRefId& aSolidRefId : aCS.SolidRefIds)
@@ -416,24 +416,24 @@ TopoDS_Shape BRepGraphInc_Reconstruct::Node(const BRepGraphInc_Storage&      the
 
 TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
   const BRepGraphInc_Storage&      theStorage,
-  const int                        theFaceIdx,
+  const BRepGraph_FaceId           theFaceId,
   Cache&                           theCache,
   const BRepGraph_LayerParam*      theParams,
   const BRepGraph_LayerRegularity* theRegularities)
 {
-  if (theFaceIdx < 0 || theFaceIdx >= theStorage.NbFaces())
+  if (!theFaceId.IsValid(theStorage.NbFaces()))
     return TopoDS_Shape();
 
   Cache::TempScope aTempScope(theCache);
 
   // Check cache first - 1 NodeId = 1 TShape.
-  BRepGraph_NodeId    aFaceNodeId = BRepGraph_FaceId(theFaceIdx);
+  BRepGraph_NodeId    aFaceNodeId = theFaceId;
   const TopoDS_Shape* aCachedFace = theCache.Seek(aFaceNodeId);
   if (aCachedFace != nullptr)
     return *aCachedFace;
 
   BRep_Builder                 aBB;
-  const BRepGraphInc::FaceDef& aFace = theStorage.Face(BRepGraph_FaceId(theFaceIdx));
+  const BRepGraphInc::FaceDef& aFace = theStorage.Face(theFaceId);
 
   // Resolve surface from rep storage (may be null for bare topology faces).
   occ::handle<Geom_Surface> aFaceSurface;
@@ -462,13 +462,13 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
   }
 
   // Helper: get or build edge from cache.
-  const auto aGetOrBuildEdge = [&](const int theEdgeIdx) -> TopoDS_Edge {
-    BRepGraph_NodeId    anEdgeId = BRepGraph_EdgeId(theEdgeIdx);
-    const TopoDS_Shape* aCached  = theCache.Seek(anEdgeId);
+  const auto aGetOrBuildEdge = [&](const BRepGraph_EdgeId theEdgeId) -> TopoDS_Edge {
+    BRepGraph_NodeId    anEdgeNodeId = theEdgeId;
+    const TopoDS_Shape* aCached      = theCache.Seek(anEdgeNodeId);
     if (aCached != nullptr)
       return TopoDS::Edge(*aCached);
 
-    const BRepGraphInc::EdgeDef& anEdge = theStorage.Edge(BRepGraph_EdgeId(theEdgeIdx));
+    const BRepGraphInc::EdgeDef& anEdge = theStorage.Edge(theEdgeId);
     TopoDS_Edge                  aNewEdge;
     if (anEdge.IsDegenerate)
     {
@@ -492,24 +492,24 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
     aBB.SameRange(aNewEdge, anEdge.SameRange);
 
     // Vertices (also cached).
-    const auto aGetOrBuildVertex = [&](const int theVtxIdx) -> TopoDS_Shape {
-      if (theVtxIdx < 0)
+    const auto aGetOrBuildVertex = [&](const BRepGraph_VertexId theVtxId) -> TopoDS_Shape {
+      if (!theVtxId.IsValid())
         return TopoDS_Shape();
-      BRepGraph_NodeId    aVtxId     = BRepGraph_VertexId(theVtxIdx);
-      const TopoDS_Shape* aVtxCached = theCache.Seek(aVtxId);
+      BRepGraph_NodeId    aVtxNodeId = theVtxId;
+      const TopoDS_Shape* aVtxCached = theCache.Seek(aVtxNodeId);
       if (aVtxCached != nullptr)
         return *aVtxCached;
-      const BRepGraphInc::VertexDef& aVtx = theStorage.Vertex(BRepGraph_VertexId(theVtxIdx));
+      const BRepGraphInc::VertexDef& aVtx = theStorage.Vertex(theVtxId);
       TopoDS_Vertex                  aNewVtx;
       aBB.MakeVertex(aNewVtx, aVtx.Point, aVtx.Tolerance);
-      theCache.Bind(aVtxId, aNewVtx);
+      theCache.Bind(aVtxNodeId, aNewVtx);
       return aNewVtx;
     };
 
     if (anEdge.StartVertexRefId.IsValid())
     {
       const BRepGraphInc::VertexRef& aStartVR  = theStorage.VertexRef(anEdge.StartVertexRefId);
-      TopoDS_Shape                   aStartVtx = aGetOrBuildVertex(aStartVR.VertexDefId.Index);
+      TopoDS_Shape                   aStartVtx = aGetOrBuildVertex(aStartVR.VertexDefId);
       if (!aStartVtx.IsNull())
       {
         aStartVtx.Orientation(TopAbs_FORWARD);
@@ -521,7 +521,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
     if (anEdge.EndVertexRefId.IsValid())
     {
       const BRepGraphInc::VertexRef& anEndVR  = theStorage.VertexRef(anEdge.EndVertexRefId);
-      TopoDS_Shape                   anEndVtx = aGetOrBuildVertex(anEndVR.VertexDefId.Index);
+      TopoDS_Shape                   anEndVtx = aGetOrBuildVertex(anEndVR.VertexDefId);
       if (!anEndVtx.IsNull())
       {
         anEndVtx.Orientation(TopAbs_REVERSED);
@@ -533,7 +533,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
     for (const BRepGraph_VertexRefId& aVRefId : anEdge.InternalVertexRefIds)
     {
       const BRepGraphInc::VertexRef& aVR  = theStorage.VertexRef(aVRefId);
-      TopoDS_Shape                   aVtx = aGetOrBuildVertex(aVR.VertexDefId.Index);
+      TopoDS_Shape                   aVtx = aGetOrBuildVertex(aVR.VertexDefId);
       if (!aVtx.IsNull())
       {
         aVtx.Orientation(aVR.Orientation);
@@ -552,12 +552,12 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
         aBB.UpdateEdge(aNewEdge, aPolygon3D, TopLoc_Location());
     }
 
-    restoreEdgeRegularities(theRegularities, BRepGraph_EdgeId(theEdgeIdx), theCache, aBB, aNewEdge);
+    restoreEdgeRegularities(theRegularities, theEdgeId, theCache, aBB, aNewEdge);
 
     if (anEdge.IsClosed)
       aNewEdge.Closed(true);
 
-    theCache.Bind(anEdgeId, aNewEdge);
+    theCache.Bind(anEdgeNodeId, aNewEdge);
     return aNewEdge;
   };
 
@@ -579,12 +579,11 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
       const BRepGraphInc::CoEdgeRef& aCoEdgeRef = theStorage.CoEdgeRef(theCoEdgeRefId);
       if (aCoEdgeRef.IsRemoved || !aCoEdgeRef.CoEdgeDefId.IsValid(theStorage.NbCoEdges()))
         return;
-      const BRepGraphInc::CoEdgeDef& aCoEdge =
-        theStorage.CoEdge(BRepGraph_CoEdgeId(aCoEdgeRef.CoEdgeDefId.Index));
+      const BRepGraphInc::CoEdgeDef& aCoEdge = theStorage.CoEdge(aCoEdgeRef.CoEdgeDefId);
       if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid(theStorage.NbEdges()))
         return;
 
-      TopoDS_Edge anEdge = aGetOrBuildEdge(aCoEdge.EdgeDefId.Index);
+      TopoDS_Edge anEdge = aGetOrBuildEdge(aCoEdge.EdgeDefId);
       if (theAddToWire)
       {
         TopoDS_Edge anEdgeInWire = anEdge;
@@ -776,8 +775,8 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
   }
   if (!anOuterWire.IsNull())
     aBB.Add(aNewFace, anOuterWire);
-  for (int anInnerWireIdx = 0; anInnerWireIdx < anInnerWires.Length(); ++anInnerWireIdx)
-    aBB.Add(aNewFace, anInnerWires.Value(anInnerWireIdx));
+  for (const TopoDS_Wire& anInnerWire : anInnerWires)
+    aBB.Add(aNewFace, anInnerWire);
 
   // Add direct INTERNAL/EXTERNAL vertex children.
   for (const BRepGraph_VertexRefId& aVRefId : aFace.VertexRefIds)
@@ -810,7 +809,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
 
   // Restore vertex point representations now that all edges and this face are cached.
   // UpdateVertex modifies TShape in-place, so cached vertex shapes are updated.
-  NCollection_Map<int> aProcessedVertices(1, theCache.myTempAllocator);
+  NCollection_Map<BRepGraph_VertexId> aProcessedVertices(1, theCache.myTempAllocator);
   for (const BRepGraph_WireRefId& aWireRefId : aFace.WireRefIds)
   {
     const BRepGraphInc::WireRef& aWireRef = theStorage.WireRef(aWireRefId);
@@ -823,7 +822,7 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
       if (aCoEdgeRef.IsRemoved || !aCoEdgeRef.CoEdgeDefId.IsValid(theStorage.NbCoEdges()))
         continue;
       const BRepGraphInc::CoEdgeDef& aCoEdge =
-        theStorage.CoEdge(BRepGraph_CoEdgeId(aCoEdgeRef.CoEdgeDefId.Index));
+        theStorage.CoEdge(BRepGraph_CoEdgeId(aCoEdgeRef.CoEdgeDefId));
       if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid(theStorage.NbEdges()))
         continue;
       const BRepGraphInc::EdgeDef& anEdgeEnt = theStorage.Edge(aCoEdge.EdgeDefId);
@@ -831,14 +830,14 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
       {
         const BRepGraph_VertexId aVertexId =
           theStorage.VertexRef(anEdgeEnt.StartVertexRefId).VertexDefId;
-        if (aProcessedVertices.Add(aVertexId.Index))
+        if (aProcessedVertices.Add(aVertexId))
           restoreVertexPointReps(theStorage, theParams, aVertexId, theCache, aBB);
       }
       if (anEdgeEnt.EndVertexRefId.IsValid())
       {
         const BRepGraph_VertexId aVertexId =
           theStorage.VertexRef(anEdgeEnt.EndVertexRefId).VertexDefId;
-        if (aProcessedVertices.Add(aVertexId.Index))
+        if (aProcessedVertices.Add(aVertexId))
           restoreVertexPointReps(theStorage, theParams, aVertexId, theCache, aBB);
       }
     }

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.hxx
@@ -88,9 +88,9 @@ public:
       if (aKindIdx < 0 || aKindIdx >= THE_KIND_COUNT)
         return nullptr;
       const NCollection_Vector<TopoDS_Shape>& aVec = myKinds[aKindIdx];
-      if (theNode.Index >= aVec.Length())
+      if (theNode.Index >= aVec.Size())
         return nullptr;
-      const TopoDS_Shape& aShape = aVec.Value(theNode.Index);
+      const TopoDS_Shape& aShape = aVec.Value(static_cast<size_t>(theNode.Index));
       return aShape.IsNull() ? nullptr : &aShape;
     }
 
@@ -101,7 +101,7 @@ public:
       if (aKindIdx < 0 || aKindIdx >= THE_KIND_COUNT)
         return;
       NCollection_Vector<TopoDS_Shape>& aVec = myKinds[aKindIdx];
-      aVec.SetValue(theNode.Index, theShape);
+      aVec.SetValue(static_cast<size_t>(theNode.Index), theShape);
     }
 
     //! Check if a node is already cached.
@@ -135,12 +135,12 @@ public:
 
   //! Reconstruct a face with shared edge/vertex cache for multi-face contexts.
   //! @param[in] theStorage    incidence storage
-  //! @param[in] theFaceIdx    face entity index
+  //! @param[in] theFaceId     face entity id
   //! @param[in,out] theCache  shared cache for edge and vertex shapes
   //! @return reconstructed face shape
   static Standard_EXPORT TopoDS_Shape
     FaceWithCache(const BRepGraphInc_Storage&      theStorage,
-                  const int                        theFaceIdx,
+                  const BRepGraph_FaceId           theFaceId,
                   Cache&                           theCache,
                   const BRepGraph_LayerParam*      theParams       = nullptr,
                   const BRepGraph_LayerRegularity* theRegularities = nullptr);

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_ReverseIndex.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_ReverseIndex.cxx
@@ -19,6 +19,7 @@
 #include <BRepGraphInc_Storage.hxx>
 #include <NCollection_LocalArray.hxx>
 #include <Standard_Assert.hxx>
+#include <algorithm>
 
 namespace
 {
@@ -28,47 +29,44 @@ BRepGraph_VertexId resolveVertexDefId(
   const NCollection_Vector<BRepGraphInc::VertexRef>& theVertexRefs,
   const T                                            theRefId)
 {
-  if (!theRefId.IsValid() || theRefId.Index < 0 || theRefId.Index >= theVertexRefs.Length())
+  if (!theRefId.IsValid(static_cast<uint32_t>(theVertexRefs.Size())))
     return BRepGraph_VertexId();
-  return theVertexRefs.Value(theRefId.Index).VertexDefId;
+  return theVertexRefs.Value(static_cast<size_t>(theRefId.Index)).VertexDefId;
 }
 
-template <typename T>
-bool containsIndexInTable(const NCollection_Vector<NCollection_Vector<T>>& theIdx,
-                          const int                                        theKey,
-                          const int                                        theVal)
+template <typename TKey, typename TVal>
+bool containsIndexInTable(const NCollection_Vector<NCollection_Vector<TVal>>& theIdx,
+                          const TKey                                          theKey,
+                          const TVal                                          theVal)
 {
-  if (theKey < 0 || theKey >= theIdx.Length())
+  if (!theKey.IsValid(static_cast<uint32_t>(theIdx.Size())))
     return false;
-  const NCollection_Vector<T>& aVec = theIdx.Value(theKey);
-  for (const T& anElem : aVec)
-  {
-    if (anElem.Index == theVal)
+  const NCollection_Vector<TVal>& aVec = theIdx.Value(static_cast<size_t>(theKey.Index));
+  for (const TVal& anElem : aVec)
+    if (anElem == theVal)
       return true;
-  }
   return false;
 }
 
 static bool hasActiveFaceForEdgeInCoEdges(
   const NCollection_Vector<BRepGraph_CoEdgeId>&      theCoEdgeIds,
   const NCollection_Vector<BRepGraphInc::CoEdgeDef>& theCoEdges,
-  const int                                          theEdgeIdx,
-  const int                                          theFaceIdx)
+  const BRepGraph_EdgeId                             theEdgeId,
+  const BRepGraph_FaceId                             theFaceId)
 {
   for (const BRepGraph_CoEdgeId& aCoEdgeId : theCoEdgeIds)
   {
-    const int aCoEdgeIdx = aCoEdgeId.Index;
-    if (aCoEdgeIdx < 0 || aCoEdgeIdx >= theCoEdges.Length())
+    if (!aCoEdgeId.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
     {
       continue;
     }
 
-    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeIdx);
+    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(static_cast<size_t>(aCoEdgeId.Index));
     if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid() || !aCoEdge.FaceDefId.IsValid())
     {
       continue;
     }
-    if (aCoEdge.EdgeDefId.Index == theEdgeIdx && aCoEdge.FaceDefId.Index == theFaceIdx)
+    if (aCoEdge.EdgeDefId == theEdgeId && aCoEdge.FaceDefId == theFaceId)
     {
       return true;
     }
@@ -166,36 +164,36 @@ void BRepGraphInc_ReverseIndex::Build(
   // Returns an invalid id if the ref id is invalid or out of range.
 
   // Scan edges for max vertex index to pre-size myVertexToEdges.
-  int       aMaxVertexIdx = -1;
-  const int aNbEdges      = theEdges.Length();
+  uint32_t       aNewVertexCapacity = 0;
+  const uint32_t aNbEdges           = static_cast<uint32_t>(theEdges.Size());
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(anEdgeId.Index);
+    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(static_cast<size_t>(anEdgeId.Index));
     if (anEdge.IsRemoved)
       continue;
     const BRepGraph_VertexId aStartVtx = resolveVertexDefId(theVertexRefs, anEdge.StartVertexRefId);
     const BRepGraph_VertexId anEndVtx  = resolveVertexDefId(theVertexRefs, anEdge.EndVertexRefId);
-    if (aStartVtx.IsValid() && aStartVtx.Index > aMaxVertexIdx)
-      aMaxVertexIdx = aStartVtx.Index;
-    if (anEndVtx.IsValid() && anEndVtx.Index > aMaxVertexIdx)
-      aMaxVertexIdx = anEndVtx.Index;
+    if (aStartVtx.IsValid() && aStartVtx.Index + 1 > aNewVertexCapacity)
+      aNewVertexCapacity = aStartVtx.Index + 1;
+    if (anEndVtx.IsValid() && anEndVtx.Index + 1 > aNewVertexCapacity)
+      aNewVertexCapacity = anEndVtx.Index + 1;
   }
 
   // Pre-size all outer vectors to their known key range.
   // Pass allocator so inner vectors use IncAllocator for O(1) alloc/free.
-  preSize(myVertexToEdges, aMaxVertexIdx + 1, myAllocator);
-  preSize(myEdgeToWires, theEdges.Length(), myAllocator);
-  preSize(myEdgeToFaces, theEdges.Length(), myAllocator);
-  preSize(myWireToFaces, theWires.Length(), myAllocator);
-  preSize(myFaceToShells, theFaces.Length(), myAllocator);
-  preSize(myShellToSolids, theShells.Length(), myAllocator);
+  preSize(myVertexToEdges, aNewVertexCapacity, myAllocator);
+  preSize(myEdgeToWires, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  preSize(myEdgeToFaces, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  preSize(myWireToFaces, static_cast<uint32_t>(theWires.Size()), myAllocator);
+  preSize(myFaceToShells, static_cast<uint32_t>(theFaces.Size()), myAllocator);
+  preSize(myShellToSolids, static_cast<uint32_t>(theShells.Size()), myAllocator);
 
   // Vertex -> Edges: scan edge entities for start/end vertex indices.
   // Closed edges have StartVertexRefId and EndVertexRefId resolving to the same VertexDefId,
   // so skip duplicate.
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(anEdgeId.Index);
+    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(static_cast<size_t>(anEdgeId.Index));
     if (anEdge.IsRemoved)
       continue;
     const BRepGraph_VertexId aStartVtx = resolveVertexDefId(theVertexRefs, anEdge.StartVertexRefId);
@@ -207,22 +205,22 @@ void BRepGraphInc_ReverseIndex::Build(
   }
 
   // Edge -> Wires: iterate wire entities and their CoEdgeRefIds for O(1) parent lookup.
-  const int aNbWires = theWires.Length();
+  const uint32_t aNbWires = static_cast<uint32_t>(theWires.Size());
   for (BRepGraph_WireId aWireId(0); aWireId.IsValid(aNbWires); ++aWireId)
   {
-    const BRepGraphInc::WireDef& aWire = theWires.Value(aWireId.Index);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aWireId.Index));
     if (aWire.IsRemoved)
       continue;
     for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId : aWire.CoEdgeRefIds)
     {
-      const int aRefIdx = aCoEdgeRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theCoEdgeRefs.Length())
+      if (!aCoEdgeRefId.IsValid(static_cast<uint32_t>(theCoEdgeRefs.Size())))
         continue;
-      const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid() || aRef.CoEdgeDefId.Index < 0
-          || aRef.CoEdgeDefId.Index >= theCoEdges.Length())
+      const BRepGraphInc::CoEdgeRef& aRef =
+        theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
+      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
         continue;
-      const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aRef.CoEdgeDefId.Index);
+      const BRepGraphInc::CoEdgeDef& aCoEdge =
+        theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index));
       if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid())
         continue;
       appendDirect(myEdgeToWires, aCoEdge.EdgeDefId.Index, aWireId);
@@ -230,59 +228,49 @@ void BRepGraphInc_ReverseIndex::Build(
   }
 
   // Edge -> CoEdges: derive from CoEdge.EdgeDefId field.
-  preSize(myEdgeToCoEdges, theEdges.Length(), myAllocator);
-  const int aNbCoEdges = theCoEdges.Length();
+  preSize(myEdgeToCoEdges, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  const uint32_t aNbCoEdges = static_cast<uint32_t>(theCoEdges.Size());
   for (BRepGraph_CoEdgeId aCoEdgeId(0); aCoEdgeId.IsValid(aNbCoEdges); ++aCoEdgeId)
   {
-    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeId.Index);
+    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(static_cast<size_t>(aCoEdgeId.Index));
     if (aCoEdge.IsRemoved)
       continue;
     if (aCoEdge.EdgeDefId.IsValid())
       appendDirect(myEdgeToCoEdges, aCoEdge.EdgeDefId.Index, aCoEdgeId);
   }
-  myNbIndexedCoEdges = theCoEdges.Length();
+  myNbIndexedCoEdges = static_cast<uint32_t>(theCoEdges.Size());
 
   // Edge -> Faces: derive from CoEdge.FaceDefId (replaces legacy PCurve-based derivation).
   // Seam edges have two CoEdges with same FaceDefId but opposite Orientation.
   // Deduplicate per edge using the edge->coedges index built above.
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    if (theEdges.Value(anEdgeId.Index).IsRemoved)
+    if (theEdges.Value(static_cast<size_t>(anEdgeId.Index)).IsRemoved)
       continue;
     const NCollection_Vector<BRepGraph_CoEdgeId>* aCoEdgeIdxs =
       seekVec(myEdgeToCoEdges, anEdgeId.Index);
     if (aCoEdgeIdxs == nullptr)
       continue;
-    const int aNbCE = aCoEdgeIdxs->Length();
+    const size_t aNbCE = aCoEdgeIdxs->Size();
 
     // Collect face indices from coedges (stack-allocated for small counts).
-    NCollection_LocalArray<int, 8> aFaces(aNbCE);
-    int                            aNbFaces = 0;
-    for (int i = 0; i < aNbCE; ++i)
+    NCollection_LocalArray<uint32_t, 8> aFaces(aNbCE);
+    size_t                              aNbFaces = 0;
+    for (const auto& aCoEdgeId : *aCoEdgeIdxs)
     {
-      const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeIdxs->Value(i).Index);
+      const BRepGraphInc::CoEdgeDef& aCoEdge =
+        theCoEdges.Value(static_cast<size_t>(aCoEdgeId.Index));
       if (aCoEdge.FaceDefId.IsValid())
         aFaces[aNbFaces++] = aCoEdge.FaceDefId.Index;
     }
     if (aNbFaces == 0)
       continue;
 
-    // Insertion sort (optimal for small N).
-    for (int i = 1; i < aNbFaces; ++i)
-    {
-      const int aKey = aFaces[i];
-      int       j    = i - 1;
-      while (j >= 0 && aFaces[j] > aKey)
-      {
-        aFaces[j + 1] = aFaces[j];
-        --j;
-      }
-      aFaces[j + 1] = aKey;
-    }
+    std::sort(static_cast<uint32_t*>(aFaces), static_cast<uint32_t*>(aFaces) + aNbFaces);
 
     // Append unique sorted values.
-    int aPrev = -1;
-    for (int i = 0; i < aNbFaces; ++i)
+    uint32_t aPrev = UINT32_MAX;
+    for (size_t i = 0; i < aNbFaces; ++i)
     {
       if (aFaces[i] != aPrev)
       {
@@ -293,66 +281,61 @@ void BRepGraphInc_ReverseIndex::Build(
   }
 
   // Wire -> Faces: iterate face entities and their WireRefIds for O(1) parent lookup.
-  const int aNbFaces = theFaces.Length();
+  const uint32_t aNbFaces = static_cast<uint32_t>(theFaces.Size());
   for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaces); ++aFaceId)
   {
-    const BRepGraphInc::FaceDef& aFace = theFaces.Value(aFaceId.Index);
+    const BRepGraphInc::FaceDef& aFace = theFaces.Value(static_cast<size_t>(aFaceId.Index));
     if (aFace.IsRemoved)
       continue;
     for (const BRepGraph_WireRefId& aWireRefId : aFace.WireRefIds)
     {
-      const int aRefIdx = aWireRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theWireRefs.Length())
+      if (!aWireRefId.IsValid(static_cast<uint32_t>(theWireRefs.Size())))
         continue;
-      const BRepGraphInc::WireRef& aRef = theWireRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.WireDefId.IsValid() || aRef.WireDefId.Index < 0
-          || aRef.WireDefId.Index >= theWires.Length())
+      const BRepGraphInc::WireRef& aRef = theWireRefs.Value(static_cast<size_t>(aWireRefId.Index));
+      if (aRef.IsRemoved || !aRef.WireDefId.IsValid(static_cast<uint32_t>(theWires.Size())))
         continue;
-      if (theWires.Value(aRef.WireDefId.Index).IsRemoved)
+      if (theWires.Value(static_cast<size_t>(aRef.WireDefId.Index)).IsRemoved)
         continue;
       appendDirect(myWireToFaces, aRef.WireDefId.Index, aFaceId);
     }
   }
 
   // Face -> Shells: iterate shell entities and their FaceRefIds for O(1) parent lookup.
-  const int aNbShells = theShells.Length();
+  const uint32_t aNbShells = static_cast<uint32_t>(theShells.Size());
   for (BRepGraph_ShellId aShellId(0); aShellId.IsValid(aNbShells); ++aShellId)
   {
-    const BRepGraphInc::ShellDef& aShell = theShells.Value(aShellId.Index);
+    const BRepGraphInc::ShellDef& aShell = theShells.Value(static_cast<size_t>(aShellId.Index));
     if (aShell.IsRemoved)
       continue;
     for (const BRepGraph_FaceRefId& aFaceRefId : aShell.FaceRefIds)
     {
-      const int aRefIdx = aFaceRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theFaceRefs.Length())
+      if (!aFaceRefId.IsValid(static_cast<uint32_t>(theFaceRefs.Size())))
         continue;
-      const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.FaceDefId.IsValid() || aRef.FaceDefId.Index < 0
-          || aRef.FaceDefId.Index >= theFaces.Length())
+      const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(static_cast<size_t>(aFaceRefId.Index));
+      if (aRef.IsRemoved || !aRef.FaceDefId.IsValid(static_cast<uint32_t>(theFaces.Size())))
         continue;
-      if (theFaces.Value(aRef.FaceDefId.Index).IsRemoved)
+      if (theFaces.Value(static_cast<size_t>(aRef.FaceDefId.Index)).IsRemoved)
         continue;
       appendDirect(myFaceToShells, aRef.FaceDefId.Index, aShellId);
     }
   }
 
   // Shell -> Solids: iterate solid entities and their ShellRefIds for O(1) parent lookup.
-  const int aNbSolids = theSolids.Length();
+  const uint32_t aNbSolids = static_cast<uint32_t>(theSolids.Size());
   for (BRepGraph_SolidId aSolidId(0); aSolidId.IsValid(aNbSolids); ++aSolidId)
   {
-    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(aSolidId.Index);
+    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(static_cast<size_t>(aSolidId.Index));
     if (aSolid.IsRemoved)
       continue;
     for (const BRepGraph_ShellRefId& aShellRefId : aSolid.ShellRefIds)
     {
-      const int aRefIdx = aShellRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theShellRefs.Length())
+      if (!aShellRefId.IsValid(static_cast<uint32_t>(theShellRefs.Size())))
         continue;
-      const BRepGraphInc::ShellRef& aRef = theShellRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.ShellDefId.IsValid() || aRef.ShellDefId.Index < 0
-          || aRef.ShellDefId.Index >= theShells.Length())
+      const BRepGraphInc::ShellRef& aRef =
+        theShellRefs.Value(static_cast<size_t>(aShellRefId.Index));
+      if (aRef.IsRemoved || !aRef.ShellDefId.IsValid(static_cast<uint32_t>(theShells.Size())))
         continue;
-      if (theShells.Value(aRef.ShellDefId.Index).IsRemoved)
+      if (theShells.Value(static_cast<size_t>(aRef.ShellDefId.Index)).IsRemoved)
         continue;
       appendDirect(myShellToSolids, aRef.ShellDefId.Index, aSolidId);
     }
@@ -362,95 +345,95 @@ void BRepGraphInc_ReverseIndex::Build(
   // Covers all legal TopoDS_Compound child kinds (Solid/Shell/Face/Compound/CompSolid
   // + atomic Wire/Edge/Vertex); missing any kind causes silent unindexing of legal
   // compounds and later reverse-lookup returns empty.
-  preSize(myCompoundsOfSolid, theSolids.Length(), myAllocator);
-  preSize(myCompoundsOfShell, theShells.Length(), myAllocator);
-  preSize(myCompoundsOfFace, theFaces.Length(), myAllocator);
-  preSize(myCompoundsOfCompound, theCompounds.Length(), myAllocator);
-  preSize(myCompoundsOfCompSolid, theCompSolids.Length(), myAllocator);
-  preSize(myCompoundsOfWire, theWires.Length(), myAllocator);
-  preSize(myCompoundsOfEdge, theEdges.Length(), myAllocator);
-  preSize(myCompoundsOfVertex, theVertices.Length(), myAllocator);
-  const int aNbCompounds = theCompounds.Length();
+  preSize(myCompoundsOfSolid, static_cast<uint32_t>(theSolids.Size()), myAllocator);
+  preSize(myCompoundsOfShell, static_cast<uint32_t>(theShells.Size()), myAllocator);
+  preSize(myCompoundsOfFace, static_cast<uint32_t>(theFaces.Size()), myAllocator);
+  preSize(myCompoundsOfCompound, static_cast<uint32_t>(theCompounds.Size()), myAllocator);
+  preSize(myCompoundsOfCompSolid, static_cast<uint32_t>(theCompSolids.Size()), myAllocator);
+  preSize(myCompoundsOfWire, static_cast<uint32_t>(theWires.Size()), myAllocator);
+  preSize(myCompoundsOfEdge, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  preSize(myCompoundsOfVertex, static_cast<uint32_t>(theVertices.Size()), myAllocator);
+  const uint32_t aNbCompounds = static_cast<uint32_t>(theCompounds.Size());
   for (BRepGraph_CompoundId aCompoundId(0); aCompoundId.IsValid(aNbCompounds); ++aCompoundId)
   {
-    const BRepGraphInc::CompoundDef& aComp = theCompounds.Value(aCompoundId.Index);
+    const BRepGraphInc::CompoundDef& aComp =
+      theCompounds.Value(static_cast<size_t>(aCompoundId.Index));
     if (aComp.IsRemoved)
       continue;
     for (const BRepGraph_ChildRefId& aChildRefId : aComp.ChildRefIds)
     {
-      const int aChildRefIdx = aChildRefId.Index;
-      if (aChildRefIdx < 0 || aChildRefIdx >= theChildRefs.Length())
+      const uint32_t aChildRefIdx = aChildRefId.Index;
+      if (aChildRefIdx >= theChildRefs.Size())
         continue;
-      const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(aChildRefIdx);
+      const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(static_cast<size_t>(aChildRefIdx));
       if (aRef.IsRemoved || !aRef.ChildDefId.IsValid())
         continue;
-      if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Solid && aRef.ChildDefId.Index >= 0
-          && aRef.ChildDefId.Index < theSolids.Length())
+      if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Solid
+          && aRef.ChildDefId.Index < theSolids.Size())
         appendDirect(myCompoundsOfSolid, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Shell
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theShells.Length())
+               && aRef.ChildDefId.Index < theShells.Size())
         appendDirect(myCompoundsOfShell, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Face
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theFaces.Length())
+               && aRef.ChildDefId.Index < theFaces.Size())
         appendDirect(myCompoundsOfFace, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Compound
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theCompounds.Length())
+               && aRef.ChildDefId.Index < theCompounds.Size())
         appendDirect(myCompoundsOfCompound, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::CompSolid
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theCompSolids.Length())
+               && aRef.ChildDefId.Index < theCompSolids.Size())
         appendDirect(myCompoundsOfCompSolid, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Wire
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theWires.Length())
+               && aRef.ChildDefId.Index < theWires.Size())
         appendDirect(myCompoundsOfWire, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Edge
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theEdges.Length())
+               && aRef.ChildDefId.Index < theEdges.Size())
         appendDirect(myCompoundsOfEdge, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Vertex
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theVertices.Length())
+               && aRef.ChildDefId.Index < theVertices.Size())
         appendDirect(myCompoundsOfVertex, aRef.ChildDefId.Index, aCompoundId);
     }
   }
 
   // CompSolid -> Solid reverse index: iterate comp-solid entities and their SolidRefIds.
-  preSize(myCompSolidsOfSolid, theSolids.Length(), myAllocator);
-  const int aNbCompSolids = theCompSolids.Length();
+  preSize(myCompSolidsOfSolid, static_cast<uint32_t>(theSolids.Size()), myAllocator);
+  const uint32_t aNbCompSolids = static_cast<uint32_t>(theCompSolids.Size());
   for (BRepGraph_CompSolidId aCompSolidId(0); aCompSolidId.IsValid(aNbCompSolids); ++aCompSolidId)
   {
-    const BRepGraphInc::CompSolidDef& aCS = theCompSolids.Value(aCompSolidId.Index);
+    const BRepGraphInc::CompSolidDef& aCS =
+      theCompSolids.Value(static_cast<size_t>(aCompSolidId.Index));
     if (aCS.IsRemoved)
       continue;
     for (const BRepGraph_SolidRefId& aSolidRefId : aCS.SolidRefIds)
     {
-      const int aRefIdx = aSolidRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theSolidRefs.Length())
+      if (!aSolidRefId.IsValid(static_cast<uint32_t>(theSolidRefs.Size())))
         continue;
-      const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.SolidDefId.IsValid() || aRef.SolidDefId.Index < 0
-          || aRef.SolidDefId.Index >= theSolids.Length())
+      const BRepGraphInc::SolidRef& aRef =
+        theSolidRefs.Value(static_cast<size_t>(aSolidRefId.Index));
+      if (aRef.IsRemoved || !aRef.SolidDefId.IsValid(static_cast<uint32_t>(theSolids.Size())))
         continue;
-      if (theSolids.Value(aRef.SolidDefId.Index).IsRemoved)
+      if (theSolids.Value(static_cast<size_t>(aRef.SolidDefId.Index)).IsRemoved)
         continue;
       appendDirect(myCompSolidsOfSolid, aRef.SolidDefId.Index, aCompSolidId);
     }
   }
 
   // CoEdge -> Wires: iterate wire entities and their CoEdgeRefIds for O(1) parent lookup.
-  preSize(myCoEdgeToWires, theCoEdges.Length(), myAllocator);
+  preSize(myCoEdgeToWires, static_cast<uint32_t>(theCoEdges.Size()), myAllocator);
   for (BRepGraph_WireId aWireId(0); aWireId.IsValid(aNbWires); ++aWireId)
   {
-    const BRepGraphInc::WireDef& aWire = theWires.Value(aWireId.Index);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aWireId.Index));
     if (aWire.IsRemoved)
       continue;
     for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId : aWire.CoEdgeRefIds)
     {
-      const int aRefIdx = aCoEdgeRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theCoEdgeRefs.Length())
+      if (!aCoEdgeRefId.IsValid(static_cast<uint32_t>(theCoEdgeRefs.Size())))
         continue;
-      const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid() || aRef.CoEdgeDefId.Index < 0
-          || aRef.CoEdgeDefId.Index >= theCoEdges.Length())
+      const BRepGraphInc::CoEdgeRef& aRef =
+        theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
+      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
         continue;
-      if (theCoEdges.Value(aRef.CoEdgeDefId.Index).IsRemoved)
+      if (theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index)).IsRemoved)
         continue;
       appendDirect(myCoEdgeToWires, aRef.CoEdgeDefId.Index, aWireId);
     }
@@ -476,58 +459,58 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
   const NCollection_Vector<BRepGraphInc::SolidRef>&     theSolidRefs,
   const NCollection_Vector<BRepGraphInc::ChildRef>&     theChildRefs,
   const NCollection_Vector<BRepGraphInc::VertexRef>&    theVertexRefs,
-  const int                                             theOldNbEdges,
-  const int                                             theOldNbWires,
-  const int                                             theOldNbFaces,
-  const int                                             theOldNbShells,
-  const int                                             theOldNbSolids,
-  const int                                             theOldNbCompounds,
-  const int                                             theOldNbCompSolids,
-  const int                                             theOldNbChildRefs,
-  const int                                             theOldNbSolidRefs)
+  const uint32_t                                        theOldNbEdges,
+  const uint32_t                                        theOldNbWires,
+  const uint32_t                                        theOldNbFaces,
+  const uint32_t                                        theOldNbShells,
+  const uint32_t                                        theOldNbSolids,
+  const uint32_t                                        theOldNbCompounds,
+  const uint32_t                                        theOldNbCompSolids,
+  const uint32_t                                        theOldNbChildRefs,
+  const uint32_t                                        theOldNbSolidRefs)
 {
 
   // Helper: resolve a VertexRefId to the corresponding VertexDefId (BRepGraph_VertexId).
   // Returns an invalid id if the ref id is invalid or out of range.
 
   // Scan new edges for max vertex index to possibly extend myVertexToEdges.
-  int       aMaxVertexIdx = myVertexToEdges.Length() - 1;
-  const int aNbEdges      = theEdges.Length();
+  uint32_t       aNewVertexCapacity = static_cast<uint32_t>(myVertexToEdges.Size());
+  const uint32_t aNbEdges           = static_cast<uint32_t>(theEdges.Size());
   for (BRepGraph_EdgeId anEdgeId(theOldNbEdges); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(anEdgeId.Index);
+    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(static_cast<size_t>(anEdgeId.Index));
     if (anEdge.IsRemoved)
       continue;
     const BRepGraph_VertexId aStartVtx = resolveVertexDefId(theVertexRefs, anEdge.StartVertexRefId);
     const BRepGraph_VertexId anEndVtx  = resolveVertexDefId(theVertexRefs, anEdge.EndVertexRefId);
-    if (aStartVtx.IsValid() && aStartVtx.Index > aMaxVertexIdx)
-      aMaxVertexIdx = aStartVtx.Index;
-    if (anEndVtx.IsValid() && anEndVtx.Index > aMaxVertexIdx)
-      aMaxVertexIdx = anEndVtx.Index;
+    if (aStartVtx.IsValid() && aStartVtx.Index + 1 > aNewVertexCapacity)
+      aNewVertexCapacity = aStartVtx.Index + 1;
+    if (anEndVtx.IsValid() && anEndVtx.Index + 1 > aNewVertexCapacity)
+      aNewVertexCapacity = anEndVtx.Index + 1;
   }
 
   // Extend outer vectors if needed (pre-size for new key ranges).
-  ensureSize(myVertexToEdges, aMaxVertexIdx + 1, myAllocator);
-  ensureSize(myEdgeToWires, theEdges.Length(), myAllocator);
-  ensureSize(myEdgeToFaces, theEdges.Length(), myAllocator);
-  ensureSize(myEdgeToCoEdges, theEdges.Length(), myAllocator);
-  ensureSize(myWireToFaces, theWires.Length(), myAllocator);
-  ensureSize(myFaceToShells, theFaces.Length(), myAllocator);
-  ensureSize(myShellToSolids, theShells.Length(), myAllocator);
-  ensureSize(myCompoundsOfSolid, theSolids.Length(), myAllocator);
-  ensureSize(myCompSolidsOfSolid, theSolids.Length(), myAllocator);
-  ensureSize(myCompoundsOfShell, theShells.Length(), myAllocator);
-  ensureSize(myCompoundsOfFace, theFaces.Length(), myAllocator);
-  ensureSize(myCompoundsOfCompound, theCompounds.Length(), myAllocator);
-  ensureSize(myCompoundsOfCompSolid, theCompSolids.Length(), myAllocator);
-  ensureSize(myCompoundsOfWire, theWires.Length(), myAllocator);
-  ensureSize(myCompoundsOfEdge, theEdges.Length(), myAllocator);
-  ensureSize(myCompoundsOfVertex, theVertices.Length(), myAllocator);
+  ensureSize(myVertexToEdges, aNewVertexCapacity, myAllocator);
+  ensureSize(myEdgeToWires, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  ensureSize(myEdgeToFaces, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  ensureSize(myEdgeToCoEdges, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  ensureSize(myWireToFaces, static_cast<uint32_t>(theWires.Size()), myAllocator);
+  ensureSize(myFaceToShells, static_cast<uint32_t>(theFaces.Size()), myAllocator);
+  ensureSize(myShellToSolids, static_cast<uint32_t>(theShells.Size()), myAllocator);
+  ensureSize(myCompoundsOfSolid, static_cast<uint32_t>(theSolids.Size()), myAllocator);
+  ensureSize(myCompSolidsOfSolid, static_cast<uint32_t>(theSolids.Size()), myAllocator);
+  ensureSize(myCompoundsOfShell, static_cast<uint32_t>(theShells.Size()), myAllocator);
+  ensureSize(myCompoundsOfFace, static_cast<uint32_t>(theFaces.Size()), myAllocator);
+  ensureSize(myCompoundsOfCompound, static_cast<uint32_t>(theCompounds.Size()), myAllocator);
+  ensureSize(myCompoundsOfCompSolid, static_cast<uint32_t>(theCompSolids.Size()), myAllocator);
+  ensureSize(myCompoundsOfWire, static_cast<uint32_t>(theWires.Size()), myAllocator);
+  ensureSize(myCompoundsOfEdge, static_cast<uint32_t>(theEdges.Size()), myAllocator);
+  ensureSize(myCompoundsOfVertex, static_cast<uint32_t>(theVertices.Size()), myAllocator);
 
   // Vertex -> Edges: only new edges.
   for (BRepGraph_EdgeId anEdgeId(theOldNbEdges); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(anEdgeId.Index);
+    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(static_cast<size_t>(anEdgeId.Index));
     if (anEdge.IsRemoved)
       continue;
     const BRepGraph_VertexId aStartVtx = resolveVertexDefId(theVertexRefs, anEdge.StartVertexRefId);
@@ -539,22 +522,22 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
   }
 
   // Edge -> Wires: iterate only new wire entities and their CoEdgeRefIds.
-  const int aNbWires = theWires.Length();
+  const uint32_t aNbWires = static_cast<uint32_t>(theWires.Size());
   for (BRepGraph_WireId aWireId(theOldNbWires); aWireId.IsValid(aNbWires); ++aWireId)
   {
-    const BRepGraphInc::WireDef& aWire = theWires.Value(aWireId.Index);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aWireId.Index));
     if (aWire.IsRemoved)
       continue;
     for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId : aWire.CoEdgeRefIds)
     {
-      const int aRefIdx = aCoEdgeRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theCoEdgeRefs.Length())
+      if (!aCoEdgeRefId.IsValid(static_cast<uint32_t>(theCoEdgeRefs.Size())))
         continue;
-      const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid() || aRef.CoEdgeDefId.Index < 0
-          || aRef.CoEdgeDefId.Index >= theCoEdges.Length())
+      const BRepGraphInc::CoEdgeRef& aRef =
+        theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
+      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
         continue;
-      const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aRef.CoEdgeDefId.Index);
+      const BRepGraphInc::CoEdgeDef& aCoEdge =
+        theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index));
       if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid())
         continue;
       appendUnique(myEdgeToWires, aCoEdge.EdgeDefId.Index, aWireId);
@@ -563,39 +546,38 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
 
   // Edge -> CoEdges: scan only newly appended coedges (they may reference old edges).
   Standard_ASSERT_RAISE(
-    myNbIndexedCoEdges >= 0 && myNbIndexedCoEdges <= theCoEdges.Length(),
+    myNbIndexedCoEdges <= theCoEdges.Size(),
     "BRepGraphInc_ReverseIndex::BuildDelta: myNbIndexedCoEdges cursor out of range "
     "(indicates CoEdge vector shrank between delta calls, which is unsupported)");
-  const int aOldNbIndexedCoEdges = myNbIndexedCoEdges;
-  const int aNbCoEdges           = theCoEdges.Length();
+  const uint32_t aOldNbIndexedCoEdges = myNbIndexedCoEdges;
+  const uint32_t aNbCoEdges           = static_cast<uint32_t>(theCoEdges.Size());
   for (BRepGraph_CoEdgeId aCoEdgeId(aOldNbIndexedCoEdges); aCoEdgeId.IsValid(aNbCoEdges);
        ++aCoEdgeId)
   {
-    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeId.Index);
+    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(static_cast<size_t>(aCoEdgeId.Index));
     if (aCoEdge.IsRemoved)
       continue;
     if (aCoEdge.EdgeDefId.IsValid())
       appendUnique(myEdgeToCoEdges, aCoEdge.EdgeDefId.Index, aCoEdgeId);
   }
-  myNbIndexedCoEdges = theCoEdges.Length();
+  myNbIndexedCoEdges = static_cast<uint32_t>(theCoEdges.Size());
 
   // CoEdge -> Wires: iterate only new wire entities and their CoEdgeRefIds.
-  ensureSize(myCoEdgeToWires, theCoEdges.Length(), myAllocator);
+  ensureSize(myCoEdgeToWires, static_cast<uint32_t>(theCoEdges.Size()), myAllocator);
   for (BRepGraph_WireId aWireId(theOldNbWires); aWireId.IsValid(aNbWires); ++aWireId)
   {
-    const BRepGraphInc::WireDef& aWire = theWires.Value(aWireId.Index);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aWireId.Index));
     if (aWire.IsRemoved)
       continue;
     for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId : aWire.CoEdgeRefIds)
     {
-      const int aRefIdx = aCoEdgeRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theCoEdgeRefs.Length())
+      if (!aCoEdgeRefId.IsValid(static_cast<uint32_t>(theCoEdgeRefs.Size())))
         continue;
-      const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid() || aRef.CoEdgeDefId.Index < 0
-          || aRef.CoEdgeDefId.Index >= theCoEdges.Length())
+      const BRepGraphInc::CoEdgeRef& aRef =
+        theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
+      if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
         continue;
-      if (theCoEdges.Value(aRef.CoEdgeDefId.Index).IsRemoved)
+      if (theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index)).IsRemoved)
         continue;
       appendUnique(myCoEdgeToWires, aRef.CoEdgeDefId.Index, aWireId);
     }
@@ -604,39 +586,30 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
   // Edge -> Faces: derive from CoEdge.FaceDefId for new edges.
   for (BRepGraph_EdgeId anEdgeId(theOldNbEdges); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    if (theEdges.Value(anEdgeId.Index).IsRemoved)
+    if (theEdges.Value(static_cast<size_t>(anEdgeId.Index)).IsRemoved)
       continue;
     const NCollection_Vector<BRepGraph_CoEdgeId>* aCoEdgeIdxs =
       seekVec(myEdgeToCoEdges, anEdgeId.Index);
     if (aCoEdgeIdxs == nullptr)
       continue;
-    const int aNbCE = aCoEdgeIdxs->Length();
+    const size_t aNbCE = aCoEdgeIdxs->Size();
 
-    NCollection_LocalArray<int, 8> aFaces(aNbCE);
-    int                            aNbFaces = 0;
-    for (int i = 0; i < aNbCE; ++i)
+    NCollection_LocalArray<uint32_t, 8> aFaces(aNbCE);
+    size_t                              aNbFaces = 0;
+    for (const auto& aCoEdgeId : *aCoEdgeIdxs)
     {
-      const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeIdxs->Value(i).Index);
+      const BRepGraphInc::CoEdgeDef& aCoEdge =
+        theCoEdges.Value(static_cast<size_t>(aCoEdgeId.Index));
       if (aCoEdge.FaceDefId.IsValid())
         aFaces[aNbFaces++] = aCoEdge.FaceDefId.Index;
     }
     if (aNbFaces == 0)
       continue;
 
-    for (int i = 1; i < aNbFaces; ++i)
-    {
-      const int aKey = aFaces[i];
-      int       j    = i - 1;
-      while (j >= 0 && aFaces[j] > aKey)
-      {
-        aFaces[j + 1] = aFaces[j];
-        --j;
-      }
-      aFaces[j + 1] = aKey;
-    }
+    std::sort(static_cast<uint32_t*>(aFaces), static_cast<uint32_t*>(aFaces) + aNbFaces);
 
-    int aPrev = -1;
-    for (int i = 0; i < aNbFaces; ++i)
+    uint32_t aPrev = UINT32_MAX;
+    for (size_t i = 0; i < aNbFaces; ++i)
     {
       if (aFaces[i] != aPrev)
       {
@@ -647,116 +620,112 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
   }
 
   // Wire -> Faces: iterate only new face entities and their WireRefIds.
-  const int aNbFaces = theFaces.Length();
+  const uint32_t aNbFaces = static_cast<uint32_t>(theFaces.Size());
   for (BRepGraph_FaceId aFaceId(theOldNbFaces); aFaceId.IsValid(aNbFaces); ++aFaceId)
   {
-    const BRepGraphInc::FaceDef& aFace = theFaces.Value(aFaceId.Index);
+    const BRepGraphInc::FaceDef& aFace = theFaces.Value(static_cast<size_t>(aFaceId.Index));
     if (aFace.IsRemoved)
       continue;
     for (const BRepGraph_WireRefId& aWireRefId : aFace.WireRefIds)
     {
-      const int aRefIdx = aWireRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theWireRefs.Length())
+      if (!aWireRefId.IsValid(static_cast<uint32_t>(theWireRefs.Size())))
         continue;
-      const BRepGraphInc::WireRef& aRef = theWireRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.WireDefId.IsValid() || aRef.WireDefId.Index < 0
-          || aRef.WireDefId.Index >= theWires.Length())
+      const BRepGraphInc::WireRef& aRef = theWireRefs.Value(static_cast<size_t>(aWireRefId.Index));
+      if (aRef.IsRemoved || !aRef.WireDefId.IsValid(static_cast<uint32_t>(theWires.Size())))
         continue;
-      if (theWires.Value(aRef.WireDefId.Index).IsRemoved)
+      if (theWires.Value(static_cast<size_t>(aRef.WireDefId.Index)).IsRemoved)
         continue;
       appendUnique(myWireToFaces, aRef.WireDefId.Index, aFaceId);
     }
   }
 
   // Face -> Shells: iterate only new shell entities and their FaceRefIds.
-  const int aNbShells = theShells.Length();
+  const uint32_t aNbShells = static_cast<uint32_t>(theShells.Size());
   for (BRepGraph_ShellId aShellId(theOldNbShells); aShellId.IsValid(aNbShells); ++aShellId)
   {
-    const BRepGraphInc::ShellDef& aShell = theShells.Value(aShellId.Index);
+    const BRepGraphInc::ShellDef& aShell = theShells.Value(static_cast<size_t>(aShellId.Index));
     if (aShell.IsRemoved)
       continue;
     for (const BRepGraph_FaceRefId& aFaceRefId : aShell.FaceRefIds)
     {
-      const int aRefIdx = aFaceRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theFaceRefs.Length())
+      if (!aFaceRefId.IsValid(static_cast<uint32_t>(theFaceRefs.Size())))
         continue;
-      const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.FaceDefId.IsValid() || aRef.FaceDefId.Index < 0
-          || aRef.FaceDefId.Index >= theFaces.Length())
+      const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(static_cast<size_t>(aFaceRefId.Index));
+      if (aRef.IsRemoved || !aRef.FaceDefId.IsValid(static_cast<uint32_t>(theFaces.Size())))
         continue;
-      if (theFaces.Value(aRef.FaceDefId.Index).IsRemoved)
+      if (theFaces.Value(static_cast<size_t>(aRef.FaceDefId.Index)).IsRemoved)
         continue;
       appendUnique(myFaceToShells, aRef.FaceDefId.Index, aShellId);
     }
   }
 
   // Shell -> Solids: iterate only new solid entities and their ShellRefIds.
-  const int aNbSolids = theSolids.Length();
+  const uint32_t aNbSolids = static_cast<uint32_t>(theSolids.Size());
   for (BRepGraph_SolidId aSolidId(theOldNbSolids); aSolidId.IsValid(aNbSolids); ++aSolidId)
   {
-    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(aSolidId.Index);
+    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(static_cast<size_t>(aSolidId.Index));
     if (aSolid.IsRemoved)
       continue;
     for (const BRepGraph_ShellRefId& aShellRefId : aSolid.ShellRefIds)
     {
-      const int aRefIdx = aShellRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theShellRefs.Length())
+      if (!aShellRefId.IsValid(static_cast<uint32_t>(theShellRefs.Size())))
         continue;
-      const BRepGraphInc::ShellRef& aRef = theShellRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.ShellDefId.IsValid() || aRef.ShellDefId.Index < 0
-          || aRef.ShellDefId.Index >= theShells.Length())
+      const BRepGraphInc::ShellRef& aRef =
+        theShellRefs.Value(static_cast<size_t>(aShellRefId.Index));
+      if (aRef.IsRemoved || !aRef.ShellDefId.IsValid(static_cast<uint32_t>(theShells.Size())))
         continue;
-      if (theShells.Value(aRef.ShellDefId.Index).IsRemoved)
+      if (theShells.Value(static_cast<size_t>(aRef.ShellDefId.Index)).IsRemoved)
         continue;
       appendUnique(myShellToSolids, aRef.ShellDefId.Index, aSolidId);
     }
   }
 
-  int anOldNbCompounds = theOldNbCompounds;
-  if (anOldNbCompounds < 0 || anOldNbCompounds > theCompounds.Length())
+  uint32_t anOldNbCompounds = theOldNbCompounds;
+  if (anOldNbCompounds > theCompounds.Size())
     anOldNbCompounds = 0;
 
   // Compound -> child reverse indices:
   // 1) process all refs of newly appended compound parents
   // 2) process refs attached to pre-existing parents (covers appended refs on old parents)
-  const int aNbCompounds = theCompounds.Length();
+  const uint32_t aNbCompounds = static_cast<uint32_t>(theCompounds.Size());
   for (BRepGraph_CompoundId aCompoundId(anOldNbCompounds); aCompoundId.IsValid(aNbCompounds);
        ++aCompoundId)
   {
-    const BRepGraphInc::CompoundDef& aComp = theCompounds.Value(aCompoundId.Index);
+    const BRepGraphInc::CompoundDef& aComp =
+      theCompounds.Value(static_cast<size_t>(aCompoundId.Index));
     if (aComp.IsRemoved)
       continue;
     for (const BRepGraph_ChildRefId& aChildRefId : aComp.ChildRefIds)
     {
-      const int aChildRefIdx = aChildRefId.Index;
-      if (aChildRefIdx < 0 || aChildRefIdx >= theChildRefs.Length())
+      const uint32_t aChildRefIdx = aChildRefId.Index;
+      if (aChildRefIdx >= theChildRefs.Size())
         continue;
-      const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(aChildRefIdx);
+      const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(static_cast<size_t>(aChildRefIdx));
       if (aRef.IsRemoved || !aRef.ChildDefId.IsValid())
         continue;
-      if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Solid && aRef.ChildDefId.Index >= 0
-          && aRef.ChildDefId.Index < theSolids.Length())
+      if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Solid
+          && aRef.ChildDefId.Index < theSolids.Size())
         appendUnique(myCompoundsOfSolid, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Shell
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theShells.Length())
+               && aRef.ChildDefId.Index < theShells.Size())
         appendUnique(myCompoundsOfShell, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Face
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theFaces.Length())
+               && aRef.ChildDefId.Index < theFaces.Size())
         appendUnique(myCompoundsOfFace, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Compound
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theCompounds.Length())
+               && aRef.ChildDefId.Index < theCompounds.Size())
         appendUnique(myCompoundsOfCompound, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::CompSolid
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theCompSolids.Length())
+               && aRef.ChildDefId.Index < theCompSolids.Size())
         appendUnique(myCompoundsOfCompSolid, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Wire
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theWires.Length())
+               && aRef.ChildDefId.Index < theWires.Size())
         appendUnique(myCompoundsOfWire, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Edge
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theEdges.Length())
+               && aRef.ChildDefId.Index < theEdges.Size())
         appendUnique(myCompoundsOfEdge, aRef.ChildDefId.Index, aCompoundId);
       else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Vertex
-               && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theVertices.Length())
+               && aRef.ChildDefId.Index < theVertices.Size())
         appendUnique(myCompoundsOfVertex, aRef.ChildDefId.Index, aCompoundId);
     }
   }
@@ -764,81 +733,80 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
   // Loop 2: process ChildRefs appended during this delta that point to a
   // pre-existing compound parent. Iterate only [theOldNbChildRefs, NbChildRefs)
   // so cost stays O(delta refs) regardless of pre-existing graph size.
-  int aOldNbChildRefs = theOldNbChildRefs;
-  if (aOldNbChildRefs < 0 || aOldNbChildRefs > theChildRefs.Length())
+  uint32_t aOldNbChildRefs = theOldNbChildRefs;
+  if (aOldNbChildRefs > theChildRefs.Size())
     aOldNbChildRefs = 0;
-  const int aNbChildRefs = theChildRefs.Length();
+  const uint32_t aNbChildRefs = static_cast<uint32_t>(theChildRefs.Size());
   for (BRepGraph_ChildRefId aChildRefId(aOldNbChildRefs); aChildRefId.IsValid(aNbChildRefs);
        ++aChildRefId)
   {
-    const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(aChildRefId.Index);
+    const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(static_cast<size_t>(aChildRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid() || !aRef.ChildDefId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Compound)
       continue;
 
-    const int aCompoundIdx = aRef.ParentId.Index;
-    if (aCompoundIdx < 0 || aCompoundIdx >= theCompounds.Length()
-        || aCompoundIdx >= anOldNbCompounds)
+    const uint32_t aCompoundIdx = aRef.ParentId.Index;
+    if (aCompoundIdx >= theCompounds.Size() || aCompoundIdx >= anOldNbCompounds)
       continue;
 
-    const BRepGraphInc::CompoundDef& aComp = theCompounds.Value(aCompoundIdx);
+    const BRepGraphInc::CompoundDef& aComp = theCompounds.Value(static_cast<size_t>(aCompoundIdx));
     if (aComp.IsRemoved)
       continue;
 
-    if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Solid && aRef.ChildDefId.Index >= 0
-        && aRef.ChildDefId.Index < theSolids.Length())
+    if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Solid
+        && aRef.ChildDefId.Index < theSolids.Size())
       appendUnique(myCompoundsOfSolid, aRef.ChildDefId.Index, BRepGraph_CompoundId(aCompoundIdx));
-    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Shell && aRef.ChildDefId.Index >= 0
-             && aRef.ChildDefId.Index < theShells.Length())
+    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Shell
+             && aRef.ChildDefId.Index < theShells.Size())
       appendUnique(myCompoundsOfShell, aRef.ChildDefId.Index, BRepGraph_CompoundId(aCompoundIdx));
-    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Face && aRef.ChildDefId.Index >= 0
-             && aRef.ChildDefId.Index < theFaces.Length())
+    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Face
+             && aRef.ChildDefId.Index < theFaces.Size())
       appendUnique(myCompoundsOfFace, aRef.ChildDefId.Index, BRepGraph_CompoundId(aCompoundIdx));
     else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Compound
-             && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theCompounds.Length())
+             && aRef.ChildDefId.Index < theCompounds.Size())
       appendUnique(myCompoundsOfCompound,
                    aRef.ChildDefId.Index,
                    BRepGraph_CompoundId(aCompoundIdx));
     else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::CompSolid
-             && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theCompSolids.Length())
+             && aRef.ChildDefId.Index < theCompSolids.Size())
       appendUnique(myCompoundsOfCompSolid,
                    aRef.ChildDefId.Index,
                    BRepGraph_CompoundId(aCompoundIdx));
-    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Wire && aRef.ChildDefId.Index >= 0
-             && aRef.ChildDefId.Index < theWires.Length())
+    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Wire
+             && aRef.ChildDefId.Index < theWires.Size())
       appendUnique(myCompoundsOfWire, aRef.ChildDefId.Index, BRepGraph_CompoundId(aCompoundIdx));
-    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Edge && aRef.ChildDefId.Index >= 0
-             && aRef.ChildDefId.Index < theEdges.Length())
+    else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Edge
+             && aRef.ChildDefId.Index < theEdges.Size())
       appendUnique(myCompoundsOfEdge, aRef.ChildDefId.Index, BRepGraph_CompoundId(aCompoundIdx));
     else if (aRef.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Vertex
-             && aRef.ChildDefId.Index >= 0 && aRef.ChildDefId.Index < theVertices.Length())
+             && aRef.ChildDefId.Index < theVertices.Size())
       appendUnique(myCompoundsOfVertex, aRef.ChildDefId.Index, BRepGraph_CompoundId(aCompoundIdx));
   }
 
-  int anOldNbCompSolids = theOldNbCompSolids;
-  if (anOldNbCompSolids < 0 || anOldNbCompSolids > theCompSolids.Length())
+  uint32_t anOldNbCompSolids = theOldNbCompSolids;
+  if (anOldNbCompSolids > theCompSolids.Size())
     anOldNbCompSolids = 0;
 
   // CompSolid -> Solid reverse index:
   // 1) process all refs of newly appended compsolid parents
   // 2) process refs attached to pre-existing parents (covers appended refs on old parents)
-  const int aNbCompSolids = theCompSolids.Length();
+  const uint32_t aNbCompSolids = static_cast<uint32_t>(theCompSolids.Size());
   for (BRepGraph_CompSolidId aCompSolidId(anOldNbCompSolids); aCompSolidId.IsValid(aNbCompSolids);
        ++aCompSolidId)
   {
-    const BRepGraphInc::CompSolidDef& aCS = theCompSolids.Value(aCompSolidId.Index);
+    const BRepGraphInc::CompSolidDef& aCS =
+      theCompSolids.Value(static_cast<size_t>(aCompSolidId.Index));
     if (aCS.IsRemoved)
       continue;
     for (const BRepGraph_SolidRefId& aSolidRefId : aCS.SolidRefIds)
     {
-      const int aRefIdx = aSolidRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theSolidRefs.Length())
+      if (!aSolidRefId.IsValid(static_cast<uint32_t>(theSolidRefs.Size())))
         continue;
-      const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(aRefIdx);
-      if (aRef.IsRemoved || !aRef.SolidDefId.IsValid() || aRef.SolidDefId.Index < 0
-          || aRef.SolidDefId.Index >= theSolids.Length())
+      const BRepGraphInc::SolidRef& aRef =
+        theSolidRefs.Value(static_cast<size_t>(aSolidRefId.Index));
+      if (aRef.IsRemoved || !aRef.SolidDefId.IsValid(static_cast<uint32_t>(theSolids.Size())))
         continue;
-      if (theSolids.Value(aRef.SolidDefId.Index).IsRemoved)
+      if (theSolids.Value(static_cast<size_t>(aRef.SolidDefId.Index)).IsRemoved)
         continue;
       appendUnique(myCompSolidsOfSolid, aRef.SolidDefId.Index, aCompSolidId);
     }
@@ -846,26 +814,25 @@ void BRepGraphInc_ReverseIndex::BuildDelta(
 
   // Loop 2: process SolidRefs appended during this delta that target a
   // pre-existing compsolid parent. Iterate only [theOldNbSolidRefs, NbSolidRefs).
-  int aOldNbSolidRefs = theOldNbSolidRefs;
-  if (aOldNbSolidRefs < 0 || aOldNbSolidRefs > theSolidRefs.Length())
+  uint32_t aOldNbSolidRefs = theOldNbSolidRefs;
+  if (aOldNbSolidRefs > theSolidRefs.Size())
     aOldNbSolidRefs = 0;
-  const int aNbSolidRefs = theSolidRefs.Length();
+  const uint32_t aNbSolidRefs = static_cast<uint32_t>(theSolidRefs.Size());
   for (BRepGraph_SolidRefId aSolidRefId(aOldNbSolidRefs); aSolidRefId.IsValid(aNbSolidRefs);
        ++aSolidRefId)
   {
-    const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(aSolidRefId.Index);
+    const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(static_cast<size_t>(aSolidRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid() || !aRef.SolidDefId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::CompSolid)
       continue;
 
-    const int aCompSolidIdx = aRef.ParentId.Index;
-    if (aCompSolidIdx < 0 || aCompSolidIdx >= theCompSolids.Length()
-        || aCompSolidIdx >= anOldNbCompSolids || aRef.SolidDefId.Index < 0
-        || aRef.SolidDefId.Index >= theSolids.Length())
+    const uint32_t aCompSolidIdx = aRef.ParentId.Index;
+    if (aCompSolidIdx >= theCompSolids.Size() || aCompSolidIdx >= anOldNbCompSolids
+        || !aRef.SolidDefId.IsValid(static_cast<uint32_t>(theSolids.Size())))
       continue;
 
-    const BRepGraphInc::CompSolidDef& aCS = theCompSolids.Value(aCompSolidIdx);
-    if (aCS.IsRemoved || theSolids.Value(aRef.SolidDefId.Index).IsRemoved)
+    const BRepGraphInc::CompSolidDef& aCS = theCompSolids.Value(static_cast<size_t>(aCompSolidIdx));
+    if (aCS.IsRemoved || theSolids.Value(static_cast<size_t>(aRef.SolidDefId.Index)).IsRemoved)
       continue;
 
     appendUnique(myCompSolidsOfSolid, aRef.SolidDefId.Index, BRepGraph_CompSolidId(aCompSolidIdx));
@@ -893,15 +860,18 @@ void BRepGraphInc_ReverseIndex::BindCoEdgeToWire(const BRepGraph_CoEdgeId theCoE
 void BRepGraphInc_ReverseIndex::UnbindEdgeFromWire(const BRepGraph_EdgeId theEdgeId,
                                                    const BRepGraph_WireId theWireId)
 {
-  if (theEdgeId.Index < 0 || theEdgeId.Index >= myEdgeToWires.Length())
+  if (theEdgeId.Index >= myEdgeToWires.Size())
     return;
-  NCollection_Vector<BRepGraph_WireId>& aWires = myEdgeToWires.ChangeValue(theEdgeId.Index);
-  for (int i = 0; i < aWires.Length(); ++i)
+  NCollection_Vector<BRepGraph_WireId>& aWires =
+    myEdgeToWires.ChangeValue(static_cast<size_t>(theEdgeId.Index));
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_WireId>::Iterator anIt(aWires); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aWires.Value(i) == theWireId)
+    if (anIt.Value() == theWireId)
     {
-      if (i < aWires.Length() - 1)
-        aWires.ChangeValue(i) = aWires.Value(aWires.Length() - 1);
+      if (anIdx < static_cast<uint32_t>(aWires.Size()) - 1u)
+        aWires.ChangeValue(static_cast<size_t>(anIdx)) = aWires.Value(aWires.Size() - 1u);
       aWires.EraseLast();
       break;
     }
@@ -913,15 +883,18 @@ void BRepGraphInc_ReverseIndex::UnbindEdgeFromWire(const BRepGraph_EdgeId theEdg
 void BRepGraphInc_ReverseIndex::UnbindCoEdgeFromWire(const BRepGraph_CoEdgeId theCoEdgeId,
                                                      const BRepGraph_WireId   theWireId)
 {
-  if (theCoEdgeId.Index < 0 || theCoEdgeId.Index >= myCoEdgeToWires.Length())
+  if (theCoEdgeId.Index >= myCoEdgeToWires.Size())
     return;
-  NCollection_Vector<BRepGraph_WireId>& aWires = myCoEdgeToWires.ChangeValue(theCoEdgeId.Index);
-  for (int i = 0; i < aWires.Length(); ++i)
+  NCollection_Vector<BRepGraph_WireId>& aWires =
+    myCoEdgeToWires.ChangeValue(static_cast<size_t>(theCoEdgeId.Index));
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_WireId>::Iterator anIt(aWires); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aWires.Value(i) == theWireId)
+    if (anIt.Value() == theWireId)
     {
-      if (i < aWires.Length() - 1)
-        aWires.ChangeValue(i) = aWires.Value(aWires.Length() - 1);
+      if (anIdx < static_cast<uint32_t>(aWires.Size()) - 1u)
+        aWires.ChangeValue(static_cast<size_t>(anIdx)) = aWires.Value(aWires.Size() - 1u);
       aWires.EraseLast();
       break;
     }
@@ -951,15 +924,18 @@ void BRepGraphInc_ReverseIndex::BindVertexToEdge(const BRepGraph_VertexId theVer
 void BRepGraphInc_ReverseIndex::UnbindVertexFromEdge(const BRepGraph_VertexId theVertexId,
                                                      const BRepGraph_EdgeId   theEdgeId)
 {
-  if (theVertexId.Index < 0 || theVertexId.Index >= myVertexToEdges.Length())
+  if (theVertexId.Index >= myVertexToEdges.Size())
     return;
-  NCollection_Vector<BRepGraph_EdgeId>& anEdges = myVertexToEdges.ChangeValue(theVertexId.Index);
-  for (int i = 0; i < anEdges.Length(); ++i)
+  NCollection_Vector<BRepGraph_EdgeId>& anEdges =
+    myVertexToEdges.ChangeValue(static_cast<size_t>(theVertexId.Index));
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_EdgeId>::Iterator anIt(anEdges); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (anEdges.Value(i) == theEdgeId)
+    if (anIt.Value() == theEdgeId)
     {
-      if (i < anEdges.Length() - 1)
-        anEdges.ChangeValue(i) = anEdges.Value(anEdges.Length() - 1);
+      if (anIdx < static_cast<uint32_t>(anEdges.Size()) - 1u)
+        anEdges.ChangeValue(static_cast<size_t>(anIdx)) = anEdges.Value(anEdges.Size() - 1u);
       anEdges.EraseLast();
       break;
     }
@@ -979,15 +955,18 @@ void BRepGraphInc_ReverseIndex::BindEdgeToCoEdge(const BRepGraph_EdgeId   theEdg
 void BRepGraphInc_ReverseIndex::UnbindEdgeFromCoEdge(const BRepGraph_EdgeId   theEdgeId,
                                                      const BRepGraph_CoEdgeId theCoEdgeId)
 {
-  if (theEdgeId.Index < 0 || theEdgeId.Index >= myEdgeToCoEdges.Length())
+  if (theEdgeId.Index >= myEdgeToCoEdges.Size())
     return;
-  NCollection_Vector<BRepGraph_CoEdgeId>& aCoEdges = myEdgeToCoEdges.ChangeValue(theEdgeId.Index);
-  for (int i = 0; i < aCoEdges.Length(); ++i)
+  NCollection_Vector<BRepGraph_CoEdgeId>& aCoEdges =
+    myEdgeToCoEdges.ChangeValue(static_cast<size_t>(theEdgeId.Index));
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_CoEdgeId>::Iterator anIt(aCoEdges); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aCoEdges.Value(i) == theCoEdgeId)
+    if (anIt.Value() == theCoEdgeId)
     {
-      if (i < aCoEdges.Length() - 1)
-        aCoEdges.ChangeValue(i) = aCoEdges.Value(aCoEdges.Length() - 1);
+      if (anIdx < static_cast<uint32_t>(aCoEdges.Size()) - 1u)
+        aCoEdges.ChangeValue(static_cast<size_t>(anIdx)) = aCoEdges.Value(aCoEdges.Size() - 1u);
       aCoEdges.EraseLast();
       break;
     }
@@ -1007,17 +986,18 @@ void BRepGraphInc_ReverseIndex::BindEdgeToFace(const BRepGraph_EdgeId theEdgeId,
 void BRepGraphInc_ReverseIndex::UnbindEdgeFromFace(const BRepGraph_EdgeId theEdgeId,
                                                    const BRepGraph_FaceId theFaceId)
 {
-  if (theEdgeId.Index < 0 || theEdgeId.Index >= myEdgeToFaces.Length())
+  if (theEdgeId.Index >= myEdgeToFaces.Size())
     return;
-  NCollection_Vector<BRepGraph_FaceId>& aFaces = myEdgeToFaces.ChangeValue(theEdgeId.Index);
-  for (int i = 0; i < aFaces.Length(); ++i)
+  NCollection_Vector<BRepGraph_FaceId>& aFaces =
+    myEdgeToFaces.ChangeValue(static_cast<size_t>(theEdgeId.Index));
+  uint32_t anIdx = 0;
+  for (NCollection_Vector<BRepGraph_FaceId>::Iterator anIt(aFaces); anIt.More();
+       anIt.Next(), ++anIdx)
   {
-    if (aFaces.Value(i) == theFaceId)
+    if (anIt.Value() == theFaceId)
     {
-      // Swap-remove: overwrite found entry with the last element, then erase the last.
-      // O(1) removal without shifting; adjacency list order is not significant.
-      if (i < aFaces.Length() - 1)
-        aFaces.ChangeValue(i) = aFaces.Value(aFaces.Length() - 1);
+      if (anIdx < static_cast<uint32_t>(aFaces.Size()) - 1u)
+        aFaces.ChangeValue(static_cast<size_t>(anIdx)) = aFaces.Value(aFaces.Size() - 1u);
       aFaces.EraseLast();
       break;
     }
@@ -1044,45 +1024,45 @@ bool BRepGraphInc_ReverseIndex::Validate(
   const NCollection_Vector<BRepGraphInc::ChildRef>&     theChildRefs,
   const NCollection_Vector<BRepGraphInc::VertexRef>&    theVertexRefs) const
 {
-  auto hasActiveWireUsageOfEdge = [&](const int theWireIdx, const int theEdgeIdx) -> bool {
-    if (theWireIdx < 0 || theWireIdx >= theWires.Length() || theEdgeIdx < 0
-        || theEdgeIdx >= theEdges.Length())
+  auto hasActiveWireUsageOfEdge = [&](const BRepGraph_WireId theWireId,
+                                      const BRepGraph_EdgeId theEdgeId) -> bool {
+    if (!theWireId.IsValid(static_cast<uint32_t>(theWires.Size()))
+        || !theEdgeId.IsValid(static_cast<uint32_t>(theEdges.Size())))
     {
       return false;
     }
-    const BRepGraphInc::WireDef& aWire = theWires.Value(theWireIdx);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(theWireId.Index));
     if (aWire.IsRemoved)
     {
       return false;
     }
     for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId : aWire.CoEdgeRefIds)
     {
-      const int aRefIdx = aCoEdgeRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theCoEdgeRefs.Length())
+      if (!aCoEdgeRefId.IsValid(static_cast<uint32_t>(theCoEdgeRefs.Size())))
       {
         continue;
       }
-      const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aRefIdx);
+      const BRepGraphInc::CoEdgeRef& aRef =
+        theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
       if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid())
       {
         continue;
       }
-      if (aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Wire
-          || aRef.ParentId.Index != theWireIdx)
+      if (BRepGraph_WireId(aRef.ParentId) != theWireId)
       {
         continue;
       }
-      const int aCoEdgeIdx = aRef.CoEdgeDefId.Index;
-      if (aCoEdgeIdx < 0 || aCoEdgeIdx >= theCoEdges.Length())
+      if (!aRef.CoEdgeDefId.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
       {
         continue;
       }
-      const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeIdx);
+      const BRepGraphInc::CoEdgeDef& aCoEdge =
+        theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index));
       if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid())
       {
         continue;
       }
-      if (aCoEdge.EdgeDefId.Index == theEdgeIdx)
+      if (aCoEdge.EdgeDefId == theEdgeId)
       {
         return true;
       }
@@ -1090,35 +1070,34 @@ bool BRepGraphInc_ReverseIndex::Validate(
     return false;
   };
 
-  auto hasActiveFaceRefForWire = [&](const int theWireIdx, const int theFaceIdx) -> bool {
-    if (theWireIdx < 0 || theWireIdx >= theWires.Length() || theFaceIdx < 0
-        || theFaceIdx >= theFaces.Length())
+  auto hasActiveFaceRefForWire = [&](const BRepGraph_WireId theWireId,
+                                     const BRepGraph_FaceId theFaceId) -> bool {
+    if (!theWireId.IsValid(static_cast<uint32_t>(theWires.Size()))
+        || !theFaceId.IsValid(static_cast<uint32_t>(theFaces.Size())))
     {
       return false;
     }
-    const BRepGraphInc::FaceDef& aFace = theFaces.Value(theFaceIdx);
+    const BRepGraphInc::FaceDef& aFace = theFaces.Value(static_cast<size_t>(theFaceId.Index));
     if (aFace.IsRemoved)
     {
       return false;
     }
     for (const BRepGraph_WireRefId& aWireRefId : aFace.WireRefIds)
     {
-      const int aRefIdx = aWireRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theWireRefs.Length())
+      if (!aWireRefId.IsValid(static_cast<uint32_t>(theWireRefs.Size())))
       {
         continue;
       }
-      const BRepGraphInc::WireRef& aRef = theWireRefs.Value(aRefIdx);
+      const BRepGraphInc::WireRef& aRef = theWireRefs.Value(static_cast<size_t>(aWireRefId.Index));
       if (aRef.IsRemoved || !aRef.WireDefId.IsValid())
       {
         continue;
       }
-      if (aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Face
-          || aRef.ParentId.Index != theFaceIdx)
+      if (BRepGraph_FaceId(aRef.ParentId) != theFaceId)
       {
         continue;
       }
-      if (aRef.WireDefId.Index == theWireIdx)
+      if (aRef.WireDefId == theWireId)
       {
         return true;
       }
@@ -1126,56 +1105,57 @@ bool BRepGraphInc_ReverseIndex::Validate(
     return false;
   };
 
-  auto hasActiveFaceForEdge = [&](const int theEdgeIdx, const int theFaceIdx) -> bool {
-    if (theEdgeIdx < 0 || theEdgeIdx >= theEdges.Length() || theFaceIdx < 0
-        || theFaceIdx >= theFaces.Length())
+  auto hasActiveFaceForEdge = [&](const BRepGraph_EdgeId theEdgeId,
+                                  const BRepGraph_FaceId theFaceId) -> bool {
+    if (!theEdgeId.IsValid(static_cast<uint32_t>(theEdges.Size()))
+        || !theFaceId.IsValid(static_cast<uint32_t>(theFaces.Size())))
     {
       return false;
     }
-    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(theEdgeIdx);
+    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(static_cast<size_t>(theEdgeId.Index));
     if (anEdge.IsRemoved)
     {
       return false;
     }
 
-    const NCollection_Vector<BRepGraph_CoEdgeId>* aCoEdgeIds = seekVec(myEdgeToCoEdges, theEdgeIdx);
+    const NCollection_Vector<BRepGraph_CoEdgeId>* aCoEdgeIds =
+      seekVec(myEdgeToCoEdges, theEdgeId.Index);
     if (aCoEdgeIds == nullptr)
     {
       return false;
     }
 
-    return hasActiveFaceForEdgeInCoEdges(*aCoEdgeIds, theCoEdges, theEdgeIdx, theFaceIdx);
+    return hasActiveFaceForEdgeInCoEdges(*aCoEdgeIds, theCoEdges, theEdgeId, theFaceId);
   };
 
-  auto hasActiveFaceRef = [&](const int theShellIdx, const int theFaceIdx) -> bool {
-    if (theShellIdx < 0 || theShellIdx >= theShells.Length() || theFaceIdx < 0
-        || theFaceIdx >= theFaces.Length())
+  auto hasActiveFaceRef = [&](const BRepGraph_ShellId theShellId,
+                              const BRepGraph_FaceId  theFaceId) -> bool {
+    if (!theShellId.IsValid(static_cast<uint32_t>(theShells.Size()))
+        || !theFaceId.IsValid(static_cast<uint32_t>(theFaces.Size())))
     {
       return false;
     }
-    const BRepGraphInc::ShellDef& aShell = theShells.Value(theShellIdx);
+    const BRepGraphInc::ShellDef& aShell = theShells.Value(static_cast<size_t>(theShellId.Index));
     if (aShell.IsRemoved)
     {
       return false;
     }
     for (const BRepGraph_FaceRefId& aFaceRefId : aShell.FaceRefIds)
     {
-      const int aRefIdx = aFaceRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theFaceRefs.Length())
+      if (!aFaceRefId.IsValid(static_cast<uint32_t>(theFaceRefs.Size())))
       {
         continue;
       }
-      const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(aRefIdx);
+      const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(static_cast<size_t>(aFaceRefId.Index));
       if (aRef.IsRemoved || !aRef.FaceDefId.IsValid())
       {
         continue;
       }
-      if (aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Shell
-          || aRef.ParentId.Index != theShellIdx)
+      if (BRepGraph_ShellId(aRef.ParentId) != theShellId)
       {
         continue;
       }
-      if (aRef.FaceDefId.Index == theFaceIdx)
+      if (aRef.FaceDefId == theFaceId)
       {
         return true;
       }
@@ -1183,35 +1163,35 @@ bool BRepGraphInc_ReverseIndex::Validate(
     return false;
   };
 
-  auto hasActiveShellRef = [&](const int theSolidIdx, const int theShellIdx) -> bool {
-    if (theSolidIdx < 0 || theSolidIdx >= theSolids.Length() || theShellIdx < 0
-        || theShellIdx >= theShells.Length())
+  auto hasActiveShellRef = [&](const BRepGraph_SolidId theSolidId,
+                               const BRepGraph_ShellId theShellId) -> bool {
+    if (!theSolidId.IsValid(static_cast<uint32_t>(theSolids.Size()))
+        || !theShellId.IsValid(static_cast<uint32_t>(theShells.Size())))
     {
       return false;
     }
-    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(theSolidIdx);
+    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(static_cast<size_t>(theSolidId.Index));
     if (aSolid.IsRemoved)
     {
       return false;
     }
     for (const BRepGraph_ShellRefId& aShellRefId : aSolid.ShellRefIds)
     {
-      const int aRefIdx = aShellRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theShellRefs.Length())
+      if (!aShellRefId.IsValid(static_cast<uint32_t>(theShellRefs.Size())))
       {
         continue;
       }
-      const BRepGraphInc::ShellRef& aRef = theShellRefs.Value(aRefIdx);
+      const BRepGraphInc::ShellRef& aRef =
+        theShellRefs.Value(static_cast<size_t>(aShellRefId.Index));
       if (aRef.IsRemoved || !aRef.ShellDefId.IsValid())
       {
         continue;
       }
-      if (aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Solid
-          || aRef.ParentId.Index != theSolidIdx)
+      if (BRepGraph_SolidId(aRef.ParentId) != theSolidId)
       {
         continue;
       }
-      if (aRef.ShellDefId.Index == theShellIdx)
+      if (aRef.ShellDefId == theShellId)
       {
         return true;
       }
@@ -1220,7 +1200,7 @@ bool BRepGraphInc_ReverseIndex::Validate(
   };
 
   auto isActiveChildNode = [&](const BRepGraph_NodeId theChildId) -> bool {
-    if (!theChildId.IsValid() || theChildId.Index < 0)
+    if (!theChildId.IsValid())
     {
       return false;
     }
@@ -1228,40 +1208,44 @@ bool BRepGraphInc_ReverseIndex::Validate(
     switch (theChildId.NodeKind)
     {
       case BRepGraph_NodeId::Kind::Solid:
-        return theChildId.Index < theSolids.Length()
-               && !theSolids.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theSolids.Size()
+               && !theSolids.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::Shell:
-        return theChildId.Index < theShells.Length()
-               && !theShells.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theShells.Size()
+               && !theShells.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::Face:
-        return theChildId.Index < theFaces.Length() && !theFaces.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theFaces.Size()
+               && !theFaces.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::Compound:
-        return theChildId.Index < theCompounds.Length()
-               && !theCompounds.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theCompounds.Size()
+               && !theCompounds.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::CompSolid:
-        return theChildId.Index < theCompSolids.Length()
-               && !theCompSolids.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theCompSolids.Size()
+               && !theCompSolids.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::Wire:
-        return theChildId.Index < theWires.Length() && !theWires.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theWires.Size()
+               && !theWires.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::Edge:
-        return theChildId.Index < theEdges.Length() && !theEdges.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theEdges.Size()
+               && !theEdges.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       case BRepGraph_NodeId::Kind::Vertex:
-        return theChildId.Index < theVertices.Length()
-               && !theVertices.Value(theChildId.Index).IsRemoved;
+        return theChildId.Index < theVertices.Size()
+               && !theVertices.Value(static_cast<size_t>(theChildId.Index)).IsRemoved;
       default:
         return false;
     }
   };
 
-  auto hasActiveCompoundChildRef = [&](const int              theCompoundIdx,
-                                       const BRepGraph_NodeId theChildId) -> bool {
-    if (theCompoundIdx < 0 || theCompoundIdx >= theCompounds.Length()
+  auto hasActiveCompoundChildRef = [&](const BRepGraph_CompoundId theCompoundId,
+                                       const BRepGraph_NodeId     theChildId) -> bool {
+    if (!theCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size()))
         || !isActiveChildNode(theChildId))
     {
       return false;
     }
 
-    const BRepGraphInc::CompoundDef& aCompound = theCompounds.Value(theCompoundIdx);
+    const BRepGraphInc::CompoundDef& aCompound =
+      theCompounds.Value(static_cast<size_t>(theCompoundId.Index));
     if (aCompound.IsRemoved)
     {
       return false;
@@ -1269,18 +1253,17 @@ bool BRepGraphInc_ReverseIndex::Validate(
 
     for (const BRepGraph_ChildRefId& aChildRefId : aCompound.ChildRefIds)
     {
-      const int aRefIdx = aChildRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theChildRefs.Length())
+      if (!aChildRefId.IsValid(static_cast<uint32_t>(theChildRefs.Size())))
       {
         continue;
       }
-      const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(aRefIdx);
+      const BRepGraphInc::ChildRef& aRef =
+        theChildRefs.Value(static_cast<size_t>(aChildRefId.Index));
       if (aRef.IsRemoved || !aRef.ChildDefId.IsValid())
       {
         continue;
       }
-      if (aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Compound
-          || aRef.ParentId.Index != theCompoundIdx)
+      if (BRepGraph_CompoundId(aRef.ParentId) != theCompoundId)
       {
         continue;
       }
@@ -1292,37 +1275,38 @@ bool BRepGraphInc_ReverseIndex::Validate(
     return false;
   };
 
-  auto hasActiveCompSolidRef = [&](const int theCompSolidIdx, const int theSolidIdx) -> bool {
-    if (theCompSolidIdx < 0 || theCompSolidIdx >= theCompSolids.Length() || theSolidIdx < 0
-        || theSolidIdx >= theSolids.Length())
+  auto hasActiveCompSolidRef = [&](const BRepGraph_CompSolidId theCompSolidId,
+                                   const BRepGraph_SolidId     theSolidId) -> bool {
+    if (!theCompSolidId.IsValid(static_cast<uint32_t>(theCompSolids.Size()))
+        || !theSolidId.IsValid(static_cast<uint32_t>(theSolids.Size())))
     {
       return false;
     }
 
-    const BRepGraphInc::CompSolidDef& aCompSolid = theCompSolids.Value(theCompSolidIdx);
-    if (aCompSolid.IsRemoved || theSolids.Value(theSolidIdx).IsRemoved)
+    const BRepGraphInc::CompSolidDef& aCompSolid =
+      theCompSolids.Value(static_cast<size_t>(theCompSolidId.Index));
+    if (aCompSolid.IsRemoved || theSolids.Value(static_cast<size_t>(theSolidId.Index)).IsRemoved)
     {
       return false;
     }
 
     for (const BRepGraph_SolidRefId& aSolidRefId : aCompSolid.SolidRefIds)
     {
-      const int aRefIdx = aSolidRefId.Index;
-      if (aRefIdx < 0 || aRefIdx >= theSolidRefs.Length())
+      if (!aSolidRefId.IsValid(static_cast<uint32_t>(theSolidRefs.Size())))
       {
         continue;
       }
-      const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(aRefIdx);
+      const BRepGraphInc::SolidRef& aRef =
+        theSolidRefs.Value(static_cast<size_t>(aSolidRefId.Index));
       if (aRef.IsRemoved || !aRef.SolidDefId.IsValid())
       {
         continue;
       }
-      if (aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::CompSolid
-          || aRef.ParentId.Index != theCompSolidIdx)
+      if (BRepGraph_CompSolidId(aRef.ParentId) != theCompSolidId)
       {
         continue;
       }
-      if (aRef.SolidDefId.Index == theSolidIdx)
+      if (aRef.SolidDefId == theSolidId)
       {
         return true;
       }
@@ -1331,174 +1315,179 @@ bool BRepGraphInc_ReverseIndex::Validate(
   };
 
   // Check: for each coedge ref entry, edge->wire reverse entry must exist.
-  const int aNbCoEdgeRefs = theCoEdgeRefs.Length();
+  const uint32_t aNbCoEdgeRefs = static_cast<uint32_t>(theCoEdgeRefs.Size());
   for (BRepGraph_CoEdgeRefId aCoEdgeRefId(0); aCoEdgeRefId.IsValid(aNbCoEdgeRefs); ++aCoEdgeRefId)
   {
-    const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aCoEdgeRefId.Index);
+    const BRepGraphInc::CoEdgeRef& aRef =
+      theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Wire || !aRef.CoEdgeDefId.IsValid())
       continue;
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theWires.Length()
-        || aRef.CoEdgeDefId.Index < 0 || aRef.CoEdgeDefId.Index >= theCoEdges.Length())
+    if (aRef.ParentId.Index >= theWires.Size() || aRef.CoEdgeDefId.Index >= theCoEdges.Size())
       return false;
-    const BRepGraphInc::WireDef& aWire = theWires.Value(aRef.ParentId.Index);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aRef.ParentId.Index));
     if (aWire.IsRemoved)
       continue;
-    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aRef.CoEdgeDefId.Index);
+    const BRepGraphInc::CoEdgeDef& aCoEdge =
+      theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index));
     if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid())
       return false;
-    if (!containsIndexInTable(myEdgeToWires, aCoEdge.EdgeDefId.Index, aRef.ParentId.Index))
+    if (!containsIndexInTable(myEdgeToWires, aCoEdge.EdgeDefId, BRepGraph_WireId(aRef.ParentId)))
       return false;
   }
 
   // Check: for each active coedge ref entry, coedge->wire reverse entry must exist.
   for (BRepGraph_CoEdgeRefId aCoEdgeRefId(0); aCoEdgeRefId.IsValid(aNbCoEdgeRefs); ++aCoEdgeRefId)
   {
-    const BRepGraphInc::CoEdgeRef& aRef = theCoEdgeRefs.Value(aCoEdgeRefId.Index);
+    const BRepGraphInc::CoEdgeRef& aRef =
+      theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Wire || !aRef.CoEdgeDefId.IsValid())
       continue;
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theWires.Length()
-        || aRef.CoEdgeDefId.Index < 0 || aRef.CoEdgeDefId.Index >= theCoEdges.Length())
+    if (aRef.ParentId.Index >= theWires.Size() || aRef.CoEdgeDefId.Index >= theCoEdges.Size())
       return false;
-    const BRepGraphInc::WireDef& aWire = theWires.Value(aRef.ParentId.Index);
+    const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aRef.ParentId.Index));
     if (aWire.IsRemoved)
       continue;
-    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aRef.CoEdgeDefId.Index);
+    const BRepGraphInc::CoEdgeDef& aCoEdge =
+      theCoEdges.Value(static_cast<size_t>(aRef.CoEdgeDefId.Index));
     if (aCoEdge.IsRemoved)
       continue;
-    if (!containsIndexInTable(myCoEdgeToWires, aRef.CoEdgeDefId.Index, aRef.ParentId.Index))
+    if (!containsIndexInTable(myCoEdgeToWires, aRef.CoEdgeDefId, BRepGraph_WireId(aRef.ParentId)))
       return false;
   }
 
   // Check: for each edge's start/end vertex, vertex->edge reverse entry must exist.
-  const int aNbEdges = theEdges.Length();
+  const uint32_t aNbEdges = static_cast<uint32_t>(theEdges.Size());
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
   {
-    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(anEdgeId.Index);
+    const BRepGraphInc::EdgeDef& anEdge = theEdges.Value(static_cast<size_t>(anEdgeId.Index));
     if (anEdge.IsRemoved)
       continue;
     const BRepGraph_VertexId aStartVtx = resolveVertexDefId(theVertexRefs, anEdge.StartVertexRefId);
     const BRepGraph_VertexId anEndVtx  = resolveVertexDefId(theVertexRefs, anEdge.EndVertexRefId);
     if (aStartVtx.IsValid())
     {
-      if (!containsIndexInTable(myVertexToEdges, aStartVtx.Index, anEdgeId.Index))
+      if (!containsIndexInTable(myVertexToEdges, aStartVtx, anEdgeId))
         return false;
     }
     if (anEndVtx.IsValid() && anEndVtx != aStartVtx)
     {
-      if (!containsIndexInTable(myVertexToEdges, anEndVtx.Index, anEdgeId.Index))
+      if (!containsIndexInTable(myVertexToEdges, anEndVtx, anEdgeId))
         return false;
     }
   }
 
   // Check: for each edge's CoEdges with valid FaceDefId, edge->face reverse entry must exist.
-  const int aNbCoEdges = theCoEdges.Length();
+  const uint32_t aNbCoEdges = static_cast<uint32_t>(theCoEdges.Size());
   for (BRepGraph_CoEdgeId aCoEdgeId(0); aCoEdgeId.IsValid(aNbCoEdges); ++aCoEdgeId)
   {
-    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeId.Index);
+    const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(static_cast<size_t>(aCoEdgeId.Index));
     if (aCoEdge.IsRemoved || !aCoEdge.FaceDefId.IsValid())
       continue;
-    if (!containsIndexInTable(myEdgeToFaces, aCoEdge.EdgeDefId.Index, aCoEdge.FaceDefId.Index))
+    if (!containsIndexInTable(myEdgeToFaces, aCoEdge.EdgeDefId, aCoEdge.FaceDefId))
       return false;
   }
 
   // Check: for each wire ref entry, wire->face reverse entry must exist.
-  const int aNbWireRefs = theWireRefs.Length();
+  const uint32_t aNbWireRefs = static_cast<uint32_t>(theWireRefs.Size());
   for (BRepGraph_WireRefId aWireRefId(0); aWireRefId.IsValid(aNbWireRefs); ++aWireRefId)
   {
-    const BRepGraphInc::WireRef& aRef = theWireRefs.Value(aWireRefId.Index);
+    const BRepGraphInc::WireRef& aRef = theWireRefs.Value(static_cast<size_t>(aWireRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Face || !aRef.WireDefId.IsValid())
       continue;
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theFaces.Length()
-        || aRef.WireDefId.Index < 0 || aRef.WireDefId.Index >= theWires.Length())
+    if (aRef.ParentId.Index >= theFaces.Size() || aRef.WireDefId.Index >= theWires.Size())
       return false;
-    const BRepGraphInc::FaceDef& aFace = theFaces.Value(aRef.ParentId.Index);
-    if (aFace.IsRemoved || theWires.Value(aRef.WireDefId.Index).IsRemoved)
+    const BRepGraphInc::FaceDef& aFace = theFaces.Value(static_cast<size_t>(aRef.ParentId.Index));
+    if (aFace.IsRemoved || theWires.Value(static_cast<size_t>(aRef.WireDefId.Index)).IsRemoved)
       continue;
-    if (!containsIndexInTable(myWireToFaces, aRef.WireDefId.Index, aRef.ParentId.Index))
+    if (!containsIndexInTable(myWireToFaces, aRef.WireDefId, BRepGraph_FaceId(aRef.ParentId)))
       return false;
   }
 
   // Check: for each face ref entry, face->shell reverse entry must exist.
-  const int aNbFaceRefs = theFaceRefs.Length();
+  const uint32_t aNbFaceRefs = static_cast<uint32_t>(theFaceRefs.Size());
   for (BRepGraph_FaceRefId aFaceRefId(0); aFaceRefId.IsValid(aNbFaceRefs); ++aFaceRefId)
   {
-    const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(aFaceRefId.Index);
+    const BRepGraphInc::FaceRef& aRef = theFaceRefs.Value(static_cast<size_t>(aFaceRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Shell || !aRef.FaceDefId.IsValid())
       continue;
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theShells.Length()
-        || aRef.FaceDefId.Index < 0 || aRef.FaceDefId.Index >= theFaces.Length())
+    if (aRef.ParentId.Index >= theShells.Size() || aRef.FaceDefId.Index >= theFaces.Size())
       return false;
-    const BRepGraphInc::ShellDef& aShell = theShells.Value(aRef.ParentId.Index);
-    if (aShell.IsRemoved || theFaces.Value(aRef.FaceDefId.Index).IsRemoved)
+    const BRepGraphInc::ShellDef& aShell =
+      theShells.Value(static_cast<size_t>(aRef.ParentId.Index));
+    if (aShell.IsRemoved || theFaces.Value(static_cast<size_t>(aRef.FaceDefId.Index)).IsRemoved)
       continue;
-    if (!containsIndexInTable(myFaceToShells, aRef.FaceDefId.Index, aRef.ParentId.Index))
+    if (!containsIndexInTable(myFaceToShells, aRef.FaceDefId, BRepGraph_ShellId(aRef.ParentId)))
       return false;
   }
 
   // Check: for each shell ref entry, shell->solid reverse entry must exist.
-  const int aNbShellRefs = theShellRefs.Length();
+  const uint32_t aNbShellRefs = static_cast<uint32_t>(theShellRefs.Size());
   for (BRepGraph_ShellRefId aShellRefId(0); aShellRefId.IsValid(aNbShellRefs); ++aShellRefId)
   {
-    const BRepGraphInc::ShellRef& aRef = theShellRefs.Value(aShellRefId.Index);
+    const BRepGraphInc::ShellRef& aRef = theShellRefs.Value(static_cast<size_t>(aShellRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Solid || !aRef.ShellDefId.IsValid())
       continue;
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theSolids.Length()
-        || aRef.ShellDefId.Index < 0 || aRef.ShellDefId.Index >= theShells.Length())
+    if (aRef.ParentId.Index >= theSolids.Size() || aRef.ShellDefId.Index >= theShells.Size())
       return false;
-    const BRepGraphInc::SolidDef& aSolid = theSolids.Value(aRef.ParentId.Index);
-    if (aSolid.IsRemoved || theShells.Value(aRef.ShellDefId.Index).IsRemoved)
+    const BRepGraphInc::SolidDef& aSolid =
+      theSolids.Value(static_cast<size_t>(aRef.ParentId.Index));
+    if (aSolid.IsRemoved || theShells.Value(static_cast<size_t>(aRef.ShellDefId.Index)).IsRemoved)
       continue;
-    if (!containsIndexInTable(myShellToSolids, aRef.ShellDefId.Index, aRef.ParentId.Index))
+    if (!containsIndexInTable(myShellToSolids, aRef.ShellDefId, BRepGraph_SolidId(aRef.ParentId)))
       return false;
   }
 
   // Check: for each solid ref entry, solid->compsolid reverse entry must exist.
-  const int aNbSolidRefs = theSolidRefs.Length();
+  const uint32_t aNbSolidRefs = static_cast<uint32_t>(theSolidRefs.Size());
   for (BRepGraph_SolidRefId aSolidRefId(0); aSolidRefId.IsValid(aNbSolidRefs); ++aSolidRefId)
   {
-    const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(aSolidRefId.Index);
+    const BRepGraphInc::SolidRef& aRef = theSolidRefs.Value(static_cast<size_t>(aSolidRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::CompSolid
         || !aRef.SolidDefId.IsValid())
     {
       continue;
     }
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theCompSolids.Length()
-        || aRef.SolidDefId.Index < 0 || aRef.SolidDefId.Index >= theSolids.Length())
+    if (aRef.ParentId.Index >= theCompSolids.Size() || aRef.SolidDefId.Index >= theSolids.Size())
     {
       return false;
     }
-    const BRepGraphInc::CompSolidDef& aCompSolid = theCompSolids.Value(aRef.ParentId.Index);
-    if (aCompSolid.IsRemoved || theSolids.Value(aRef.SolidDefId.Index).IsRemoved)
+    const BRepGraphInc::CompSolidDef& aCompSolid =
+      theCompSolids.Value(static_cast<size_t>(aRef.ParentId.Index));
+    if (aCompSolid.IsRemoved
+        || theSolids.Value(static_cast<size_t>(aRef.SolidDefId.Index)).IsRemoved)
     {
       continue;
     }
-    if (!containsIndexInTable(myCompSolidsOfSolid, aRef.SolidDefId.Index, aRef.ParentId.Index))
+    if (!containsIndexInTable(myCompSolidsOfSolid,
+                              aRef.SolidDefId,
+                              BRepGraph_CompSolidId(aRef.ParentId)))
     {
       return false;
     }
   }
 
   // Check: for each compound child ref entry, child->compound reverse entry must exist.
-  const int aNbChildRefs = theChildRefs.Length();
+  const uint32_t aNbChildRefs = static_cast<uint32_t>(theChildRefs.Size());
   for (BRepGraph_ChildRefId aChildRefId(0); aChildRefId.IsValid(aNbChildRefs); ++aChildRefId)
   {
-    const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(aChildRefId.Index);
+    const BRepGraphInc::ChildRef& aRef = theChildRefs.Value(static_cast<size_t>(aChildRefId.Index));
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
         || aRef.ParentId.NodeKind != BRepGraph_NodeId::Kind::Compound || !aRef.ChildDefId.IsValid())
     {
       continue;
     }
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= theCompounds.Length())
+    if (aRef.ParentId.Index >= theCompounds.Size())
     {
       return false;
     }
-    const BRepGraphInc::CompoundDef& aCompound = theCompounds.Value(aRef.ParentId.Index);
+    const BRepGraphInc::CompoundDef& aCompound =
+      theCompounds.Value(static_cast<size_t>(aRef.ParentId.Index));
     if (aCompound.IsRemoved || !isActiveChildNode(aRef.ChildDefId))
     {
       continue;
@@ -1507,39 +1496,51 @@ bool BRepGraphInc_ReverseIndex::Validate(
     switch (aRef.ChildDefId.NodeKind)
     {
       case BRepGraph_NodeId::Kind::Solid:
-        if (!containsIndexInTable(myCompoundsOfSolid, aRef.ChildDefId.Index, aRef.ParentId.Index))
+        if (!containsIndexInTable(myCompoundsOfSolid,
+                                  BRepGraph_SolidId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::Shell:
-        if (!containsIndexInTable(myCompoundsOfShell, aRef.ChildDefId.Index, aRef.ParentId.Index))
+        if (!containsIndexInTable(myCompoundsOfShell,
+                                  BRepGraph_ShellId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::Face:
-        if (!containsIndexInTable(myCompoundsOfFace, aRef.ChildDefId.Index, aRef.ParentId.Index))
+        if (!containsIndexInTable(myCompoundsOfFace,
+                                  BRepGraph_FaceId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::Compound:
         if (!containsIndexInTable(myCompoundsOfCompound,
-                                  aRef.ChildDefId.Index,
-                                  aRef.ParentId.Index))
+                                  BRepGraph_CompoundId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::CompSolid:
         if (!containsIndexInTable(myCompoundsOfCompSolid,
-                                  aRef.ChildDefId.Index,
-                                  aRef.ParentId.Index))
+                                  BRepGraph_CompSolidId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::Wire:
-        if (!containsIndexInTable(myCompoundsOfWire, aRef.ChildDefId.Index, aRef.ParentId.Index))
+        if (!containsIndexInTable(myCompoundsOfWire,
+                                  BRepGraph_WireId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::Edge:
-        if (!containsIndexInTable(myCompoundsOfEdge, aRef.ChildDefId.Index, aRef.ParentId.Index))
+        if (!containsIndexInTable(myCompoundsOfEdge,
+                                  BRepGraph_EdgeId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       case BRepGraph_NodeId::Kind::Vertex:
-        if (!containsIndexInTable(myCompoundsOfVertex, aRef.ChildDefId.Index, aRef.ParentId.Index))
+        if (!containsIndexInTable(myCompoundsOfVertex,
+                                  BRepGraph_VertexId(aRef.ChildDefId),
+                                  BRepGraph_CompoundId(aRef.ParentId)))
           return false;
         break;
       default:
@@ -1548,63 +1549,60 @@ bool BRepGraphInc_ReverseIndex::Validate(
   }
 
   // Check reverse tables for stale/extra entries not backed by active forward refs.
-  const int aNbEdgeToWires = myEdgeToWires.Length();
+  const uint32_t aNbEdgeToWires = static_cast<uint32_t>(myEdgeToWires.Size());
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdgeToWires); ++anEdgeId)
   {
     const NCollection_Vector<BRepGraph_WireId>& aWires = WiresOfEdgeRef(anEdgeId);
     for (const BRepGraph_WireId& aWireId2 : aWires)
     {
-      const int aWireIdx = aWireId2.Index;
-      if (aWireIdx < 0 || aWireIdx >= theWires.Length())
+      if (!aWireId2.IsValid(static_cast<uint32_t>(theWires.Size())))
       {
         return false;
       }
-      if (!hasActiveWireUsageOfEdge(aWireIdx, anEdgeId.Index))
+      if (!hasActiveWireUsageOfEdge(aWireId2, anEdgeId))
       {
         return false;
       }
     }
   }
 
-  const int aNbEdgeToCoEdges = myEdgeToCoEdges.Length();
+  const uint32_t aNbEdgeToCoEdges = static_cast<uint32_t>(myEdgeToCoEdges.Size());
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdgeToCoEdges); ++anEdgeId)
   {
     const NCollection_Vector<BRepGraph_CoEdgeId>& aCoEdges = CoEdgesOfEdgeRef(anEdgeId);
     for (const BRepGraph_CoEdgeId& aCoEdgeId2 : aCoEdges)
     {
-      const int aCoEdgeIdx = aCoEdgeId2.Index;
-      if (aCoEdgeIdx < 0 || aCoEdgeIdx >= theCoEdges.Length())
+      if (!aCoEdgeId2.IsValid(static_cast<uint32_t>(theCoEdges.Size())))
       {
         return false;
       }
-      const BRepGraphInc::CoEdgeDef& aCoEdge = theCoEdges.Value(aCoEdgeIdx);
-      if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid()
-          || aCoEdge.EdgeDefId.Index != anEdgeId.Index)
+      const BRepGraphInc::CoEdgeDef& aCoEdge =
+        theCoEdges.Value(static_cast<size_t>(aCoEdgeId2.Index));
+      if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid() || aCoEdge.EdgeDefId != anEdgeId)
       {
         return false;
       }
     }
   }
 
-  const int aNbWireToFaces = myWireToFaces.Length();
+  const uint32_t aNbWireToFaces = static_cast<uint32_t>(myWireToFaces.Size());
   for (BRepGraph_WireId aWireId(0); aWireId.IsValid(aNbWireToFaces); ++aWireId)
   {
     const NCollection_Vector<BRepGraph_FaceId>& aFaces = FacesOfWireRef(aWireId);
     for (const BRepGraph_FaceId& aFaceId2 : aFaces)
     {
-      const int aFaceIdx = aFaceId2.Index;
-      if (aFaceIdx < 0 || aFaceIdx >= theFaces.Length())
+      if (!aFaceId2.IsValid(static_cast<uint32_t>(theFaces.Size())))
       {
         return false;
       }
-      if (!hasActiveFaceRefForWire(aWireId.Index, aFaceIdx))
+      if (!hasActiveFaceRefForWire(aWireId, aFaceId2))
       {
         return false;
       }
     }
   }
 
-  const int aNbEdgeToFaces = myEdgeToFaces.Length();
+  const uint32_t aNbEdgeToFaces = static_cast<uint32_t>(myEdgeToFaces.Size());
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdgeToFaces); ++anEdgeId)
   {
     const NCollection_Vector<BRepGraph_FaceId>* aFaces = seekVec(myEdgeToFaces, anEdgeId.Index);
@@ -1614,19 +1612,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_FaceId& aFaceId2 : *aFaces)
     {
-      const int aFaceIdx = aFaceId2.Index;
-      if (aFaceIdx < 0 || aFaceIdx >= theFaces.Length())
+      if (!aFaceId2.IsValid(static_cast<uint32_t>(theFaces.Size())))
       {
         return false;
       }
-      if (!hasActiveFaceForEdge(anEdgeId.Index, aFaceIdx))
+      if (!hasActiveFaceForEdge(anEdgeId, aFaceId2))
       {
         return false;
       }
     }
   }
 
-  const int aNbFaceToShells = myFaceToShells.Length();
+  const uint32_t aNbFaceToShells = static_cast<uint32_t>(myFaceToShells.Size());
   for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaceToShells); ++aFaceId)
   {
     const NCollection_Vector<BRepGraph_ShellId>* aShellsVec =
@@ -1637,19 +1634,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_ShellId& aShellId2 : *aShellsVec)
     {
-      const int aShellIdx = aShellId2.Index;
-      if (aShellIdx < 0 || aShellIdx >= theShells.Length())
+      if (!aShellId2.IsValid(static_cast<uint32_t>(theShells.Size())))
       {
         return false;
       }
-      if (!hasActiveFaceRef(aShellIdx, aFaceId.Index))
+      if (!hasActiveFaceRef(aShellId2, aFaceId))
       {
         return false;
       }
     }
   }
 
-  const int aNbShellToSolids = myShellToSolids.Length();
+  const uint32_t aNbShellToSolids = static_cast<uint32_t>(myShellToSolids.Size());
   for (BRepGraph_ShellId aShellId(0); aShellId.IsValid(aNbShellToSolids); ++aShellId)
   {
     const NCollection_Vector<BRepGraph_SolidId>* aSolidsVec =
@@ -1660,19 +1656,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_SolidId& aSolidId2 : *aSolidsVec)
     {
-      const int aSolidIdx = aSolidId2.Index;
-      if (aSolidIdx < 0 || aSolidIdx >= theSolids.Length())
+      if (!aSolidId2.IsValid(static_cast<uint32_t>(theSolids.Size())))
       {
         return false;
       }
-      if (!hasActiveShellRef(aSolidIdx, aShellId.Index))
+      if (!hasActiveShellRef(aSolidId2, aShellId))
       {
         return false;
       }
     }
   }
 
-  const int aNbCompoundsOfSolid = myCompoundsOfSolid.Length();
+  const uint32_t aNbCompoundsOfSolid = static_cast<uint32_t>(myCompoundsOfSolid.Size());
   for (BRepGraph_SolidId aSolidId(0); aSolidId.IsValid(aNbCompoundsOfSolid); ++aSolidId)
   {
     const NCollection_Vector<BRepGraph_CompoundId>* aCompoundsVec =
@@ -1683,18 +1678,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, BRepGraph_SolidId(aSolidId.Index)))
+      if (!hasActiveCompoundChildRef(aCompoundId, aSolidId))
       {
         return false;
       }
     }
   }
 
-  const int aNbCompSolidsOfSolid = myCompSolidsOfSolid.Length();
+  const uint32_t aNbCompSolidsOfSolid = static_cast<uint32_t>(myCompSolidsOfSolid.Size());
   for (BRepGraph_SolidId aSolidId(0); aSolidId.IsValid(aNbCompSolidsOfSolid); ++aSolidId)
   {
     const NCollection_Vector<BRepGraph_CompSolidId>* aCompSolidsVec =
@@ -1705,18 +1700,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompSolidId& aCompSolidId : *aCompSolidsVec)
     {
-      if (aCompSolidId.Index < 0 || aCompSolidId.Index >= theCompSolids.Length())
+      if (!aCompSolidId.IsValid(static_cast<uint32_t>(theCompSolids.Size())))
       {
         return false;
       }
-      if (!hasActiveCompSolidRef(aCompSolidId.Index, aSolidId.Index))
+      if (!hasActiveCompSolidRef(aCompSolidId, aSolidId))
       {
         return false;
       }
     }
   }
 
-  const int aNbCompoundsOfShell = myCompoundsOfShell.Length();
+  const uint32_t aNbCompoundsOfShell = static_cast<uint32_t>(myCompoundsOfShell.Size());
   for (BRepGraph_ShellId aShellId(0); aShellId.IsValid(aNbCompoundsOfShell); ++aShellId)
   {
     const NCollection_Vector<BRepGraph_CompoundId>* aCompoundsVec =
@@ -1727,18 +1722,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, BRepGraph_ShellId(aShellId.Index)))
+      if (!hasActiveCompoundChildRef(aCompoundId, aShellId))
       {
         return false;
       }
     }
   }
 
-  const int aNbCompoundsOfFace = myCompoundsOfFace.Length();
+  const uint32_t aNbCompoundsOfFace = static_cast<uint32_t>(myCompoundsOfFace.Size());
   for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbCompoundsOfFace); ++aFaceId)
   {
     const NCollection_Vector<BRepGraph_CompoundId>* aCompoundsVec =
@@ -1749,18 +1744,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, BRepGraph_FaceId(aFaceId.Index)))
+      if (!hasActiveCompoundChildRef(aCompoundId, aFaceId))
       {
         return false;
       }
     }
   }
 
-  const int aNbCompoundsOfCompound = myCompoundsOfCompound.Length();
+  const uint32_t aNbCompoundsOfCompound = static_cast<uint32_t>(myCompoundsOfCompound.Size());
   for (BRepGraph_CompoundId aCompoundId(0); aCompoundId.IsValid(aNbCompoundsOfCompound);
        ++aCompoundId)
   {
@@ -1772,18 +1767,18 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aParentCompoundId : *aCompoundsVec)
     {
-      if (aParentCompoundId.Index < 0 || aParentCompoundId.Index >= theCompounds.Length())
+      if (!aParentCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aParentCompoundId.Index, aCompoundId))
+      if (!hasActiveCompoundChildRef(aParentCompoundId, aCompoundId))
       {
         return false;
       }
     }
   }
 
-  const int aNbCompoundsOfCompSolid = myCompoundsOfCompSolid.Length();
+  const uint32_t aNbCompoundsOfCompSolid = static_cast<uint32_t>(myCompoundsOfCompSolid.Size());
   for (BRepGraph_CompSolidId aCompSolidId(0); aCompSolidId.IsValid(aNbCompoundsOfCompSolid);
        ++aCompSolidId)
   {
@@ -1795,11 +1790,11 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, aCompSolidId))
+      if (!hasActiveCompoundChildRef(aCompoundId, aCompSolidId))
       {
         return false;
       }
@@ -1807,7 +1802,7 @@ bool BRepGraphInc_ReverseIndex::Validate(
   }
 
   // Check reverse: myCompoundsOfWire - each entry must be backed by an active compound ChildRef.
-  const int aNbCompoundsOfWire = myCompoundsOfWire.Length();
+  const uint32_t aNbCompoundsOfWire = static_cast<uint32_t>(myCompoundsOfWire.Size());
   for (BRepGraph_WireId aWireId(0); aWireId.IsValid(aNbCompoundsOfWire); ++aWireId)
   {
     const NCollection_Vector<BRepGraph_CompoundId>* aCompoundsVec =
@@ -1818,11 +1813,11 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, BRepGraph_WireId(aWireId.Index)))
+      if (!hasActiveCompoundChildRef(aCompoundId, aWireId))
       {
         return false;
       }
@@ -1830,7 +1825,7 @@ bool BRepGraphInc_ReverseIndex::Validate(
   }
 
   // Check reverse: myCompoundsOfEdge - each entry must be backed by an active compound ChildRef.
-  const int aNbCompoundsOfEdge = myCompoundsOfEdge.Length();
+  const uint32_t aNbCompoundsOfEdge = static_cast<uint32_t>(myCompoundsOfEdge.Size());
   for (BRepGraph_EdgeId anEdgeId2(0); anEdgeId2.IsValid(aNbCompoundsOfEdge); ++anEdgeId2)
   {
     const NCollection_Vector<BRepGraph_CompoundId>* aCompoundsVec =
@@ -1841,11 +1836,11 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, BRepGraph_EdgeId(anEdgeId2.Index)))
+      if (!hasActiveCompoundChildRef(aCompoundId, anEdgeId2))
       {
         return false;
       }
@@ -1853,7 +1848,7 @@ bool BRepGraphInc_ReverseIndex::Validate(
   }
 
   // Check reverse: myCompoundsOfVertex - each entry must be backed by an active compound ChildRef.
-  const int aNbCompoundsOfVertex = myCompoundsOfVertex.Length();
+  const uint32_t aNbCompoundsOfVertex = static_cast<uint32_t>(myCompoundsOfVertex.Size());
   for (BRepGraph_VertexId aVertexId(0); aVertexId.IsValid(aNbCompoundsOfVertex); ++aVertexId)
   {
     const NCollection_Vector<BRepGraph_CompoundId>* aCompoundsVec =
@@ -1864,11 +1859,11 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_CompoundId& aCompoundId : *aCompoundsVec)
     {
-      if (aCompoundId.Index < 0 || aCompoundId.Index >= theCompounds.Length())
+      if (!aCompoundId.IsValid(static_cast<uint32_t>(theCompounds.Size())))
       {
         return false;
       }
-      if (!hasActiveCompoundChildRef(aCompoundId.Index, BRepGraph_VertexId(aVertexId.Index)))
+      if (!hasActiveCompoundChildRef(aCompoundId, aVertexId))
       {
         return false;
       }
@@ -1876,7 +1871,7 @@ bool BRepGraphInc_ReverseIndex::Validate(
   }
 
   // Check reverse: myCoEdgeToWires - each entry must be backed by an active CoEdgeRef in that wire.
-  const int aNbCoEdgeToWires = myCoEdgeToWires.Length();
+  const uint32_t aNbCoEdgeToWires = static_cast<uint32_t>(myCoEdgeToWires.Size());
   for (BRepGraph_CoEdgeId aCoEdgeId2(0); aCoEdgeId2.IsValid(aNbCoEdgeToWires); ++aCoEdgeId2)
   {
     const NCollection_Vector<BRepGraph_WireId>* aWiresVec =
@@ -1887,11 +1882,11 @@ bool BRepGraphInc_ReverseIndex::Validate(
     }
     for (const BRepGraph_WireId& aWireId2 : *aWiresVec)
     {
-      if (aWireId2.Index < 0 || aWireId2.Index >= theWires.Length())
+      if (aWireId2.Index >= theWires.Size())
       {
         return false;
       }
-      const BRepGraphInc::WireDef& aWire = theWires.Value(aWireId2.Index);
+      const BRepGraphInc::WireDef& aWire = theWires.Value(static_cast<size_t>(aWireId2.Index));
       if (aWire.IsRemoved)
       {
         // Stale entry: wire was removed but myCoEdgeToWires was not updated.
@@ -1900,9 +1895,10 @@ bool BRepGraphInc_ReverseIndex::Validate(
       bool aFound = false;
       for (const BRepGraph_CoEdgeRefId& aCoEdgeRefId2 : aWire.CoEdgeRefIds)
       {
-        if (aCoEdgeRefId2.Index < 0 || aCoEdgeRefId2.Index >= theCoEdgeRefs.Length())
+        if (aCoEdgeRefId2.Index >= theCoEdgeRefs.Size())
           continue;
-        const BRepGraphInc::CoEdgeRef& aRef2 = theCoEdgeRefs.Value(aCoEdgeRefId2.Index);
+        const BRepGraphInc::CoEdgeRef& aRef2 =
+          theCoEdgeRefs.Value(static_cast<size_t>(aCoEdgeRefId2.Index));
         if (aRef2.IsRemoved || !aRef2.CoEdgeDefId.IsValid())
           continue;
         if (aRef2.CoEdgeDefId.Index == aCoEdgeId2.Index)
@@ -1925,7 +1921,7 @@ bool BRepGraphInc_ReverseIndex::Validate(
 
 void BRepGraphInc_ReverseIndex::BuildProductOccurrences(
   const NCollection_Vector<BRepGraphInc::OccurrenceDef>& theOccurrences,
-  const int                                              theNbProducts)
+  const uint32_t                                         theNbProducts)
 {
   myProductToOccurrences.Clear();
   preSize(myProductToOccurrences, theNbProducts, myAllocator);

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_ReverseIndex.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_ReverseIndex.hxx
@@ -137,22 +137,22 @@ public:
     const NCollection_Vector<BRepGraphInc::SolidRef>&     theSolidRefs,
     const NCollection_Vector<BRepGraphInc::ChildRef>&     theChildRefs,
     const NCollection_Vector<BRepGraphInc::VertexRef>&    theVertexRefs,
-    const int                                             theOldNbEdges,
-    const int                                             theOldNbWires,
-    const int                                             theOldNbFaces,
-    const int                                             theOldNbShells,
-    const int                                             theOldNbSolids,
-    const int                                             theOldNbCompounds,
-    const int                                             theOldNbCompSolids,
-    const int                                             theOldNbChildRefs,
-    const int                                             theOldNbSolidRefs);
+    const uint32_t                                        theOldNbEdges,
+    const uint32_t                                        theOldNbWires,
+    const uint32_t                                        theOldNbFaces,
+    const uint32_t                                        theOldNbShells,
+    const uint32_t                                        theOldNbSolids,
+    const uint32_t                                        theOldNbCompounds,
+    const uint32_t                                        theOldNbCompSolids,
+    const uint32_t                                        theOldNbChildRefs,
+    const uint32_t                                        theOldNbSolidRefs);
 
   //! Build product-to-occurrences reverse index.
   //! @param[in] theOccurrences occurrence entity vector
   //! @param[in] theNbProducts  total number of products (for pre-sizing)
   Standard_EXPORT void BuildProductOccurrences(
     const NCollection_Vector<BRepGraphInc::OccurrenceDef>& theOccurrences,
-    const int                                              theNbProducts);
+    const uint32_t                                         theNbProducts);
 
   //! Return wire indices containing the given edge.
   [[nodiscard]] const NCollection_Vector<BRepGraph_WireId>* WiresOfEdge(
@@ -177,11 +177,10 @@ public:
 
   //! Return the number of faces incident to an edge - O(1).
   //! Derived directly from the edge-to-faces adjacency vector to keep a single source of truth.
-  [[nodiscard]] int NbFacesOfEdge(const BRepGraph_EdgeId theEdgeId) const
+  [[nodiscard]] uint32_t NbFacesOfEdge(const BRepGraph_EdgeId theEdgeId) const
   {
-    if (theEdgeId.Index < 0 || theEdgeId.Index >= myEdgeToFaces.Length())
-      return 0;
-    return myEdgeToFaces.Value(theEdgeId.Index).Length();
+    const NCollection_Vector<BRepGraph_FaceId>* aFaces = seekVec(myEdgeToFaces, theEdgeId.Index);
+    return aFaces != nullptr ? static_cast<uint32_t>(aFaces->Size()) : 0u;
   }
 
   //! Return edge indices incident to the given vertex.
@@ -418,17 +417,19 @@ private:
 
   //! Bounds-checked lookup returning nullptr for out-of-range or empty slots.
   template <typename T>
-  static const NCollection_Vector<T>* seekVec(const TypedIndexTable<T>& theIdx, const int theKey)
+  static const NCollection_Vector<T>* seekVec(const TypedIndexTable<T>& theIdx,
+                                              const uint32_t            theKey)
   {
-    if (theKey < 0 || theKey >= theIdx.Length())
+    if (theKey >= theIdx.Size())
       return nullptr;
-    const NCollection_Vector<T>& aVec = theIdx.Value(theKey);
+    const NCollection_Vector<T>& aVec = theIdx.Value(static_cast<size_t>(theKey));
     return aVec.IsEmpty() ? nullptr : &aVec;
   }
 
   //! Bounds-checked lookup returning a const reference (empty vector for missing keys).
   template <typename T>
-  static const NCollection_Vector<T>& seekRef(const TypedIndexTable<T>& theIdx, const int theKey)
+  static const NCollection_Vector<T>& seekRef(const TypedIndexTable<T>& theIdx,
+                                              const uint32_t            theKey)
   {
     const NCollection_Vector<T>* aPtr = seekVec(theIdx, theKey);
     if (aPtr != nullptr)
@@ -441,23 +442,23 @@ private:
   //! If theAlloc is non-null, inner vectors are constructed with it.
   template <typename T>
   static void ensureSize(TypedIndexTable<T>&                           theIdx,
-                         const int                                     theSize,
+                         const uint32_t                                theSize,
                          const occ::handle<NCollection_BaseAllocator>& theAlloc =
                            occ::handle<NCollection_BaseAllocator>())
   {
-    if (theSize <= theIdx.Length())
+    if (theSize <= theIdx.Size())
       return;
 
     if (!theAlloc.IsNull())
     {
-      for (int i = theIdx.Length(); i < theSize; ++i)
+      for (size_t i = theIdx.Size(), aNb = static_cast<size_t>(theSize); i < aNb; ++i)
       {
         theIdx.Append(NCollection_Vector<T>(16, theAlloc));
       }
     }
     else
     {
-      for (int i = theIdx.Length(); i < theSize; ++i)
+      for (size_t i = theIdx.Size(), aNb = static_cast<size_t>(theSize); i < aNb; ++i)
       {
         theIdx.Appended();
       }
@@ -467,9 +468,9 @@ private:
   //! Ensure theVec has at least theSize elements.
   //! New elements are default-constructed (zero for scalar types).
   template <typename T>
-  static void ensureSize(NCollection_Vector<T>& theVec, const int theSize)
+  static void ensureSize(NCollection_Vector<T>& theVec, const uint32_t theSize)
   {
-    while (theVec.Length() < theSize)
+    while (theVec.Size() < static_cast<size_t>(theSize))
     {
       theVec.Appended();
     }
@@ -478,7 +479,7 @@ private:
   //! Resize theIdx exactly to theSize slots (clears previous content first).
   template <typename T>
   static void preSize(TypedIndexTable<T>&                           theIdx,
-                      const int                                     theSize,
+                      const uint32_t                                theSize,
                       const occ::handle<NCollection_BaseAllocator>& theAlloc =
                         occ::handle<NCollection_BaseAllocator>())
   {
@@ -488,14 +489,12 @@ private:
 
   //! Add theVal to the vector at theKey, creating if needed.  Skips duplicates.
   template <typename T>
-  static void appendUnique(TypedIndexTable<T>& theIdx, const int theKey, const T theVal)
+  static void appendUnique(TypedIndexTable<T>& theIdx, const uint32_t theKey, const T theVal)
   {
-    Standard_ASSERT_RETURN(theKey >= 0, "appendUnique: negative key", );
-    // Grow if needed for incremental mutation after ReverseIndex::Build().
-    if (theKey >= theIdx.Length())
-      ensureSize(theIdx, theKey + 1);
+    if (theKey >= theIdx.Size())
+      ensureSize(theIdx, theKey + 1u);
 
-    NCollection_Vector<T>& aVec = theIdx.ChangeValue(theKey);
+    NCollection_Vector<T>& aVec = theIdx.ChangeValue(static_cast<size_t>(theKey));
     for (const T& anElem : aVec)
     {
       if (anElem == theVal)
@@ -507,15 +506,12 @@ private:
   //! Add theVal to the vector at theKey unconditionally (no duplicate check).
   //! Used during ReverseIndex::Build() where freshly-cleared indices guarantee no duplicates.
   template <typename T>
-  static void appendDirect(TypedIndexTable<T>& theIdx, const int theKey, const T theVal)
+  static void appendDirect(TypedIndexTable<T>& theIdx, const uint32_t theKey, const T theVal)
   {
-    Standard_ASSERT_RETURN(theKey >= 0, "appendDirect: negative key", );
-    // During ReverseIndex::Build(), outer vector is pre-sized so theKey < Length().
-    // For safety, grow if somehow out of range.
-    if (theKey >= theIdx.Length())
-      ensureSize(theIdx, theKey + 1);
+    if (theKey >= theIdx.Size())
+      ensureSize(theIdx, theKey + 1u);
 
-    theIdx.ChangeValue(theKey).Append(theVal);
+    theIdx.ChangeValue(static_cast<size_t>(theKey)).Append(theVal);
   }
 
   occ::handle<NCollection_BaseAllocator> myAllocator;
@@ -543,7 +539,7 @@ private:
   TypedIndexTable<BRepGraph_CompoundId> myCompoundsOfVertex; //!< Vertex -> parent Compound indices.
   TypedIndexTable<BRepGraph_WireId>     myCoEdgeToWires;     //!< CoEdge -> parent Wire indices.
 
-  int myNbIndexedCoEdges = 0; //!< Number of coedges indexed by ReverseIndex::Build()/BuildDelta().
+  uint32_t myNbIndexedCoEdges = 0; //!< Number of coedges indexed by ReverseIndex::Build()/BuildDelta().
 };
 
 #endif // _BRepGraphInc_ReverseIndex_HeaderFile

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_ReverseIndex.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_ReverseIndex.hxx
@@ -539,7 +539,8 @@ private:
   TypedIndexTable<BRepGraph_CompoundId> myCompoundsOfVertex; //!< Vertex -> parent Compound indices.
   TypedIndexTable<BRepGraph_WireId>     myCoEdgeToWires;     //!< CoEdge -> parent Wire indices.
 
-  uint32_t myNbIndexedCoEdges = 0; //!< Number of coedges indexed by ReverseIndex::Build()/BuildDelta().
+  uint32_t myNbIndexedCoEdges =
+    0; //!< Number of coedges indexed by ReverseIndex::Build()/BuildDelta().
 };
 
 #endif // _BRepGraphInc_ReverseIndex_HeaderFile

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.cxx
@@ -19,7 +19,7 @@ namespace
 {
 
 template <typename T>
-bool containsNodeIndex(const NCollection_Vector<T>* theVec, const int theIndex)
+bool containsNodeIndex(const NCollection_Vector<T>* theVec, const uint32_t theIndex)
 {
   if (theVec == nullptr)
   {
@@ -479,98 +479,82 @@ void BRepGraphInc_Storage::BuildReverseIndex()
   myPolygons3D.NbActive        = 0;
   myPolygons2D.NbActive        = 0;
   myPolygonsOnTri.NbActive     = 0;
-  const int aNbVertices        = myVertices.Nb();
-  for (BRepGraph_VertexId aVertexId(0); aVertexId.IsValid(aNbVertices); ++aVertexId)
-    if (!myVertices.Get(aVertexId).IsRemoved)
+  for (BRepGraph_VertexId aId = BRepGraph_VertexId::Start(); aId.IsValid(myVertices.Nb()); ++aId)
+    if (!myVertices.Get(aId).IsRemoved)
       ++myVertices.NbActive;
-  const int aNbEdges = myEdges.Nb();
-  for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
-    if (!myEdges.Get(anEdgeId).IsRemoved)
+  for (BRepGraph_EdgeId aId = BRepGraph_EdgeId::Start(); aId.IsValid(myEdges.Nb()); ++aId)
+    if (!myEdges.Get(aId).IsRemoved)
       ++myEdges.NbActive;
-  const int aNbCoEdges = myCoEdges.Nb();
-  for (BRepGraph_CoEdgeId aCoEdgeId(0); aCoEdgeId.IsValid(aNbCoEdges); ++aCoEdgeId)
-    if (!myCoEdges.Get(aCoEdgeId).IsRemoved)
+  for (BRepGraph_CoEdgeId aId = BRepGraph_CoEdgeId::Start(); aId.IsValid(myCoEdges.Nb()); ++aId)
+    if (!myCoEdges.Get(aId).IsRemoved)
       ++myCoEdges.NbActive;
-  const int aNbWires = myWires.Nb();
-  for (BRepGraph_WireId aWireId(0); aWireId.IsValid(aNbWires); ++aWireId)
-    if (!myWires.Get(aWireId).IsRemoved)
+  for (BRepGraph_WireId aId = BRepGraph_WireId::Start(); aId.IsValid(myWires.Nb()); ++aId)
+    if (!myWires.Get(aId).IsRemoved)
       ++myWires.NbActive;
-  const int aNbFaces = myFaces.Nb();
-  for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaces); ++aFaceId)
-    if (!myFaces.Get(aFaceId).IsRemoved)
+  for (BRepGraph_FaceId aId = BRepGraph_FaceId::Start(); aId.IsValid(myFaces.Nb()); ++aId)
+    if (!myFaces.Get(aId).IsRemoved)
       ++myFaces.NbActive;
-  const int aNbShells = myShells.Nb();
-  for (BRepGraph_ShellId aShellId(0); aShellId.IsValid(aNbShells); ++aShellId)
-    if (!myShells.Get(aShellId).IsRemoved)
+  for (BRepGraph_ShellId aId = BRepGraph_ShellId::Start(); aId.IsValid(myShells.Nb()); ++aId)
+    if (!myShells.Get(aId).IsRemoved)
       ++myShells.NbActive;
-  const int aNbSolids = mySolids.Nb();
-  for (BRepGraph_SolidId aSolidId(0); aSolidId.IsValid(aNbSolids); ++aSolidId)
-    if (!mySolids.Get(aSolidId).IsRemoved)
+  for (BRepGraph_SolidId aId = BRepGraph_SolidId::Start(); aId.IsValid(mySolids.Nb()); ++aId)
+    if (!mySolids.Get(aId).IsRemoved)
       ++mySolids.NbActive;
-  const int aNbCompounds = myCompounds.Nb();
-  for (BRepGraph_CompoundId aCompoundId(0); aCompoundId.IsValid(aNbCompounds); ++aCompoundId)
-    if (!myCompounds.Get(aCompoundId).IsRemoved)
+  for (BRepGraph_CompoundId aId = BRepGraph_CompoundId::Start(); aId.IsValid(myCompounds.Nb()); ++aId)
+    if (!myCompounds.Get(aId).IsRemoved)
       ++myCompounds.NbActive;
-  const int aNbCompSolids = myCompSolids.Nb();
-  for (BRepGraph_CompSolidId aCompSolidId(0); aCompSolidId.IsValid(aNbCompSolids); ++aCompSolidId)
-    if (!myCompSolids.Get(aCompSolidId).IsRemoved)
+  for (BRepGraph_CompSolidId aId = BRepGraph_CompSolidId::Start();
+       aId.IsValid(myCompSolids.Nb()); ++aId)
+    if (!myCompSolids.Get(aId).IsRemoved)
       ++myCompSolids.NbActive;
-  const int aNbProducts = myProducts.Nb();
-  for (BRepGraph_ProductId aProductId(0); aProductId.IsValid(aNbProducts); ++aProductId)
-    if (!myProducts.Get(aProductId).IsRemoved)
+  for (BRepGraph_ProductId aId = BRepGraph_ProductId::Start(); aId.IsValid(myProducts.Nb()); ++aId)
+    if (!myProducts.Get(aId).IsRemoved)
       ++myProducts.NbActive;
-  const int aNbOccurrences = myOccurrences.Nb();
-  for (BRepGraph_OccurrenceId anOccurrenceId(0); anOccurrenceId.IsValid(aNbOccurrences);
-       ++anOccurrenceId)
-    if (!myOccurrences.Get(anOccurrenceId).IsRemoved)
+  for (BRepGraph_OccurrenceId aId = BRepGraph_OccurrenceId::Start();
+       aId.IsValid(myOccurrences.Nb()); ++aId)
+    if (!myOccurrences.Get(aId).IsRemoved)
       ++myOccurrences.NbActive;
-  const int aNbSurfaces = mySurfaces.Nb();
-  for (BRepGraph_SurfaceRepId aSurfaceRepId(0); aSurfaceRepId.IsValid(aNbSurfaces); ++aSurfaceRepId)
-    if (!mySurfaces.Get(aSurfaceRepId).IsRemoved)
+  for (BRepGraph_SurfaceRepId aId = BRepGraph_SurfaceRepId::Start();
+       aId.IsValid(mySurfaces.Nb()); ++aId)
+    if (!mySurfaces.Get(aId).IsRemoved)
       ++mySurfaces.NbActive;
-  const int aNbCurves3D = myCurves3D.Nb();
-  for (BRepGraph_Curve3DRepId aCurve3DRepId(0); aCurve3DRepId.IsValid(aNbCurves3D); ++aCurve3DRepId)
-    if (!myCurves3D.Get(aCurve3DRepId).IsRemoved)
+  for (BRepGraph_Curve3DRepId aId = BRepGraph_Curve3DRepId::Start();
+       aId.IsValid(myCurves3D.Nb()); ++aId)
+    if (!myCurves3D.Get(aId).IsRemoved)
       ++myCurves3D.NbActive;
-  const int aNbCurves2D = myCurves2D.Nb();
-  for (BRepGraph_Curve2DRepId aCurve2DRepId(0); aCurve2DRepId.IsValid(aNbCurves2D); ++aCurve2DRepId)
-    if (!myCurves2D.Get(aCurve2DRepId).IsRemoved)
+  for (BRepGraph_Curve2DRepId aId = BRepGraph_Curve2DRepId::Start();
+       aId.IsValid(myCurves2D.Nb()); ++aId)
+    if (!myCurves2D.Get(aId).IsRemoved)
       ++myCurves2D.NbActive;
-  const int aNbTriangulations = myTriangulationsRep.Nb();
-  for (BRepGraph_TriangulationRepId aTriangulationRepId(0);
-       aTriangulationRepId.IsValid(aNbTriangulations);
-       ++aTriangulationRepId)
-    if (!myTriangulationsRep.Get(aTriangulationRepId).IsRemoved)
+  for (BRepGraph_TriangulationRepId aId = BRepGraph_TriangulationRepId::Start();
+       aId.IsValid(myTriangulationsRep.Nb()); ++aId)
+    if (!myTriangulationsRep.Get(aId).IsRemoved)
       ++myTriangulationsRep.NbActive;
-  const int aNbPolygons3D = myPolygons3D.Nb();
-  for (BRepGraph_Polygon3DRepId aPolygon3DRepId(0); aPolygon3DRepId.IsValid(aNbPolygons3D);
-       ++aPolygon3DRepId)
-    if (!myPolygons3D.Get(aPolygon3DRepId).IsRemoved)
+  for (BRepGraph_Polygon3DRepId aId = BRepGraph_Polygon3DRepId::Start();
+       aId.IsValid(myPolygons3D.Nb()); ++aId)
+    if (!myPolygons3D.Get(aId).IsRemoved)
       ++myPolygons3D.NbActive;
-  const int aNbPolygons2D = myPolygons2D.Nb();
-  for (BRepGraph_Polygon2DRepId aPolygon2DRepId(0); aPolygon2DRepId.IsValid(aNbPolygons2D);
-       ++aPolygon2DRepId)
-    if (!myPolygons2D.Get(aPolygon2DRepId).IsRemoved)
+  for (BRepGraph_Polygon2DRepId aId = BRepGraph_Polygon2DRepId::Start();
+       aId.IsValid(myPolygons2D.Nb()); ++aId)
+    if (!myPolygons2D.Get(aId).IsRemoved)
       ++myPolygons2D.NbActive;
-  const int aNbPolygonsOnTri = myPolygonsOnTri.Nb();
-  for (BRepGraph_PolygonOnTriRepId aPolygonOnTriRepId(0);
-       aPolygonOnTriRepId.IsValid(aNbPolygonsOnTri);
-       ++aPolygonOnTriRepId)
-    if (!myPolygonsOnTri.Get(aPolygonOnTriRepId).IsRemoved)
+  for (BRepGraph_PolygonOnTriRepId aId = BRepGraph_PolygonOnTriRepId::Start();
+       aId.IsValid(myPolygonsOnTri.Nb()); ++aId)
+    if (!myPolygonsOnTri.Get(aId).IsRemoved)
       ++myPolygonsOnTri.NbActive;
 }
 
 //=================================================================================================
 
-void BRepGraphInc_Storage::BuildDeltaReverseIndex(const int theOldNbEdges,
-                                                  const int theOldNbWires,
-                                                  const int theOldNbFaces,
-                                                  const int theOldNbShells,
-                                                  const int theOldNbSolids,
-                                                  const int theOldNbCompounds,
-                                                  const int theOldNbCompSolids,
-                                                  const int theOldNbChildRefs,
-                                                  const int theOldNbSolidRefs)
+void BRepGraphInc_Storage::BuildDeltaReverseIndex(const uint32_t theOldNbEdges,
+                                                  const uint32_t theOldNbWires,
+                                                  const uint32_t theOldNbFaces,
+                                                  const uint32_t theOldNbShells,
+                                                  const uint32_t theOldNbSolids,
+                                                  const uint32_t theOldNbCompounds,
+                                                  const uint32_t theOldNbCompSolids,
+                                                  const uint32_t theOldNbChildRefs,
+                                                  const uint32_t theOldNbSolidRefs)
 {
   // Ensure allocator is set for reverse index inner vectors.
   // BuildReverseIndex() always calls SetAllocator(), but when
@@ -634,8 +618,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
   }
 
   // Wire -> CoEdge and Edge -> CoEdge coherence via coedge ref entries.
-  const int aNbCoEdgeRefs = myCoEdgeRefs.Nb();
-  for (BRepGraph_CoEdgeRefId aCoEdgeRefId(0); aCoEdgeRefId.IsValid(aNbCoEdgeRefs); ++aCoEdgeRefId)
+  for (BRepGraph_CoEdgeRefId aCoEdgeRefId = BRepGraph_CoEdgeRefId::Start();
+       aCoEdgeRefId.IsValid(myCoEdgeRefs.Nb()); ++aCoEdgeRefId)
   {
     const BRepGraphInc::CoEdgeRef& aRef = myCoEdgeRefs.Get(aCoEdgeRefId);
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
@@ -643,8 +627,7 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
     {
       continue;
     }
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= myWires.Nb() || aRef.CoEdgeDefId.Index < 0
-        || aRef.CoEdgeDefId.Index >= myCoEdges.Nb())
+    if (!aRef.ParentId.IsValid(myWires.Nb()) || !aRef.CoEdgeDefId.IsValid(myCoEdges.Nb()))
     {
       return false;
     }
@@ -668,8 +651,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
   }
 
   // Reverse Edge -> CoEdges entries must point back to active CoEdges.
-  const int aNbEdges = myEdges.Nb();
-  for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
+       anEdgeId.IsValid(myEdges.Nb()); ++anEdgeId)
   {
     const NCollection_Vector<BRepGraph_CoEdgeId>* aCoEdges = myReverseIdx.CoEdgesOfEdge(anEdgeId);
     if (aCoEdges == nullptr)
@@ -678,14 +661,13 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
     }
     for (const BRepGraph_CoEdgeId& aCoEdgeElem : *aCoEdges)
     {
-      const int aRefIdx = aCoEdgeElem.Index;
-      if (aRefIdx < 0 || aRefIdx >= myCoEdges.Nb())
+      if (!aCoEdgeElem.IsValid(myCoEdges.Nb()))
       {
         return false;
       }
       const BRepGraphInc::CoEdgeDef& aCoEdge = myCoEdges.Get(aCoEdgeElem);
       if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid()
-          || aCoEdge.EdgeDefId.Index != anEdgeId.Index)
+          || aCoEdge.EdgeDefId != anEdgeId)
       {
         return false;
       }
@@ -693,8 +675,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
   }
 
   // Compound child reverse maps via child ref entries.
-  const int aNbChildRefs = myChildRefs.Nb();
-  for (BRepGraph_ChildRefId aChildRefId(0); aChildRefId.IsValid(aNbChildRefs); ++aChildRefId)
+  for (BRepGraph_ChildRefId aChildRefId = BRepGraph_ChildRefId::Start();
+       aChildRefId.IsValid(myChildRefs.Nb()); ++aChildRefId)
   {
     const BRepGraphInc::ChildRef& aRef = myChildRefs.Get(aChildRefId);
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
@@ -702,7 +684,7 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
     {
       continue;
     }
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= myCompounds.Nb())
+    if (!aRef.ParentId.IsValid(myCompounds.Nb()))
     {
       return false;
     }
@@ -786,8 +768,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
   }
 
   // CompSolid -> Solid reverse map via solid ref entries.
-  const int aNbSolidRefs = mySolidRefs.Nb();
-  for (BRepGraph_SolidRefId aSolidRefId(0); aSolidRefId.IsValid(aNbSolidRefs); ++aSolidRefId)
+  for (BRepGraph_SolidRefId aSolidRefId = BRepGraph_SolidRefId::Start();
+       aSolidRefId.IsValid(mySolidRefs.Nb()); ++aSolidRefId)
   {
     const BRepGraphInc::SolidRef& aRef = mySolidRefs.Get(aSolidRefId);
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
@@ -796,8 +778,7 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
     {
       continue;
     }
-    if (aRef.ParentId.Index < 0 || aRef.ParentId.Index >= myCompSolids.Nb()
-        || aRef.SolidDefId.Index < 0 || aRef.SolidDefId.Index >= mySolids.Nb())
+    if (!aRef.ParentId.IsValid(myCompSolids.Nb()) || !aRef.SolidDefId.IsValid(mySolids.Nb()))
     {
       return false;
     }
@@ -826,7 +807,7 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
       }
       if (anOcc.ChildDefId.NodeKind == BRepGraph_NodeId::Kind::Product)
       {
-        if (anOcc.ChildDefId.Index >= myProducts.Nb())
+        if (!anOcc.ChildDefId.IsValid(myProducts.Nb()))
         {
           return false;
         }
@@ -843,8 +824,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
 
   // Reverse Product -> Occurrences entries must point to active occurrences
   // that reference the same product.
-  const int aNbProducts = myProducts.Nb();
-  for (BRepGraph_ProductId aProductId(0); aProductId.IsValid(aNbProducts); ++aProductId)
+  for (BRepGraph_ProductId aProductId = BRepGraph_ProductId::Start();
+       aProductId.IsValid(myProducts.Nb()); ++aProductId)
   {
     const NCollection_Vector<BRepGraph_OccurrenceId>* anOccs =
       myReverseIdx.OccurrencesOfProduct(aProductId);
@@ -854,15 +835,14 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
     }
     for (const BRepGraph_OccurrenceId& anOccElem : *anOccs)
     {
-      const int anOccIdx = anOccElem.Index;
-      if (anOccIdx < 0 || anOccIdx >= myOccurrences.Nb())
+      if (!anOccElem.IsValid(myOccurrences.Nb()))
       {
         return false;
       }
       const BRepGraphInc::OccurrenceDef& anOcc = myOccurrences.Get(anOccElem);
       if (anOcc.IsRemoved || !anOcc.ChildDefId.IsValid()
           || anOcc.ChildDefId.NodeKind != BRepGraph_NodeId::Kind::Product
-          || anOcc.ChildDefId.Index != aProductId.Index)
+          || anOcc.ChildDefId != aProductId)
       {
         return false;
       }

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.cxx
@@ -500,46 +500,52 @@ void BRepGraphInc_Storage::BuildReverseIndex()
   for (BRepGraph_SolidId aId = BRepGraph_SolidId::Start(); aId.IsValid(mySolids.Nb()); ++aId)
     if (!mySolids.Get(aId).IsRemoved)
       ++mySolids.NbActive;
-  for (BRepGraph_CompoundId aId = BRepGraph_CompoundId::Start(); aId.IsValid(myCompounds.Nb()); ++aId)
+  for (BRepGraph_CompoundId aId = BRepGraph_CompoundId::Start(); aId.IsValid(myCompounds.Nb());
+       ++aId)
     if (!myCompounds.Get(aId).IsRemoved)
       ++myCompounds.NbActive;
-  for (BRepGraph_CompSolidId aId = BRepGraph_CompSolidId::Start();
-       aId.IsValid(myCompSolids.Nb()); ++aId)
+  for (BRepGraph_CompSolidId aId = BRepGraph_CompSolidId::Start(); aId.IsValid(myCompSolids.Nb());
+       ++aId)
     if (!myCompSolids.Get(aId).IsRemoved)
       ++myCompSolids.NbActive;
   for (BRepGraph_ProductId aId = BRepGraph_ProductId::Start(); aId.IsValid(myProducts.Nb()); ++aId)
     if (!myProducts.Get(aId).IsRemoved)
       ++myProducts.NbActive;
   for (BRepGraph_OccurrenceId aId = BRepGraph_OccurrenceId::Start();
-       aId.IsValid(myOccurrences.Nb()); ++aId)
+       aId.IsValid(myOccurrences.Nb());
+       ++aId)
     if (!myOccurrences.Get(aId).IsRemoved)
       ++myOccurrences.NbActive;
-  for (BRepGraph_SurfaceRepId aId = BRepGraph_SurfaceRepId::Start();
-       aId.IsValid(mySurfaces.Nb()); ++aId)
+  for (BRepGraph_SurfaceRepId aId = BRepGraph_SurfaceRepId::Start(); aId.IsValid(mySurfaces.Nb());
+       ++aId)
     if (!mySurfaces.Get(aId).IsRemoved)
       ++mySurfaces.NbActive;
-  for (BRepGraph_Curve3DRepId aId = BRepGraph_Curve3DRepId::Start();
-       aId.IsValid(myCurves3D.Nb()); ++aId)
+  for (BRepGraph_Curve3DRepId aId = BRepGraph_Curve3DRepId::Start(); aId.IsValid(myCurves3D.Nb());
+       ++aId)
     if (!myCurves3D.Get(aId).IsRemoved)
       ++myCurves3D.NbActive;
-  for (BRepGraph_Curve2DRepId aId = BRepGraph_Curve2DRepId::Start();
-       aId.IsValid(myCurves2D.Nb()); ++aId)
+  for (BRepGraph_Curve2DRepId aId = BRepGraph_Curve2DRepId::Start(); aId.IsValid(myCurves2D.Nb());
+       ++aId)
     if (!myCurves2D.Get(aId).IsRemoved)
       ++myCurves2D.NbActive;
   for (BRepGraph_TriangulationRepId aId = BRepGraph_TriangulationRepId::Start();
-       aId.IsValid(myTriangulationsRep.Nb()); ++aId)
+       aId.IsValid(myTriangulationsRep.Nb());
+       ++aId)
     if (!myTriangulationsRep.Get(aId).IsRemoved)
       ++myTriangulationsRep.NbActive;
   for (BRepGraph_Polygon3DRepId aId = BRepGraph_Polygon3DRepId::Start();
-       aId.IsValid(myPolygons3D.Nb()); ++aId)
+       aId.IsValid(myPolygons3D.Nb());
+       ++aId)
     if (!myPolygons3D.Get(aId).IsRemoved)
       ++myPolygons3D.NbActive;
   for (BRepGraph_Polygon2DRepId aId = BRepGraph_Polygon2DRepId::Start();
-       aId.IsValid(myPolygons2D.Nb()); ++aId)
+       aId.IsValid(myPolygons2D.Nb());
+       ++aId)
     if (!myPolygons2D.Get(aId).IsRemoved)
       ++myPolygons2D.NbActive;
   for (BRepGraph_PolygonOnTriRepId aId = BRepGraph_PolygonOnTriRepId::Start();
-       aId.IsValid(myPolygonsOnTri.Nb()); ++aId)
+       aId.IsValid(myPolygonsOnTri.Nb());
+       ++aId)
     if (!myPolygonsOnTri.Get(aId).IsRemoved)
       ++myPolygonsOnTri.NbActive;
 }
@@ -619,7 +625,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
 
   // Wire -> CoEdge and Edge -> CoEdge coherence via coedge ref entries.
   for (BRepGraph_CoEdgeRefId aCoEdgeRefId = BRepGraph_CoEdgeRefId::Start();
-       aCoEdgeRefId.IsValid(myCoEdgeRefs.Nb()); ++aCoEdgeRefId)
+       aCoEdgeRefId.IsValid(myCoEdgeRefs.Nb());
+       ++aCoEdgeRefId)
   {
     const BRepGraphInc::CoEdgeRef& aRef = myCoEdgeRefs.Get(aCoEdgeRefId);
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
@@ -651,8 +658,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
   }
 
   // Reverse Edge -> CoEdges entries must point back to active CoEdges.
-  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
-       anEdgeId.IsValid(myEdges.Nb()); ++anEdgeId)
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start(); anEdgeId.IsValid(myEdges.Nb());
+       ++anEdgeId)
   {
     const NCollection_Vector<BRepGraph_CoEdgeId>* aCoEdges = myReverseIdx.CoEdgesOfEdge(anEdgeId);
     if (aCoEdges == nullptr)
@@ -666,8 +673,7 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
         return false;
       }
       const BRepGraphInc::CoEdgeDef& aCoEdge = myCoEdges.Get(aCoEdgeElem);
-      if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid()
-          || aCoEdge.EdgeDefId != anEdgeId)
+      if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid() || aCoEdge.EdgeDefId != anEdgeId)
       {
         return false;
       }
@@ -676,7 +682,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
 
   // Compound child reverse maps via child ref entries.
   for (BRepGraph_ChildRefId aChildRefId = BRepGraph_ChildRefId::Start();
-       aChildRefId.IsValid(myChildRefs.Nb()); ++aChildRefId)
+       aChildRefId.IsValid(myChildRefs.Nb());
+       ++aChildRefId)
   {
     const BRepGraphInc::ChildRef& aRef = myChildRefs.Get(aChildRefId);
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
@@ -769,7 +776,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
 
   // CompSolid -> Solid reverse map via solid ref entries.
   for (BRepGraph_SolidRefId aSolidRefId = BRepGraph_SolidRefId::Start();
-       aSolidRefId.IsValid(mySolidRefs.Nb()); ++aSolidRefId)
+       aSolidRefId.IsValid(mySolidRefs.Nb());
+       ++aSolidRefId)
   {
     const BRepGraphInc::SolidRef& aRef = mySolidRefs.Get(aSolidRefId);
     if (aRef.IsRemoved || !aRef.ParentId.IsValid()
@@ -825,7 +833,8 @@ bool BRepGraphInc_Storage::ValidateReverseIndex() const
   // Reverse Product -> Occurrences entries must point to active occurrences
   // that reference the same product.
   for (BRepGraph_ProductId aProductId = BRepGraph_ProductId::Start();
-       aProductId.IsValid(myProducts.Nb()); ++aProductId)
+       aProductId.IsValid(myProducts.Nb());
+       ++aProductId)
   {
     const NCollection_Vector<BRepGraph_OccurrenceId>* anOccs =
       myReverseIdx.OccurrencesOfProduct(aProductId);

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.hxx
@@ -61,160 +61,160 @@ public:
   }
 
   //! Returns the total number of vertex entities (including removed).
-  [[nodiscard]] int NbVertices() const { return myVertices.Nb(); }
+  [[nodiscard]] uint32_t NbVertices() const { return myVertices.Nb(); }
 
   //! Returns the total number of edge entities (including removed).
-  [[nodiscard]] int NbEdges() const { return myEdges.Nb(); }
+  [[nodiscard]] uint32_t NbEdges() const { return myEdges.Nb(); }
 
   //! Returns the total number of coedge entities (including removed).
-  [[nodiscard]] int NbCoEdges() const { return myCoEdges.Nb(); }
+  [[nodiscard]] uint32_t NbCoEdges() const { return myCoEdges.Nb(); }
 
   //! Returns the total number of wire entities (including removed).
-  [[nodiscard]] int NbWires() const { return myWires.Nb(); }
+  [[nodiscard]] uint32_t NbWires() const { return myWires.Nb(); }
 
   //! Returns the total number of face entities (including removed).
-  [[nodiscard]] int NbFaces() const { return myFaces.Nb(); }
+  [[nodiscard]] uint32_t NbFaces() const { return myFaces.Nb(); }
 
   //! Returns the total number of shell entities (including removed).
-  [[nodiscard]] int NbShells() const { return myShells.Nb(); }
+  [[nodiscard]] uint32_t NbShells() const { return myShells.Nb(); }
 
   //! Returns the total number of solid entities (including removed).
-  [[nodiscard]] int NbSolids() const { return mySolids.Nb(); }
+  [[nodiscard]] uint32_t NbSolids() const { return mySolids.Nb(); }
 
   //! Returns the total number of compound entities (including removed).
-  [[nodiscard]] int NbCompounds() const { return myCompounds.Nb(); }
+  [[nodiscard]] uint32_t NbCompounds() const { return myCompounds.Nb(); }
 
   //! Returns the total number of compsolid entities (including removed).
-  [[nodiscard]] int NbCompSolids() const { return myCompSolids.Nb(); }
+  [[nodiscard]] uint32_t NbCompSolids() const { return myCompSolids.Nb(); }
 
   //! Returns the total number of product entities (including removed).
-  [[nodiscard]] int NbProducts() const { return myProducts.Nb(); }
+  [[nodiscard]] uint32_t NbProducts() const { return myProducts.Nb(); }
 
   //! Returns the total number of occurrence entities (including removed).
-  [[nodiscard]] int NbOccurrences() const { return myOccurrences.Nb(); }
+  [[nodiscard]] uint32_t NbOccurrences() const { return myOccurrences.Nb(); }
 
   //! Returns the total number of shell reference entries (including removed).
-  [[nodiscard]] int NbShellRefs() const { return myShellRefs.Nb(); }
+  [[nodiscard]] uint32_t NbShellRefs() const { return myShellRefs.Nb(); }
 
   //! Returns the total number of face reference entries (including removed).
-  [[nodiscard]] int NbFaceRefs() const { return myFaceRefs.Nb(); }
+  [[nodiscard]] uint32_t NbFaceRefs() const { return myFaceRefs.Nb(); }
 
   //! Returns the total number of wire reference entries (including removed).
-  [[nodiscard]] int NbWireRefs() const { return myWireRefs.Nb(); }
+  [[nodiscard]] uint32_t NbWireRefs() const { return myWireRefs.Nb(); }
 
   //! Returns the total number of coedge reference entries (including removed).
-  [[nodiscard]] int NbCoEdgeRefs() const { return myCoEdgeRefs.Nb(); }
+  [[nodiscard]] uint32_t NbCoEdgeRefs() const { return myCoEdgeRefs.Nb(); }
 
   //! Returns the total number of vertex reference entries (including removed).
-  [[nodiscard]] int NbVertexRefs() const { return myVertexRefs.Nb(); }
+  [[nodiscard]] uint32_t NbVertexRefs() const { return myVertexRefs.Nb(); }
 
   //! Returns the total number of solid reference entries (including removed).
-  [[nodiscard]] int NbSolidRefs() const { return mySolidRefs.Nb(); }
+  [[nodiscard]] uint32_t NbSolidRefs() const { return mySolidRefs.Nb(); }
 
   //! Returns the total number of child reference entries (including removed).
-  [[nodiscard]] int NbChildRefs() const { return myChildRefs.Nb(); }
+  [[nodiscard]] uint32_t NbChildRefs() const { return myChildRefs.Nb(); }
 
   //! Returns the total number of occurrence reference entries (including removed).
-  [[nodiscard]] int NbOccurrenceRefs() const { return myOccurrenceRefs.Nb(); }
+  [[nodiscard]] uint32_t NbOccurrenceRefs() const { return myOccurrenceRefs.Nb(); }
 
   //! Returns the total number of surface representations.
-  [[nodiscard]] int NbSurfaces() const { return mySurfaces.Nb(); }
+  [[nodiscard]] uint32_t NbSurfaces() const { return mySurfaces.Nb(); }
 
   //! Returns the total number of 3D curve representations.
-  [[nodiscard]] int NbCurves3D() const { return myCurves3D.Nb(); }
+  [[nodiscard]] uint32_t NbCurves3D() const { return myCurves3D.Nb(); }
 
   //! Returns the total number of 2D curve representations.
-  [[nodiscard]] int NbCurves2D() const { return myCurves2D.Nb(); }
+  [[nodiscard]] uint32_t NbCurves2D() const { return myCurves2D.Nb(); }
 
   //! Returns the total number of triangulation representations.
-  [[nodiscard]] int NbTriangulations() const { return myTriangulationsRep.Nb(); }
+  [[nodiscard]] uint32_t NbTriangulations() const { return myTriangulationsRep.Nb(); }
 
   //! Returns the total number of 3D polygon representations.
-  [[nodiscard]] int NbPolygons3D() const { return myPolygons3D.Nb(); }
+  [[nodiscard]] uint32_t NbPolygons3D() const { return myPolygons3D.Nb(); }
 
   //! Returns the total number of 2D polygon representations.
-  [[nodiscard]] int NbPolygons2D() const { return myPolygons2D.Nb(); }
+  [[nodiscard]] uint32_t NbPolygons2D() const { return myPolygons2D.Nb(); }
 
   //! Returns the total number of polygon-on-triangulation representations.
-  [[nodiscard]] int NbPolygonsOnTri() const { return myPolygonsOnTri.Nb(); }
+  [[nodiscard]] uint32_t NbPolygonsOnTri() const { return myPolygonsOnTri.Nb(); }
 
   //! Returns the number of active surface representations (excluding removed).
-  [[nodiscard]] int NbActiveSurfaces() const { return mySurfaces.NbActive; }
+  [[nodiscard]] uint32_t NbActiveSurfaces() const { return mySurfaces.NbActive; }
 
   //! Returns the number of active 3D curve representations (excluding removed).
-  [[nodiscard]] int NbActiveCurves3D() const { return myCurves3D.NbActive; }
+  [[nodiscard]] uint32_t NbActiveCurves3D() const { return myCurves3D.NbActive; }
 
   //! Returns the number of active 2D curve representations (excluding removed).
-  [[nodiscard]] int NbActiveCurves2D() const { return myCurves2D.NbActive; }
+  [[nodiscard]] uint32_t NbActiveCurves2D() const { return myCurves2D.NbActive; }
 
   //! Returns the number of active triangulation representations (excluding removed).
-  [[nodiscard]] int NbActiveTriangulations() const { return myTriangulationsRep.NbActive; }
+  [[nodiscard]] uint32_t NbActiveTriangulations() const { return myTriangulationsRep.NbActive; }
 
   //! Returns the number of active 3D polygon representations (excluding removed).
-  [[nodiscard]] int NbActivePolygons3D() const { return myPolygons3D.NbActive; }
+  [[nodiscard]] uint32_t NbActivePolygons3D() const { return myPolygons3D.NbActive; }
 
   //! Returns the number of active 2D polygon representations (excluding removed).
-  [[nodiscard]] int NbActivePolygons2D() const { return myPolygons2D.NbActive; }
+  [[nodiscard]] uint32_t NbActivePolygons2D() const { return myPolygons2D.NbActive; }
 
   //! Returns the number of active polygon-on-triangulation representations (excluding removed).
-  [[nodiscard]] int NbActivePolygonsOnTri() const { return myPolygonsOnTri.NbActive; }
+  [[nodiscard]] uint32_t NbActivePolygonsOnTri() const { return myPolygonsOnTri.NbActive; }
 
   //! Returns the number of active vertex entities (excluding removed).
-  [[nodiscard]] int NbActiveVertices() const { return myVertices.NbActive; }
+  [[nodiscard]] uint32_t NbActiveVertices() const { return myVertices.NbActive; }
 
   //! Returns the number of active edge entities (excluding removed).
-  [[nodiscard]] int NbActiveEdges() const { return myEdges.NbActive; }
+  [[nodiscard]] uint32_t NbActiveEdges() const { return myEdges.NbActive; }
 
   //! Returns the number of active coedge entities (excluding removed).
-  [[nodiscard]] int NbActiveCoEdges() const { return myCoEdges.NbActive; }
+  [[nodiscard]] uint32_t NbActiveCoEdges() const { return myCoEdges.NbActive; }
 
   //! Returns the number of active wire entities (excluding removed).
-  [[nodiscard]] int NbActiveWires() const { return myWires.NbActive; }
+  [[nodiscard]] uint32_t NbActiveWires() const { return myWires.NbActive; }
 
   //! Returns the number of active face entities (excluding removed).
-  [[nodiscard]] int NbActiveFaces() const { return myFaces.NbActive; }
+  [[nodiscard]] uint32_t NbActiveFaces() const { return myFaces.NbActive; }
 
   //! Returns the number of active shell entities (excluding removed).
-  [[nodiscard]] int NbActiveShells() const { return myShells.NbActive; }
+  [[nodiscard]] uint32_t NbActiveShells() const { return myShells.NbActive; }
 
   //! Returns the number of active solid entities (excluding removed).
-  [[nodiscard]] int NbActiveSolids() const { return mySolids.NbActive; }
+  [[nodiscard]] uint32_t NbActiveSolids() const { return mySolids.NbActive; }
 
   //! Returns the number of active compound entities (excluding removed).
-  [[nodiscard]] int NbActiveCompounds() const { return myCompounds.NbActive; }
+  [[nodiscard]] uint32_t NbActiveCompounds() const { return myCompounds.NbActive; }
 
   //! Returns the number of active compsolid entities (excluding removed).
-  [[nodiscard]] int NbActiveCompSolids() const { return myCompSolids.NbActive; }
+  [[nodiscard]] uint32_t NbActiveCompSolids() const { return myCompSolids.NbActive; }
 
   //! Returns the number of active product entities (excluding removed).
-  [[nodiscard]] int NbActiveProducts() const { return myProducts.NbActive; }
+  [[nodiscard]] uint32_t NbActiveProducts() const { return myProducts.NbActive; }
 
   //! Returns the number of active occurrence entities (excluding removed).
-  [[nodiscard]] int NbActiveOccurrences() const { return myOccurrences.NbActive; }
+  [[nodiscard]] uint32_t NbActiveOccurrences() const { return myOccurrences.NbActive; }
 
   //! Returns the number of active shell reference entries (excluding removed).
-  [[nodiscard]] int NbActiveShellRefs() const { return myShellRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveShellRefs() const { return myShellRefs.NbActive; }
 
   //! Returns the number of active face reference entries (excluding removed).
-  [[nodiscard]] int NbActiveFaceRefs() const { return myFaceRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveFaceRefs() const { return myFaceRefs.NbActive; }
 
   //! Returns the number of active wire reference entries (excluding removed).
-  [[nodiscard]] int NbActiveWireRefs() const { return myWireRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveWireRefs() const { return myWireRefs.NbActive; }
 
   //! Returns the number of active coedge reference entries (excluding removed).
-  [[nodiscard]] int NbActiveCoEdgeRefs() const { return myCoEdgeRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveCoEdgeRefs() const { return myCoEdgeRefs.NbActive; }
 
   //! Returns the number of active vertex reference entries (excluding removed).
-  [[nodiscard]] int NbActiveVertexRefs() const { return myVertexRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveVertexRefs() const { return myVertexRefs.NbActive; }
 
   //! Returns the number of active solid reference entries (excluding removed).
-  [[nodiscard]] int NbActiveSolidRefs() const { return mySolidRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveSolidRefs() const { return mySolidRefs.NbActive; }
 
   //! Returns the number of active child reference entries (excluding removed).
-  [[nodiscard]] int NbActiveChildRefs() const { return myChildRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveChildRefs() const { return myChildRefs.NbActive; }
 
   //! Returns the number of active occurrence reference entries (excluding removed).
-  [[nodiscard]] int NbActiveOccurrenceRefs() const { return myOccurrenceRefs.NbActive; }
+  [[nodiscard]] uint32_t NbActiveOccurrenceRefs() const { return myOccurrenceRefs.NbActive; }
 
   //! Mark an entity node as removed and decrement its active counter once.
   //! @param[in] theNodeId typed entity id
@@ -792,15 +792,15 @@ public:
   //! BuildReverseIndex(). Only processes entities and refs from the old counts to the
   //! current vector lengths - the caller must snapshot ChildRef / SolidRef counts before
   //! any Append so this remains O(delta), not O(total).
-  Standard_EXPORT void BuildDeltaReverseIndex(const int theOldNbEdges,
-                                              const int theOldNbWires,
-                                              const int theOldNbFaces,
-                                              const int theOldNbShells,
-                                              const int theOldNbSolids,
-                                              const int theOldNbCompounds,
-                                              const int theOldNbCompSolids,
-                                              const int theOldNbChildRefs,
-                                              const int theOldNbSolidRefs);
+  Standard_EXPORT void BuildDeltaReverseIndex(const uint32_t theOldNbEdges,
+                                              const uint32_t theOldNbWires,
+                                              const uint32_t theOldNbFaces,
+                                              const uint32_t theOldNbShells,
+                                              const uint32_t theOldNbSolids,
+                                              const uint32_t theOldNbCompounds,
+                                              const uint32_t theOldNbCompSolids,
+                                              const uint32_t theOldNbChildRefs,
+                                              const uint32_t theOldNbSolidRefs);
 
   //! Debug: verify reverse index consistency against entity tables.
   //! @return true if all forward refs have matching reverse entries
@@ -822,7 +822,7 @@ private:
 
     NCollection_Vector<EntityT>       Entities;
     NCollection_Vector<BRepGraph_UID> UIDs;
-    int                               NbActive = 0;
+    uint32_t                          NbActive = 0;
 
     DefStore() = default;
 
@@ -832,16 +832,22 @@ private:
     {
     }
 
-    int Nb() const { return Entities.Length(); }
+    uint32_t Nb() const { return static_cast<uint32_t>(Entities.Size()); }
 
-    const EntityT& Get(const TypeId theId) const { return Entities.Value(theId.Index); }
+    const EntityT& Get(const TypeId theId) const
+    {
+      return Entities.Value(static_cast<size_t>(theId.Index));
+    }
 
-    EntityT& Change(const TypeId theId) { return Entities.ChangeValue(theId.Index); }
+    EntityT& Change(const TypeId theId)
+    {
+      return Entities.ChangeValue(static_cast<size_t>(theId.Index));
+    }
 
     //! Append a default-constructed entity and return its typed slot id.
     TypeId Append(const occ::handle<NCollection_BaseAllocator>& theAlloc)
     {
-      const TypeId anId(Entities.Length());
+      const TypeId anId(static_cast<uint32_t>(Entities.Size()));
       ++NbActive;
       Entities.Appended().InitVectors(theAlloc);
       return anId;
@@ -849,14 +855,14 @@ private:
 
     void DecrementActive()
     {
-      Standard_ASSERT_VOID(NbActive > 0, "DefStore::DecrementActive: underflow");
-      if (NbActive > 0)
+      Standard_ASSERT_VOID(NbActive > 0u, "DefStore::DecrementActive: underflow");
+      if (NbActive > 0u)
         --NbActive;
     }
 
     bool MarkRemoved(const TypeId theId)
     {
-      if (!theId.IsValid(Entities.Length()))
+      if (!theId.IsValid(Nb()))
       {
         return false;
       }
@@ -888,7 +894,7 @@ private:
     using ValueType = RepT;
 
     NCollection_Vector<RepT> Entities;
-    int                      NbActive = 0;
+    uint32_t                 NbActive = 0;
 
     RepStore() = default;
 
@@ -897,16 +903,19 @@ private:
     {
     }
 
-    int Nb() const { return Entities.Length(); }
+    uint32_t Nb() const { return static_cast<uint32_t>(Entities.Size()); }
 
-    const RepT& Get(const TypeId theId) const { return Entities.Value(theId.Index); }
+    const RepT& Get(const TypeId theId) const
+    {
+      return Entities.Value(static_cast<size_t>(theId.Index));
+    }
 
-    RepT& Change(const TypeId theId) { return Entities.ChangeValue(theId.Index); }
+    RepT& Change(const TypeId theId) { return Entities.ChangeValue(static_cast<size_t>(theId.Index)); }
 
     //! Append a default-constructed rep and return its typed slot id.
     TypeId Append()
     {
-      const TypeId anId(Entities.Length());
+      const TypeId anId(static_cast<uint32_t>(Entities.Size()));
       ++NbActive;
       Entities.Appended();
       return anId;
@@ -914,14 +923,14 @@ private:
 
     void DecrementActive()
     {
-      Standard_ASSERT_VOID(NbActive > 0, "RepStore::DecrementActive: underflow");
-      if (NbActive > 0)
+      Standard_ASSERT_VOID(NbActive > 0u, "RepStore::DecrementActive: underflow");
+      if (NbActive > 0u)
         --NbActive;
     }
 
     bool MarkRemoved(const TypeId theId)
     {
-      if (!theId.IsValid(Entities.Length()))
+      if (!theId.IsValid(Nb()))
       {
         return false;
       }
@@ -938,8 +947,8 @@ private:
 
     void EraseLast()
     {
-      Standard_ASSERT_VOID(NbActive > 0, "RepStore::EraseLast: underflow");
-      if (NbActive > 0)
+      Standard_ASSERT_VOID(NbActive > 0u, "RepStore::EraseLast: underflow");
+      if (NbActive > 0u)
       {
         Entities.EraseLast();
         --NbActive;
@@ -963,7 +972,7 @@ private:
 
     NCollection_Vector<RefT>             Refs;
     NCollection_Vector<BRepGraph_RefUID> UIDs;
-    int                                  NbActive = 0;
+    uint32_t                             NbActive = 0;
 
     RefStore() = default;
 
@@ -973,16 +982,19 @@ private:
     {
     }
 
-    int Nb() const { return Refs.Length(); }
+    uint32_t Nb() const { return static_cast<uint32_t>(Refs.Size()); }
 
-    const RefT& Get(const TypeId theId) const { return Refs.Value(theId.Index); }
+    const RefT& Get(const TypeId theId) const
+    {
+      return Refs.Value(static_cast<size_t>(theId.Index));
+    }
 
-    RefT& Change(const TypeId theId) { return Refs.ChangeValue(theId.Index); }
+    RefT& Change(const TypeId theId) { return Refs.ChangeValue(static_cast<size_t>(theId.Index)); }
 
     //! Append a default-constructed ref entry and return its typed slot id.
     TypeId Append()
     {
-      const TypeId anId(Refs.Length());
+      const TypeId anId(static_cast<uint32_t>(Refs.Size()));
       ++NbActive;
       Refs.Appended();
       return anId;
@@ -990,14 +1002,14 @@ private:
 
     void DecrementActive()
     {
-      Standard_ASSERT_VOID(NbActive > 0, "RefStore::DecrementActive: underflow");
-      if (NbActive > 0)
+      Standard_ASSERT_VOID(NbActive > 0u, "RefStore::DecrementActive: underflow");
+      if (NbActive > 0u)
         --NbActive;
     }
 
     bool MarkRemoved(const TypeId theId)
     {
-      if (!theId.IsValid(Refs.Length()))
+      if (!theId.IsValid(Nb()))
       {
         return false;
       }

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Storage.hxx
@@ -910,7 +910,10 @@ private:
       return Entities.Value(static_cast<size_t>(theId.Index));
     }
 
-    RepT& Change(const TypeId theId) { return Entities.ChangeValue(static_cast<size_t>(theId.Index)); }
+    RepT& Change(const TypeId theId)
+    {
+      return Entities.ChangeValue(static_cast<size_t>(theId.Index));
+    }
 
     //! Append a default-constructed rep and return its typed slot id.
     TypeId Append()

--- a/src/ModelingData/TKBRep/GTests/BRepGraphInc_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraphInc_Test.cxx
@@ -1348,7 +1348,8 @@ TEST(BRepGraphIncTest, ReverseIndex_CompSolid_ReverseMaintained_AfterBuild)
 
   // Both solids must appear in myCompSolidsOfSolid.
   for (BRepGraph_SolidId aSolidId = BRepGraph_SolidId::Start();
-       aSolidId.IsValid(aStorage.NbSolids()); ++aSolidId)
+       aSolidId.IsValid(aStorage.NbSolids());
+       ++aSolidId)
   {
     const NCollection_Vector<BRepGraph_CompSolidId>* aCSVec =
       aStorage.ReverseIndex().CompSolidsOfSolid(aSolidId);

--- a/src/ModelingData/TKBRep/GTests/BRepGraphInc_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraphInc_Test.cxx
@@ -1347,11 +1347,12 @@ TEST(BRepGraphIncTest, ReverseIndex_CompSolid_ReverseMaintained_AfterBuild)
   ASSERT_GE(aStorage.NbSolids(), 2);
 
   // Both solids must appear in myCompSolidsOfSolid.
-  for (int i = 0; i < aStorage.NbSolids(); ++i)
+  for (BRepGraph_SolidId aSolidId = BRepGraph_SolidId::Start();
+       aSolidId.IsValid(aStorage.NbSolids()); ++aSolidId)
   {
     const NCollection_Vector<BRepGraph_CompSolidId>* aCSVec =
-      aStorage.ReverseIndex().CompSolidsOfSolid(BRepGraph_SolidId(i));
-    EXPECT_NE(aCSVec, nullptr) << "Solid " << i << " not in any CompSolid";
+      aStorage.ReverseIndex().CompSolidsOfSolid(aSolidId);
+    EXPECT_NE(aCSVec, nullptr) << "Solid " << aSolidId.Index << " not in any CompSolid";
     if (aCSVec != nullptr)
     {
       EXPECT_EQ(aCSVec->Length(), 1);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Compact_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Compact_Test.cxx
@@ -18,7 +18,6 @@
 #include <Bnd_Box.hxx>
 #include <BRepGraph.hxx>
 #include <BRepGraph_EditorView.hxx>
-#include <BRepGraphAlgo_BndLib.hxx>
 #include <BRepGraph_TopoView.hxx>
 #include <BRepGraph_History.hxx>
 #include <BRepGraph_HistoryRecord.hxx>
@@ -90,6 +89,14 @@ int countHistoryRecordsByOp(const BRepGraph& theGraph, const TCollection_AsciiSt
       ++aCount;
   }
   return aCount;
+}
+
+void addGraphBounds(const BRepGraph& theGraph, Bnd_Box& theBox)
+{
+  for (BRepGraph_VertexIterator aVertIt(theGraph); aVertIt.More(); aVertIt.Next())
+  {
+    theBox.Add(theGraph.Topo().Vertices().Definition(aVertIt.CurrentId()).Point);
+  }
 }
 
 void expectBoxNear(const Bnd_Box& theLeft, const Bnd_Box& theRight, const double theTol)
@@ -252,17 +259,17 @@ TEST(BRepGraph_CompactTest, RemovalCompact_PreservesBounds_AndDoesNotGrowTopolog
 
   aGraph.Editor().Gen().RemoveNode(BRepGraph_FaceId(2));
 
-  const int aCoEdgesBeforeCompact = aGraph.Topo().CoEdges().Nb();
+  const uint32_t aCoEdgesBeforeCompact = aGraph.Topo().CoEdges().Nb();
 
   Bnd_Box aBoxBeforeCompact;
-  BRepGraphAlgo_BndLib::Add(aGraph, aBoxBeforeCompact);
+  addGraphBounds(aGraph, aBoxBeforeCompact);
 
   const BRepGraph_Compact::Result aRes = BRepGraph_Compact::Perform(aGraph);
   EXPECT_GE(aRes.NbNodesBefore, aRes.NbNodesAfter);
   EXPECT_LE(aGraph.Topo().CoEdges().Nb(), aCoEdgesBeforeCompact);
 
   Bnd_Box aBoxAfterCompact;
-  BRepGraphAlgo_BndLib::Add(aGraph, aBoxAfterCompact);
+  addGraphBounds(aGraph, aBoxAfterCompact);
   expectBoxNear(aBoxAfterCompact, aBoxBeforeCompact, Precision::Confusion());
 
   const BRepGraph_Validate::Result aValResult = BRepGraph_Validate::Perform(aGraph);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Compact_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Compact_Test.cxx
@@ -18,6 +18,7 @@
 #include <Bnd_Box.hxx>
 #include <BRepGraph.hxx>
 #include <BRepGraph_EditorView.hxx>
+#include <BRepGraphAlgo_BndLib.hxx>
 #include <BRepGraph_TopoView.hxx>
 #include <BRepGraph_History.hxx>
 #include <BRepGraph_HistoryRecord.hxx>
@@ -83,12 +84,30 @@ TopoDS_Compound makeBoxWithLooseEdge()
 int countHistoryRecordsByOp(const BRepGraph& theGraph, const TCollection_AsciiString& theOp)
 {
   int aCount = 0;
-  for (int aRecIdx = 0; aRecIdx < theGraph.History().NbRecords(); ++aRecIdx)
+  for (size_t aRecIdx = 0; aRecIdx < theGraph.History().NbRecords(); ++aRecIdx)
   {
     if (theGraph.History().Record(aRecIdx).OperationName == theOp)
       ++aCount;
   }
   return aCount;
+}
+
+void expectBoxNear(const Bnd_Box& theLeft, const Bnd_Box& theRight, const double theTol)
+{
+  ASSERT_FALSE(theLeft.IsVoid());
+  ASSERT_FALSE(theRight.IsVoid());
+
+  double aLeftMinX, aLeftMinY, aLeftMinZ, aLeftMaxX, aLeftMaxY, aLeftMaxZ;
+  double aRightMinX, aRightMinY, aRightMinZ, aRightMaxX, aRightMaxY, aRightMaxZ;
+  theLeft.Get(aLeftMinX, aLeftMinY, aLeftMinZ, aLeftMaxX, aLeftMaxY, aLeftMaxZ);
+  theRight.Get(aRightMinX, aRightMinY, aRightMinZ, aRightMaxX, aRightMaxY, aRightMaxZ);
+
+  EXPECT_NEAR(aLeftMinX, aRightMinX, theTol);
+  EXPECT_NEAR(aLeftMinY, aRightMinY, theTol);
+  EXPECT_NEAR(aLeftMinZ, aRightMinZ, theTol);
+  EXPECT_NEAR(aLeftMaxX, aRightMaxX, theTol);
+  EXPECT_NEAR(aLeftMaxY, aRightMaxY, theTol);
+  EXPECT_NEAR(aLeftMaxZ, aRightMaxZ, theTol);
 }
 
 } // namespace
@@ -102,9 +121,9 @@ TEST(BRepGraph_CompactTest, NoRemovedNodes_Noop)
   BRepGraph_Builder::Perform(aGraph, aBox);
   ASSERT_TRUE(aGraph.IsDone());
 
-  const int aNbVerticesBefore = aGraph.Topo().Vertices().Nb();
-  const int aNbEdgesBefore    = aGraph.Topo().Edges().Nb();
-  const int aNbFacesBefore    = aGraph.Topo().Faces().Nb();
+  const uint32_t aNbVerticesBefore = aGraph.Topo().Vertices().Nb();
+  const uint32_t aNbEdgesBefore    = aGraph.Topo().Edges().Nb();
+  const uint32_t aNbFacesBefore    = aGraph.Topo().Faces().Nb();
 
   const BRepGraph_Compact::Result aRes = BRepGraph_Compact::Perform(aGraph);
 
@@ -147,17 +166,17 @@ TEST(BRepGraph_CompactTest, IndexDensity_NoGaps)
   (void)BRepGraph_Compact::Perform(aGraph);
 
   // After compaction, there should be no removed defs.
-  const int aNbVertices = aGraph.Topo().Vertices().Nb();
-  for (BRepGraph_VertexId aVertexId(0); aVertexId.IsValid(aNbVertices); ++aVertexId)
+  for (BRepGraph_VertexId aVertexId = BRepGraph_VertexId::Start();
+       aVertexId.IsValid(aGraph.Topo().Vertices().Nb()); ++aVertexId)
     EXPECT_FALSE(aGraph.Topo().Vertices().Definition(aVertexId).IsRemoved);
-  const int aNbEdges = aGraph.Topo().Edges().Nb();
-  for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
+       anEdgeId.IsValid(aGraph.Topo().Edges().Nb()); ++anEdgeId)
     EXPECT_FALSE(aGraph.Topo().Edges().Definition(anEdgeId).IsRemoved);
-  const int aNbFaces = aGraph.Topo().Faces().Nb();
-  for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaces); ++aFaceId)
+  for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start();
+       aFaceId.IsValid(aGraph.Topo().Faces().Nb()); ++aFaceId)
     EXPECT_FALSE(aGraph.Topo().Faces().Definition(aFaceId).IsRemoved);
-  const int aNbWires = aGraph.Topo().Wires().Nb();
-  for (BRepGraph_WireId aWireId(0); aWireId.IsValid(aNbWires); ++aWireId)
+  for (BRepGraph_WireId aWireId = BRepGraph_WireId::Start();
+       aWireId.IsValid(aGraph.Topo().Wires().Nb()); ++aWireId)
     EXPECT_FALSE(aGraph.Topo().Wires().Definition(aWireId).IsRemoved);
 }
 
@@ -212,6 +231,36 @@ TEST(BRepGraph_CompactTest, FullPipeline_Deduplicate_Compact_Validate)
   EXPECT_EQ(aCompactRes.NbNodesAfter, aCompactRes.NbNodesBefore);
 
   // Validate.
+  const BRepGraph_Validate::Result aValResult = BRepGraph_Validate::Perform(aGraph);
+  EXPECT_TRUE(aValResult.IsValid());
+}
+
+TEST(BRepGraph_CompactTest, RemovalCompact_PreservesBounds_AndDoesNotGrowTopology)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 20.0, 30.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+
+  BRepGraph aGraph;
+  BRepGraph_Builder::Perform(aGraph, aBox);
+  ASSERT_TRUE(aGraph.IsDone());
+  ASSERT_GT(aGraph.Topo().CoEdges().Nb(), 0);
+  ASSERT_GT(aGraph.Topo().Faces().Nb(), 2);
+
+  aGraph.Editor().Gen().RemoveNode(BRepGraph_FaceId(2));
+
+  const int aCoEdgesBeforeCompact = aGraph.Topo().CoEdges().Nb();
+
+  Bnd_Box aBoxBeforeCompact;
+  BRepGraphAlgo_BndLib::Add(aGraph, aBoxBeforeCompact);
+
+  const BRepGraph_Compact::Result aRes = BRepGraph_Compact::Perform(aGraph);
+  EXPECT_GE(aRes.NbNodesBefore, aRes.NbNodesAfter);
+  EXPECT_LE(aGraph.Topo().CoEdges().Nb(), aCoEdgesBeforeCompact);
+
+  Bnd_Box aBoxAfterCompact;
+  BRepGraphAlgo_BndLib::Add(aGraph, aBoxAfterCompact);
+  expectBoxNear(aBoxAfterCompact, aBoxBeforeCompact, Precision::Confusion());
+
   const BRepGraph_Validate::Result aValResult = BRepGraph_Validate::Perform(aGraph);
   EXPECT_TRUE(aValResult.IsValid());
 }
@@ -399,8 +448,8 @@ TEST(BRepGraph_CompactTest, OwnGen_SurvivesCompact)
   // Edge 0 may have been remapped. Find the edge that carries the mutated
   // tolerance and verify both the tolerance value and OwnGen are preserved.
   bool      aFound               = false;
-  const int aNbEdgesAfterCompact = aGraph.Topo().Edges().Nb();
-  for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdgesAfterCompact); ++anEdgeId)
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
+       anEdgeId.IsValid(aGraph.Topo().Edges().Nb()); ++anEdgeId)
   {
     const BRepGraphInc::EdgeDef& anEdge = aGraph.Topo().Edges().Definition(anEdgeId);
     if (std::abs(anEdge.Tolerance - THE_MUTATED_EDGE_TOLERANCE) < Precision::Confusion())

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Compact_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Compact_Test.cxx
@@ -167,16 +167,20 @@ TEST(BRepGraph_CompactTest, IndexDensity_NoGaps)
 
   // After compaction, there should be no removed defs.
   for (BRepGraph_VertexId aVertexId = BRepGraph_VertexId::Start();
-       aVertexId.IsValid(aGraph.Topo().Vertices().Nb()); ++aVertexId)
+       aVertexId.IsValid(aGraph.Topo().Vertices().Nb());
+       ++aVertexId)
     EXPECT_FALSE(aGraph.Topo().Vertices().Definition(aVertexId).IsRemoved);
   for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
-       anEdgeId.IsValid(aGraph.Topo().Edges().Nb()); ++anEdgeId)
+       anEdgeId.IsValid(aGraph.Topo().Edges().Nb());
+       ++anEdgeId)
     EXPECT_FALSE(aGraph.Topo().Edges().Definition(anEdgeId).IsRemoved);
   for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start();
-       aFaceId.IsValid(aGraph.Topo().Faces().Nb()); ++aFaceId)
+       aFaceId.IsValid(aGraph.Topo().Faces().Nb());
+       ++aFaceId)
     EXPECT_FALSE(aGraph.Topo().Faces().Definition(aFaceId).IsRemoved);
   for (BRepGraph_WireId aWireId = BRepGraph_WireId::Start();
-       aWireId.IsValid(aGraph.Topo().Wires().Nb()); ++aWireId)
+       aWireId.IsValid(aGraph.Topo().Wires().Nb());
+       ++aWireId)
     EXPECT_FALSE(aGraph.Topo().Wires().Definition(aWireId).IsRemoved);
 }
 
@@ -447,9 +451,10 @@ TEST(BRepGraph_CompactTest, OwnGen_SurvivesCompact)
 
   // Edge 0 may have been remapped. Find the edge that carries the mutated
   // tolerance and verify both the tolerance value and OwnGen are preserved.
-  bool      aFound               = false;
+  bool aFound = false;
   for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
-       anEdgeId.IsValid(aGraph.Topo().Edges().Nb()); ++anEdgeId)
+       anEdgeId.IsValid(aGraph.Topo().Edges().Nb());
+       ++anEdgeId)
   {
     const BRepGraphInc::EdgeDef& anEdge = aGraph.Topo().Edges().Definition(anEdgeId);
     if (std::abs(anEdge.Tolerance - THE_MUTATED_EDGE_TOLERANCE) < Precision::Confusion())

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Deduplicate_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Deduplicate_Test.cxx
@@ -1560,7 +1560,8 @@ TEST(BRepGraph_DeduplicateTest, AnalyzeOnly_NoBackRefChangesOrNullification)
   for (BRepGraph_FullFaceIterator aFaceIt(aGraph); aFaceIt.More(); aFaceIt.Next())
   {
     const BRepGraph_FaceId aFaceId = aFaceIt.CurrentId();
-    EXPECT_EQ(BRepGraph_Tool::Face::Surface(aGraph, aFaceId).get(), aSurfPtrs.Value(static_cast<int>(aFaceId.Index)));
+    EXPECT_EQ(BRepGraph_Tool::Face::Surface(aGraph, aFaceId).get(),
+              aSurfPtrs.Value(static_cast<int>(aFaceId.Index)));
   }
   for (BRepGraph_FullEdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
   {

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Deduplicate_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Deduplicate_Test.cxx
@@ -132,7 +132,7 @@ int nbPCurveEntries(const BRepGraph& theGraph)
 int countHistoryRecordsByOp(const BRepGraph& theGraph, const TCollection_AsciiString& theOp)
 {
   int aCount = 0;
-  for (int aRecIdx = 0; aRecIdx < theGraph.History().NbRecords(); ++aRecIdx)
+  for (size_t aRecIdx = 0; aRecIdx < theGraph.History().NbRecords(); ++aRecIdx)
   {
     if (theGraph.History().Record(aRecIdx).OperationName == theOp)
     {
@@ -336,7 +336,7 @@ TEST(BRepGraph_DeduplicateTest, CanonicalizeSurfaces_RewritesAndRecordsHistory)
   anOpts.AnalyzeOnly = false;
   anOpts.HistoryMode = true;
 
-  const int                           aHistoryBefore = aGraph.History().NbRecords();
+  const size_t                        aHistoryBefore = aGraph.History().NbRecords();
   const BRepGraph_Deduplicate::Result aRes = BRepGraph_Deduplicate::Perform(aGraph, anOpts);
 
   EXPECT_EQ(aRes.NbSurfaceRewrites, 1);
@@ -853,7 +853,7 @@ TEST(BRepGraph_DeduplicateTest, HistoryFindOriginal_TracesBackToCanonical)
   ASSERT_EQ(aRes.NbHistoryRecords, 5);
 
   // For each history record, FindOriginal on the replacement should trace back.
-  for (int aRecIdx = 0; aRecIdx < aGraph.History().NbRecords(); ++aRecIdx)
+  for (size_t aRecIdx = 0; aRecIdx < aGraph.History().NbRecords(); ++aRecIdx)
   {
     const BRepGraph_HistoryRecord& aRec = aGraph.History().Record(aRecIdx);
     for (NCollection_DataMap<BRepGraph_NodeId, NCollection_Vector<BRepGraph_NodeId>>::Iterator
@@ -892,7 +892,7 @@ TEST(BRepGraph_DeduplicateTest, HistoryFindDerived_ContainsCanonicalNode)
   // For each history record, FindDerived on the original should contain the replacements.
   // All records are canonicalize records with 1 replacement (no nullify records).
   int aNbCanonMappings = 0;
-  for (int aRecIdx = 0; aRecIdx < aGraph.History().NbRecords(); ++aRecIdx)
+  for (size_t aRecIdx = 0; aRecIdx < aGraph.History().NbRecords(); ++aRecIdx)
   {
     const BRepGraph_HistoryRecord& aRec = aGraph.History().Record(aRecIdx);
     for (NCollection_DataMap<BRepGraph_NodeId, NCollection_Vector<BRepGraph_NodeId>>::Iterator
@@ -921,12 +921,15 @@ TEST(BRepGraph_DeduplicateTest, HistoryRecordSequenceNumbers_AreMonotonic)
 
   (void)BRepGraph_Deduplicate::Perform(aGraph, anOpts);
 
-  int aPrevSeq = -1;
-  for (int aRecIdx = 0; aRecIdx < aGraph.History().NbRecords(); ++aRecIdx)
+  bool   isFirst  = true;
+  size_t aPrevSeq = 0;
+  for (size_t aRecIdx = 0; aRecIdx < aGraph.History().NbRecords(); ++aRecIdx)
   {
     const BRepGraph_HistoryRecord& aRec = aGraph.History().Record(aRecIdx);
-    EXPECT_GT(aRec.SequenceNumber, aPrevSeq);
+    if (!isFirst)
+      EXPECT_GT(aRec.SequenceNumber, aPrevSeq);
     aPrevSeq = aRec.SequenceNumber;
+    isFirst  = false;
   }
 }
 
@@ -1557,13 +1560,13 @@ TEST(BRepGraph_DeduplicateTest, AnalyzeOnly_NoBackRefChangesOrNullification)
   for (BRepGraph_FullFaceIterator aFaceIt(aGraph); aFaceIt.More(); aFaceIt.Next())
   {
     const BRepGraph_FaceId aFaceId = aFaceIt.CurrentId();
-    EXPECT_EQ(BRepGraph_Tool::Face::Surface(aGraph, aFaceId).get(), aSurfPtrs.Value(aFaceId.Index));
+    EXPECT_EQ(BRepGraph_Tool::Face::Surface(aGraph, aFaceId).get(), aSurfPtrs.Value(static_cast<int>(aFaceId.Index)));
   }
   for (BRepGraph_FullEdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
   {
     const BRepGraph_EdgeId anEdgeId = anEdgeIt.CurrentId();
     EXPECT_EQ(BRepGraph_Tool::Edge::Curve(aGraph, anEdgeId).get(),
-              aCurvePtrs.Value(anEdgeId.Index));
+              aCurvePtrs.Value(static_cast<int>(anEdgeId.Index)));
   }
 
   // All handles still non-null.

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Deduplicate_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Deduplicate_Test.cxx
@@ -927,7 +927,9 @@ TEST(BRepGraph_DeduplicateTest, HistoryRecordSequenceNumbers_AreMonotonic)
   {
     const BRepGraph_HistoryRecord& aRec = aGraph.History().Record(aRecIdx);
     if (!isFirst)
+    {
       EXPECT_GT(aRec.SequenceNumber, aPrevSeq);
+    }
     aPrevSeq = aRec.SequenceNumber;
     isFirst  = false;
   }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Geometry_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Geometry_Test.cxx
@@ -885,19 +885,19 @@ TEST(BRepGraph_GeometryTest, Cylinder_TriangulationReps_Populated)
 
 TEST(BRepGraph_GeometryTest, RepId_FactoryMethods)
 {
-  const BRepGraph_SurfaceRepId aSurfId = BRepGraph_RepId::Surface(42);
+  const BRepGraph_SurfaceRepId aSurfId(42);
   EXPECT_EQ(BRepGraph_RepId(aSurfId).RepKind, BRepGraph_RepId::Kind::Surface);
-  EXPECT_EQ(aSurfId.Index, 42);
+  EXPECT_EQ(aSurfId.Index, 42u);
   EXPECT_TRUE(aSurfId.IsValid());
 
-  const BRepGraph_Curve3DRepId aCurve3DId = BRepGraph_RepId::Curve3D(7);
+  const BRepGraph_Curve3DRepId aCurve3DId(7);
   EXPECT_EQ(BRepGraph_RepId(aCurve3DId).RepKind, BRepGraph_RepId::Kind::Curve3D);
-  EXPECT_EQ(aCurve3DId.Index, 7);
+  EXPECT_EQ(aCurve3DId.Index, 7u);
 
   const BRepGraph_RepId aDefaultId;
   EXPECT_FALSE(aDefaultId.IsValid());
 
-  EXPECT_EQ(aSurfId, BRepGraph_RepId::Surface(42));
+  EXPECT_EQ(aSurfId, BRepGraph_SurfaceRepId(42));
   EXPECT_NE(BRepGraph_RepId(aSurfId), BRepGraph_RepId(aCurve3DId));
 }
 

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_History_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_History_Test.cxx
@@ -137,7 +137,7 @@ TEST_F(BRepGraph_HistoryTest, FindDerived_UnmodifiedNode_ReturnsEmpty)
 
 TEST_F(BRepGraph_HistoryTest, Disabled_RecordHistory_NoRecordStored)
 {
-  const int aNbBefore = myGraph.History().NbRecords();
+  const size_t aNbBefore = myGraph.History().NbRecords();
   myGraph.History().SetEnabled(false);
 
   const BRepGraph_NodeId               anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
@@ -173,7 +173,7 @@ TEST_F(BRepGraph_HistoryTest, ReEnabled_RecordsAfterReEnable)
   myGraph.History().SetEnabled(true);
   EXPECT_TRUE(myGraph.History().IsEnabled());
 
-  const int                            aNbBefore = myGraph.History().NbRecords();
+  const size_t                         aNbBefore = myGraph.History().NbRecords();
   const BRepGraph_NodeId               anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   NCollection_Vector<BRepGraph_NodeId> aReplacements;
   aReplacements.Append(BRepGraph_NodeId(BRepGraph_NodeId::Kind::Edge, 1));
@@ -185,7 +185,7 @@ TEST_F(BRepGraph_HistoryTest, ReEnabled_RecordsAfterReEnable)
 TEST_F(BRepGraph_HistoryTest, ApplyModification_EmptyReplacements)
 {
   const BRepGraph_NodeId anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
-  const int              aNbBefore = myGraph.History().NbRecords();
+  const size_t           aNbBefore = myGraph.History().NbRecords();
 
   myGraph.Editor().Gen().ApplyModification(
     anEdge0,
@@ -234,7 +234,7 @@ TEST_F(BRepGraph_HistoryTest, ApplyModification_MultipleReplacements)
 
 TEST_F(BRepGraph_HistoryTest, RecordHistory_EmptyReplacements_Stored)
 {
-  const int                            aNbBefore = myGraph.History().NbRecords();
+  const size_t                         aNbBefore = myGraph.History().NbRecords();
   const BRepGraph_NodeId               anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   NCollection_Vector<BRepGraph_NodeId> anEmpty;
   myGraph.History().Record("Erase", anEdge0, anEmpty);
@@ -256,7 +256,7 @@ TEST_F(BRepGraph_HistoryTest, HistoryRecord_SequenceNumber_Monotonic)
   aRepl2.Append(anEdge2);
   myGraph.History().Record("Op2", anEdge1, aRepl2);
 
-  const int aNb = myGraph.History().NbRecords();
+  const size_t aNb = myGraph.History().NbRecords();
   ASSERT_GE(aNb, 2);
   const BRepGraph_HistoryRecord& aRec1 = myGraph.History().Record(aNb - 2);
   const BRepGraph_HistoryRecord& aRec2 = myGraph.History().Record(aNb - 1);
@@ -276,7 +276,7 @@ TEST_F(BRepGraph_HistoryTest, HistoryRecord_OperationName_Stored)
 
 TEST_F(BRepGraph_HistoryTest, NbHistoryRecords_AfterMultipleOps_Correct)
 {
-  const int aNbBefore = myGraph.History().NbRecords();
+  const size_t aNbBefore = myGraph.History().NbRecords();
 
   const BRepGraph_NodeId               anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   NCollection_Vector<BRepGraph_NodeId> aRepl;
@@ -328,7 +328,7 @@ TEST_F(BRepGraph_HistoryTest, FindOriginal_TwoApply_TransitiveTrace)
 
 TEST_F(BRepGraph_HistoryTest, ApplyModification_WhenModifierThrows_DoesNotRecordHistory)
 {
-  const int aNbRecordsBefore = myGraph.History().NbRecords();
+  const size_t aNbRecordsBefore = myGraph.History().NbRecords();
 
   const BRepGraph_NodeId anEdge(BRepGraph_NodeId::Kind::Edge, 0);
 
@@ -364,8 +364,8 @@ TEST_F(BRepGraph_HistoryTest, SplitEdge_RewritesAllContainingWires)
   const NCollection_Vector<BRepGraph_WireId>& aWireIndices = myGraph.Topo().Edges().Wires(anEdgeId);
   ASSERT_GT(aWireIndices.Length(), 0);
 
-  const int aNbEdgesBefore       = myGraph.Topo().Edges().Nb();
-  const int aNbActiveEdgesBefore = myGraph.Topo().Edges().NbActive();
+  const uint32_t aNbEdgesBefore       = myGraph.Topo().Edges().Nb();
+  const uint32_t aNbActiveEdgesBefore = myGraph.Topo().Edges().NbActive();
 
   BRepGraph_EdgeId aSubA;
   BRepGraph_EdgeId aSubB;
@@ -482,8 +482,8 @@ TEST_F(BRepGraph_HistoryTest, SplitEdge_IgnoresRemovedCoEdgeRefEntries)
 
   bool      hasSubA       = false;
   bool      hasSubB       = false;
-  const int aNbCoEdgeRefs = myGraph.Refs().CoEdges().Nb();
-  for (BRepGraph_CoEdgeRefId aRefId(0); aRefId.IsValid(aNbCoEdgeRefs); ++aRefId)
+  for (BRepGraph_CoEdgeRefId aRefId = BRepGraph_CoEdgeRefId::Start();
+       aRefId.IsValid(myGraph.Refs().CoEdges().Nb()); ++aRefId)
   {
     const BRepGraphInc::CoEdgeRef& aRef = myGraph.Refs().CoEdges().Entry(aRefId);
     if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid(myGraph.Topo().CoEdges().Nb()))
@@ -510,7 +510,7 @@ TEST_F(BRepGraph_HistoryTest, ApplyModification_SplitEdge_RecordsBothDerivedNode
     myGraph.Editor().Vertices().Add(gp_Pnt(4.0, 5.0, 6.0), 1.0e-7);
   ASSERT_TRUE(aSplitVertex.IsValid());
 
-  const int aNbRecordsBefore = myGraph.History().NbRecords();
+  const size_t aNbRecordsBefore = myGraph.History().NbRecords();
 
   myGraph.Editor().Gen().ApplyModification(
     anEdgeId,

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_History_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_History_Test.cxx
@@ -480,10 +480,11 @@ TEST_F(BRepGraph_HistoryTest, SplitEdge_IgnoresRemovedCoEdgeRefEntries)
     myGraph.Topo().CoEdges().Definition(aRemovedCoEdgeId);
   EXPECT_EQ(aRemovedCoEdgeAfter.EdgeDefId, anEdgeId);
 
-  bool      hasSubA       = false;
-  bool      hasSubB       = false;
+  bool hasSubA = false;
+  bool hasSubB = false;
   for (BRepGraph_CoEdgeRefId aRefId = BRepGraph_CoEdgeRefId::Start();
-       aRefId.IsValid(myGraph.Refs().CoEdges().Nb()); ++aRefId)
+       aRefId.IsValid(myGraph.Refs().CoEdges().Nb());
+       ++aRefId)
   {
     const BRepGraphInc::CoEdgeRef& aRef = myGraph.Refs().CoEdges().Entry(aRefId);
     if (aRef.IsRemoved || !aRef.CoEdgeDefId.IsValid(myGraph.Topo().CoEdges().Nb()))

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_MutationGen_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_MutationGen_Test.cxx
@@ -149,14 +149,14 @@ TEST_F(BRepGraph_MutationGenTest, SubtreeGen_DeferredPropagatedParent_Incremente
   // At least one parent wire must have SubtreeGen incremented vs its baseline.
   bool aAnyWireSubtreeIncremented = false;
   for (BRepGraph_WireIterator aWireIt(myGraph); aWireIt.More(); aWireIt.Next())
-    if (aWireIt.Current().SubtreeGen > aWireSubtreeGensBefore.Value(aWireIt.CurrentId().Index))
+    if (aWireIt.Current().SubtreeGen > aWireSubtreeGensBefore.Value(static_cast<int>(aWireIt.CurrentId().Index)))
       aAnyWireSubtreeIncremented = true;
   EXPECT_TRUE(aAnyWireSubtreeIncremented);
 
   // At least one parent face must have SubtreeGen incremented vs its baseline.
   bool aAnyFaceSubtreeIncremented = false;
   for (BRepGraph_FaceIterator aFaceIt(myGraph); aFaceIt.More(); aFaceIt.Next())
-    if (aFaceIt.Current().SubtreeGen > aFaceSubtreeGensBefore.Value(aFaceIt.CurrentId().Index))
+    if (aFaceIt.Current().SubtreeGen > aFaceSubtreeGensBefore.Value(static_cast<int>(aFaceIt.CurrentId().Index)))
       aAnyFaceSubtreeIncremented = true;
   EXPECT_TRUE(aAnyFaceSubtreeIncremented);
 }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_MutationGen_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_MutationGen_Test.cxx
@@ -149,14 +149,16 @@ TEST_F(BRepGraph_MutationGenTest, SubtreeGen_DeferredPropagatedParent_Incremente
   // At least one parent wire must have SubtreeGen incremented vs its baseline.
   bool aAnyWireSubtreeIncremented = false;
   for (BRepGraph_WireIterator aWireIt(myGraph); aWireIt.More(); aWireIt.Next())
-    if (aWireIt.Current().SubtreeGen > aWireSubtreeGensBefore.Value(static_cast<int>(aWireIt.CurrentId().Index)))
+    if (aWireIt.Current().SubtreeGen
+        > aWireSubtreeGensBefore.Value(static_cast<int>(aWireIt.CurrentId().Index)))
       aAnyWireSubtreeIncremented = true;
   EXPECT_TRUE(aAnyWireSubtreeIncremented);
 
   // At least one parent face must have SubtreeGen incremented vs its baseline.
   bool aAnyFaceSubtreeIncremented = false;
   for (BRepGraph_FaceIterator aFaceIt(myGraph); aFaceIt.More(); aFaceIt.Next())
-    if (aFaceIt.Current().SubtreeGen > aFaceSubtreeGensBefore.Value(static_cast<int>(aFaceIt.CurrentId().Index)))
+    if (aFaceIt.Current().SubtreeGen
+        > aFaceSubtreeGensBefore.Value(static_cast<int>(aFaceIt.CurrentId().Index)))
       aAnyFaceSubtreeIncremented = true;
   EXPECT_TRUE(aAnyFaceSubtreeIncremented);
 }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_RefId_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_RefId_Test.cxx
@@ -263,7 +263,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   ASSERT_TRUE(aGraph.IsDone());
 
   for (BRepGraph_FaceRefId aFaceRefId = BRepGraph_FaceRefId::Start();
-       aFaceRefId.IsValid(aGraph.Refs().Faces().Nb()); ++aFaceRefId)
+       aFaceRefId.IsValid(aGraph.Refs().Faces().Nb());
+       ++aFaceRefId)
   {
     const BRepGraph_RefId        aRefId = aFaceRefId;
     const BRepGraph_RefUID       aUID   = aGraph.UIDs().Of(aRefId);
@@ -281,7 +282,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   }
 
   for (BRepGraph_WireRefId aWireRefId = BRepGraph_WireRefId::Start();
-       aWireRefId.IsValid(aGraph.Refs().Wires().Nb()); ++aWireRefId)
+       aWireRefId.IsValid(aGraph.Refs().Wires().Nb());
+       ++aWireRefId)
   {
     const BRepGraph_RefId        aRefId  = aWireRefId;
     const BRepGraph_RefUID       aUID    = aGraph.UIDs().Of(aRefId);
@@ -293,7 +295,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   }
 
   for (BRepGraph_CoEdgeRefId aCoEdgeRefId = BRepGraph_CoEdgeRefId::Start();
-       aCoEdgeRefId.IsValid(aGraph.Refs().CoEdges().Nb()); ++aCoEdgeRefId)
+       aCoEdgeRefId.IsValid(aGraph.Refs().CoEdges().Nb());
+       ++aCoEdgeRefId)
   {
     const BRepGraph_RefId          aRefId  = aCoEdgeRefId;
     const BRepGraph_RefUID         aUID    = aGraph.UIDs().Of(aRefId);
@@ -305,7 +308,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   }
 
   for (BRepGraph_ShellRefId aShellRefId = BRepGraph_ShellRefId::Start();
-       aShellRefId.IsValid(aGraph.Refs().Shells().Nb()); ++aShellRefId)
+       aShellRefId.IsValid(aGraph.Refs().Shells().Nb());
+       ++aShellRefId)
   {
     const BRepGraph_RefId         aRefId  = aShellRefId;
     const BRepGraph_RefUID        aUID    = aGraph.UIDs().Of(aRefId);
@@ -317,7 +321,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   }
 
   for (BRepGraph_VertexRefId aVertexRefId = BRepGraph_VertexRefId::Start();
-       aVertexRefId.IsValid(aGraph.Refs().Vertices().Nb()); ++aVertexRefId)
+       aVertexRefId.IsValid(aGraph.Refs().Vertices().Nb());
+       ++aVertexRefId)
   {
     const BRepGraph_RefId          aRefId  = aVertexRefId;
     const BRepGraph_RefUID         aUID    = aGraph.UIDs().Of(aRefId);
@@ -330,7 +335,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   }
 
   for (BRepGraph_SolidRefId aSolidRefId = BRepGraph_SolidRefId::Start();
-       aSolidRefId.IsValid(aGraph.Refs().Solids().Nb()); ++aSolidRefId)
+       aSolidRefId.IsValid(aGraph.Refs().Solids().Nb());
+       ++aSolidRefId)
   {
     const BRepGraph_RefId         aRefId  = aSolidRefId;
     const BRepGraph_RefUID        aUID    = aGraph.UIDs().Of(aRefId);
@@ -342,7 +348,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   }
 
   for (BRepGraph_ChildRefId aChildRefId = BRepGraph_ChildRefId::Start();
-       aChildRefId.IsValid(aGraph.Refs().Children().Nb()); ++aChildRefId)
+       aChildRefId.IsValid(aGraph.Refs().Children().Nb());
+       ++aChildRefId)
   {
     const BRepGraph_RefId         aRefId  = aChildRefId;
     const BRepGraph_RefUID        aUID    = aGraph.UIDs().Of(aRefId);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_RefId_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_RefId_Test.cxx
@@ -262,8 +262,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
   BRepGraph_Builder::Perform(aGraph, BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape());
   ASSERT_TRUE(aGraph.IsDone());
 
-  const int aNbFaceRefs = aGraph.Refs().Faces().Nb();
-  for (BRepGraph_FaceRefId aFaceRefId(0); aFaceRefId.IsValid(aNbFaceRefs); ++aFaceRefId)
+  for (BRepGraph_FaceRefId aFaceRefId = BRepGraph_FaceRefId::Start();
+       aFaceRefId.IsValid(aGraph.Refs().Faces().Nb()); ++aFaceRefId)
   {
     const BRepGraph_RefId        aRefId = aFaceRefId;
     const BRepGraph_RefUID       aUID   = aGraph.UIDs().Of(aRefId);
@@ -280,8 +280,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
     EXPECT_TRUE(anEntry.FaceDefId.IsValid(aGraph.Topo().Faces().Nb()));
   }
 
-  const int aNbWireRefs = aGraph.Refs().Wires().Nb();
-  for (BRepGraph_WireRefId aWireRefId(0); aWireRefId.IsValid(aNbWireRefs); ++aWireRefId)
+  for (BRepGraph_WireRefId aWireRefId = BRepGraph_WireRefId::Start();
+       aWireRefId.IsValid(aGraph.Refs().Wires().Nb()); ++aWireRefId)
   {
     const BRepGraph_RefId        aRefId  = aWireRefId;
     const BRepGraph_RefUID       aUID    = aGraph.UIDs().Of(aRefId);
@@ -292,8 +292,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
     EXPECT_TRUE(anEntry.WireDefId.IsValid(aGraph.Topo().Wires().Nb()));
   }
 
-  const int aNbCoEdgeRefs = aGraph.Refs().CoEdges().Nb();
-  for (BRepGraph_CoEdgeRefId aCoEdgeRefId(0); aCoEdgeRefId.IsValid(aNbCoEdgeRefs); ++aCoEdgeRefId)
+  for (BRepGraph_CoEdgeRefId aCoEdgeRefId = BRepGraph_CoEdgeRefId::Start();
+       aCoEdgeRefId.IsValid(aGraph.Refs().CoEdges().Nb()); ++aCoEdgeRefId)
   {
     const BRepGraph_RefId          aRefId  = aCoEdgeRefId;
     const BRepGraph_RefUID         aUID    = aGraph.UIDs().Of(aRefId);
@@ -304,8 +304,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
     EXPECT_TRUE(anEntry.CoEdgeDefId.IsValid(aGraph.Topo().CoEdges().Nb()));
   }
 
-  const int aNbShellRefs = aGraph.Refs().Shells().Nb();
-  for (BRepGraph_ShellRefId aShellRefId(0); aShellRefId.IsValid(aNbShellRefs); ++aShellRefId)
+  for (BRepGraph_ShellRefId aShellRefId = BRepGraph_ShellRefId::Start();
+       aShellRefId.IsValid(aGraph.Refs().Shells().Nb()); ++aShellRefId)
   {
     const BRepGraph_RefId         aRefId  = aShellRefId;
     const BRepGraph_RefUID        aUID    = aGraph.UIDs().Of(aRefId);
@@ -316,8 +316,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
     EXPECT_TRUE(anEntry.ShellDefId.IsValid(aGraph.Topo().Shells().Nb()));
   }
 
-  const int aNbVertexRefs = aGraph.Refs().Vertices().Nb();
-  for (BRepGraph_VertexRefId aVertexRefId(0); aVertexRefId.IsValid(aNbVertexRefs); ++aVertexRefId)
+  for (BRepGraph_VertexRefId aVertexRefId = BRepGraph_VertexRefId::Start();
+       aVertexRefId.IsValid(aGraph.Refs().Vertices().Nb()); ++aVertexRefId)
   {
     const BRepGraph_RefId          aRefId  = aVertexRefId;
     const BRepGraph_RefUID         aUID    = aGraph.UIDs().Of(aRefId);
@@ -329,8 +329,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
     EXPECT_TRUE(anEntry.VertexDefId.IsValid(aGraph.Topo().Vertices().Nb()));
   }
 
-  const int aNbSolidRefs = aGraph.Refs().Solids().Nb();
-  for (BRepGraph_SolidRefId aSolidRefId(0); aSolidRefId.IsValid(aNbSolidRefs); ++aSolidRefId)
+  for (BRepGraph_SolidRefId aSolidRefId = BRepGraph_SolidRefId::Start();
+       aSolidRefId.IsValid(aGraph.Refs().Solids().Nb()); ++aSolidRefId)
   {
     const BRepGraph_RefId         aRefId  = aSolidRefId;
     const BRepGraph_RefUID        aUID    = aGraph.UIDs().Of(aRefId);
@@ -341,8 +341,8 @@ TEST(BRepGraph_RefIdTest, RefsView_AfterBuild_UIDRoundtripAndParentKinds)
     EXPECT_TRUE(anEntry.SolidDefId.IsValid(aGraph.Topo().Solids().Nb()));
   }
 
-  const int aNbChildRefs = aGraph.Refs().Children().Nb();
-  for (BRepGraph_ChildRefId aChildRefId(0); aChildRefId.IsValid(aNbChildRefs); ++aChildRefId)
+  for (BRepGraph_ChildRefId aChildRefId = BRepGraph_ChildRefId::Start();
+       aChildRefId.IsValid(aGraph.Refs().Children().Nb()); ++aChildRefId)
   {
     const BRepGraph_RefId         aRefId  = aChildRefId;
     const BRepGraph_RefUID        aUID    = aGraph.UIDs().Of(aRefId);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
@@ -312,11 +312,12 @@ TEST(BRepGraph_ScenarioMatrix, CompSolid_TwoBoxes_BothSubsystemsMutateReconstruc
   ASSERT_GE(aOrigStorage.NbSolids(), 2);
 
   // Both solids must be reverse-indexed into the CompSolid.
-  for (int i = 0; i < aOrigStorage.NbSolids(); ++i)
+  for (BRepGraph_SolidId aSolidId = BRepGraph_SolidId::Start();
+       aSolidId.IsValid(aOrigStorage.NbSolids()); ++aSolidId)
   {
     const NCollection_Vector<BRepGraph_CompSolidId>* aCSVec =
-      aOrigStorage.ReverseIndex().CompSolidsOfSolid(BRepGraph_SolidId(i));
-    EXPECT_NE(aCSVec, nullptr) << "Solid " << i << " not in any CompSolid";
+      aOrigStorage.ReverseIndex().CompSolidsOfSolid(aSolidId);
+    EXPECT_NE(aCSVec, nullptr) << "Solid " << aSolidId.Index << " not in any CompSolid";
   }
   EXPECT_TRUE(aOrigStorage.ValidateReverseIndex()) << "Reverse index must be consistent";
 

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
@@ -313,7 +313,8 @@ TEST(BRepGraph_ScenarioMatrix, CompSolid_TwoBoxes_BothSubsystemsMutateReconstruc
 
   // Both solids must be reverse-indexed into the CompSolid.
   for (BRepGraph_SolidId aSolidId = BRepGraph_SolidId::Start();
-       aSolidId.IsValid(aOrigStorage.NbSolids()); ++aSolidId)
+       aSolidId.IsValid(aOrigStorage.NbSolids());
+       ++aSolidId)
   {
     const NCollection_Vector<BRepGraph_CompSolidId>* aCSVec =
       aOrigStorage.ReverseIndex().CompSolidsOfSolid(aSolidId);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Sharing_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Sharing_Test.cxx
@@ -59,8 +59,8 @@ TEST_F(BRepGraph_SharingTest, EdgeDef_EachSharedByTwoFaces)
   {
     const BRepGraph_EdgeId anEdgeId   = anEdgeIt.CurrentId();
     const uint32_t         aFaceCount = myGraph.Topo().Edges().NbFaces(anEdgeId);
-    EXPECT_EQ(aFaceCount, 2) << "Edge def " << anEdgeId.Index
-                             << " expected to be shared by 2 faces, got " << aFaceCount;
+    EXPECT_EQ(aFaceCount, 2u) << "Edge def " << anEdgeId.Index
+                              << " expected to be shared by 2 faces, got " << aFaceCount;
   }
 }
 

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Sharing_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Sharing_Test.cxx
@@ -58,7 +58,7 @@ TEST_F(BRepGraph_SharingTest, EdgeDef_EachSharedByTwoFaces)
   for (BRepGraph_EdgeIterator anEdgeIt(myGraph); anEdgeIt.More(); anEdgeIt.Next())
   {
     const BRepGraph_EdgeId anEdgeId   = anEdgeIt.CurrentId();
-    const int              aFaceCount = myGraph.Topo().Edges().NbFaces(anEdgeId);
+    const uint32_t         aFaceCount = myGraph.Topo().Edges().NbFaces(anEdgeId);
     EXPECT_EQ(aFaceCount, 2) << "Edge def " << anEdgeId.Index
                              << " expected to be shared by 2 faces, got " << aFaceCount;
   }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Test.cxx
@@ -1264,7 +1264,7 @@ TEST_F(BRepGraphTest, NbFacesOfEdge_SharedEdge)
   {
     if (!BRepGraph_Tool::Edge::Degenerated(myGraph, anEdgeIt.CurrentId()))
     {
-      const int aCount = myGraph.Topo().Edges().NbFaces(anEdgeIt.CurrentId());
+      const uint32_t aCount = myGraph.Topo().Edges().NbFaces(anEdgeIt.CurrentId());
       EXPECT_EQ(aCount, 2) << "Edge " << anEdgeIt.CurrentId().Index
                            << " should be shared by 2 faces";
     }
@@ -1279,7 +1279,7 @@ TEST_F(BRepGraphTest, FreeEdges_ClosedBox_Empty)
 
 TEST_F(BRepGraphTest, RecordHistory_BasicEntry)
 {
-  int                                  aBefore = myGraph.History().NbRecords();
+  size_t                               aBefore = myGraph.History().NbRecords();
   BRepGraph_NodeId                     anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   BRepGraph_NodeId                     anEdge1(BRepGraph_NodeId::Kind::Edge, 1);
   NCollection_Vector<BRepGraph_NodeId> aRepl;
@@ -1693,7 +1693,7 @@ TEST(BRepGraph_UIDsViewTest, ReverseLookupStaysCurrentAfterProgrammaticAdd)
 
 TEST_F(BRepGraphTest, RecordHistory_MultipleRecords_SequenceNumbers)
 {
-  const int aBefore = myGraph.History().NbRecords();
+  const size_t aBefore = myGraph.History().NbRecords();
 
   BRepGraph_NodeId                     anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   BRepGraph_NodeId                     anEdge1(BRepGraph_NodeId::Kind::Edge, 1);
@@ -1707,7 +1707,7 @@ TEST_F(BRepGraphTest, RecordHistory_MultipleRecords_SequenceNumbers)
   EXPECT_EQ(myGraph.History().NbRecords(), aBefore + 3);
 
   // Check monotonically increasing sequence numbers.
-  for (int anIdx = aBefore + 1; anIdx < aBefore + 3; ++anIdx)
+  for (size_t anIdx = aBefore + 1; anIdx < aBefore + 3; ++anIdx)
   {
     EXPECT_GT(myGraph.History().Record(anIdx).SequenceNumber,
               myGraph.History().Record(anIdx - 1).SequenceNumber)
@@ -2289,8 +2289,8 @@ TEST_F(BRepGraphTest, Decompose_ThreeDisconnectedFaces_ThreeComponents)
 TEST_F(BRepGraphTest, DetectToleranceConflicts_ManualConflict_Detected)
 {
   // Find two edges that share the same Curve3d handle.
-  bool      isConflictSetUp = false;
-  const int aNbEdges        = myGraph.Topo().Edges().Nb();
+  bool           isConflictSetUp = false;
+  const uint32_t aNbEdges        = myGraph.Topo().Edges().Nb();
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges) && !isConflictSetUp; ++anEdgeId)
   {
     if (BRepGraph_Tool::Edge::Degenerated(myGraph, anEdgeId)
@@ -2781,7 +2781,7 @@ TEST_F(BRepGraphTest, SetHistoryEnabled_DisableAndQuery)
 
 TEST_F(BRepGraphTest, RecordHistory_Disabled_NoRecordAdded)
 {
-  const int aBefore = myGraph.History().NbRecords();
+  const size_t aBefore = myGraph.History().NbRecords();
 
   myGraph.History().SetEnabled(false);
 
@@ -2798,7 +2798,7 @@ TEST_F(BRepGraphTest, RecordHistory_ReEnabled_RecordsAgain)
 {
   myGraph.History().SetEnabled(false);
 
-  const int aBefore = myGraph.History().NbRecords();
+  const size_t aBefore = myGraph.History().NbRecords();
 
   BRepGraph_NodeId                     anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   BRepGraph_NodeId                     anEdge1(BRepGraph_NodeId::Kind::Edge, 1);
@@ -2817,7 +2817,7 @@ TEST_F(BRepGraphTest, ApplyModification_HistoryDisabled_NoHistoryNoDerivedEdges)
 {
   myGraph.History().SetEnabled(false);
 
-  const int aNbHistBefore = myGraph.History().NbRecords();
+  const size_t aNbHistBefore = myGraph.History().NbRecords();
 
   BRepGraph_NodeId anEdge0(BRepGraph_NodeId::Kind::Edge, 0);
   BRepGraph_NodeId anEdge1(BRepGraph_NodeId::Kind::Edge, 1);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Test.cxx
@@ -1265,8 +1265,8 @@ TEST_F(BRepGraphTest, NbFacesOfEdge_SharedEdge)
     if (!BRepGraph_Tool::Edge::Degenerated(myGraph, anEdgeIt.CurrentId()))
     {
       const uint32_t aCount = myGraph.Topo().Edges().NbFaces(anEdgeIt.CurrentId());
-      EXPECT_EQ(aCount, 2) << "Edge " << anEdgeIt.CurrentId().Index
-                           << " should be shared by 2 faces";
+      EXPECT_EQ(aCount, 2u) << "Edge " << anEdgeIt.CurrentId().Index
+                            << " should be shared by 2 faces";
     }
   }
 }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Tool_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Tool_Test.cxx
@@ -42,11 +42,11 @@ protected:
 
 TEST_F(BRepGraph_QuerySurfaceTest, Face_NbWires_BoxFaceHasOneWire)
 {
-  const int aNbFaces = myBoxGraph.Topo().Faces().Nb();
-  for (BRepGraph_FaceId aFaceId(0); aFaceId.IsValid(aNbFaces); ++aFaceId)
+  for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start();
+       aFaceId.IsValid(myBoxGraph.Topo().Faces().Nb()); ++aFaceId)
   {
-    const int aNb = BRepGraph_Tool::Face::NbWires(myBoxGraph, aFaceId);
-    EXPECT_EQ(aNb, 1) << "Box face " << aFaceId.Index << " should have exactly 1 wire";
+    const uint32_t aNb = BRepGraph_Tool::Face::NbWires(myBoxGraph, aFaceId);
+    EXPECT_EQ(aNb, 1u) << "Box face " << aFaceId.Index << " should have exactly 1 wire";
   }
 }
 
@@ -102,12 +102,12 @@ TEST_F(BRepGraph_QuerySurfaceTest, Wire_IsOuter_FirstWireOfBoxFaceIsOuter)
 
 TEST_F(BRepGraph_QuerySurfaceTest, Edge_NbFaces_BoxEdgeHasExactlyTwoFaces)
 {
-  const int aNbEdges = myBoxGraph.Topo().Edges().Nb();
-  for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
+  for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
+       anEdgeId.IsValid(myBoxGraph.Topo().Edges().Nb()); ++anEdgeId)
   {
-    const int aNbFaces = BRepGraph_Tool::Edge::NbFaces(myBoxGraph, anEdgeId);
-    EXPECT_EQ(aNbFaces, 2) << "Box edge " << anEdgeId.Index
-                           << " should be shared by exactly 2 faces";
+    const uint32_t aNbFaces = BRepGraph_Tool::Edge::NbFaces(myBoxGraph, anEdgeId);
+    EXPECT_EQ(aNbFaces, 2u) << "Box edge " << anEdgeId.Index
+                            << " should be shared by exactly 2 faces";
   }
 }
 

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Tool_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Tool_Test.cxx
@@ -43,7 +43,8 @@ protected:
 TEST_F(BRepGraph_QuerySurfaceTest, Face_NbWires_BoxFaceHasOneWire)
 {
   for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start();
-       aFaceId.IsValid(myBoxGraph.Topo().Faces().Nb()); ++aFaceId)
+       aFaceId.IsValid(myBoxGraph.Topo().Faces().Nb());
+       ++aFaceId)
   {
     const uint32_t aNb = BRepGraph_Tool::Face::NbWires(myBoxGraph, aFaceId);
     EXPECT_EQ(aNb, 1u) << "Box face " << aFaceId.Index << " should have exactly 1 wire";
@@ -103,7 +104,8 @@ TEST_F(BRepGraph_QuerySurfaceTest, Wire_IsOuter_FirstWireOfBoxFaceIsOuter)
 TEST_F(BRepGraph_QuerySurfaceTest, Edge_NbFaces_BoxEdgeHasExactlyTwoFaces)
 {
   for (BRepGraph_EdgeId anEdgeId = BRepGraph_EdgeId::Start();
-       anEdgeId.IsValid(myBoxGraph.Topo().Edges().Nb()); ++anEdgeId)
+       anEdgeId.IsValid(myBoxGraph.Topo().Edges().Nb());
+       ++anEdgeId)
   {
     const uint32_t aNbFaces = BRepGraph_Tool::Edge::NbFaces(myBoxGraph, anEdgeId);
     EXPECT_EQ(aNbFaces, 2u) << "Box edge " << anEdgeId.Index

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Views_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Views_Test.cxx
@@ -636,18 +636,18 @@ TEST_F(BRepGraph_ViewsTest, EdgeOps_FindCoEdgeId_InvalidPair_ReturnsInvalid)
 {
   // Use a valid edge but a face that doesn't share it.
   // Edge 0 and the last face are very unlikely to share a coedge in a box.
-  const int                                   aNbFaces = myGraph.Topo().Faces().Nb();
   const BRepGraph_EdgeId                      anEdge(0);
   const NCollection_Vector<BRepGraph_FaceId>& aEdgeFaces = myGraph.Topo().Edges().Faces(anEdge);
 
   // Find a face NOT adjacent to edge 0.
   BRepGraph_FaceId aNonAdjacentFace;
-  for (int aFaceIdx = 0; aFaceIdx < aNbFaces; ++aFaceIdx)
+  for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start();
+       aFaceId.IsValid(myGraph.Topo().Faces().Nb()); ++aFaceId)
   {
     bool isAdjacent = false;
     for (const BRepGraph_FaceId& aFace : aEdgeFaces)
     {
-      if (aFace.Index == aFaceIdx)
+      if (aFace.Index == aFaceId.Index)
       {
         isAdjacent = true;
         break;
@@ -655,7 +655,7 @@ TEST_F(BRepGraph_ViewsTest, EdgeOps_FindCoEdgeId_InvalidPair_ReturnsInvalid)
     }
     if (!isAdjacent)
     {
-      aNonAdjacentFace = BRepGraph_FaceId(aFaceIdx);
+      aNonAdjacentFace = aFaceId;
       break;
     }
   }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Views_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Views_Test.cxx
@@ -642,7 +642,8 @@ TEST_F(BRepGraph_ViewsTest, EdgeOps_FindCoEdgeId_InvalidPair_ReturnsInvalid)
   // Find a face NOT adjacent to edge 0.
   BRepGraph_FaceId aNonAdjacentFace;
   for (BRepGraph_FaceId aFaceId = BRepGraph_FaceId::Start();
-       aFaceId.IsValid(myGraph.Topo().Faces().Nb()); ++aFaceId)
+       aFaceId.IsValid(myGraph.Topo().Faces().Nb());
+       ++aFaceId)
   {
     bool isAdjacent = false;
     for (const BRepGraph_FaceId& aFace : aEdgeFaces)


### PR DESCRIPTION
- Updated loop indices in various tests to use size_t instead of int for better type safety and consistency.
- Replaced direct integer indexing with BRepGraph_*Id::Start() and IsValid() methods for improved readability and maintainability.
- Added new utility function expectBoxNear to simplify bounding box comparison in tests.
- Enhanced assertions to provide clearer error messages and ensure proper validation of graph structures.
- Ensured that all tests maintain consistent expectations regarding the number of vertices, edges, and faces in the BRepGraph.