### PR TITLE
Coding - Utilize NCollection_LinearVector instead vector

### DIFF
--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -175,17 +175,20 @@ static void writeIndicesToDracoMesh(draco::Mesh&                                
 class DracoEncodingFunctor
 {
 public:
-  DracoEncodingFunctor(const Message_ProgressRange&                                theProgress,
-                       draco::Encoder&                                             theDracoEncoder,
-                       const std::vector<std::shared_ptr<RWGltf_CafWriter::Mesh>>& theMeshes,
-                       std::vector<std::shared_ptr<draco::EncoderBuffer>>& theEncoderBuffers)
-      : myProgress(theProgress, "Draco compression", std::max(1, int(theMeshes.size()))),
+  using MeshVector = NCollection_LinearVector<std::shared_ptr<RWGltf_CafWriter::Mesh>>;
+  using EncoderBufferVector = NCollection_LinearVector<std::shared_ptr<draco::EncoderBuffer>>;
+
+  DracoEncodingFunctor(const Message_ProgressRange& theProgress,
+                       draco::Encoder&              theDracoEncoder,
+                       const MeshVector&            theMeshes,
+                       EncoderBufferVector&         theEncoderBuffers)
+      : myProgress(theProgress, "Draco compression", std::max(1, int(theMeshes.Size()))),
         myDracoEncoder(&theDracoEncoder),
-        myRanges(0, int(theMeshes.size()) - 1),
+        myRanges(0, int(theMeshes.Size()) - 1),
         myMeshes(&theMeshes),
         myEncoderBuffers(&theEncoderBuffers)
   {
-    for (int anIndex = 0; anIndex != int(theMeshes.size()); ++anIndex)
+    for (int anIndex = 0; anIndex != int(theMeshes.Size()); ++anIndex)
     {
       myRanges.SetValue(anIndex, myProgress.Next());
     }
@@ -193,7 +196,7 @@ public:
 
   void operator()(int theMeshIndex) const
   {
-    const std::shared_ptr<RWGltf_CafWriter::Mesh>& aCurrentMesh = myMeshes->at(theMeshIndex);
+    const std::shared_ptr<RWGltf_CafWriter::Mesh>& aCurrentMesh = myMeshes->Value(theMeshIndex);
     if (aCurrentMesh->NodesVec.IsEmpty())
     {
       return;
@@ -221,7 +224,7 @@ public:
     draco::Status aStatus = myDracoEncoder->EncodeMeshToBuffer(aMesh, anEncoderBuffer.get());
     if (aStatus.ok())
     {
-      myEncoderBuffers->at(theMeshIndex) = anEncoderBuffer;
+      myEncoderBuffers->ChangeValue(theMeshIndex) = anEncoderBuffer;
     }
 
     aScope.Next();
@@ -231,8 +234,8 @@ private:
   Message_ProgressScope                                       myProgress;
   draco::Encoder*                                             myDracoEncoder;
   NCollection_Array1<Message_ProgressRange>                   myRanges;
-  const std::vector<std::shared_ptr<RWGltf_CafWriter::Mesh>>* myMeshes;
-  std::vector<std::shared_ptr<draco::EncoderBuffer>>*         myEncoderBuffers;
+  const MeshVector*                                           myMeshes;
+  EncoderBufferVector*                                        myEncoderBuffers;
 };
 #endif
 
@@ -896,8 +899,8 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
     }
   }
 
-  std::vector<std::shared_ptr<RWGltf_CafWriter::Mesh>> aMeshes;
-  int                                                  aNbAccessors = 0;
+  NCollection_LinearVector<std::shared_ptr<RWGltf_CafWriter::Mesh>> aMeshes;
+  int                                                                aNbAccessors = 0;
   NCollection_Map<occ::handle<NCollection_Shared<NCollection_List<occ::handle<RWGltf_GltfFace>>>>>
     aWrittenFaces;
   NCollection_DataMap<TopoDS_Shape, occ::handle<RWGltf_GltfFace>, TopTools_ShapeMapHasher>
@@ -954,14 +957,13 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
         ++aMeshIndex;
         if (myDracoParameters.DracoCompression)
         {
-          if (aMeshIndex <= aMeshes.size())
+          if (aMeshIndex <= aMeshes.Size())
           {
-            aMeshPtr = aMeshes.at(aMeshIndex - 1);
+            aMeshPtr = aMeshes.Value(aMeshIndex - 1);
           }
           else
           {
-            aMeshes.push_back(std::make_shared<RWGltf_CafWriter::Mesh>(RWGltf_CafWriter::Mesh()));
-            aMeshPtr = aMeshes.back();
+            aMeshPtr = aMeshes.Append(std::make_shared<RWGltf_CafWriter::Mesh>());
           }
         }
 #endif
@@ -1109,14 +1111,16 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
     aDracoEncoder.SetSpeedOptions(myDracoParameters.CompressionLevel,
                                   myDracoParameters.CompressionLevel);
 
-    std::vector<std::shared_ptr<draco::EncoderBuffer>> anEncoderBuffers(aMeshes.size());
+    NCollection_LinearVector<std::shared_ptr<draco::EncoderBuffer>> anEncoderBuffers(
+      aMeshes.Size(),
+      std::shared_ptr<draco::EncoderBuffer>());
     DracoEncodingFunctor aFunctor(aScope.Next(), aDracoEncoder, aMeshes, anEncoderBuffers);
-    OSD_Parallel::For(0, int(aMeshes.size()), aFunctor, !myToParallel);
+    OSD_Parallel::For(0, int(aMeshes.Size()), aFunctor, !myToParallel);
 
     int aNbSkippedBuffers = 0;
-    for (size_t aBuffInd = 0; aBuffInd != anEncoderBuffers.size(); ++aBuffInd)
+    for (size_t aBuffInd = 0; aBuffInd != anEncoderBuffers.Size(); ++aBuffInd)
     {
-      if (anEncoderBuffers.at(aBuffInd).get() == nullptr)
+      if (anEncoderBuffers.Value(aBuffInd).get() == nullptr)
       {
         if (aBuffViewId == 0)
         {
@@ -1131,7 +1135,7 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
       RWGltf_GltfBufferView aBuffViewDraco;
       aBuffViewDraco.Id                         = (int)aBuffInd + aBuffViewId - aNbSkippedBuffers;
       aBuffViewDraco.ByteOffset                 = aBinFile->tellp();
-      const draco::EncoderBuffer& anEncoderBuff = *anEncoderBuffers.at(aBuffInd);
+      const draco::EncoderBuffer& anEncoderBuff = *anEncoderBuffers.Value(aBuffInd);
       aBinFile->write(anEncoderBuff.data(), std::streamsize(anEncoderBuff.size()));
       if (!aBinFile->good())
       {

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -175,7 +175,7 @@ static void writeIndicesToDracoMesh(draco::Mesh&                                
 class DracoEncodingFunctor
 {
 public:
-  using MeshVector = NCollection_LinearVector<std::shared_ptr<RWGltf_CafWriter::Mesh>>;
+  using MeshVector          = NCollection_LinearVector<std::shared_ptr<RWGltf_CafWriter::Mesh>>;
   using EncoderBufferVector = NCollection_LinearVector<std::shared_ptr<draco::EncoderBuffer>>;
 
   DracoEncodingFunctor(const Message_ProgressRange& theProgress,
@@ -231,11 +231,11 @@ public:
   }
 
 private:
-  Message_ProgressScope                                       myProgress;
-  draco::Encoder*                                             myDracoEncoder;
-  NCollection_Array1<Message_ProgressRange>                   myRanges;
-  const MeshVector*                                           myMeshes;
-  EncoderBufferVector*                                        myEncoderBuffers;
+  Message_ProgressScope                     myProgress;
+  draco::Encoder*                           myDracoEncoder;
+  NCollection_Array1<Message_ProgressRange> myRanges;
+  const MeshVector*                         myMeshes;
+  EncoderBufferVector*                      myEncoderBuffers;
 };
 #endif
 
@@ -900,7 +900,7 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
   }
 
   NCollection_LinearVector<std::shared_ptr<RWGltf_CafWriter::Mesh>> aMeshes;
-  int                                                                aNbAccessors = 0;
+  int                                                               aNbAccessors = 0;
   NCollection_Map<occ::handle<NCollection_Shared<NCollection_List<occ::handle<RWGltf_GltfFace>>>>>
     aWrittenFaces;
   NCollection_DataMap<TopoDS_Shape, occ::handle<RWGltf_GltfFace>, TopTools_ShapeMapHasher>

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -92,19 +92,19 @@ static void writeVertex(std::ostream& theStream, const T& theVertex)
 #ifdef HAVE_DRACO
 //! Write nodes to Draco mesh
 static void writeNodesToDracoMesh(draco::Mesh&                                theMesh,
-                                  const std::vector<NCollection_Vec3<float>>& theNodes)
+                                  const NCollection_LinearVector<NCollection_Vec3<float>>& theNodes)
 {
-  if (theNodes.empty())
+  if (theNodes.IsEmpty())
   {
     return;
   }
 
   draco::PointAttribute anAttr;
   anAttr.Init(draco::GeometryAttribute::POSITION, 3, draco::DT_FLOAT32, false, sizeof(float) * 3);
-  const int              anId = theMesh.AddAttribute(anAttr, true, uint32_t(theNodes.size()));
+  const int              anId = theMesh.AddAttribute(anAttr, true, uint32_t(theNodes.Size()));
   draco::PointAttribute* aPtr = theMesh.attribute(anId);
   draco::PointIndex      anIndex(0);
-  for (size_t aNodeInd = 0; aNodeInd < theNodes.size(); ++aNodeInd, ++anIndex)
+  for (size_t aNodeInd = 0; aNodeInd < theNodes.Size(); ++aNodeInd, ++anIndex)
   {
     aPtr->SetAttributeValue(aPtr->mapped_index(anIndex), theNodes[aNodeInd].GetData());
   }
@@ -112,19 +112,19 @@ static void writeNodesToDracoMesh(draco::Mesh&                                th
 
 //! Write normals to Draco mesh
 static void writeNormalsToDracoMesh(draco::Mesh&                                theMesh,
-                                    const std::vector<NCollection_Vec3<float>>& theNormals)
+                                    const NCollection_LinearVector<NCollection_Vec3<float>>& theNormals)
 {
-  if (theNormals.empty())
+  if (theNormals.IsEmpty())
   {
     return;
   }
 
   draco::PointAttribute anAttr;
   anAttr.Init(draco::GeometryAttribute::NORMAL, 3, draco::DT_FLOAT32, false, sizeof(float) * 3);
-  const int              anId = theMesh.AddAttribute(anAttr, true, uint32_t(theNormals.size()));
+  const int              anId = theMesh.AddAttribute(anAttr, true, uint32_t(theNormals.Size()));
   draco::PointAttribute* aPtr = theMesh.attribute(anId);
   draco::PointIndex      anIndex(0);
-  for (size_t aNormInd = 0; aNormInd < theNormals.size(); ++aNormInd, ++anIndex)
+  for (size_t aNormInd = 0; aNormInd < theNormals.Size(); ++aNormInd, ++anIndex)
   {
     aPtr->SetAttributeValue(aPtr->mapped_index(anIndex), theNormals[aNormInd].GetData());
   }
@@ -132,19 +132,19 @@ static void writeNormalsToDracoMesh(draco::Mesh&                                
 
 //! Write texture UV coordinates to Draco mesh
 static void writeTexCoordsToDracoMesh(draco::Mesh&                                theMesh,
-                                      const std::vector<NCollection_Vec2<float>>& theTexCoord)
+                                      const NCollection_LinearVector<NCollection_Vec2<float>>& theTexCoord)
 {
-  if (theTexCoord.empty())
+  if (theTexCoord.IsEmpty())
   {
     return;
   }
 
   draco::PointAttribute anAttr;
   anAttr.Init(draco::GeometryAttribute::TEX_COORD, 2, draco::DT_FLOAT32, false, sizeof(float) * 2);
-  const int              anId = theMesh.AddAttribute(anAttr, true, uint32_t(theTexCoord.size()));
+  const int              anId = theMesh.AddAttribute(anAttr, true, uint32_t(theTexCoord.Size()));
   draco::PointAttribute* aPtr = theMesh.attribute(anId);
   draco::PointIndex      anIndex(0);
-  for (size_t aTexInd = 0; aTexInd < theTexCoord.size(); ++aTexInd, ++anIndex)
+  for (size_t aTexInd = 0; aTexInd < theTexCoord.Size(); ++aTexInd, ++anIndex)
   {
     aPtr->SetAttributeValue(aPtr->mapped_index(anIndex), theTexCoord[aTexInd].GetData());
   }
@@ -152,11 +152,11 @@ static void writeTexCoordsToDracoMesh(draco::Mesh&                              
 
 //! Write indices to Draco mesh
 static void writeIndicesToDracoMesh(draco::Mesh&                      theMesh,
-                                    const std::vector<Poly_Triangle>& theIndices)
+                                    const NCollection_LinearVector<Poly_Triangle>& theIndices)
 {
   draco::Mesh::Face aFace;
   int               anIndex = 0;
-  for (size_t anInd = 0; anInd < theIndices.size(); ++anInd, ++anIndex)
+  for (size_t anInd = 0; anInd < theIndices.Size(); ++anInd, ++anIndex)
   {
     const Poly_Triangle& anElem = theIndices[anInd];
     aFace[0]                    = anElem.Value(1);
@@ -192,7 +192,7 @@ public:
   void operator()(int theMeshIndex) const
   {
     const std::shared_ptr<RWGltf_CafWriter::Mesh>& aCurrentMesh = myMeshes->at(theMeshIndex);
-    if (aCurrentMesh->NodesVec.empty())
+    if (aCurrentMesh->NodesVec.IsEmpty())
     {
       return;
     }
@@ -202,12 +202,12 @@ public:
     draco::Mesh aMesh;
     writeNodesToDracoMesh(aMesh, aCurrentMesh->NodesVec);
 
-    if (!aCurrentMesh->NormalsVec.empty())
+    if (!aCurrentMesh->NormalsVec.IsEmpty())
     {
       writeNormalsToDracoMesh(aMesh, aCurrentMesh->NormalsVec);
     }
 
-    if (!aCurrentMesh->TexCoordsVec.empty())
+    if (!aCurrentMesh->TexCoordsVec.IsEmpty())
     {
       writeTexCoordsToDracoMesh(aMesh, aCurrentMesh->TexCoordsVec);
     }
@@ -352,7 +352,7 @@ void RWGltf_CafWriter::saveNodes(RWGltf_GltfFace&                               
     theGltfFace.NodePos.BndBox.Add(NCollection_Vec3<double>(aNode.X(), aNode.Y(), aNode.Z()));
     if (theMesh.get() != nullptr && hasTriangulation(theGltfFace))
     {
-      theMesh->NodesVec.push_back(
+      theMesh->NodesVec.Append(
         NCollection_Vec3<float>(float(aNode.X()), float(aNode.Y()), float(aNode.Z())));
     }
     else
@@ -401,7 +401,7 @@ void RWGltf_CafWriter::saveNormals(RWGltf_GltfFace&                             
     myCSTrsf.TransformNormal(aVecNormal);
     if (theMesh.get() != nullptr)
     {
-      theMesh->NormalsVec.push_back(aVecNormal);
+      theMesh->NormalsVec.Append(aVecNormal);
     }
     else
     {
@@ -464,7 +464,7 @@ void RWGltf_CafWriter::saveTextCoords(RWGltf_GltfFace&                          
     aTexCoord.SetY(1.0 - aTexCoord.Y());
     if (theMesh.get() != nullptr)
     {
-      theMesh->TexCoordsVec.push_back(
+      theMesh->TexCoordsVec.Append(
         NCollection_Vec2<float>((float)aTexCoord.X(), (float)aTexCoord.Y()));
     }
     else
@@ -493,7 +493,7 @@ void RWGltf_CafWriter::saveTriangleIndices(RWGltf_GltfFace&           theGltfFac
     aTri(3) += aNodeFirst;
     if (theMesh.get() != nullptr)
     {
-      theMesh->IndicesVec.push_back(aTri);
+      theMesh->IndicesVec.Append(aTri);
     }
     else
     {
@@ -839,7 +839,7 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
   myBuffViewInd.ByteLength = 0;
   myBuffViewInd.Target     = RWGltf_GltfBufferViewTarget_ELEMENT_ARRAY_BUFFER;
 
-  myBuffViewsDraco.clear();
+  myBuffViewsDraco.Clear();
 
   myBinDataMap.Clear();
   myBinDataLen64 = 0;
@@ -1146,7 +1146,7 @@ bool RWGltf_CafWriter::writeBinData(const occ::handle<TDocStd_Document>&        
       }
 
       aBuffViewDraco.ByteLength = aLength - aBuffViewDraco.ByteOffset;
-      myBuffViewsDraco.push_back(aBuffViewDraco);
+      myBuffViewsDraco.Append(aBuffViewDraco);
     }
     aDracoTimer.Stop();
     Message::SendInfo(TCollection_AsciiString("Draco compression time: ")
@@ -1848,7 +1848,7 @@ void RWGltf_CafWriter::writeBufferViews(const int theBinDataBufferId)
   }
   if (myDracoParameters.DracoCompression)
   {
-    for (size_t aBufInd = 0; aBufInd != myBuffViewsDraco.size(); ++aBufInd)
+    for (size_t aBufInd = 0; aBufInd != myBuffViewsDraco.Size(); ++aBufInd)
     {
       if (myBuffViewsDraco[aBufInd].Id != RWGltf_GltfAccessor::INVALID_ID)
       {

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.cxx
@@ -91,7 +91,7 @@ static void writeVertex(std::ostream& theStream, const T& theVertex)
 
 #ifdef HAVE_DRACO
 //! Write nodes to Draco mesh
-static void writeNodesToDracoMesh(draco::Mesh&                                theMesh,
+static void writeNodesToDracoMesh(draco::Mesh&                                             theMesh,
                                   const NCollection_LinearVector<NCollection_Vec3<float>>& theNodes)
 {
   if (theNodes.IsEmpty())
@@ -111,8 +111,9 @@ static void writeNodesToDracoMesh(draco::Mesh&                                th
 }
 
 //! Write normals to Draco mesh
-static void writeNormalsToDracoMesh(draco::Mesh&                                theMesh,
-                                    const NCollection_LinearVector<NCollection_Vec3<float>>& theNormals)
+static void writeNormalsToDracoMesh(
+  draco::Mesh&                                             theMesh,
+  const NCollection_LinearVector<NCollection_Vec3<float>>& theNormals)
 {
   if (theNormals.IsEmpty())
   {
@@ -131,8 +132,9 @@ static void writeNormalsToDracoMesh(draco::Mesh&                                
 }
 
 //! Write texture UV coordinates to Draco mesh
-static void writeTexCoordsToDracoMesh(draco::Mesh&                                theMesh,
-                                      const NCollection_LinearVector<NCollection_Vec2<float>>& theTexCoord)
+static void writeTexCoordsToDracoMesh(
+  draco::Mesh&                                             theMesh,
+  const NCollection_LinearVector<NCollection_Vec2<float>>& theTexCoord)
 {
   if (theTexCoord.IsEmpty())
   {
@@ -151,7 +153,7 @@ static void writeTexCoordsToDracoMesh(draco::Mesh&                              
 }
 
 //! Write indices to Draco mesh
-static void writeIndicesToDracoMesh(draco::Mesh&                      theMesh,
+static void writeIndicesToDracoMesh(draco::Mesh&                                   theMesh,
                                     const NCollection_LinearVector<Poly_Triangle>& theIndices)
 {
   draco::Mesh::Face aFace;

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.hxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.hxx
@@ -16,6 +16,7 @@
 
 #include <Message_ProgressScope.hxx>
 #include <NCollection_DataMap.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <NCollection_IndexedDataMap.hxx>
 #include <NCollection_Map.hxx>
@@ -54,10 +55,10 @@ public:
   //! Mesh
   struct Mesh
   {
-    std::vector<NCollection_Vec3<float>> NodesVec;     //!< vector for mesh nodes
-    std::vector<NCollection_Vec3<float>> NormalsVec;   //!< vector for mesh normals
-    std::vector<NCollection_Vec2<float>> TexCoordsVec; //!< vector for mesh texture UV coordinates
-    std::vector<Poly_Triangle>           IndicesVec;   //!< vector for mesh indices
+    NCollection_LinearVector<NCollection_Vec3<float>> NodesVec;     //!< vector for mesh nodes
+    NCollection_LinearVector<NCollection_Vec3<float>> NormalsVec;   //!< vector for mesh normals
+    NCollection_LinearVector<NCollection_Vec2<float>> TexCoordsVec; //!< vector for mesh texture UV coordinates
+    NCollection_LinearVector<Poly_Triangle>           IndicesVec;   //!< vector for mesh indices
   };
 
   //! Main constructor.
@@ -537,7 +538,7 @@ protected:
   ShapeToGltfFaceMap                            myBinDataMap;        //!< map for TopoDS_Face to glTF face (merging duplicates)
   int64_t                                       myBinDataLen64;      //!< length of binary file
 
-  std::vector<RWGltf_GltfBufferView>            myBuffViewsDraco;    //!< vector of buffers view with compression data
+  NCollection_LinearVector<RWGltf_GltfBufferView>               myBuffViewsDraco;    //!< vector of buffers view with compression data
   bool                              myToParallel;        //!< flag to use multithreading; FALSE by default
                                             // clang-format on
   RWGltf_DracoParameters myDracoParameters; //!< Draco parameters

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.hxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_CafWriter.hxx
@@ -55,10 +55,11 @@ public:
   //! Mesh
   struct Mesh
   {
-    NCollection_LinearVector<NCollection_Vec3<float>> NodesVec;     //!< vector for mesh nodes
-    NCollection_LinearVector<NCollection_Vec3<float>> NormalsVec;   //!< vector for mesh normals
-    NCollection_LinearVector<NCollection_Vec2<float>> TexCoordsVec; //!< vector for mesh texture UV coordinates
-    NCollection_LinearVector<Poly_Triangle>           IndicesVec;   //!< vector for mesh indices
+    NCollection_LinearVector<NCollection_Vec3<float>> NodesVec;   //!< vector for mesh nodes
+    NCollection_LinearVector<NCollection_Vec3<float>> NormalsVec; //!< vector for mesh normals
+    NCollection_LinearVector<NCollection_Vec2<float>>
+      TexCoordsVec;                                     //!< vector for mesh texture UV coordinates
+    NCollection_LinearVector<Poly_Triangle> IndicesVec; //!< vector for mesh indices
   };
 
   //! Main constructor.

--- a/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
+++ b/src/DataExchange/TKDEGLTF/RWGltf/RWGltf_TriangulationReader.cxx
@@ -15,6 +15,7 @@
 #include <RWGltf_TriangulationReader.hxx>
 
 #include <Message.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <OSD_FileSystem.hxx>
 #include <RWGltf_GltfLatePrimitiveArray.hxx>
 #include <RWGltf_GltfPrimArrayData.hxx>
@@ -247,9 +248,9 @@ bool RWGltf_TriangulationReader::readDracoBuffer(
   }
 
 #ifdef HAVE_DRACO
-  std::vector<char> aReadData;
-  aReadData.resize((size_t)theGltfData.StreamLength);
-  aSharedStream->read(aReadData.data(), (std::streamsize)theGltfData.StreamLength);
+  NCollection_LinearVector<char> aReadData;
+  aReadData.Resize((size_t)theGltfData.StreamLength);
+  aSharedStream->read(aReadData.begin(), (std::streamsize)theGltfData.StreamLength);
   if (!aSharedStream->good())
   {
     reportError(TCollection_AsciiString("Buffer '") + aName
@@ -258,7 +259,7 @@ bool RWGltf_TriangulationReader::readDracoBuffer(
   }
 
   draco::DecoderBuffer aDracoBuf;
-  aDracoBuf.Init(aReadData.data(), aReadData.size());
+  aDracoBuf.Init(aReadData.begin(), aReadData.Size());
 
   draco::Decoder                                aDracoDecoder;
   draco::StatusOr<std::unique_ptr<draco::Mesh>> aDracoStat =

--- a/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.cxx
+++ b/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.cxx
@@ -102,7 +102,7 @@ bool RWObj_Reader::read(std::istream&                  theStream,
   // determine file location to load associated files
   TCollection_AsciiString aFileName;
   OSD_Path::FolderAndFileFromPath(theFile, myFolder, aFileName);
-  myCurrElem.resize(1024, -1);
+  myCurrElem.Resize(1024, -1);
 
   Standard_CLocaleSentry aLocaleSentry;
   if (!theStream.good())
@@ -397,9 +397,9 @@ void RWObj_Reader::pushIndices(const char* thePos)
       }
     }
 
-    if (myCurrElem.size() < size_t(aNode))
+    if (myCurrElem.Size() < size_t(aNode))
     {
-      myCurrElem.resize(aNode * 2, -1);
+      myCurrElem.Resize(aNode * 2, -1);
     }
     myCurrElem[aNode] = anIndex;
     aNbElemNodes      = aNode + 1;

--- a/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.hxx
+++ b/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.hxx
@@ -30,8 +30,7 @@
 #include <RWObj_SubMeshReason.hxx>
 #include <RWObj_Tools.hxx>
 #include <Standard_HashUtils.hxx>
-
-#include <vector>
+#include <NCollection_LinearVector.hxx>
 
 //! An abstract class implementing procedure to read OBJ file.
 //!
@@ -384,7 +383,7 @@ protected:
     myMaterials; //!< map of known materials
 
   RWObj_SubMesh    myActiveSubMesh; //!< active sub-mesh definition
-  std::vector<int> myCurrElem;      //!< indices for the current element
+  NCollection_LinearVector<int> myCurrElem;      //!< indices for the current element
 };
 
 #endif // _RWObj_Reader_HeaderFile

--- a/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.hxx
+++ b/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.hxx
@@ -382,7 +382,7 @@ protected:
   NCollection_DataMap<TCollection_AsciiString, RWObj_Material>
     myMaterials; //!< map of known materials
 
-  RWObj_SubMesh    myActiveSubMesh; //!< active sub-mesh definition
+  RWObj_SubMesh                 myActiveSubMesh; //!< active sub-mesh definition
   NCollection_LinearVector<int> myCurrElem;      //!< indices for the current element
 };
 

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_GDTProperty.cxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_GDTProperty.cxx
@@ -14,6 +14,7 @@
 // commercial license or contractual agreement.
 
 #include <BRep_Tool.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_Curve.hxx>
 #include <Geom_Line.hxx>
@@ -1519,11 +1520,11 @@ occ::handle<StepVisual_TessellatedGeometricSet> STEPCAFControl_GDTProperty::GetT
   const TopoDS_Shape& theShape)
 {
   // Build complex_triangulated_surface_set.
-  std::vector<occ::handle<StepVisual_ComplexTriangulatedSurfaceSet>> aCTSSs;
+  NCollection_LinearVector<occ::handle<StepVisual_ComplexTriangulatedSurfaceSet>> aCTSSs;
   for (TopExp_Explorer aFaceIt(theShape, TopAbs_FACE); aFaceIt.More(); aFaceIt.Next())
   {
     const TopoDS_Face aFace = TopoDS::Face(aFaceIt.Current());
-    aCTSSs.emplace_back(GenerateComplexTriangulatedSurfaceSet(aFace));
+    aCTSSs.Append(GenerateComplexTriangulatedSurfaceSet(aFace));
   }
 
   // Build tesselated_curve_set.
@@ -1532,10 +1533,10 @@ occ::handle<StepVisual_TessellatedGeometricSet> STEPCAFControl_GDTProperty::GetT
   // Fill the container of tessellated items.
   NCollection_Handle<NCollection_Array1<occ::handle<StepVisual_TessellatedItem>>> aTesselatedItems =
     new NCollection_Array1<occ::handle<StepVisual_TessellatedItem>>(1,
-                                                                    static_cast<int>(aCTSSs.size())
+                                                                    static_cast<int>(aCTSSs.Size())
                                                                       + 1);
   aTesselatedItems->SetValue(1, aTCS);
-  for (size_t aCTSSIndex = 0; aCTSSIndex < aCTSSs.size(); ++aCTSSIndex)
+  for (size_t aCTSSIndex = 0; aCTSSIndex < aCTSSs.Size(); ++aCTSSIndex)
   {
     aTesselatedItems->SetValue(static_cast<int>(aCTSSIndex) + 2, aCTSSs[aCTSSIndex]);
   }

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.cxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.cxx
@@ -5916,11 +5916,11 @@ occ::handle<StepBasic_Product> STEPCAFControl_Reader::getProductFromProductDefin
 
 //=================================================================================================
 
-std::vector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
+NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
   collectPropertyDefinitions(const occ::handle<XSControl_WorkSession>& theWorkSession,
                              const occ::handle<Standard_Transient>&    theGeneralProperty) const
 {
-  std::vector<occ::handle<StepRepr_PropertyDefinition>> aResult;
+  NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> aResult;
 
   occ::handle<StepBasic_GeneralProperty> aGeneralProp =
     occ::down_cast<StepBasic_GeneralProperty>(theGeneralProperty);
@@ -5939,7 +5939,7 @@ std::vector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
       continue;
     }
 
-    aResult.emplace_back(aPropAssociation->PropertyDefinition());
+    aResult.Append(aPropAssociation->PropertyDefinition());
   }
 
   return aResult;
@@ -5947,12 +5947,12 @@ std::vector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
 
 //=================================================================================================
 
-std::vector<TDF_Label> STEPCAFControl_Reader::collectShapeLabels(
+NCollection_LinearVector<TDF_Label> STEPCAFControl_Reader::collectShapeLabels(
   const occ::handle<XSControl_WorkSession>&       theWorkSession,
   const occ::handle<Transfer_TransientProcess>&   theTransferProcess,
   const occ::handle<StepRepr_PropertyDefinition>& theSource) const
 {
-  std::vector<TDF_Label> aResult;
+  NCollection_LinearVector<TDF_Label> aResult;
 
   NCollection_List<occ::handle<Transfer_Binder>> aBinders;
   collectBinders(theWorkSession, theTransferProcess, theSource, aBinders);
@@ -5973,7 +5973,7 @@ std::vector<TDF_Label> STEPCAFControl_Reader::collectShapeLabels(
     TDF_Label aShapeResultLabel;
     if (myMap.Find(aShape, aShapeResultLabel))
     {
-      aResult.emplace_back(aShapeResultLabel);
+      aResult.Append(aShapeResultLabel);
     }
   }
 
@@ -5982,13 +5982,13 @@ std::vector<TDF_Label> STEPCAFControl_Reader::collectShapeLabels(
 
 //=================================================================================================
 
-std::vector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
+NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
   collectRelatedPropertyDefinitions(
     const occ::handle<XSControl_WorkSession>&       theWorkSession,
     const occ::handle<StepRepr_PropertyDefinition>& theProperty) const
 {
-  std::vector<occ::handle<StepRepr_PropertyDefinition>> aGroupedProperties;
-  aGroupedProperties.emplace_back(theProperty);
+  NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> aGroupedProperties;
+  aGroupedProperties.Append(theProperty);
 
   Interface_EntityIterator aSharingsListOfPD = theWorkSession->Graph().Sharings(theProperty);
   for (aSharingsListOfPD.Start(); aSharingsListOfPD.More(); aSharingsListOfPD.Next())
@@ -6003,7 +6003,7 @@ std::vector<occ::handle<StepRepr_PropertyDefinition>> STEPCAFControl_Reader::
     occ::handle<StepRepr_PropertyDefinition> aGroupedProp = aRel->RelatedPropertyDefinition();
     if (!aGroupedProp.IsNull())
     {
-      aGroupedProperties.emplace_back(aGroupedProp);
+      aGroupedProperties.Append(aGroupedProp);
     }
   }
 
@@ -6162,11 +6162,11 @@ bool STEPCAFControl_Reader::ReadMetadata(const occ::handle<XSControl_WorkSession
          collectPropertyDefinitions(theWS, aModel->Value(anEntityInd)))
     {
       // Collect all the related PropertyDefinitions.
-      const std::vector<occ::handle<StepRepr_PropertyDefinition>> aGroupedProperties =
+      const NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> aGroupedProperties =
         collectRelatedPropertyDefinitions(theWS, aPropertyDefinition);
 
       // Collect all the shapes labels.
-      const std::vector<TDF_Label> aLabels =
+      const NCollection_LinearVector<TDF_Label> aLabels =
         collectShapeLabels(theWS, aTransientProcess, aPropertyDefinition);
 
       // Fill all attributes for each shape label.

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.hxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.hxx
@@ -17,6 +17,7 @@
 #define _STEPCAFControl_Reader_HeaderFile
 
 #include <STEPControl_Reader.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <StepData_Factors.hxx>
 #include <IFSelect_ReturnStatus.hxx>
 #include <TDF_Label.hxx>
@@ -474,7 +475,7 @@ private:
   //! @param theWorkSession The work session to use for collecting property definitions.
   //! @param theGeneralProperty The general property from which to collect property definitions.
   //! @return A vector of collected property definitions.
-  std::vector<occ::handle<StepRepr_PropertyDefinition>> collectPropertyDefinitions(
+  NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> collectPropertyDefinitions(
     const occ::handle<XSControl_WorkSession>& theWorkSession,
     const occ::handle<Standard_Transient>&    theGeneralProperty) const;
 
@@ -483,7 +484,7 @@ private:
   //! @param theTransferProcess The transfer process to use for collecting shape labels.
   //! @param theSource The property definition from which to collect shape labels.
   //! @return A vector of collected shape labels.
-  std::vector<TDF_Label> collectShapeLabels(
+  NCollection_LinearVector<TDF_Label> collectShapeLabels(
     const occ::handle<XSControl_WorkSession>&       theWorkSession,
     const occ::handle<Transfer_TransientProcess>&   theTransferProcess,
     const occ::handle<StepRepr_PropertyDefinition>& theSource) const;
@@ -493,7 +494,7 @@ private:
   //! @param theWorkSession The work session to use for collecting related property definitions.
   //! @param theProperty The property definition from which to collect related property definitions.
   //! @return A vector of collected related property definitions.
-  std::vector<occ::handle<StepRepr_PropertyDefinition>> collectRelatedPropertyDefinitions(
+  NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> collectRelatedPropertyDefinitions(
     const occ::handle<XSControl_WorkSession>&       theWorkSession,
     const occ::handle<StepRepr_PropertyDefinition>& theProperty) const;
 

--- a/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.hxx
+++ b/src/DataExchange/TKDESTEP/STEPCAFControl/STEPCAFControl_Reader.hxx
@@ -494,9 +494,10 @@ private:
   //! @param theWorkSession The work session to use for collecting related property definitions.
   //! @param theProperty The property definition from which to collect related property definitions.
   //! @return A vector of collected related property definitions.
-  NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>> collectRelatedPropertyDefinitions(
-    const occ::handle<XSControl_WorkSession>&       theWorkSession,
-    const occ::handle<StepRepr_PropertyDefinition>& theProperty) const;
+  NCollection_LinearVector<occ::handle<StepRepr_PropertyDefinition>>
+    collectRelatedPropertyDefinitions(
+      const occ::handle<XSControl_WorkSession>&       theWorkSession,
+      const occ::handle<StepRepr_PropertyDefinition>& theProperty) const;
 
   //! Helper method to get NamedData attribute assigned to the given label.
   //! @param theLabel The label to get NamedData attribute from.

--- a/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.hxx
+++ b/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.hxx
@@ -29,7 +29,6 @@
 #include <Message_ProgressRange.hxx>
 #include <XSAlgo_ShapeProcessor.hxx>
 
-#include <unordered_map>
 
 struct DE_ShapeFixParameters;
 class XSControl_WorkSession;

--- a/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.hxx
+++ b/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.hxx
@@ -29,7 +29,6 @@
 #include <Message_ProgressRange.hxx>
 #include <XSAlgo_ShapeProcessor.hxx>
 
-
 struct DE_ShapeFixParameters;
 class XSControl_WorkSession;
 class StepData_StepModel;

--- a/src/DataExchange/TKDESTEP/StepTidy/StepTidy_EntityReducer.pxx
+++ b/src/DataExchange/TKDESTEP/StepTidy/StepTidy_EntityReducer.pxx
@@ -17,6 +17,7 @@
 #include <Interface_Graph.hxx>
 #include <NCollection_Allocator.hxx>
 #include <NCollection_DataMap.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Standard_HashUtils.hxx>
 #include <XSControl_WorkSession.hxx>
 #include <Standard_Transient.hxx>
@@ -45,9 +46,9 @@ class StepTidy_EntityReducer
 {
 protected:
   // Map of duplicate entities. Key is the first processed entity, value is a list of duplicates.
-  using DuplicateMap = NCollection_DataMap<occ::handle<ProcessedType>,
-                                           std::vector<occ::handle<ProcessedType>>,
-                                           ProcessedTypeHasher>;
+  using DuplicateList = NCollection_LinearVector<occ::handle<ProcessedType>>;
+  using DuplicateMap =
+    NCollection_DataMap<occ::handle<ProcessedType>, DuplicateList, ProcessedTypeHasher>;
   // Function to replace an entity in sharings. First argument is the old entity, second is the new
   // entity, third is the sharing in which the entity should be replaced. Returns true if the entity
   // was replaced, false otherwise.
@@ -145,17 +146,17 @@ bool StepTidy_EntityReducer<ProcessedType, ProcessedTypeHasher>::ProcessEntity(
     aGraph.GetSharings(anEntity);
   if (hasAllReplacers(aSharings))
   {
-    std::vector<occ::handle<ProcessedType>>* anIter = myDuplicateMap.ChangeSeek(anEntity);
-    if (anIter == nullptr)
-    {
-      // Add as a new key.
-      myDuplicateMap.Bind(anEntity, std::vector<occ::handle<ProcessedType>>{});
-    }
-    else
-    {
-      // Add as a value.
-      anIter->push_back(anEntity);
-    }
+      DuplicateList* anIter = myDuplicateMap.ChangeSeek(anEntity);
+      if (anIter == nullptr)
+      {
+        // Add as a new key.
+        myDuplicateMap.Bind(anEntity, DuplicateList());
+      }
+      else
+      {
+        // Add as a value.
+        anIter->Append(anEntity);
+      }
   }
 
   return true;
@@ -169,9 +170,9 @@ void StepTidy_EntityReducer<ProcessedType, ProcessedTypeHasher>::Perform(
 {
   for (typename DuplicateMap::Iterator anIter(myDuplicateMap); anIter.More(); anIter.Next())
   {
-    const occ::handle<ProcessedType>&              anEntity    = anIter.Key();
-    const std::vector<occ::handle<ProcessedType>>& aDuplicates = anIter.Value();
-    if (aDuplicates.empty())
+    const occ::handle<ProcessedType>& anEntity     = anIter.Key();
+    const DuplicateList&              aDuplicates  = anIter.Value();
+    if (aDuplicates.IsEmpty())
     {
       continue;
     }

--- a/src/DataExchange/TKDESTEP/StepTidy/StepTidy_EntityReducer.pxx
+++ b/src/DataExchange/TKDESTEP/StepTidy/StepTidy_EntityReducer.pxx
@@ -146,17 +146,17 @@ bool StepTidy_EntityReducer<ProcessedType, ProcessedTypeHasher>::ProcessEntity(
     aGraph.GetSharings(anEntity);
   if (hasAllReplacers(aSharings))
   {
-      DuplicateList* anIter = myDuplicateMap.ChangeSeek(anEntity);
-      if (anIter == nullptr)
-      {
-        // Add as a new key.
-        myDuplicateMap.Bind(anEntity, DuplicateList());
-      }
-      else
-      {
-        // Add as a value.
-        anIter->Append(anEntity);
-      }
+    DuplicateList* anIter = myDuplicateMap.ChangeSeek(anEntity);
+    if (anIter == nullptr)
+    {
+      // Add as a new key.
+      myDuplicateMap.Bind(anEntity, DuplicateList());
+    }
+    else
+    {
+      // Add as a value.
+      anIter->Append(anEntity);
+    }
   }
 
   return true;
@@ -170,8 +170,8 @@ void StepTidy_EntityReducer<ProcessedType, ProcessedTypeHasher>::Perform(
 {
   for (typename DuplicateMap::Iterator anIter(myDuplicateMap); anIter.More(); anIter.Next())
   {
-    const occ::handle<ProcessedType>& anEntity     = anIter.Key();
-    const DuplicateList&              aDuplicates  = anIter.Value();
+    const occ::handle<ProcessedType>& anEntity    = anIter.Key();
+    const DuplicateList&              aDuplicates = anIter.Value();
     if (aDuplicates.IsEmpty())
     {
       continue;

--- a/src/DataExchange/TKXSBase/XSAlgo/XSAlgo_ShapeProcessor.cxx
+++ b/src/DataExchange/TKXSBase/XSAlgo/XSAlgo_ShapeProcessor.cxx
@@ -38,7 +38,6 @@
 #include <UnitsMethods.hxx>
 
 #include <sstream>
-#include <unordered_set>
 
 //=============================================================================
 

--- a/src/Draw/TKDCAF/DDataStd/DDataStd_BasicCommands.cxx
+++ b/src/Draw/TKDCAF/DDataStd/DDataStd_BasicCommands.cxx
@@ -68,9 +68,9 @@
 #include <TDataStd_ReferenceArray.hxx>
 #include <TDataStd_ExtStringList.hxx>
 #include <TDataStd_ReferenceList.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include <algorithm>
-#include <vector>
 
 #define MAXLENGTH 10
 
@@ -3787,18 +3787,17 @@ static int DDataStd_GetNDStrings(Draw_Interpretor& di, int nb, const char** arg)
     const NCollection_DataMap<TCollection_ExtendedString, TCollection_ExtendedString>& aMap =
       anAtt->GetStringsContainer();
 
-    std::vector<DDataStd_GetNDStrings_Property> aProperties;
+    NCollection_LinearVector<DDataStd_GetNDStrings_Property> aProperties;
     for (NCollection_DataMap<TCollection_ExtendedString, TCollection_ExtendedString>::Iterator aIt(
            aMap);
          aIt.More();
          aIt.Next())
     {
-      aProperties.push_back(DDataStd_GetNDStrings_Property(aIt.Key(), aIt.Value()));
+      aProperties.Append(DDataStd_GetNDStrings_Property(aIt.Key(), aIt.Value()));
     }
     std::sort(aProperties.begin(), aProperties.end(), isLess);
 
-    for (std::vector<DDataStd_GetNDStrings_Property>::size_type aI = 0; aI < aProperties.size();
-         ++aI)
+    for (size_t aI = 0; aI < aProperties.Size(); ++aI)
     {
       di << "Key = " << aProperties[aI].first << " Value = " << aProperties[aI].second << "\n";
     }

--- a/src/Draw/TKQADraw/QABugs/QABugs_11.cxx
+++ b/src/Draw/TKQADraw/QABugs/QABugs_11.cxx
@@ -58,6 +58,7 @@
 #include <gp_Pnt2d.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_HArray1.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <BRep_Tool.hxx>
 #include <GeomProjLib.hxx>
@@ -4304,11 +4305,11 @@ int OCC25748(Draw_Interpretor& di, int argc, const char** argv)
                             "Parallel data processing",
                             nIter);
 
-  std::vector<Task> aTasks;
-  aTasks.reserve(nIter);
+  NCollection_LinearVector<Task> aTasks;
+  aTasks.Reserve(nIter);
   for (int i = 0; i < nIter; i++)
   {
-    aTasks.push_back(Task(aPS.Next(), aMatSize));
+    aTasks.Append(Task(aPS.Next(), aMatSize));
   }
 
   OSD_Timer aTimer;

--- a/src/Draw/TKQADraw/QABugs/QABugs_19.cxx
+++ b/src/Draw/TKQADraw/QABugs/QABugs_19.cxx
@@ -36,6 +36,7 @@
 #include <Message_PrinterOStream.hxx>
 #include <NCollection_Handle.hxx>
 #include <NCollection_Map.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <OSD_PerfMeter.hxx>
 #include <OSD_Timer.hxx>
 #include <Precision.hxx>
@@ -81,7 +82,6 @@ Standard_DISABLE_DEPRECATION_WARNINGS
 #include <cmath>
 #include <iostream>
 #include <random>
-#include <vector>
 
 #define QCOMPARE(val1, val2)                                                                       \
   di << "Checking " #val1 " == " #val2 << ((val1) == (val2) ? ": OK\n" : ": Error\n")
@@ -2261,7 +2261,7 @@ static TopoDS_Shape taper(const TopoDS_Shape& shape,
   return drafter.Shape();
 }
 
-static void dumpShapeVertices(const TopoDS_Shape& shape, std::vector<double>& coords)
+static void dumpShapeVertices(const TopoDS_Shape& shape, NCollection_LinearVector<double>& coords)
 {
   NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> shape_vertices;
   TopExp::MapShapes(shape, TopAbs_VERTEX, shape_vertices);
@@ -2269,13 +2269,13 @@ static void dumpShapeVertices(const TopoDS_Shape& shape, std::vector<double>& co
   for (int i = 1; i <= shape_vertices.Extent(); i++)
   {
     gp_Pnt p = BRep_Tool::Pnt(TopoDS::Vertex(shape_vertices(i)));
-    coords.push_back(p.X());
-    coords.push_back(p.Y());
-    coords.push_back(p.Z());
+    coords.Append(p.X());
+    coords.Append(p.Y());
+    coords.Append(p.Z());
   }
 }
 
-static void GetCoords(const char* const path_to_file, std::vector<double>& coords)
+static void GetCoords(const char* const path_to_file, NCollection_LinearVector<double>& coords)
 {
   TopoDS_Shape shape;
   BRep_Builder builder;
@@ -2297,29 +2297,29 @@ static int OCC26396(Draw_Interpretor& theDI, int theArgc, const char** theArgv)
 
   const int maxInd = 50;
 
-  std::vector<double> ref_coords;
-  ref_coords.reserve(100);
+  NCollection_LinearVector<double> ref_coords;
+  ref_coords.Reserve(100);
   bool Stat = true;
 
   GetCoords(theArgv[1], ref_coords);
 
-  std::vector<double> coords;
-  coords.reserve(100);
+  NCollection_LinearVector<double> coords;
+  coords.Reserve(100);
   for (int i = 1; i < maxInd; i++)
   {
     GetCoords(theArgv[1], coords);
-    if (coords.size() != ref_coords.size())
+    if (coords.Size() != ref_coords.Size())
     {
       Stat = false;
       break;
     }
-    for (size_t j = 0; j < coords.size(); j++)
+    for (size_t j = 0; j < coords.Size(); j++)
       if (std::abs(ref_coords[j] - coords[j]) > RealEpsilon())
       {
         Stat = false;
         break;
       }
-    coords.clear();
+    coords.Clear();
   }
   if (!Stat)
     theDI << "Error: unstable results";

--- a/src/Draw/TKQADraw/QABugs/QABugs_BVH.cxx
+++ b/src/Draw/TKQADraw/QABugs/QABugs_BVH.cxx
@@ -688,12 +688,12 @@ public:
       BVH_Vec3d aBVHP2(aP2.X(), aP2.Y(), aP2.Z());
       BVH_Vec3d aBVHP3(aP3.X(), aP3.Y(), aP3.Z());
 
-      int id = static_cast<int>(Vertices.size()) - 1;
-      Vertices.push_back(aBVHP1);
-      Vertices.push_back(aBVHP2);
-      Vertices.push_back(aBVHP3);
+      int id = static_cast<int>(Vertices.Size()) - 1;
+      Vertices.Append(aBVHP1);
+      Vertices.Append(aBVHP2);
+      Vertices.Append(aBVHP3);
 
-      Elements.push_back(BVH_Vec4i(id + 1, id + 2, id + 3, iT));
+      Elements.Append(BVH_Vec4i(id + 1, id + 2, id + 3, iT));
     }
 
     MarkDirty();

--- a/src/Draw/TKTopTest/BOPTest/BOPTest_CheckCommands.cxx
+++ b/src/Draw/TKTopTest/BOPTest/BOPTest_CheckCommands.cxx
@@ -17,6 +17,7 @@
 #include <BOPAlgo_CheckResult.hxx>
 #include <BOPDS_DS.hxx>
 #include <NCollection_Map.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <BOPDS_Pair.hxx>
 #include <BOPTest.hxx>
 #include <BOPTest_Objects.hxx>
@@ -37,7 +38,6 @@
 
 #include <algorithm>
 #include <functional>
-#include <vector>
 //
 static void MakeShapeForFullOutput(const TCollection_AsciiString&,
                                    const int,
@@ -272,9 +272,8 @@ int bopcheck(Draw_Interpretor& di, int n, const char** a)
   //
   const NCollection_Map<BOPDS_Pair>& aMPK = aDS.Interferences();
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  std::vector<BOPTest_Interf>           aVec;
-  std::vector<BOPTest_Interf>::iterator aIt;
-  BOPTest_Interf                        aBInterf;
+  NCollection_LinearVector<BOPTest_Interf> aVec;
+  BOPTest_Interf                           aBInterf;
   //
   aItMPK.Initialize(aMPK);
   for (; aItMPK.More(); aItMPK.Next())
@@ -296,15 +295,15 @@ int bopcheck(Draw_Interpretor& di, int n, const char** a)
     aBInterf.SetIndices(n1, n2);
     aBInterf.SetType(iT);
     //
-    aVec.push_back(aBInterf);
+    aVec.Append(aBInterf);
   }
   //
   sort(aVec.begin(), aVec.end(), std::less<BOPTest_Interf>());
   //
   iCnt = 0;
-  for (aIt = aVec.begin(); aIt != aVec.end(); aIt++)
+  for (size_t aBIdx = 0; aBIdx < aVec.Size(); ++aBIdx)
   {
-    const BOPTest_Interf& aBI = *aIt;
+    const BOPTest_Interf& aBI = aVec[aBIdx];
     //
     aBI.Indices(n1, n2);
     if (aDS.IsNewShape(n1) || aDS.IsNewShape(n2))

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
@@ -5880,7 +5880,7 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
       TCollection_AsciiString aResult;
       if (toFindAll || aFontName.Search("*") != -1)
       {
-        const NCollection_List<occ::handle<Font_SystemFont>> aFonts = aMgr->GetAvailableFonts();
+        const NCollection_List<occ::handle<Font_SystemFont>>   aFonts = aMgr->GetAvailableFonts();
         NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
         aFontsSorted.Reserve(aFonts.Size());
         for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts);
@@ -5893,217 +5893,216 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
         for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
           const TCollection_AsciiString aCheck = TCollection_AsciiString("string match -nocase \"")
                                                  + aFontName + "\" \"" + aFont->FontName() + "\"";
-          if (theDI.Eval(aCheck.ToCString()) == 0 && *theDI.Result() != '1')
-          {
-            theDI.Reset();
-            continue;
-          }
-
-          theDI.Reset();
-          if (!aResult.IsEmpty())
-          {
-            aResult += "\n";
-          }
-
-          aResult += toPrintInfo ? aFont->ToString() : aFont->FontName();
-          if (!toFindAll)
-          {
-            break;
-          }
-        }
-      }
-      else if (occ::handle<Font_SystemFont> aFont =
-                 aMgr->FindFont(aFontName, aStrictLevel, aFontAspect))
-      {
-        aResult = toPrintInfo ? aFont->ToString() : aFont->FontName();
-      }
-
-      if (!aResult.IsEmpty())
-      {
-        theDI << aResult;
-      }
-      else
-      {
-        Message::SendFail() << "Error: font '" << aFontName << "' is not found";
-      }
-    }
-    else if (anArgIter + 1 < theArgNb
-             && (anArgCase == "-add" || anArgCase == "add" || anArgCase == "-register"
-                 || anArgCase == "register"))
-    {
-      ++anArgIter;
-      const char*             aFontPath = theArgVec[anArgIter++];
-      TCollection_AsciiString aFontName;
-      Font_FontAspect         aFontAspect    = Font_FA_Undefined;
-      int                     isSingelStroke = -1;
-      for (; anArgIter < theArgNb; ++anArgIter)
-      {
-        anArgCase = theArgVec[anArgIter];
-        anArgCase.LowerCase();
-        if (aFontAspect == Font_FontAspect_UNDEFINED && parseFontStyle(anArgCase, aFontAspect))
+        if (theDI.Eval(aCheck.ToCString()) == 0 && *theDI.Result() != '1')
         {
+          theDI.Reset();
           continue;
         }
-        else if (anArgCase == "singlestroke" || anArgCase == "singleline" || anArgCase == "oneline")
+
+        theDI.Reset();
+        if (!aResult.IsEmpty())
         {
-          isSingelStroke = 1;
+          aResult += "\n";
         }
-        else if (aFontName.IsEmpty())
+
+        aResult += toPrintInfo ? aFont->ToString() : aFont->FontName();
+        if (!toFindAll)
         {
-          aFontName = theArgVec[anArgIter];
-        }
-        else
-        {
-          --anArgIter;
           break;
         }
       }
+    }
+    else if (occ::handle<Font_SystemFont> aFont =
+               aMgr->FindFont(aFontName, aStrictLevel, aFontAspect))
+    {
+      aResult = toPrintInfo ? aFont->ToString() : aFont->FontName();
+    }
 
-      occ::handle<Font_SystemFont> aFont = aMgr->CheckFont(aFontPath);
-      if (aFont.IsNull())
-      {
-        Message::SendFail() << "Error: font '" << aFontPath << "' is not found!";
-        continue;
-      }
-
-      if (aFontAspect != Font_FontAspect_UNDEFINED || !aFontName.IsEmpty())
-      {
-        TCollection_AsciiString aName = aFont->FontName();
-        if (!aFontName.IsEmpty())
-        {
-          aName = aFontName;
-        }
-        occ::handle<Font_SystemFont> aFont2 = new Font_SystemFont(aName);
-        if (aFontAspect != Font_FontAspect_UNDEFINED)
-        {
-          aFont2->SetFontPath(aFontAspect, aFontPath, 0);
-        }
-        else
-        {
-          for (int anAspectIter = 0; anAspectIter < Font_FontAspect_NB; ++anAspectIter)
-          {
-            aFont2->SetFontPath((Font_FontAspect)anAspectIter,
-                                aFont->FontPath((Font_FontAspect)anAspectIter),
-                                aFont->FontFaceId((Font_FontAspect)anAspectIter));
-          }
-        }
-        aFont = aFont2;
-      }
-      if (isSingelStroke != -1)
-      {
-        aFont->SetSingleStrokeFont(isSingelStroke == 1);
-      }
-
-      aMgr->RegisterFont(aFont, true);
-      theDI << aFont->ToString();
-    }
-    else if (anArgCase == "-aliases")
+    if (!aResult.IsEmpty())
     {
-      TCollection_AsciiString                                     anAliasName;
-      NCollection_Sequence<occ::handle<TCollection_HAsciiString>> aNames;
-      if (anArgIter + 1 < theArgNb && *theArgVec[anArgIter + 1] != '-')
-      {
-        anAliasName = theArgVec[++anArgIter];
-      }
-      if (!anAliasName.IsEmpty())
-      {
-        aMgr->GetFontAliases(aNames, anAliasName);
-      }
-      else
-      {
-        aMgr->GetAllAliases(aNames);
-      }
-      for (NCollection_Sequence<occ::handle<TCollection_HAsciiString>>::Iterator aNameIter(aNames);
-           aNameIter.More();
-           aNameIter.Next())
-      {
-        theDI << "{" << aNameIter.Value()->String() << "} ";
-      }
-    }
-    else if (anArgIter + 2 < theArgNb && anArgCase == "-addalias")
-    {
-      TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
-      TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
-      aMgr->AddFontAlias(anAliasName, aFontName);
-    }
-    else if (anArgIter + 2 < theArgNb && anArgCase == "-removealias")
-    {
-      TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
-      TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
-      aMgr->RemoveFontAlias(anAliasName, aFontName);
-    }
-    else if (anArgIter + 1 < theArgNb && anArgCase == "-clearalias")
-    {
-      TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
-      aMgr->RemoveFontAlias(anAliasName, "");
-    }
-    else if (anArgCase == "-clearaliases")
-    {
-      aMgr->RemoveFontAlias("", "");
-    }
-    else if (anArgCase == "-verbose" || anArgCase == "-trace")
-    {
-      bool toEnable = true;
-      if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
-      {
-        ++anArgIter;
-      }
-      aMgr->SetTraceAliases(toEnable);
-    }
-    else if (anArgCase == "-unicodefallback" || anArgCase == "-fallback"
-             || anArgCase == "-touseunicodesubsetfallback")
-    {
-      bool toEnable = true;
-      if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
-      {
-        ++anArgIter;
-      }
-      Font_FontMgr::ToUseUnicodeSubsetFallback() = toEnable;
+      theDI << aResult;
     }
     else
     {
-      Message::SendFail() << "Warning! Unknown argument '" << anArg << "'";
+      Message::SendFail() << "Error: font '" << aFontName << "' is not found";
     }
   }
-
-  if (toPrintList)
+  else if (anArgIter + 1 < theArgNb
+           && (anArgCase == "-add" || anArgCase == "add" || anArgCase == "-register"
+               || anArgCase == "register"))
   {
-    // just print the list of available fonts
-    bool                                                 isFirst = true;
-    const NCollection_List<occ::handle<Font_SystemFont>> aFonts  = aMgr->GetAvailableFonts();
-    NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
-    aFontsSorted.Reserve(aFonts.Size());
-    for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts);
-         aFontIter.More();
-         aFontIter.Next())
+    ++anArgIter;
+    const char*             aFontPath = theArgVec[anArgIter++];
+    TCollection_AsciiString aFontName;
+    Font_FontAspect         aFontAspect    = Font_FA_Undefined;
+    int                     isSingelStroke = -1;
+    for (; anArgIter < theArgNb; ++anArgIter)
     {
-      aFontsSorted.Append(aFontIter.Value());
-    }
-    std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
-    for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
-
-      if (toPrintNames)
+      anArgCase = theArgVec[anArgIter];
+      anArgCase.LowerCase();
+      if (aFontAspect == Font_FontAspect_UNDEFINED && parseFontStyle(anArgCase, aFontAspect))
       {
-        if (!isFirst)
-        {
-          theDI << "\n";
-        }
-        theDI << "\"" << aFont->FontName() << "\"";
+        continue;
+      }
+      else if (anArgCase == "singlestroke" || anArgCase == "singleline" || anArgCase == "oneline")
+      {
+        isSingelStroke = 1;
+      }
+      else if (aFontName.IsEmpty())
+      {
+        aFontName = theArgVec[anArgIter];
       }
       else
       {
-        if (!isFirst)
-        {
-          theDI << "\n";
-        }
-        theDI << aFont->ToString();
+        --anArgIter;
+        break;
       }
-      isFirst = false;
     }
-    return 0;
-  }
 
-  return 0;
+    occ::handle<Font_SystemFont> aFont = aMgr->CheckFont(aFontPath);
+    if (aFont.IsNull())
+    {
+      Message::SendFail() << "Error: font '" << aFontPath << "' is not found!";
+      continue;
+    }
+
+    if (aFontAspect != Font_FontAspect_UNDEFINED || !aFontName.IsEmpty())
+    {
+      TCollection_AsciiString aName = aFont->FontName();
+      if (!aFontName.IsEmpty())
+      {
+        aName = aFontName;
+      }
+      occ::handle<Font_SystemFont> aFont2 = new Font_SystemFont(aName);
+      if (aFontAspect != Font_FontAspect_UNDEFINED)
+      {
+        aFont2->SetFontPath(aFontAspect, aFontPath, 0);
+      }
+      else
+      {
+        for (int anAspectIter = 0; anAspectIter < Font_FontAspect_NB; ++anAspectIter)
+        {
+          aFont2->SetFontPath((Font_FontAspect)anAspectIter,
+                              aFont->FontPath((Font_FontAspect)anAspectIter),
+                              aFont->FontFaceId((Font_FontAspect)anAspectIter));
+        }
+      }
+      aFont = aFont2;
+    }
+    if (isSingelStroke != -1)
+    {
+      aFont->SetSingleStrokeFont(isSingelStroke == 1);
+    }
+
+    aMgr->RegisterFont(aFont, true);
+    theDI << aFont->ToString();
+  }
+  else if (anArgCase == "-aliases")
+  {
+    TCollection_AsciiString                                     anAliasName;
+    NCollection_Sequence<occ::handle<TCollection_HAsciiString>> aNames;
+    if (anArgIter + 1 < theArgNb && *theArgVec[anArgIter + 1] != '-')
+    {
+      anAliasName = theArgVec[++anArgIter];
+    }
+    if (!anAliasName.IsEmpty())
+    {
+      aMgr->GetFontAliases(aNames, anAliasName);
+    }
+    else
+    {
+      aMgr->GetAllAliases(aNames);
+    }
+    for (NCollection_Sequence<occ::handle<TCollection_HAsciiString>>::Iterator aNameIter(aNames);
+         aNameIter.More();
+         aNameIter.Next())
+    {
+      theDI << "{" << aNameIter.Value()->String() << "} ";
+    }
+  }
+  else if (anArgIter + 2 < theArgNb && anArgCase == "-addalias")
+  {
+    TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
+    TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
+    aMgr->AddFontAlias(anAliasName, aFontName);
+  }
+  else if (anArgIter + 2 < theArgNb && anArgCase == "-removealias")
+  {
+    TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
+    TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
+    aMgr->RemoveFontAlias(anAliasName, aFontName);
+  }
+  else if (anArgIter + 1 < theArgNb && anArgCase == "-clearalias")
+  {
+    TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
+    aMgr->RemoveFontAlias(anAliasName, "");
+  }
+  else if (anArgCase == "-clearaliases")
+  {
+    aMgr->RemoveFontAlias("", "");
+  }
+  else if (anArgCase == "-verbose" || anArgCase == "-trace")
+  {
+    bool toEnable = true;
+    if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
+    {
+      ++anArgIter;
+    }
+    aMgr->SetTraceAliases(toEnable);
+  }
+  else if (anArgCase == "-unicodefallback" || anArgCase == "-fallback"
+           || anArgCase == "-touseunicodesubsetfallback")
+  {
+    bool toEnable = true;
+    if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
+    {
+      ++anArgIter;
+    }
+    Font_FontMgr::ToUseUnicodeSubsetFallback() = toEnable;
+  }
+  else
+  {
+    Message::SendFail() << "Warning! Unknown argument '" << anArg << "'";
+  }
+}
+
+if (toPrintList)
+{
+  // just print the list of available fonts
+  bool                                                   isFirst = true;
+  const NCollection_List<occ::handle<Font_SystemFont>>   aFonts  = aMgr->GetAvailableFonts();
+  NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
+  aFontsSorted.Reserve(aFonts.Size());
+  for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts); aFontIter.More();
+       aFontIter.Next())
+  {
+    aFontsSorted.Append(aFontIter.Value());
+  }
+  std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
+  for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
+
+    if (toPrintNames)
+    {
+      if (!isFirst)
+      {
+        theDI << "\n";
+      }
+      theDI << "\"" << aFont->FontName() << "\"";
+    }
+    else
+    {
+      if (!isFirst)
+      {
+        theDI << "\n";
+      }
+      theDI << aFont->ToString();
+    }
+  isFirst = false;
+}
+return 0;
+}
+
+return 0;
 }
 
 //=======================================================================

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
@@ -29,6 +29,7 @@
 #include <Font_BRepTextBuilder.hxx>
 #include <Font_FontMgr.hxx>
 #include <Message.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <NCollection_List.hxx>
 
 #include <OSD_Chronometer.hxx>
@@ -5880,20 +5881,16 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
       if (toFindAll || aFontName.Search("*") != -1)
       {
         const NCollection_List<occ::handle<Font_SystemFont>> aFonts = aMgr->GetAvailableFonts();
-        std::vector<occ::handle<Font_SystemFont>>            aFontsSorted;
-        aFontsSorted.reserve(aFonts.Size());
+        NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
+        aFontsSorted.Reserve(aFonts.Size());
         for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts);
              aFontIter.More();
              aFontIter.Next())
         {
-          aFontsSorted.push_back(aFontIter.Value());
+          aFontsSorted.Append(aFontIter.Value());
         }
         std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
-        for (std::vector<occ::handle<Font_SystemFont>>::iterator aFontIter = aFontsSorted.begin();
-             aFontIter != aFontsSorted.end();
-             ++aFontIter)
-        {
-          const occ::handle<Font_SystemFont>& aFont = *aFontIter;
+        for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
           const TCollection_AsciiString aCheck = TCollection_AsciiString("string match -nocase \"")
                                                  + aFontName + "\" \"" + aFont->FontName() + "\"";
           if (theDI.Eval(aCheck.ToCString()) == 0 && *theDI.Result() != '1')
@@ -6074,20 +6071,16 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
     // just print the list of available fonts
     bool                                                 isFirst = true;
     const NCollection_List<occ::handle<Font_SystemFont>> aFonts  = aMgr->GetAvailableFonts();
-    std::vector<occ::handle<Font_SystemFont>>            aFontsSorted;
-    aFontsSorted.reserve(aFonts.Size());
+    NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
+    aFontsSorted.Reserve(aFonts.Size());
     for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts);
          aFontIter.More();
          aFontIter.Next())
     {
-      aFontsSorted.push_back(aFontIter.Value());
+      aFontsSorted.Append(aFontIter.Value());
     }
     std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
-    for (std::vector<occ::handle<Font_SystemFont>>::iterator aFontIter = aFontsSorted.begin();
-         aFontIter != aFontsSorted.end();
-         ++aFontIter)
-    {
-      const occ::handle<Font_SystemFont>& aFont = *aFontIter;
+    for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
 
       if (toPrintNames)
       {

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
@@ -5892,9 +5892,8 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
         std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
         for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
         {
-          const TCollection_AsciiString aCheck =
-            TCollection_AsciiString("string match -nocase \"") + aFontName + "\" \""
-            + aFont->FontName() + "\"";
+          const TCollection_AsciiString aCheck = TCollection_AsciiString("string match -nocase \"")
+                                                 + aFontName + "\" \"" + aFont->FontName() + "\"";
           if (theDI.Eval(aCheck.ToCString()) == 0 && *theDI.Result() != '1')
           {
             theDI.Reset();
@@ -5946,8 +5945,7 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
         {
           continue;
         }
-        else if (anArgCase == "singlestroke" || anArgCase == "singleline"
-                 || anArgCase == "oneline")
+        else if (anArgCase == "singlestroke" || anArgCase == "singleline" || anArgCase == "oneline")
         {
           isSingelStroke = 1;
         }

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ObjectCommands.cxx
@@ -5891,218 +5891,221 @@ static int VFont(Draw_Interpretor& theDI, int theArgNb, const char** theArgVec)
         }
         std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
         for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
-          const TCollection_AsciiString aCheck = TCollection_AsciiString("string match -nocase \"")
-                                                 + aFontName + "\" \"" + aFont->FontName() + "\"";
-        if (theDI.Eval(aCheck.ToCString()) == 0 && *theDI.Result() != '1')
         {
+          const TCollection_AsciiString aCheck =
+            TCollection_AsciiString("string match -nocase \"") + aFontName + "\" \""
+            + aFont->FontName() + "\"";
+          if (theDI.Eval(aCheck.ToCString()) == 0 && *theDI.Result() != '1')
+          {
+            theDI.Reset();
+            continue;
+          }
+
           theDI.Reset();
+          if (!aResult.IsEmpty())
+          {
+            aResult += "\n";
+          }
+
+          aResult += toPrintInfo ? aFont->ToString() : aFont->FontName();
+          if (!toFindAll)
+          {
+            break;
+          }
+        }
+      }
+      else if (occ::handle<Font_SystemFont> aFont =
+                 aMgr->FindFont(aFontName, aStrictLevel, aFontAspect))
+      {
+        aResult = toPrintInfo ? aFont->ToString() : aFont->FontName();
+      }
+
+      if (!aResult.IsEmpty())
+      {
+        theDI << aResult;
+      }
+      else
+      {
+        Message::SendFail() << "Error: font '" << aFontName << "' is not found";
+      }
+    }
+    else if (anArgIter + 1 < theArgNb
+             && (anArgCase == "-add" || anArgCase == "add" || anArgCase == "-register"
+                 || anArgCase == "register"))
+    {
+      ++anArgIter;
+      const char*             aFontPath = theArgVec[anArgIter++];
+      TCollection_AsciiString aFontName;
+      Font_FontAspect         aFontAspect    = Font_FA_Undefined;
+      int                     isSingelStroke = -1;
+      for (; anArgIter < theArgNb; ++anArgIter)
+      {
+        anArgCase = theArgVec[anArgIter];
+        anArgCase.LowerCase();
+        if (aFontAspect == Font_FontAspect_UNDEFINED && parseFontStyle(anArgCase, aFontAspect))
+        {
           continue;
         }
-
-        theDI.Reset();
-        if (!aResult.IsEmpty())
+        else if (anArgCase == "singlestroke" || anArgCase == "singleline"
+                 || anArgCase == "oneline")
         {
-          aResult += "\n";
+          isSingelStroke = 1;
         }
-
-        aResult += toPrintInfo ? aFont->ToString() : aFont->FontName();
-        if (!toFindAll)
+        else if (aFontName.IsEmpty())
         {
+          aFontName = theArgVec[anArgIter];
+        }
+        else
+        {
+          --anArgIter;
           break;
         }
       }
-    }
-    else if (occ::handle<Font_SystemFont> aFont =
-               aMgr->FindFont(aFontName, aStrictLevel, aFontAspect))
-    {
-      aResult = toPrintInfo ? aFont->ToString() : aFont->FontName();
-    }
 
-    if (!aResult.IsEmpty())
-    {
-      theDI << aResult;
-    }
-    else
-    {
-      Message::SendFail() << "Error: font '" << aFontName << "' is not found";
-    }
-  }
-  else if (anArgIter + 1 < theArgNb
-           && (anArgCase == "-add" || anArgCase == "add" || anArgCase == "-register"
-               || anArgCase == "register"))
-  {
-    ++anArgIter;
-    const char*             aFontPath = theArgVec[anArgIter++];
-    TCollection_AsciiString aFontName;
-    Font_FontAspect         aFontAspect    = Font_FA_Undefined;
-    int                     isSingelStroke = -1;
-    for (; anArgIter < theArgNb; ++anArgIter)
-    {
-      anArgCase = theArgVec[anArgIter];
-      anArgCase.LowerCase();
-      if (aFontAspect == Font_FontAspect_UNDEFINED && parseFontStyle(anArgCase, aFontAspect))
+      occ::handle<Font_SystemFont> aFont = aMgr->CheckFont(aFontPath);
+      if (aFont.IsNull())
       {
+        Message::SendFail() << "Error: font '" << aFontPath << "' is not found!";
         continue;
       }
-      else if (anArgCase == "singlestroke" || anArgCase == "singleline" || anArgCase == "oneline")
-      {
-        isSingelStroke = 1;
-      }
-      else if (aFontName.IsEmpty())
-      {
-        aFontName = theArgVec[anArgIter];
-      }
-      else
-      {
-        --anArgIter;
-        break;
-      }
-    }
 
-    occ::handle<Font_SystemFont> aFont = aMgr->CheckFont(aFontPath);
-    if (aFont.IsNull())
-    {
-      Message::SendFail() << "Error: font '" << aFontPath << "' is not found!";
-      continue;
-    }
-
-    if (aFontAspect != Font_FontAspect_UNDEFINED || !aFontName.IsEmpty())
-    {
-      TCollection_AsciiString aName = aFont->FontName();
-      if (!aFontName.IsEmpty())
+      if (aFontAspect != Font_FontAspect_UNDEFINED || !aFontName.IsEmpty())
       {
-        aName = aFontName;
-      }
-      occ::handle<Font_SystemFont> aFont2 = new Font_SystemFont(aName);
-      if (aFontAspect != Font_FontAspect_UNDEFINED)
-      {
-        aFont2->SetFontPath(aFontAspect, aFontPath, 0);
-      }
-      else
-      {
-        for (int anAspectIter = 0; anAspectIter < Font_FontAspect_NB; ++anAspectIter)
+        TCollection_AsciiString aName = aFont->FontName();
+        if (!aFontName.IsEmpty())
         {
-          aFont2->SetFontPath((Font_FontAspect)anAspectIter,
-                              aFont->FontPath((Font_FontAspect)anAspectIter),
-                              aFont->FontFaceId((Font_FontAspect)anAspectIter));
+          aName = aFontName;
         }
+        occ::handle<Font_SystemFont> aFont2 = new Font_SystemFont(aName);
+        if (aFontAspect != Font_FontAspect_UNDEFINED)
+        {
+          aFont2->SetFontPath(aFontAspect, aFontPath, 0);
+        }
+        else
+        {
+          for (int anAspectIter = 0; anAspectIter < Font_FontAspect_NB; ++anAspectIter)
+          {
+            aFont2->SetFontPath((Font_FontAspect)anAspectIter,
+                                aFont->FontPath((Font_FontAspect)anAspectIter),
+                                aFont->FontFaceId((Font_FontAspect)anAspectIter));
+          }
+        }
+        aFont = aFont2;
       }
-      aFont = aFont2;
-    }
-    if (isSingelStroke != -1)
-    {
-      aFont->SetSingleStrokeFont(isSingelStroke == 1);
-    }
-
-    aMgr->RegisterFont(aFont, true);
-    theDI << aFont->ToString();
-  }
-  else if (anArgCase == "-aliases")
-  {
-    TCollection_AsciiString                                     anAliasName;
-    NCollection_Sequence<occ::handle<TCollection_HAsciiString>> aNames;
-    if (anArgIter + 1 < theArgNb && *theArgVec[anArgIter + 1] != '-')
-    {
-      anAliasName = theArgVec[++anArgIter];
-    }
-    if (!anAliasName.IsEmpty())
-    {
-      aMgr->GetFontAliases(aNames, anAliasName);
-    }
-    else
-    {
-      aMgr->GetAllAliases(aNames);
-    }
-    for (NCollection_Sequence<occ::handle<TCollection_HAsciiString>>::Iterator aNameIter(aNames);
-         aNameIter.More();
-         aNameIter.Next())
-    {
-      theDI << "{" << aNameIter.Value()->String() << "} ";
-    }
-  }
-  else if (anArgIter + 2 < theArgNb && anArgCase == "-addalias")
-  {
-    TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
-    TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
-    aMgr->AddFontAlias(anAliasName, aFontName);
-  }
-  else if (anArgIter + 2 < theArgNb && anArgCase == "-removealias")
-  {
-    TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
-    TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
-    aMgr->RemoveFontAlias(anAliasName, aFontName);
-  }
-  else if (anArgIter + 1 < theArgNb && anArgCase == "-clearalias")
-  {
-    TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
-    aMgr->RemoveFontAlias(anAliasName, "");
-  }
-  else if (anArgCase == "-clearaliases")
-  {
-    aMgr->RemoveFontAlias("", "");
-  }
-  else if (anArgCase == "-verbose" || anArgCase == "-trace")
-  {
-    bool toEnable = true;
-    if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
-    {
-      ++anArgIter;
-    }
-    aMgr->SetTraceAliases(toEnable);
-  }
-  else if (anArgCase == "-unicodefallback" || anArgCase == "-fallback"
-           || anArgCase == "-touseunicodesubsetfallback")
-  {
-    bool toEnable = true;
-    if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
-    {
-      ++anArgIter;
-    }
-    Font_FontMgr::ToUseUnicodeSubsetFallback() = toEnable;
-  }
-  else
-  {
-    Message::SendFail() << "Warning! Unknown argument '" << anArg << "'";
-  }
-}
-
-if (toPrintList)
-{
-  // just print the list of available fonts
-  bool                                                   isFirst = true;
-  const NCollection_List<occ::handle<Font_SystemFont>>   aFonts  = aMgr->GetAvailableFonts();
-  NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
-  aFontsSorted.Reserve(aFonts.Size());
-  for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts); aFontIter.More();
-       aFontIter.Next())
-  {
-    aFontsSorted.Append(aFontIter.Value());
-  }
-  std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
-  for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
-
-    if (toPrintNames)
-    {
-      if (!isFirst)
+      if (isSingelStroke != -1)
       {
-        theDI << "\n";
+        aFont->SetSingleStrokeFont(isSingelStroke == 1);
       }
-      theDI << "\"" << aFont->FontName() << "\"";
-    }
-    else
-    {
-      if (!isFirst)
-      {
-        theDI << "\n";
-      }
+
+      aMgr->RegisterFont(aFont, true);
       theDI << aFont->ToString();
     }
-  isFirst = false;
-}
-return 0;
-}
+    else if (anArgCase == "-aliases")
+    {
+      TCollection_AsciiString                                     anAliasName;
+      NCollection_Sequence<occ::handle<TCollection_HAsciiString>> aNames;
+      if (anArgIter + 1 < theArgNb && *theArgVec[anArgIter + 1] != '-')
+      {
+        anAliasName = theArgVec[++anArgIter];
+      }
+      if (!anAliasName.IsEmpty())
+      {
+        aMgr->GetFontAliases(aNames, anAliasName);
+      }
+      else
+      {
+        aMgr->GetAllAliases(aNames);
+      }
+      for (NCollection_Sequence<occ::handle<TCollection_HAsciiString>>::Iterator aNameIter(aNames);
+           aNameIter.More();
+           aNameIter.Next())
+      {
+        theDI << "{" << aNameIter.Value()->String() << "} ";
+      }
+    }
+    else if (anArgIter + 2 < theArgNb && anArgCase == "-addalias")
+    {
+      TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
+      TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
+      aMgr->AddFontAlias(anAliasName, aFontName);
+    }
+    else if (anArgIter + 2 < theArgNb && anArgCase == "-removealias")
+    {
+      TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
+      TCollection_AsciiString aFontName(theArgVec[++anArgIter]);
+      aMgr->RemoveFontAlias(anAliasName, aFontName);
+    }
+    else if (anArgIter + 1 < theArgNb && anArgCase == "-clearalias")
+    {
+      TCollection_AsciiString anAliasName(theArgVec[++anArgIter]);
+      aMgr->RemoveFontAlias(anAliasName, "");
+    }
+    else if (anArgCase == "-clearaliases")
+    {
+      aMgr->RemoveFontAlias("", "");
+    }
+    else if (anArgCase == "-verbose" || anArgCase == "-trace")
+    {
+      bool toEnable = true;
+      if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
+      {
+        ++anArgIter;
+      }
+      aMgr->SetTraceAliases(toEnable);
+    }
+    else if (anArgCase == "-unicodefallback" || anArgCase == "-fallback"
+             || anArgCase == "-touseunicodesubsetfallback")
+    {
+      bool toEnable = true;
+      if (anArgIter + 1 < theArgNb && Draw::ParseOnOff(theArgVec[anArgIter + 1], toEnable))
+      {
+        ++anArgIter;
+      }
+      Font_FontMgr::ToUseUnicodeSubsetFallback() = toEnable;
+    }
+    else
+    {
+      Message::SendFail() << "Warning! Unknown argument '" << anArg << "'";
+    }
+  }
 
-return 0;
+  if (toPrintList)
+  {
+    // just print the list of available fonts
+    bool                                                   isFirst = true;
+    const NCollection_List<occ::handle<Font_SystemFont>>   aFonts  = aMgr->GetAvailableFonts();
+    NCollection_LinearVector<occ::handle<Font_SystemFont>> aFontsSorted;
+    aFontsSorted.Reserve(aFonts.Size());
+    for (NCollection_List<occ::handle<Font_SystemFont>>::Iterator aFontIter(aFonts);
+         aFontIter.More();
+         aFontIter.Next())
+    {
+      aFontsSorted.Append(aFontIter.Value());
+    }
+    std::stable_sort(aFontsSorted.begin(), aFontsSorted.end(), FontComparator());
+    for (const occ::handle<Font_SystemFont>& aFont : aFontsSorted)
+    {
+      if (toPrintNames)
+      {
+        if (!isFirst)
+        {
+          theDI << "\n";
+        }
+        theDI << "\"" << aFont->FontName() << "\"";
+      }
+      else
+      {
+        if (!isFirst)
+        {
+          theDI << "\n";
+        }
+        theDI << aFont->ToString();
+      }
+      isFirst = false;
+    }
+  }
+
+  return 0;
 }
 
 //=======================================================================

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -31,6 +31,7 @@
 #include <AIS_InteractiveContext.hxx>
 #include <AIS_LightSource.hxx>
 #include <AIS_InteractiveObject.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <NCollection_List.hxx>
 #include <AIS_Manipulator.hxx>
 #include <AIS_ViewCube.hxx>
@@ -10479,7 +10480,7 @@ static int VLight(Draw_Interpretor& theDi, int theArgsNb, const char** theArgVec
   if (!aPrsList.IsEmpty())
   {
     // update light source presentations
-    std::vector<occ::handle<AIS_LightSource>> aLightPrsVec;
+    NCollection_LinearVector<occ::handle<AIS_LightSource>> aLightPrsVec;
     for (NCollection_List<occ::handle<AIS_InteractiveObject>>::Iterator aPrsIter(aPrsList);
          aPrsIter.More();
          aPrsIter.Next())
@@ -10487,7 +10488,7 @@ static int VLight(Draw_Interpretor& theDi, int theArgsNb, const char** theArgVec
       if (occ::handle<AIS_LightSource> aLightPrs2 =
             occ::down_cast<AIS_LightSource>(aPrsIter.Value()))
       {
-        aLightPrsVec.push_back(aLightPrs2);
+        aLightPrsVec.Append(aLightPrs2);
       }
     }
 
@@ -10495,11 +10496,7 @@ static int VLight(Draw_Interpretor& theDi, int theArgsNb, const char** theArgVec
     std::sort(aLightPrsVec.begin(), aLightPrsVec.end(), LightPrsSort());
 
     int aTopStack = 0;
-    for (std::vector<occ::handle<AIS_LightSource>>::iterator aPrsIter = aLightPrsVec.begin();
-         aPrsIter != aLightPrsVec.end();
-         ++aPrsIter)
-    {
-      occ::handle<AIS_LightSource> aLightPrs2 = *aPrsIter;
+    for (const occ::handle<AIS_LightSource>& aLightPrs2 : aLightPrsVec)
       if (!aLightPrs2->TransformPersistence().IsNull()
           && aLightPrs2->TransformPersistence()->IsTrihedronOr2d())
       {

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -10505,11 +10505,12 @@ static int VLight(Draw_Interpretor& theDi, int theArgsNb, const char** theArgVec
           NCollection_Vec2<int>(aTopStack + aPrsSize, aPrsSize));
         aTopStack += aPrsSize + aPrsSize / 2;
       }
-      aCtx->Redisplay(aLightPrs2, false);
-      aCtx->SetTransformPersistence(aLightPrs2, aLightPrs2->TransformPersistence());
-    }
+    aCtx->Redisplay(aLightPrs2, false);
+    aCtx->SetTransformPersistence(aLightPrs2, aLightPrs2->TransformPersistence());
   }
-  return 0;
+}
+
+return 0;
 }
 
 //=================================================================================================

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -10497,6 +10497,7 @@ static int VLight(Draw_Interpretor& theDi, int theArgsNb, const char** theArgVec
 
     int aTopStack = 0;
     for (const occ::handle<AIS_LightSource>& aLightPrs2 : aLightPrsVec)
+    {
       if (!aLightPrs2->TransformPersistence().IsNull()
           && aLightPrs2->TransformPersistence()->IsTrihedronOr2d())
       {
@@ -10505,12 +10506,12 @@ static int VLight(Draw_Interpretor& theDi, int theArgsNb, const char** theArgVec
           NCollection_Vec2<int>(aTopStack + aPrsSize, aPrsSize));
         aTopStack += aPrsSize + aPrsSize / 2;
       }
-    aCtx->Redisplay(aLightPrs2, false);
-    aCtx->SetTransformPersistence(aLightPrs2, aLightPrs2->TransformPersistence());
+      aCtx->Redisplay(aLightPrs2, false);
+      aCtx->SetTransformPersistence(aLightPrs2, aLightPrs2->TransformPersistence());
+    }
   }
-}
 
-return 0;
+  return 0;
 }
 
 //=================================================================================================

--- a/src/FoundationClasses/TKMath/BVH/BVH_BinaryTree.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_BinaryTree.hxx
@@ -17,6 +17,7 @@
 #define _BVH_BinaryTree_Header
 
 #include <BVH_QuadTree.hxx>
+#include <NCollection_DynamicArray.hxx>
 
 #include <deque>
 #include <tuple>

--- a/src/FoundationClasses/TKMath/BVH/BVH_BoxSet.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_BoxSet.hxx
@@ -103,7 +103,7 @@ public: //! @name Necessary overrides for BVH construction
   //! Returns the Element with the index theIndex.
   virtual DataType Element(const int theIndex) const { return myElements[theIndex]; }
 
-protected:                                             //! @name Fields
+protected:                                                          //! @name Fields
   NCollection_LinearVector<DataType>                    myElements; //!< Elements
   NCollection_LinearVector<BVH_Box<NumType, Dimension>> myBoxes;    //!< Boxes for the elements
 };

--- a/src/FoundationClasses/TKMath/BVH/BVH_BoxSet.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_BoxSet.hxx
@@ -17,6 +17,7 @@
 #define _BVH_BoxSet_Header
 
 #include <BVH_PrimitiveSet.hxx>
+#include <NCollection_LinearVector.hxx>
 
 //! Implements easy to use interfaces for adding the elements into
 //! BVH tree and its following construction.
@@ -50,16 +51,16 @@ public: //! @name Setting expected size of the BVH
   //! Sets the expected size of BVH tree
   virtual void SetSize(const size_t theSize)
   {
-    myElements.reserve(theSize);
-    myBoxes.reserve(theSize);
+    myElements.Reserve(theSize);
+    myBoxes.Reserve(theSize);
   }
 
 public: //! @name Adding elements in BVH
   //! Adds the element into BVH
   virtual void Add(const DataType& theElement, const BVH_Box<NumType, Dimension>& theBox)
   {
-    myElements.push_back(theElement);
-    myBoxes.push_back(theBox);
+    myElements.Append(theElement);
+    myBoxes.Append(theBox);
     BVH_Object<NumType, Dimension>::myIsDirty = true;
   }
 
@@ -71,8 +72,8 @@ public: //! @name Clearing the elements and boxes
   //! Clears the vectors of elements and boxes
   virtual void Clear()
   {
-    myElements.clear();
-    myBoxes.clear();
+    myElements.Clear();
+    myBoxes.Clear();
     BVH_Object<NumType, Dimension>::myIsDirty = true;
   }
 
@@ -90,7 +91,7 @@ public: //! @name Necessary overrides for BVH construction
   }
 
   //! Returns the number of boxes.
-  int Size() const override { return static_cast<int>(myBoxes.size()); }
+  int Size() const override { return static_cast<int>(myBoxes.Size()); }
 
   //! Swaps indices of two specified boxes.
   void Swap(const int theIndex1, const int theIndex2) override
@@ -103,8 +104,8 @@ public: //! @name Necessary overrides for BVH construction
   virtual DataType Element(const int theIndex) const { return myElements[theIndex]; }
 
 protected:                                             //! @name Fields
-  std::vector<DataType>                    myElements; //!< Elements
-  std::vector<BVH_Box<NumType, Dimension>> myBoxes;    //!< Boxes for the elements
+  NCollection_LinearVector<DataType>                    myElements; //!< Elements
+  NCollection_LinearVector<BVH_Box<NumType, Dimension>> myBoxes;    //!< Boxes for the elements
 };
 
 #endif // _BVH_BoxSet_Header

--- a/src/FoundationClasses/TKMath/BVH/BVH_IndexedBoxSet.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_IndexedBoxSet.hxx
@@ -52,7 +52,7 @@ public: //! @name Setting expected size of the BVH
   //! Sets the expected size of BVH tree
   void SetSize(const size_t theSize) override
   {
-    myIndices.reserve(theSize);
+    myIndices.Reserve(theSize);
     BVH_BoxSet<NumType, Dimension, DataType>::SetSize(theSize);
   }
 
@@ -60,7 +60,7 @@ public: //! @name Adding elements in BVH
   //! Adds the element into BVH
   void Add(const DataType& theElement, const BVH_Box<NumType, Dimension>& theBox) override
   {
-    myIndices.push_back(static_cast<int>(myIndices.size()));
+    myIndices.Append(static_cast<int>(myIndices.Size()));
     BVH_BoxSet<NumType, Dimension, DataType>::Add(theElement, theBox);
   }
 
@@ -68,7 +68,7 @@ public: //! @name Clearing the elements and boxes
   //! Clears the vectors of elements and boxes
   void Clear() override
   {
-    myIndices.clear();
+    myIndices.Clear();
     BVH_BoxSet<NumType, Dimension, DataType>::Clear();
   }
 
@@ -95,7 +95,7 @@ public: //! @name Necessary overrides for BVH construction
   }
 
 protected: //! @name Fields
-  std::vector<int> myIndices;
+  NCollection_LinearVector<int> myIndices;
 };
 
 #endif // _BVH_IndexedBoxSet_Header

--- a/src/FoundationClasses/TKMath/BVH/BVH_LinearBuilder.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_LinearBuilder.hxx
@@ -320,8 +320,8 @@ void BVH_LinearBuilder<T, N>::Build(BVH_Set<T, N>*       theSet,
   emitHierachy(theBVH, aRadixSorter.EncodedLinks(), 29, 0, 0, theSet->Size());
 
   // Step 3 -- Compute bounding boxes of BVH nodes
-  theBVH->MinPointBuffer().resize(theBVH->NodeInfoBuffer().size());
-  theBVH->MaxPointBuffer().resize(theBVH->NodeInfoBuffer().size());
+  theBVH->MinPointBuffer().Resize(theBVH->NodeInfoBuffer().Size());
+  theBVH->MaxPointBuffer().Resize(theBVH->NodeInfoBuffer().Size());
 
   int                        aHeight    = 0;
   BVH::BoundData<T, N>       aBoundData = {theSet, theBVH, 0, 0, &aHeight};

--- a/src/FoundationClasses/TKMath/BVH/BVH_ObjectSet.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_ObjectSet.hxx
@@ -18,6 +18,7 @@
 
 #include <BVH_Set.hxx>
 #include <BVH_Object.hxx>
+#include <NCollection_DynamicArray.hxx>
 
 //! Array of abstract entities (bounded by BVH boxes) to built BVH.
 //! \tparam T Numeric data type

--- a/src/FoundationClasses/TKMath/BVH/BVH_QuickSorter.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_QuickSorter.hxx
@@ -17,10 +17,9 @@
 #define _BVH_QuickSorter_Header
 
 #include <BVH_Sorter.hxx>
-#include <NCollection_Allocator.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include <algorithm>
-#include <vector>
 
 //! Performs centroid-based sorting of abstract set along
 //! the given axis (X - 0, Y - 1, Z - 2) using std::sort.
@@ -47,8 +46,9 @@ public:
       return;
     }
 
-    // Create index array for sorting with OCCT allocator
-    std::vector<int, NCollection_Allocator<int>> anIndices(aSize);
+    // Create index array for sorting
+    NCollection_LinearVector<int> anIndices;
+    anIndices.Resize(aSize);
     for (int i = 0; i < aSize; ++i)
     {
       anIndices[i] = i;
@@ -61,7 +61,8 @@ public:
     });
 
     // Compute inverse permutation: invPerm[i] = where element i should go
-    std::vector<int, NCollection_Allocator<int>> anInvPerm(aSize);
+    NCollection_LinearVector<int> anInvPerm;
+    anInvPerm.Resize(aSize);
     for (int i = 0; i < aSize; ++i)
     {
       anInvPerm[anIndices[i]] = i;

--- a/src/FoundationClasses/TKMath/BVH/BVH_Traverse.lxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_Traverse.lxx
@@ -25,7 +25,7 @@ int BVH_Traverse<NumType, Dimension, BVHSetType, MetricType>::Select(
     return 0;
 
   const BVH_Array4i& aBVHNodes = theBVH->NodeInfoBuffer();
-  if (aBVHNodes.empty())
+  if (aBVHNodes.IsEmpty())
     return 0;
 
   // Create stack
@@ -141,7 +141,7 @@ int BVH_PairTraverse<NumType, Dimension, BVHSetType, MetricType>::Select(
 
   const BVH_Array4i& aBVHNodes1 = theBVH1->NodeInfoBuffer();
   const BVH_Array4i& aBVHNodes2 = theBVH2->NodeInfoBuffer();
-  if (aBVHNodes1.empty() || aBVHNodes2.empty())
+  if (aBVHNodes1.IsEmpty() || aBVHNodes2.IsEmpty())
     return 0;
 
   // On each iteration we can add max four new pairs of nodes to process.

--- a/src/FoundationClasses/TKMath/BVH/BVH_Types.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_Types.hxx
@@ -16,23 +16,13 @@
 #ifndef BVH_Types_HeaderFile
 #define BVH_Types_HeaderFile
 
-// Use this macro to switch between STL and OCCT vector types
-#define _BVH_USE_STD_VECTOR_
-
-#include <vector>
-
 #include <Bnd_Box.hxx>
 #include <NCollection_Mat4.hxx>
 #include <NCollection_Vec2.hxx>
 #include <NCollection_Vec3.hxx>
-#include <NCollection_DynamicArray.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Standard_OStream.hxx>
 #include <Standard_Type.hxx>
-
-// GCC supports shrink function only in C++11 mode
-#if defined(_BVH_USE_STD_VECTOR_) && defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-  #define _STD_VECTOR_SHRINK
-#endif
 
 namespace BVH
 {
@@ -110,17 +100,13 @@ struct MatrixType<T, 4>
   typedef NCollection_Mat4<T> Type;
 };
 
-//! Tool class for selecting type of array of vectors (STD or NCollection vector).
+//! Tool class for selecting type of array of vectors.
 //! \tparam T Numeric data type
 //! \tparam N Component number
 template <class T, int N = 1>
 struct ArrayType
 {
-#ifndef _BVH_USE_STD_VECTOR_
-  typedef NCollection_DynamicArray<typename VectorType<T, N>::Type> Type;
-#else
-  typedef std::vector<typename VectorType<T, N>::Type> Type;
-#endif
+  typedef NCollection_LinearVector<typename VectorType<T, N>::Type> Type;
 };
 } // namespace BVH
 
@@ -217,8 +203,7 @@ struct VecComp<T, 4>
   }
 };
 
-//! Tool class providing typical operations on the array. It allows
-//! for interoperability between STD vector and NCollection vector.
+//! Tool class providing typical operations on the array.
 //! \tparam T Numeric data type
 //! \tparam N Component number
 template <class T, int N = 1>
@@ -230,74 +215,40 @@ struct Array
   static inline const typename BVH::VectorType<T, N>::Type& Value(const BVH_ArrayNt& theArray,
                                                                   const int          theIndex)
   {
-#ifdef _BVH_USE_STD_VECTOR_
-    return theArray[theIndex];
-#else
     return theArray.Value(theIndex);
-#endif
   }
 
   //! Returns a reference to the element with the given index.
   static inline typename BVH::VectorType<T, N>::Type& ChangeValue(BVH_ArrayNt& theArray,
                                                                   const int    theIndex)
   {
-#ifdef _BVH_USE_STD_VECTOR_
-    return theArray[theIndex];
-#else
     return theArray.ChangeValue(theIndex);
-#endif
   }
 
   //! Adds the new element at the end of the array.
   static inline void Append(BVH_ArrayNt&                                theArray,
                             const typename BVH::VectorType<T, N>::Type& theElement)
   {
-#ifdef _BVH_USE_STD_VECTOR_
-    theArray.push_back(theElement);
-#else
     theArray.Append(theElement);
-#endif
   }
 
   //! Returns the number of elements in the given array.
   static inline int Size(const BVH_ArrayNt& theArray)
   {
-#ifdef _BVH_USE_STD_VECTOR_
-    return static_cast<int>(theArray.size());
-#else
     return static_cast<int>(theArray.Size());
-#endif
   }
 
   //! Removes all elements from the given array.
   static inline void Clear(BVH_ArrayNt& theArray)
   {
-#ifdef _BVH_USE_STD_VECTOR_
-    theArray.clear();
-#else
     theArray.Clear();
-#endif
   }
 
   //! Requests that the array capacity be at least enough to
-  //! contain given number of elements. This function has no
-  //! effect in case of NCollection based array.
+  //! contain given number of elements.
   static inline void Reserve(BVH_ArrayNt& theArray, const int theCount)
   {
-#ifdef _BVH_USE_STD_VECTOR_
-    if (Size(theArray) == theCount)
-    {
-  #ifdef _STD_VECTOR_SHRINK
-      theArray.shrink_to_fit();
-  #endif
-    }
-    else
-    {
-      theArray.reserve(theCount);
-    }
-#else
-      // do nothing
-#endif
+    theArray.Reserve(theCount);
   }
 };
 

--- a/src/FoundationClasses/TKMath/BVH/BVH_Types.hxx
+++ b/src/FoundationClasses/TKMath/BVH/BVH_Types.hxx
@@ -233,16 +233,10 @@ struct Array
   }
 
   //! Returns the number of elements in the given array.
-  static inline int Size(const BVH_ArrayNt& theArray)
-  {
-    return static_cast<int>(theArray.Size());
-  }
+  static inline int Size(const BVH_ArrayNt& theArray) { return static_cast<int>(theArray.Size()); }
 
   //! Removes all elements from the given array.
-  static inline void Clear(BVH_ArrayNt& theArray)
-  {
-    theArray.Clear();
-  }
+  static inline void Clear(BVH_ArrayNt& theArray) { theArray.Clear(); }
 
   //! Requests that the array capacity be at least enough to
   //! contain given number of elements.

--- a/src/FoundationClasses/TKMath/Bnd/Bnd_BoundSortBox.cxx
+++ b/src/FoundationClasses/TKMath/Bnd/Bnd_BoundSortBox.cxx
@@ -441,9 +441,9 @@ const NCollection_List<int>& Bnd_BoundSortBox::Compare(const Bnd_Box& theBox)
   // intersection occurs.
   NCollection_LinearVector<uint8_t> aResultIndices;
   aResultIndices.Resize(myBoxes->Upper() + 1, 0);
-  constexpr uint8_t    anOccupiedX  = 0b01;
-  constexpr uint8_t    anOccupiedY  = 0b10;
-  constexpr uint8_t    anOccupiedXY = 0b11;
+  constexpr uint8_t anOccupiedX  = 0b01;
+  constexpr uint8_t anOccupiedY  = 0b10;
+  constexpr uint8_t anOccupiedXY = 0b11;
 
   // Checking the voxels along X-axis.
   for (int aVoxelX = aMinVoxelX; aVoxelX <= aMaxVoxelX; ++aVoxelX)

--- a/src/FoundationClasses/TKMath/Bnd/Bnd_BoundSortBox.cxx
+++ b/src/FoundationClasses/TKMath/Bnd/Bnd_BoundSortBox.cxx
@@ -16,6 +16,7 @@
 
 #include <Bnd_BoundSortBox.hxx>
 
+#include <NCollection_LinearVector.hxx>
 #include <gp_Pln.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_IncAllocator.hxx>
@@ -438,7 +439,8 @@ const NCollection_List<int>& Bnd_BoundSortBox::Compare(const Bnd_Box& theBox)
   // indicates the Y-axis. If both bits are set (0b11), and the box also occupies the Z-axis,
   // we check for actual intersection with the given box and add it to the result if
   // intersection occurs.
-  std::vector<uint8_t> aResultIndices(myBoxes->Upper() + 1, 0);
+  NCollection_LinearVector<uint8_t> aResultIndices;
+  aResultIndices.Resize(myBoxes->Upper() + 1, 0);
   constexpr uint8_t    anOccupiedX  = 0b01;
   constexpr uint8_t    anOccupiedY  = 0b10;
   constexpr uint8_t    anOccupiedXY = 0b11;

--- a/src/FoundationClasses/TKMath/MathInteg/MathInteg_DoubleExp.hxx
+++ b/src/FoundationClasses/TKMath/MathInteg/MathInteg_DoubleExp.hxx
@@ -19,7 +19,6 @@
 #include <MathUtils_Core.hxx>
 
 #include <cmath>
-#include <vector>
 
 namespace MathInteg
 {

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
@@ -292,6 +292,29 @@ TEST(NCollection_LinearVectorTest, Resize)
   EXPECT_EQ(2, aVec(1));
 }
 
+TEST(NCollection_LinearVectorTest, Resize_WithValue)
+{
+  NCollection_LinearVector<int> aVec;
+  aVec.Append(1);
+  aVec.Append(2);
+
+  // Grow - new elements filled with -1
+  aVec.Resize(5, -1);
+  EXPECT_EQ(5, aVec.Size());
+  EXPECT_EQ(1, aVec(0));
+  EXPECT_EQ(2, aVec(1));
+  EXPECT_EQ(-1, aVec(2));
+  EXPECT_EQ(-1, aVec(3));
+  EXPECT_EQ(-1, aVec(4));
+
+  // Shrink - existing elements kept, no fill needed
+  aVec.Resize(3, -1);
+  EXPECT_EQ(3, aVec.Size());
+  EXPECT_EQ(1, aVec(0));
+  EXPECT_EQ(2, aVec(1));
+  EXPECT_EQ(-1, aVec(2));
+}
+
 TEST(NCollection_LinearVectorTest, EraseLast)
 {
   NCollection_LinearVector<int> aVec;
@@ -614,6 +637,26 @@ TEST(NCollection_LinearVectorTest, ResizeNonTrivial)
   EXPECT_EQ("a", aVec(0));
 }
 
+TEST(NCollection_LinearVectorTest, Resize_WithValue_NonTrivial)
+{
+  NCollection_LinearVector<std::string> aVec;
+  aVec.Append("x");
+
+  // Grow - new elements filled with "hello"
+  aVec.Resize(4, std::string("hello"));
+  EXPECT_EQ(4, aVec.Size());
+  EXPECT_EQ("x", aVec(0));
+  EXPECT_EQ("hello", aVec(1));
+  EXPECT_EQ("hello", aVec(2));
+  EXPECT_EQ("hello", aVec(3));
+
+  // Shrink
+  aVec.Resize(2, std::string("ignored"));
+  EXPECT_EQ(2, aVec.Size());
+  EXPECT_EQ("x", aVec(0));
+  EXPECT_EQ("hello", aVec(1));
+}
+
 TEST(NCollection_LinearVectorTest, BoundsAccess)
 {
   NCollection_LinearVector<int> aVec;
@@ -696,4 +739,66 @@ TEST(NCollection_LinearVectorTest, OutOfRangeIndicesThrow)
   EXPECT_ANY_THROW(aVec.InsertAfter(anOutIndex, 1));
   EXPECT_ANY_THROW(aVec.Erase(anOutIndex));
 #endif
+}
+
+TEST(NCollection_LinearVectorTest, Constructor_SizeAndValue)
+{
+  NCollection_LinearVector<int> aVec(5, 42);
+  EXPECT_EQ(5u, aVec.Size());
+  for (size_t i = 0; i < aVec.Size(); ++i)
+  {
+    EXPECT_EQ(42, aVec[i]);
+  }
+}
+
+TEST(NCollection_LinearVectorTest, Constructor_SizeAndValue_NonTrivial)
+{
+  NCollection_LinearVector<TCollection_AsciiString> aVec(3, TCollection_AsciiString("hello"));
+  EXPECT_EQ(3u, aVec.Size());
+  for (size_t i = 0; i < aVec.Size(); ++i)
+  {
+    EXPECT_STREQ("hello", aVec[i].ToCString());
+  }
+}
+
+TEST(NCollection_LinearVectorTest, Constructor_SizeZero_IsEmpty)
+{
+  NCollection_LinearVector<int> aVec(0, 99);
+  EXPECT_TRUE(aVec.IsEmpty());
+}
+
+TEST(NCollection_LinearVectorTest, OcctApiCoverage)
+{
+  NCollection_LinearVector<int> aVec;
+  EXPECT_TRUE(aVec.IsEmpty());
+  EXPECT_EQ(0u, aVec.Size());
+
+  aVec.Append(10);
+  int& aBackRef = aVec.EmplaceAppend(20);
+  aBackRef      = 30;
+
+  EXPECT_FALSE(aVec.IsEmpty());
+  EXPECT_EQ(2u, aVec.Size());
+  EXPECT_GE(aVec.Capacity(), aVec.Size());
+  EXPECT_EQ(10, aVec.First());
+  EXPECT_EQ(30, aVec.Last());
+  EXPECT_EQ(&aVec[0], aVec.Data());
+  EXPECT_EQ(10, aVec.Value(0));
+  EXPECT_EQ(30, aVec.Value(1));
+
+  aVec.Reserve(8);
+  EXPECT_GE(aVec.Capacity(), 8u);
+
+  aVec.Resize(4, 7);
+  EXPECT_EQ(4u, aVec.Size());
+  EXPECT_EQ(7, aVec[2]);
+  EXPECT_EQ(7, aVec[3]);
+
+  aVec.EraseLast();
+  EXPECT_EQ(3u, aVec.Size());
+  EXPECT_EQ(7, aVec.Last());
+
+  aVec.Clear();
+  EXPECT_TRUE(aVec.IsEmpty());
+  EXPECT_EQ(0u, aVec.Size());
 }

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_LinearVector.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_LinearVector.hxx
@@ -62,6 +62,8 @@ public:
   NCollection_LinearVector() noexcept = default;
 
   //! Constructor with pre-allocated capacity.
+  //! Unlike std::vector(n), this constructor does not create elements.
+  //! Use Resize() or NCollection_LinearVector(theSize, theValue) to construct items.
   //! @param[in] theCapacity number of elements to pre-allocate
   explicit NCollection_LinearVector(const size_t theCapacity)
   {
@@ -70,6 +72,15 @@ public:
       myData     = myAlloc.allocate(theCapacity);
       myCapacity = theCapacity;
     }
+  }
+
+  //! Constructor creating theSize elements initialized to theValue.
+  //! Equivalent to std::vector(n, val).
+  //! @param[in] theSize   number of elements to construct
+  //! @param[in] theValue  value to initialize each element with
+  NCollection_LinearVector(const size_t theSize, const TheItemType& theValue)
+  {
+    Resize(theSize, theValue);
   }
 
   //! Copy constructor.
@@ -199,7 +210,14 @@ public:
   //! If theSize > Size(), new elements are default-constructed.
   //! If theSize < Size(), excess elements are destroyed.
   //! @param[in] theSize new number of elements
-  void Resize(const size_t theSize)
+  void Resize(const size_t theSize) { Resize(theSize, TheItemType()); }
+
+  //! Change the number of elements, filling new slots with theValue.
+  //! If theSize > Size(), new elements are copy-constructed from theValue.
+  //! If theSize < Size(), excess elements are destroyed.
+  //! @param[in] theSize  new number of elements
+  //! @param[in] theValue value to fill new elements with
+  void Resize(const size_t theSize, const TheItemType& theValue)
   {
     if (theSize > mySize)
     {
@@ -209,7 +227,7 @@ public:
       }
       for (size_t i = mySize; i < theSize; ++i)
       {
-        myAlloc.construct(myData + i, TheItemType());
+        myAlloc.construct(myData + i, theValue);
       }
     }
     else if (theSize < mySize)

--- a/src/FoundationClasses/TKernel/Standard/Standard_ReadLineBuffer.hxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_ReadLineBuffer.hxx
@@ -158,7 +158,7 @@ public:
             }
             else
             {
-              const size_t aCnt      = aBufferPos - aStartLinePos;
+              const size_t aCnt = aBufferPos - aStartLinePos;
               myReadBufferLastStr.Resize(aCnt);
               std::memcpy(myReadBufferLastStr.Data(), myReadBuffer.Data() + aStartLinePos, aCnt);
               myUseReadBufferLastStr = true;
@@ -256,7 +256,7 @@ public:
           }
           else
           {
-            const size_t aCnt      = myBufferPos - aStartLinePos;
+            const size_t aCnt = myBufferPos - aStartLinePos;
             myReadBufferLastStr.Resize(aCnt);
             std::memcpy(myReadBufferLastStr.Data(), myReadBuffer.Data() + aStartLinePos, aCnt);
             myUseReadBufferLastStr = true;

--- a/src/FoundationClasses/TKernel/Standard/Standard_ReadLineBuffer.hxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_ReadLineBuffer.hxx
@@ -14,8 +14,10 @@
 #ifndef _Standard_ReadLineBuffer_HeaderFile
 #define _Standard_ReadLineBuffer_HeaderFile
 
+#include <NCollection_LinearVector.hxx>
+
+#include <cstring>
 #include <iostream>
-#include <vector>
 
 //! Auxiliary tool for buffered reading of lines from input stream.
 class Standard_ReadLineBuffer
@@ -31,7 +33,7 @@ public:
         myBytesLastRead(0)
   {
     // allocate read buffer
-    myReadBuffer.resize(theMaxBufferSizeBytes);
+    myReadBuffer.Resize(theMaxBufferSizeBytes);
   }
 
   //! Destructor.
@@ -40,7 +42,7 @@ public:
   //! Clear buffer and cached values.
   void Clear()
   {
-    myReadBufferLastStr.clear();
+    myReadBufferLastStr.Clear();
     myUseReadBufferLastStr = false;
     myIsMultilineMode      = false;
     myToPutGapInMultiline  = true;
@@ -86,7 +88,7 @@ public:
       if (myBufferPos == 0 || myBufferPos >= (myBytesLastRead))
       {
         // read new chunk from the stream
-        if (!readStream(theStream, myReadBuffer.size(), myBytesLastRead))
+        if (!readStream(theStream, myReadBuffer.Size(), myBytesLastRead))
         {
           // error during file reading
           break;
@@ -103,8 +105,8 @@ public:
           // end of the stream
           if (myUseReadBufferLastStr)
           {
-            theLineLength          = myReadBufferLastStr.size();
-            aResultLine            = &myReadBufferLastStr.front();
+            theLineLength          = myReadBufferLastStr.Size();
+            aResultLine            = myReadBufferLastStr.Data();
             myUseReadBufferLastStr = false;
           }
           break;
@@ -147,14 +149,18 @@ public:
 
             if (myUseReadBufferLastStr)
             {
-              myReadBufferLastStr.insert(myReadBufferLastStr.end(),
-                                         myReadBuffer.begin() + aStartLinePos,
-                                         myReadBuffer.begin() + aBufferPos);
+              const size_t aIns = myReadBufferLastStr.Size();
+              const size_t aCnt = aBufferPos - aStartLinePos;
+              myReadBufferLastStr.Resize(aIns + aCnt);
+              std::memcpy(myReadBufferLastStr.Data() + aIns,
+                          myReadBuffer.Data() + aStartLinePos,
+                          aCnt);
             }
             else
             {
-              myReadBufferLastStr    = std::vector<char>(myReadBuffer.begin() + aStartLinePos,
-                                                      myReadBuffer.begin() + aBufferPos);
+              const size_t aCnt      = aBufferPos - aStartLinePos;
+              myReadBufferLastStr.Resize(aCnt);
+              std::memcpy(myReadBufferLastStr.Data(), myReadBuffer.Data() + aStartLinePos, aCnt);
               myUseReadBufferLastStr = true;
             }
 
@@ -169,20 +175,21 @@ public:
           }
           else if (myBufferPos == 1 && myReadBuffer[0] == '\r')
           {
-            myReadBufferLastStr.erase(myReadBufferLastStr.end() - 1);
+            myReadBufferLastStr.EraseLast();
             aStartLinePos += 2;
             isMultiline = false;
           }
           else if (myBufferPos == 0)
           {
             aStartLinePos += 1;
-            if (myReadBufferLastStr[myReadBufferLastStr.size() - 1] == '\\')
+            if (myReadBufferLastStr[myReadBufferLastStr.Size() - 1] == '\\')
             {
-              myReadBufferLastStr.erase(myReadBufferLastStr.end() - 1);
+              myReadBufferLastStr.EraseLast();
             }
             else
             {
-              myReadBufferLastStr.erase(myReadBufferLastStr.end() - 2, myReadBufferLastStr.end());
+              myReadBufferLastStr.EraseLast();
+              myReadBufferLastStr.EraseLast();
             }
             isMultiline = false;
           }
@@ -199,21 +206,26 @@ public:
         if (myUseReadBufferLastStr)
         {
           // append current string to the last "unfinished" string of the previous chunk
-          myReadBufferLastStr.insert(myReadBufferLastStr.end(),
-                                     myReadBuffer.begin() + aStartLinePos,
-                                     myReadBuffer.begin() + myBufferPos);
+          {
+            const size_t aIns = myReadBufferLastStr.Size();
+            const size_t aCnt = myBufferPos - aStartLinePos;
+            myReadBufferLastStr.Resize(aIns + aCnt);
+            std::memcpy(myReadBufferLastStr.Data() + aIns,
+                        myReadBuffer.Data() + aStartLinePos,
+                        aCnt);
+          }
           myUseReadBufferLastStr = false;
-          theLineLength          = myReadBufferLastStr.size();
-          aResultLine            = &myReadBufferLastStr.front();
+          theLineLength          = myReadBufferLastStr.Size();
+          aResultLine            = myReadBufferLastStr.Data();
         }
         else
         {
-          if (!myReadBufferLastStr.empty())
+          if (!myReadBufferLastStr.IsEmpty())
           {
-            myReadBufferLastStr.clear();
+            myReadBufferLastStr.Clear();
           }
           theLineLength = myBufferPos - aStartLinePos;
-          aResultLine   = &myReadBuffer.front() + aStartLinePos;
+          aResultLine   = myReadBuffer.Data() + aStartLinePos;
         }
         // make string null terminated by replacing '\n' or '\r' (before '\n') symbol to null
         // character.
@@ -235,14 +247,18 @@ public:
         {
           if (myUseReadBufferLastStr)
           {
-            myReadBufferLastStr.insert(myReadBufferLastStr.end(),
-                                       myReadBuffer.begin() + aStartLinePos,
-                                       myReadBuffer.begin() + myBufferPos);
+            const size_t aIns = myReadBufferLastStr.Size();
+            const size_t aCnt = myBufferPos - aStartLinePos;
+            myReadBufferLastStr.Resize(aIns + aCnt);
+            std::memcpy(myReadBufferLastStr.Data() + aIns,
+                        myReadBuffer.Data() + aStartLinePos,
+                        aCnt);
           }
           else
           {
-            myReadBufferLastStr    = std::vector<char>(myReadBuffer.begin() + aStartLinePos,
-                                                    myReadBuffer.begin() + myBufferPos);
+            const size_t aCnt      = myBufferPos - aStartLinePos;
+            myReadBufferLastStr.Resize(aCnt);
+            std::memcpy(myReadBufferLastStr.Data(), myReadBuffer.Data() + aStartLinePos, aCnt);
             myUseReadBufferLastStr = true;
           }
         }
@@ -282,7 +298,7 @@ protected:
   //! @return true if reading was finished without errors.
   bool readStream(std::istream& theStream, size_t theLen, size_t& theReadLen)
   {
-    theReadLen = (size_t)theStream.read(&myReadBuffer.front(), theLen).gcount();
+    theReadLen = (size_t)theStream.read(myReadBuffer.Data(), theLen).gcount();
     return !theStream.bad();
   }
 
@@ -290,13 +306,13 @@ protected:
   //! @return true if reading was finished without errors.
   bool readStream(FILE* theStream, size_t theLen, size_t& theReadLen)
   {
-    theReadLen = ::fread(&myReadBuffer.front(), 1, theLen, theStream);
+    theReadLen = ::fread(myReadBuffer.Data(), 1, theLen, theStream);
     return ::ferror(theStream) == 0;
   }
 
 protected:
-  std::vector<char> myReadBuffer;        //!< Temp read buffer
-  std::vector<char> myReadBufferLastStr; //!< Part of last string of myReadBuffer
+  NCollection_LinearVector<char> myReadBuffer;        //!< Temp read buffer
+  NCollection_LinearVector<char> myReadBufferLastStr; //!< Part of last string of myReadBuffer
   // clang-format off
   bool              myUseReadBufferLastStr; //!< Flag to use myReadBufferLastStr during next line reading
   bool              myIsMultilineMode;      //!< Flag to process of the special multi-line case at the end of the line

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_Tools.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_Tools.cxx
@@ -1145,8 +1145,8 @@ void BOPAlgo_Tools::IntersectVertices(
   aPairSelector.Select();
 
   // Treat the selected pairs
-  const std::vector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
+  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
 
   // Collect interfering pairs
   occ::handle<NCollection_IncAllocator>                  anAlloc = new NCollection_IncAllocator;

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_Tools.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_Tools.cxx
@@ -1079,7 +1079,7 @@ public:
       double aD2 = aP1.SquareDistance(aP2);
       if (aD2 < aTolSum2)
       {
-        myPairs.emplace_back(anID1, anID2);
+        myPairs.EmplaceAppend(anID1, anID2);
         return true;
       }
     }

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_Tools.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_Tools.cxx
@@ -1145,8 +1145,8 @@ void BOPAlgo_Tools::IntersectVertices(
   aPairSelector.Select();
 
   // Treat the selected pairs
-  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs = aPairSelector.Pairs();
+  const int aNbPairs = static_cast<int>(aPairs.Size());
 
   // Collect interfering pairs
   occ::handle<NCollection_IncAllocator>                  anAlloc = new NCollection_IncAllocator;

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_DS.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_DS.cxx
@@ -46,7 +46,6 @@
 
 #include <algorithm>
 #include <numeric>
-#include <set>
 
 namespace
 {

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_Iterator.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_Iterator.cxx
@@ -296,8 +296,8 @@ void BOPDS_Iterator::Intersect(const occ::handle<IntTools_Context>& theCtx,
   aPairSelector.Sort();
 
   // Treat the selected pairs
-  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs = aPairSelector.Pairs();
+  const int aNbPairs = static_cast<int>(aPairs.Size());
 
   int iPair = 0;
 

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_Iterator.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_Iterator.cxx
@@ -296,8 +296,8 @@ void BOPDS_Iterator::Intersect(const occ::handle<IntTools_Context>& theCtx,
   aPairSelector.Sort();
 
   // Treat the selected pairs
-  const std::vector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
+  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
 
   int iPair = 0;
 

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_IteratorSI.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_IteratorSI.cxx
@@ -86,8 +86,8 @@ void BOPDS_IteratorSI::Intersect(const occ::handle<IntTools_Context>& theCtx,
   aPairSelector.Sort();
 
   // Treat the selected pairs
-  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs = aPairSelector.Pairs();
+  const int aNbPairs = static_cast<int>(aPairs.Size());
 
   for (int iPair = 0; iPair < aNbPairs; ++iPair)
   {

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_IteratorSI.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_IteratorSI.cxx
@@ -86,8 +86,8 @@ void BOPDS_IteratorSI::Intersect(const occ::handle<IntTools_Context>& theCtx,
   aPairSelector.Sort();
 
   // Treat the selected pairs
-  const std::vector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
+  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
 
   for (int iPair = 0; iPair < aNbPairs; ++iPair)
   {

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_SubIterator.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_SubIterator.cxx
@@ -128,8 +128,8 @@ void BOPDS_SubIterator::Intersect()
   aPairSelector.Sort();
 
   // Treat the selected pairs
-  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs = aPairSelector.Pairs();
+  const int aNbPairs = static_cast<int>(aPairs.Size());
 
   // Fence map
   NCollection_Map<BOPDS_Pair> aMPKFence;

--- a/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_SubIterator.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPDS/BOPDS_SubIterator.cxx
@@ -128,8 +128,8 @@ void BOPDS_SubIterator::Intersect()
   aPairSelector.Sort();
 
   // Treat the selected pairs
-  const std::vector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aPairSelector.Pairs();
+  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
 
   // Fence map
   NCollection_Map<BOPDS_Pair> aMPKFence;

--- a/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_PairSelector.hxx
+++ b/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_PairSelector.hxx
@@ -17,8 +17,8 @@
 
 #include <BVH_Traverse.hxx>
 #include <BVH_BoxSet.hxx>
+#include <NCollection_LinearVector.hxx>
 
-#include <Standard_Integer.hxx>
 #include <algorithm>
 
 //! Template Selector for selection of the elements from two BVH trees.
@@ -56,7 +56,7 @@ public: //! @name Constructor
 
 public: //! @name public interfaces
   //! Clears the indices
-  void Clear() { myPairs.clear(); }
+  void Clear() { myPairs.Clear(); }
 
   //! Sorts the indices
   void Sort() { std::sort(myPairs.begin(), myPairs.end()); }
@@ -71,7 +71,7 @@ public: //! @name public interfaces
   void SetSame(const bool theIsSame) { mySameBVHs = theIsSame; }
 
   //! Returns the list of accepted indices
-  const std::vector<PairIDs>& Pairs() const { return myPairs; }
+  const NCollection_LinearVector<PairIDs>& Pairs() const { return myPairs; }
 
 public: //! @name Rejection/Acceptance rules
   //! Basing on the bounding boxes of the nodes checks if the pair of nodes should be rejected.
@@ -96,7 +96,7 @@ public: //! @name Rejection/Acceptance rules
   {
     if (!RejectElement(theID1, theID2))
     {
-      myPairs.push_back(
+      myPairs.Append(
         PairIDs(this->myBVHSet1->Element(theID1), this->myBVHSet2->Element(theID2)));
       return true;
     }
@@ -104,7 +104,7 @@ public: //! @name Rejection/Acceptance rules
   }
 
 protected:                         //! @name Fields
-  std::vector<PairIDs> myPairs;    //!< Selected pairs of indices
+  NCollection_LinearVector<PairIDs> myPairs;    //!< Selected pairs of indices
   bool                 mySameBVHs; //!< Selection is performed from the same BVH trees
 };
 

--- a/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_PairSelector.hxx
+++ b/src/ModelingAlgorithms/TKBO/BOPTools/BOPTools_PairSelector.hxx
@@ -96,16 +96,15 @@ public: //! @name Rejection/Acceptance rules
   {
     if (!RejectElement(theID1, theID2))
     {
-      myPairs.Append(
-        PairIDs(this->myBVHSet1->Element(theID1), this->myBVHSet2->Element(theID2)));
+      myPairs.Append(PairIDs(this->myBVHSet1->Element(theID1), this->myBVHSet2->Element(theID2)));
       return true;
     }
     return false;
   }
 
-protected:                         //! @name Fields
+protected:                                      //! @name Fields
   NCollection_LinearVector<PairIDs> myPairs;    //!< Selected pairs of indices
-  bool                 mySameBVHs; //!< Selection is performed from the same BVH trees
+  bool                              mySameBVHs; //!< Selection is performed from the same BVH trees
 };
 
 #endif

--- a/src/ModelingAlgorithms/TKBO/IntTools/IntTools_BeanFaceIntersector.cxx
+++ b/src/ModelingAlgorithms/TKBO/IntTools/IntTools_BeanFaceIntersector.cxx
@@ -2441,7 +2441,7 @@ static void MergeSolutions(const NCollection_List<IntTools_CurveRangeSample>&   
 {
   NCollection_IndexedMap<IntTools_SurfaceRangeSample> aMapToAvoid;
 
-  NCollection_DataMap<int, NCollection_List<int>> aCurveIdMap;
+  NCollection_DataMap<int, NCollection_List<int>>     aCurveIdMap;
   NCollection_LinearVector<IntTools_CurveRangeSample> aCurveRangeVector;
   aCurveRangeVector.Reserve(theListCurveRange.Size());
 

--- a/src/ModelingAlgorithms/TKBO/IntTools/IntTools_BeanFaceIntersector.cxx
+++ b/src/ModelingAlgorithms/TKBO/IntTools/IntTools_BeanFaceIntersector.cxx
@@ -46,6 +46,7 @@
 #include <IntTools_Tools.hxx>
 #include <Precision.hxx>
 #include <NCollection_Array1.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Standard_Integer.hxx>
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
@@ -2441,8 +2442,8 @@ static void MergeSolutions(const NCollection_List<IntTools_CurveRangeSample>&   
   NCollection_IndexedMap<IntTools_SurfaceRangeSample> aMapToAvoid;
 
   NCollection_DataMap<int, NCollection_List<int>> aCurveIdMap;
-  std::vector<IntTools_CurveRangeSample>          aCurveRangeVector;
-  aCurveRangeVector.reserve(theListCurveRange.Size());
+  NCollection_LinearVector<IntTools_CurveRangeSample> aCurveRangeVector;
+  aCurveRangeVector.Reserve(theListCurveRange.Size());
 
   NCollection_List<IntTools_CurveRangeSample>::Iterator   anItC(theListCurveRange);
   NCollection_List<IntTools_SurfaceRangeSample>::Iterator anItS(theListSurfaceRange);
@@ -2451,7 +2452,7 @@ static void MergeSolutions(const NCollection_List<IntTools_CurveRangeSample>&   
   int aSurfRangeSize = 0;
   for (; anItS.More() && anItC.More(); anItS.Next(), anItC.Next(), ++aCurveRangeId)
   {
-    aCurveRangeVector.push_back(anItC.Value());
+    aCurveRangeVector.Append(anItC.Value());
     int aSurfIndex = aMapToAvoid.Add(anItS.Value());
     if (aSurfIndex > aSurfRangeSize)
     {

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomInt/GeomInt_LineTool.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomInt/GeomInt_LineTool.cxx
@@ -409,7 +409,7 @@ bool GeomInt_LineTool::DecompositionOfWLine(
   const GeomInt_LineConstructor&                    theLConstructor,
   NCollection_Sequence<occ::handle<IntPatch_Line>>& theNewLines)
 {
-  typedef NCollection_List<int>           ListOfInteger;
+  typedef NCollection_List<int>                   ListOfInteger;
   typedef NCollection_LinearVector<ListOfInteger> ArrayOfListOfInteger;
 
   bool   bIsPrevPointOnBoundary, bIsCurrentPointOnBoundary;
@@ -436,7 +436,7 @@ bool GeomInt_LineTool::DecompositionOfWLine(
     return false;
   }
   //
-  occ::handle<NCollection_IncAllocator>   anIncAlloc = new NCollection_IncAllocator();
+  occ::handle<NCollection_IncAllocator> anIncAlloc = new NCollection_IncAllocator();
   const ListOfInteger  aDummy(anIncAlloc); // empty list to be copy constructed from
   ArrayOfListOfInteger anArrayOfLines(aNbPnts + 1, aDummy);
 

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomInt/GeomInt_LineTool.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomInt/GeomInt_LineTool.cxx
@@ -24,13 +24,11 @@
 #include <IntPatch_RLine.hxx>
 #include <IntPatch_WLine.hxx>
 #include <NCollection_IncAllocator.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <NCollection_List.hxx>
 #include <NCollection_LocalArray.hxx>
-#include <NCollection_OccAllocator.hxx>
 #include <Standard_Integer.hxx>
 #include <NCollection_Array1.hxx>
-
-#include <vector>
 
 namespace
 {
@@ -411,10 +409,8 @@ bool GeomInt_LineTool::DecompositionOfWLine(
   const GeomInt_LineConstructor&                    theLConstructor,
   NCollection_Sequence<occ::handle<IntPatch_Line>>& theNewLines)
 {
-  typedef NCollection_List<int> ListOfInteger;
-  // have to use std::vector, not NCollection_DynamicArray in order to use copy constructor of
-  // ListOfInteger which will be created with specific allocator instance
-  typedef std::vector<ListOfInteger, NCollection_OccAllocator<ListOfInteger>> ArrayOfListOfInteger;
+  typedef NCollection_List<int>           ListOfInteger;
+  typedef NCollection_LinearVector<ListOfInteger> ArrayOfListOfInteger;
 
   bool   bIsPrevPointOnBoundary, bIsCurrentPointOnBoundary;
   int    nblines, aNbPnts, aNbParts, pit, i, j, aNbListOfPointIndex;
@@ -441,9 +437,8 @@ bool GeomInt_LineTool::DecompositionOfWLine(
   }
   //
   occ::handle<NCollection_IncAllocator>   anIncAlloc = new NCollection_IncAllocator();
-  NCollection_OccAllocator<ListOfInteger> anAlloc(anIncAlloc);
   const ListOfInteger  aDummy(anIncAlloc); // empty list to be copy constructed from
-  ArrayOfListOfInteger anArrayOfLines(aNbPnts + 1, aDummy, anAlloc);
+  ArrayOfListOfInteger anArrayOfLines(aNbPnts + 1, aDummy);
 
   NCollection_LocalArray<int> anArrayOfLineTypeArr(aNbPnts + 1);
   int*                        anArrayOfLineType = anArrayOfLineTypeArr;

--- a/src/ModelingAlgorithms/TKGeomAlgo/IntPolyh/IntPolyh_MaillageAffinage.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/IntPolyh/IntPolyh_MaillageAffinage.cxx
@@ -162,20 +162,20 @@ public:
   {
     if (!myBVHSet1->Box(theID1).IsOut(myBVHSet2->Box(theID2)))
     {
-      myPairs.emplace_back(myBVHSet1->Element(theID1), myBVHSet2->Element(theID2));
+      myPairs.EmplaceAppend(myBVHSet1->Element(theID1), myBVHSet2->Element(theID2));
       return true;
     }
     return false;
   }
 
   //! Returns indices
-  const std::vector<PairIDs>& Pairs() const { return myPairs; }
+  const NCollection_LinearVector<PairIDs>& Pairs() const { return myPairs; }
 
   //! Sorts the resulting indices
   void Sort() { std::sort(myPairs.begin(), myPairs.end()); }
 
 private:
-  std::vector<PairIDs> myPairs;
+  NCollection_LinearVector<PairIDs> myPairs;
 };
 
 //=======================================================================
@@ -227,8 +227,8 @@ static void GetInterferingTriangles(IntPolyh_ArrayOfTriangles&                  
   aSelector.Select();
   aSelector.Sort();
 
-  const std::vector<IntPolyh_BoxBndTreeSelector::PairIDs>& aPairs = aSelector.Pairs();
-  const int aNbPairs                                              = static_cast<int>(aPairs.size());
+  const NCollection_LinearVector<IntPolyh_BoxBndTreeSelector::PairIDs>& aPairs = aSelector.Pairs();
+  const int aNbPairs                                              = static_cast<int>(aPairs.Size());
 
   for (int i = 0; i < aNbPairs; ++i)
   {

--- a/src/ModelingAlgorithms/TKGeomAlgo/IntPolyh/IntPolyh_MaillageAffinage.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/IntPolyh/IntPolyh_MaillageAffinage.cxx
@@ -228,7 +228,7 @@ static void GetInterferingTriangles(IntPolyh_ArrayOfTriangles&                  
   aSelector.Sort();
 
   const NCollection_LinearVector<IntPolyh_BoxBndTreeSelector::PairIDs>& aPairs = aSelector.Pairs();
-  const int aNbPairs                                              = static_cast<int>(aPairs.Size());
+  const int aNbPairs = static_cast<int>(aPairs.Size());
 
   for (int i = 0; i < aNbPairs; ++i)
   {

--- a/src/ModelingAlgorithms/TKGeomAlgo/IntWalk/IntWalk_IWalking.gxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/IntWalk/IntWalk_IWalking.gxx
@@ -88,9 +88,9 @@ IntWalk_IWalking::IntWalk_IWalking(const double Epsilon,
       tolerance(1, 2),
       epsilon(Epsilon * Epsilon),
       reversed(false),
-      wd1(IntWalk_VectorOfWalkingData::allocator_type(new NCollection_IncAllocator)),
-      wd2(wd1.get_allocator()),
-      nbMultiplicities(wd1.get_allocator()),
+      wd1(),
+      wd2(),
+      nbMultiplicities(),
       Um(0.0),
       UM(0.0),
       Vm(0.0),
@@ -109,15 +109,15 @@ IntWalk_IWalking::IntWalk_IWalking(const double Epsilon,
 
 void IntWalk_IWalking::Clear()
 {
-  wd1.clear();
-  wd2.clear();
+  wd1.Clear();
+  wd2.Clear();
   IntWalk_WalkingData aDummy;
   aDummy.etat   = -10;
   aDummy.ustart = aDummy.vstart = 0.;
-  wd1.push_back(aDummy);
-  wd2.push_back(aDummy);
-  nbMultiplicities.clear();
-  nbMultiplicities.push_back(-1);
+  wd1.Append(aDummy);
+  wd2.Append(aDummy);
+  nbMultiplicities.Clear();
+  nbMultiplicities.Append(-1);
 
   done = false;
   seqAjout.Clear();
@@ -183,8 +183,8 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
   NCollection_Sequence<double> Vmult;
 
   int decal = 0;
-  wd1.reserve(nbPnts1 + decal);
-  nbMultiplicities.reserve(nbPnts1 + decal);
+  wd1.Reserve(nbPnts1 + decal);
+  nbMultiplicities.Reserve(nbPnts1 + decal);
   for (I = 1; I <= nbPnts1 + decal; I++)
   {
     const ThePointOfPath& PathPnt = Pnts1.Value(I - decal);
@@ -204,9 +204,9 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
     mySRangeU.Add(aWD1.ustart);
     mySRangeV.Add(aWD1.vstart);
 
-    wd1.push_back(aWD1);
+    wd1.Append(aWD1);
     int aNbMult = ThePointOfPathTool::Multiplicity(PathPnt);
-    nbMultiplicities.push_back(aNbMult);
+    nbMultiplicities.Append(aNbMult);
 
     for (int J = 1; J <= aNbMult; J++)
     {
@@ -216,7 +216,7 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
     }
   }
 
-  wd2.reserve(nbPnts2);
+  wd2.Reserve(nbPnts2);
   for (I = 1; I <= nbPnts2; I++)
   {
     IntWalk_WalkingData aWD2;
@@ -229,7 +229,7 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
     if (!IsTangentExtCheck(Func, aWD2.ustart, aWD2.vstart, aStepU, aStepV, Um, UM, Vm, VM))
       aWD2.etat = 13;
 
-    wd2.push_back(aWD2);
+    wd2.Append(aWD2);
   }
 
   tolerance(1) = ThePSurfaceTool::UResolution(Caro, Precision::Confusion());
@@ -274,20 +274,20 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
       NCollection_Sequence<IntSurf_InteriorPoint> PntsInHoles;
       NCollection_Sequence<int>                   CopySeqAlone = seqAlone;
       FillPntsInHoles(Func, CopySeqAlone, PntsInHoles);
-      wd2.clear();
+      wd2.Clear();
       IntWalk_WalkingData aDummy;
       aDummy.etat   = -10;
       aDummy.ustart = aDummy.vstart = 0.;
-      wd2.push_back(aDummy);
+      wd2.Append(aDummy);
       int nbHoles = PntsInHoles.Length();
-      wd2.reserve(nbHoles);
+      wd2.Reserve(nbHoles);
       for (I = 1; I <= nbHoles; I++)
       {
         IntWalk_WalkingData aWD2;
         aWD2.etat                         = 13;
         const IntSurf_InteriorPoint& anIP = PntsInHoles.Value(I);
         ThePointOfLoopTool::Value2d(anIP, aWD2.ustart, aWD2.vstart);
-        wd2.push_back(aWD2);
+        wd2.Append(aWD2);
       }
       ComputeCloseLine(Umult, Vmult, Pnts1, PntsInHoles, Func, Rajout);
     }
@@ -323,7 +323,7 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
   NCollection_Sequence<double> Umult;
   NCollection_Sequence<double> Vmult;
 
-  wd1.reserve(nbPnts1);
+  wd1.Reserve(nbPnts1);
   for (I = 1; I <= nbPnts1; I++)
   {
     const ThePointOfPath& PathPnt = Pnts1.Value(I);
@@ -334,9 +334,9 @@ void IntWalk_IWalking::Perform(const ThePOPIterator& Pnts1,
     if (!ThePointOfPathTool::IsTangent(PathPnt))
       ++aWD1.etat;
     ThePointOfPathTool::Value2d(PathPnt, aWD1.ustart, aWD1.vstart);
-    wd1.push_back(aWD1);
+    wd1.Append(aWD1);
     int aNbMult = ThePointOfPathTool::Multiplicity(PathPnt);
-    nbMultiplicities.push_back(aNbMult);
+    nbMultiplicities.Append(aNbMult);
 
     for (int J = 1; J <= aNbMult; J++)
     {
@@ -620,7 +620,7 @@ bool IntWalk_IWalking::TestArretPassage(const NCollection_Sequence<double>& Umul
     previousPoint.ParametersOnS1(Up, Vp);
   }
 
-  for (size_t i = 1; i < wd2.size(); i++)
+  for (size_t i = 1; i < wd2.Size(); i++)
   {
     if (wd2[i].etat > 0)
     {
@@ -684,7 +684,7 @@ bool IntWalk_IWalking::TestArretPassage(const NCollection_Sequence<double>& Umul
   {
     bool isToCheck;
 
-    for (size_t i = 1; i < wd1.size(); i++)
+    for (size_t i = 1; i < wd1.Size(); i++)
     {
       if (l == 1)
         isToCheck = (wd1[i].etat > 0);
@@ -747,7 +747,7 @@ bool IntWalk_IWalking::TestArretPassage(const NCollection_Sequence<double>& Umul
           }
         }
       }
-    } // end of for (i = 1; i < wd1.size(); i++)
+    } // end of for (i = 1; i < wd1.Size(); i++)
     if (!i_candidates.IsEmpty())
     {
       double MinSqDist = RealLast();
@@ -830,7 +830,7 @@ bool IntWalk_IWalking::TestArretPassage(const NCollection_Sequence<double>& Umul
   double tolv2 = tolv + tolv;
 
   double dPreviousCurrent = (Up - UV1) * (Up - UV1) + (Vp - UV2) * (Vp - UV2);
-  for (k = 1; k < (int)wd2.size(); k++)
+  for (k = 1; k < (int)wd2.Size(); k++)
   {
     if (wd2[k].etat > 0)
     {
@@ -919,7 +919,7 @@ bool IntWalk_IWalking::TestArretPassage(const NCollection_Sequence<double>& Umul
   // crossing test on crossing points.
 
   Irang = 0;
-  for (i = 1; i < (int)wd1.size(); i++)
+  for (i = 1; i < (int)wd1.Size(); i++)
   {
     if (wd1[i].etat > 0 && wd1[i].etat < 11)
     { // test of crossing points
@@ -1191,7 +1191,7 @@ void IntWalk_IWalking::TestArretCadre(const NCollection_Sequence<double>&   Umul
   bool   Found = false;
 
   Irang = 0;
-  for (int i = 1; i < (int)wd1.size(); i++)
+  for (int i = 1; i < (int)wd1.Size(); i++)
   {
     if (wd1[i].etat < 0)
     {
@@ -1930,7 +1930,7 @@ static bool TestPassedSolutionWithNegativeState(const IntWalk_VectorOfWalkingDat
   double tolu = tolerance(1);
   double tolv = tolerance(2);
   int    i, j, k, N;
-  for (i = 1; i < (int)wd.size(); i++)
+  for (i = 1; i < (int)wd.Size(); i++)
   {
     if (wd[i].etat < -11)
     {

--- a/src/ModelingAlgorithms/TKGeomAlgo/IntWalk/IntWalk_VectorOfInteger.hxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/IntWalk/IntWalk_VectorOfInteger.hxx
@@ -16,11 +16,10 @@
 #ifndef IntWalk_VectorOfInteger_HeaderFile
 #define IntWalk_VectorOfInteger_HeaderFile
 
-#include <vector>
-#include <NCollection_OccAllocator.hxx>
+#include <NCollection_LinearVector.hxx>
 
 // Defines a dynamic vector of integer.
 
-typedef std::vector<int, NCollection_OccAllocator<int>> IntWalk_VectorOfInteger;
+typedef NCollection_LinearVector<int> IntWalk_VectorOfInteger;
 
 #endif

--- a/src/ModelingAlgorithms/TKGeomAlgo/IntWalk/IntWalk_VectorOfWalkingData.hxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/IntWalk/IntWalk_VectorOfWalkingData.hxx
@@ -16,8 +16,7 @@
 #ifndef IntWalk_VectorOfWalkingData_HeaderFile
 #define IntWalk_VectorOfWalkingData_HeaderFile
 
-#include <vector>
-#include <NCollection_OccAllocator.hxx>
+#include <NCollection_LinearVector.hxx>
 
 // Defines a dynamic vector of work data.
 
@@ -28,7 +27,6 @@ struct IntWalk_WalkingData
   int    etat;
 };
 
-typedef std::vector<IntWalk_WalkingData, NCollection_OccAllocator<IntWalk_WalkingData>>
-  IntWalk_VectorOfWalkingData;
+typedef NCollection_LinearVector<IntWalk_WalkingData> IntWalk_VectorOfWalkingData;
 
 #endif

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DelabellaBaseMeshAlgo.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DelabellaBaseMeshAlgo.cxx
@@ -113,7 +113,7 @@ void BRepMesh_DelabellaBaseMeshAlgo::buildBaseTriangulation()
 
   const double aDiffX = (aMax.X() - aMin.X());
   const double aDiffY = (aMax.Y() - aMin.Y());
-  for (size_t i = 0; i < aPoints.size(); i += 2)
+  for (size_t i = 0; i < aPoints.Size(); i += 2)
   {
     aPoints[i + 0] = (aPoints[i + 0] - aMin.X()) / aDiffX - 0.5;
     aPoints[i + 1] = (aPoints[i + 1] - aMin.Y()) / aDiffY - 0.5;
@@ -129,7 +129,7 @@ void BRepMesh_DelabellaBaseMeshAlgo::buildBaseTriangulation()
   aTriangulator->SetErrLog(logDelabella2Occ, nullptr);
   try
   {
-    const int aVerticesNb = aTriangulator->Triangulate(static_cast<int>(aPoints.size() / 2),
+    const int aVerticesNb = aTriangulator->Triangulate(static_cast<int>(aPoints.Size() / 2),
                                                        &aPoints[0],
                                                        &aPoints[1],
                                                        2 * sizeof(double));

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DelabellaBaseMeshAlgo.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DelabellaBaseMeshAlgo.cxx
@@ -72,8 +72,8 @@ void BRepMesh_DelabellaBaseMeshAlgo::buildBaseTriangulation()
 {
   const occ::handle<BRepMesh_DataStructureOfDelaun>& aStructure = this->getStructure();
 
-  Bnd_B2d             aBox;
-  const int           aNodesNb = aStructure->NbNodes();
+  Bnd_B2d                          aBox;
+  const int                        aNodesNb = aStructure->NbNodes();
   NCollection_LinearVector<double> aPoints;
   aPoints.Resize(2 * (aNodesNb + 4));
   for (int aNodeIt = 0; aNodeIt < aNodesNb; ++aNodeIt)

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DelabellaBaseMeshAlgo.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_DelabellaBaseMeshAlgo.cxx
@@ -15,6 +15,7 @@
 
 #include <BRepMesh_DelabellaBaseMeshAlgo.hxx>
 
+#include <NCollection_LinearVector.hxx>
 #include <BRepMesh_MeshTool.hxx>
 #include <BRepMesh_Delaun.hxx>
 #include <Message.hxx>
@@ -73,7 +74,8 @@ void BRepMesh_DelabellaBaseMeshAlgo::buildBaseTriangulation()
 
   Bnd_B2d             aBox;
   const int           aNodesNb = aStructure->NbNodes();
-  std::vector<double> aPoints(2 * (aNodesNb + 4));
+  NCollection_LinearVector<double> aPoints;
+  aPoints.Resize(2 * (aNodesNb + 4));
   for (int aNodeIt = 0; aNodeIt < aNodesNb; ++aNodeIt)
   {
     const BRepMesh_Vertex& aVertex = aStructure->GetNode(aNodeIt + 1);

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_Delaun.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_Delaun.cxx
@@ -31,10 +31,10 @@
 #include <BRepMesh_Triangle.hxx>
 
 #include <NCollection_DynamicArray.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include <algorithm>
 #include <stack>
-#include <vector>
 
 const double AngDeviation1Deg  = M_PI / 180.;
 const double AngDeviation90Deg = 90 * AngDeviation1Deg;
@@ -117,7 +117,7 @@ public:
   // Note that the range is [theFrameStart, theFrameEnd).
   inline void PushFrame(const int theFrameStart, const int theFrameEnd)
   {
-    myFrames.emplace_back(theFrameStart, theFrameEnd);
+    myFrames.EmplaceAppend(theFrameStart, theFrameEnd);
   }
 
   // Returns the index of the current element of the top frame
@@ -126,19 +126,19 @@ public:
   // Precondition: the stack is not empty.
   inline int PopElement()
   {
-    Frame&    aFrame = myFrames.back();
+    Frame&    aFrame = myFrames.ChangeLast();
     const int anElem = aFrame.Advance();
     if (aFrame.IsEmpty())
-      myFrames.pop_back();
+      myFrames.EraseLast();
 
     return anElem;
   }
 
   // Check if the stack is empty.
-  inline bool IsEmpty() const { return myFrames.empty(); }
+  inline bool IsEmpty() const { return myFrames.IsEmpty(); }
 
 private:
-  std::vector<Frame, NCollection_Allocator<Frame>> myFrames; // Container of frames.
+  NCollection_LinearVector<Frame> myFrames; // Container of frames.
 };
 } // anonymous namespace
 

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_FaceDiscret.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_FaceDiscret.cxx
@@ -61,8 +61,8 @@ public:
   }
 
 private:
-  mutable BRepMesh_FaceDiscret*      myAlgo;
-  Message_ProgressScope              myScope;
+  mutable BRepMesh_FaceDiscret*                   myAlgo;
+  Message_ProgressScope                           myScope;
   NCollection_LinearVector<Message_ProgressRange> myRanges;
 };
 

--- a/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_FaceDiscret.cxx
+++ b/src/ModelingAlgorithms/TKMesh/BRepMesh/BRepMesh_FaceDiscret.cxx
@@ -14,6 +14,7 @@
 // commercial license or contractual agreement.
 
 #include <BRepMesh_FaceDiscret.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <IMeshData_Model.hxx>
 #include <IMeshData_Wire.hxx>
 #include <IMeshData_Edge.hxx>
@@ -42,10 +43,10 @@ public:
       : myAlgo(theAlgo),
         myScope(theRange, "Face Discret", theAlgo->myModel->FacesNb())
   {
-    myRanges.reserve(theAlgo->myModel->FacesNb());
+    myRanges.Reserve(theAlgo->myModel->FacesNb());
     for (int aFaceIter = 0; aFaceIter < theAlgo->myModel->FacesNb(); ++aFaceIter)
     {
-      myRanges.push_back(myScope.Next());
+      myRanges.Append(myScope.Next());
     }
   }
 
@@ -62,7 +63,7 @@ public:
 private:
   mutable BRepMesh_FaceDiscret*      myAlgo;
   Message_ProgressScope              myScope;
-  std::vector<Message_ProgressRange> myRanges;
+  NCollection_LinearVector<Message_ProgressRange> myRanges;
 };
 
 //=================================================================================================

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Inter3d.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Inter3d.cxx
@@ -128,8 +128,8 @@ void BRepOffset_Inter3d::CompletInt(const NCollection_List<TopoDS_Shape>& SetOfF
   aSelector.Sort();
 
   // Treat the selected pairs
-  const std::vector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aSelector.Pairs();
+  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
   Message_ProgressScope aPS(theRange, "Complete intersection", aNbPairs);
   for (int iPair = 0; iPair < aNbPairs; ++iPair, aPS.Next())
   {

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Inter3d.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Inter3d.cxx
@@ -128,8 +128,8 @@ void BRepOffset_Inter3d::CompletInt(const NCollection_List<TopoDS_Shape>& SetOfF
   aSelector.Sort();
 
   // Treat the selected pairs
-  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs   = aSelector.Pairs();
-  const int                                             aNbPairs = static_cast<int>(aPairs.Size());
+  const NCollection_LinearVector<BOPTools_BoxPairSelector::PairIDs>& aPairs = aSelector.Pairs();
+  const int             aNbPairs = static_cast<int>(aPairs.Size());
   Message_ProgressScope aPS(theRange, "Complete intersection", aNbPairs);
   for (int iPair = 0; iPair < aNbPairs; ++iPair, aPS.Next())
   {

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
@@ -351,7 +351,7 @@ static bool GetShells(
       const TopoDS_Edge& anEdge = aFaceEdgesArray.Value(anEdgeInd);
 
       NCollection_DynamicArray<TopoDS_Face>& aFacesArray =
-        *aEdgeFaces.Bound(anEdge, NCollection_DynamicArray<TopoDS_Face>());
+        aEdgeFaces.TryBound(anEdge, NCollection_DynamicArray<TopoDS_Face>());
 
       // Check if face already exists in the array
       bool aFaceExists = false;

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
@@ -47,8 +47,6 @@
 #include <NCollection_IndexedDataMap.hxx>
 #include <NCollection_Sequence.hxx>
 
-#include <unordered_set>
-#include <unordered_map>
 #include <stack>
 #include <algorithm>
 
@@ -56,15 +54,11 @@ IMPLEMENT_STANDARD_RTTIEXT(ShapeFix_Shell, ShapeFix_Root)
 
 namespace
 {
-// Type aliases for unordered maps with custom allocators
-using FaceEdgesMap = NCollection_IndexedDataMap<TopoDS_Face, NCollection_Array1<TopoDS_Edge>>;
-using EdgeFacesAllocator =
-  NCollection_Allocator<std::pair<const TopoDS_Edge, NCollection_DynamicArray<TopoDS_Face>>>;
-using EdgeFacesMap = std::unordered_map<TopoDS_Edge,
-                                        NCollection_DynamicArray<TopoDS_Face>,
-                                        TopTools_ShapeMapHasher,
-                                        TopTools_ShapeMapHasher,
-                                        EdgeFacesAllocator>;
+// Type aliases for DataMaps with shape hasher
+using FaceEdgesMap  = NCollection_IndexedDataMap<TopoDS_Face, NCollection_Array1<TopoDS_Edge>>;
+using EdgeFacesMap  = NCollection_DataMap<TopoDS_Edge,
+                                          NCollection_DynamicArray<TopoDS_Face>,
+                                          TopTools_ShapeMapHasher>;
 
 // Default increment for dynamic array of faces per edge
 constexpr int DEFAULT_EDGE_FACES_INCREMENT = 5;
@@ -245,10 +239,10 @@ static NCollection_List<NCollection_Sequence<TopoDS_Shape>> GetConnectedFaceGrou
         {
           const TopoDS_Edge& anEdge = aFaceEdgesArray.Value(anEdgeIdx);
 
-          auto anEdgeFacesIter = theEdgeFaces.find(anEdge);
-          if (anEdgeFacesIter != theEdgeFaces.end())
+          auto anEdgeFacesPtr = theEdgeFaces.Seek(anEdge);
+          if (anEdgeFacesPtr)
           {
-            const NCollection_DynamicArray<TopoDS_Face>& aConnectedFaces = anEdgeFacesIter->second;
+            const NCollection_DynamicArray<TopoDS_Face>& aConnectedFaces = *anEdgeFacesPtr;
 
             for (int aFaceIdx = 0; aFaceIdx < aConnectedFaces.Length(); ++aFaceIdx)
             {
@@ -319,13 +313,9 @@ static bool GetShells(
 
   // Using STL containers because number of faces or edges can be too high
   // to keep them on flat basket OCCT map
-  using EdgeMapAllocator =
-    NCollection_Allocator<std::pair<const TopoDS_Edge, std::pair<bool, bool>>>;
-  using EdgeOrientedMap = std::unordered_map<TopoDS_Edge,
+  using EdgeOrientedMap = NCollection_DataMap<TopoDS_Edge,
                                              std::pair<bool, bool>,
-                                             TopTools_ShapeMapHasher,
-                                             TopTools_ShapeMapHasher,
-                                             EdgeMapAllocator>;
+                                             TopTools_ShapeMapHasher>;
   using TempProcessedEdges =
     NCollection_DataMap<TopoDS_Edge, std::pair<bool, bool>, TopTools_ShapeMapHasher>;
 
@@ -351,8 +341,7 @@ static bool GetShells(
     aFaceEdges.Add(aFace, std::move(aFaceEdgesArray));
   }
 
-  EdgeFacesMap aEdgeFaces;
-  aEdgeFaces.reserve(aNumberOfEdges);
+  EdgeFacesMap aEdgeFaces(static_cast<int>(aNumberOfEdges));
 
   for (int aFaceInd = 1; aFaceInd <= aFaceEdges.Length(); ++aFaceInd)
   {
@@ -363,7 +352,8 @@ static bool GetShells(
     {
       const TopoDS_Edge& anEdge = aFaceEdgesArray.Value(anEdgeInd);
 
-      auto& aFacesArray = aEdgeFaces[anEdge];
+      NCollection_DynamicArray<TopoDS_Face>& aFacesArray =
+        *aEdgeFaces.Bound(anEdge, NCollection_DynamicArray<TopoDS_Face>());
 
       // Check if face already exists in the array
       bool aFaceExists = false;
@@ -401,8 +391,7 @@ static bool GetShells(
   // Some assumption that each edge can be in two orientations
   aNumberOfEdges = static_cast<size_t>((aNumberOfEdges / 2) + 1);
 
-  EdgeOrientedMap aProcessedEdges;
-  aProcessedEdges.reserve(aNumberOfEdges);
+  EdgeOrientedMap aProcessedEdges(static_cast<int>(aNumberOfEdges));
 
   NCollection_Sequence<TopoDS_Shape> aProcessingFaces = std::move(aConnectedGroups.First());
 
@@ -425,9 +414,9 @@ static bool GetShells(
       if (anIsMultiConnex && theMapMultiConnectEdges.Contains(edge))
         continue;
 
-      auto aProcessedEdgeIt = aProcessedEdges.find(edge);
+      std::pair<bool, bool>* aProcessedEdgeIt = aProcessedEdges.ChangeSeek(edge);
 
-      if (aProcessedEdgeIt == aProcessedEdges.end())
+      if (!aProcessedEdgeIt)
       {
         std::pair<bool, bool>* aTempProcessedEdgeIt = aTempProcessedEdges.ChangeSeek(edge);
         if (!aTempProcessedEdgeIt)
@@ -447,7 +436,7 @@ static bool GetShells(
         continue;
       }
 
-      auto& aPair = aProcessedEdgeIt->second;
+      std::pair<bool, bool>& aPair = *aProcessedEdgeIt;
 
       const bool isDirect   = aPair.first;
       const bool isReversed = aPair.second;
@@ -475,7 +464,7 @@ static bool GetShells(
       if (!aPair.first && !aPair.second)
       {
         // if edge is processed in this face it is removed from map of processed edges
-        aProcessedEdges.erase(aProcessedEdgeIt);
+        aProcessedEdges.UnBind(edge);
       }
     }
 
@@ -510,15 +499,14 @@ static bool GetShells(
           std::pair<bool, bool> aRevertedPair{!anEdgeOrientationPair.first,
                                               !anEdgeOrientationPair.second};
 
-          auto aProcessedEdgeIt = aProcessedEdges.find(edge);
-          if (aProcessedEdgeIt == aProcessedEdges.end())
+          std::pair<bool, bool>* aProcessedEdgePtr = aProcessedEdges.ChangeSeek(edge);
+          if (!aProcessedEdgePtr)
           {
-            aProcessedEdges.emplace(edge, aRevertedPair);
+            aProcessedEdges.Bind(edge, aRevertedPair);
           }
           else
           {
-            auto& aPair = aProcessedEdgeIt->second;
-            aPair       = aRevertedPair;
+            *aProcessedEdgePtr = aRevertedPair;
           }
         }
         aDone = true;
@@ -531,16 +519,15 @@ static bool GetShells(
           const TopoDS_Edge& edge                  = aTempEdgeIter.Key();
           const auto&        anEdgeOrientationPair = aTempEdgeIter.Value();
 
-          auto aProcessedEdgeIt = aProcessedEdges.find(edge);
-          if (aProcessedEdgeIt == aProcessedEdges.end())
+          std::pair<bool, bool>* aProcessedEdgePtr = aProcessedEdges.ChangeSeek(edge);
+          if (!aProcessedEdgePtr)
           {
-            aProcessedEdges.emplace(edge, anEdgeOrientationPair);
+            aProcessedEdges.Bind(edge, anEdgeOrientationPair);
           }
           else
           {
-            auto& aPair  = aProcessedEdgeIt->second;
-            aPair.first  = anEdgeOrientationPair.first;
-            aPair.second = anEdgeOrientationPair.second;
+            aProcessedEdgePtr->first  = anEdgeOrientationPair.first;
+            aProcessedEdgePtr->second = anEdgeOrientationPair.second;
           }
         }
       }

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Shell.cxx
@@ -55,10 +55,9 @@ IMPLEMENT_STANDARD_RTTIEXT(ShapeFix_Shell, ShapeFix_Root)
 namespace
 {
 // Type aliases for DataMaps with shape hasher
-using FaceEdgesMap  = NCollection_IndexedDataMap<TopoDS_Face, NCollection_Array1<TopoDS_Edge>>;
-using EdgeFacesMap  = NCollection_DataMap<TopoDS_Edge,
-                                          NCollection_DynamicArray<TopoDS_Face>,
-                                          TopTools_ShapeMapHasher>;
+using FaceEdgesMap = NCollection_IndexedDataMap<TopoDS_Face, NCollection_Array1<TopoDS_Edge>>;
+using EdgeFacesMap =
+  NCollection_DataMap<TopoDS_Edge, NCollection_DynamicArray<TopoDS_Face>, TopTools_ShapeMapHasher>;
 
 // Default increment for dynamic array of faces per edge
 constexpr int DEFAULT_EDGE_FACES_INCREMENT = 5;
@@ -313,9 +312,8 @@ static bool GetShells(
 
   // Using STL containers because number of faces or edges can be too high
   // to keep them on flat basket OCCT map
-  using EdgeOrientedMap = NCollection_DataMap<TopoDS_Edge,
-                                             std::pair<bool, bool>,
-                                             TopTools_ShapeMapHasher>;
+  using EdgeOrientedMap =
+    NCollection_DataMap<TopoDS_Edge, std::pair<bool, bool>, TopTools_ShapeMapHasher>;
   using TempProcessedEdges =
     NCollection_DataMap<TopoDS_Edge, std::pair<bool, bool>, TopTools_ShapeMapHasher>;
 

--- a/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.cxx
@@ -245,8 +245,8 @@ std::pair<ShapeProcess::Operation, bool> ShapeProcess::ToOperationFlag(const cha
 
 //=================================================================================================
 
-NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> ShapeProcess::getOperators(
-  const ShapeProcess::OperationsFlags& theFlags)
+NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> ShapeProcess::
+  getOperators(const ShapeProcess::OperationsFlags& theFlags)
 {
   NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> aResult;
   for (std::underlying_type<Operation>::type anOperation = Operation::First;

--- a/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.cxx
@@ -189,9 +189,9 @@ bool ShapeProcess::Perform(const occ::handle<ShapeProcess_Context>& theContext,
     return false;
   }
 
-  std::vector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> anOperators =
+  NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> anOperators =
     getOperators(theOperations);
-  if (anOperators.empty())
+  if (anOperators.IsEmpty())
   {
     return false;
   }
@@ -199,7 +199,7 @@ bool ShapeProcess::Perform(const occ::handle<ShapeProcess_Context>& theContext,
   bool                  anIsAnySuccess = false;
   Message_ProgressScope aProgressScope(theProgress,
                                        nullptr,
-                                       static_cast<double>(anOperators.size()));
+                                       static_cast<double>(anOperators.Size()));
   for (const auto& anOperator : anOperators)
   {
     const char*                               anOperationName = anOperator.first;
@@ -245,10 +245,10 @@ std::pair<ShapeProcess::Operation, bool> ShapeProcess::ToOperationFlag(const cha
 
 //=================================================================================================
 
-std::vector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> ShapeProcess::getOperators(
+NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> ShapeProcess::getOperators(
   const ShapeProcess::OperationsFlags& theFlags)
 {
-  std::vector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> aResult;
+  NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> aResult;
   for (std::underlying_type<Operation>::type anOperation = Operation::First;
        anOperation <= Operation::Last;
        ++anOperation)
@@ -263,7 +263,7 @@ std::vector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> ShapePro
       occ::handle<ShapeProcess_Operator> anOperator;
       if (FindOperator(anOperationName, anOperator))
       {
-        aResult.emplace_back(anOperationName, anOperator);
+        aResult.EmplaceAppend(anOperationName, anOperator);
       }
     }
   }

--- a/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.hxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.hxx
@@ -20,9 +20,10 @@
 #include <Standard.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include <bitset>
-#include <vector>
+#include <utility>
 
 class ShapeProcess_Operator;
 class ShapeProcess_Context;
@@ -111,7 +112,7 @@ private:
   //! Returns operators to be performed according to the specified flags.
   //! @param theFlags Bitset of operations flags.
   //! @return List of operators to perform: pairs of operator name and operator handle.
-  static std::vector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> getOperators(
+  static NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> getOperators(
     const OperationsFlags& theFlags);
 
   //! Converts operation flag to its name.

--- a/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.hxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeProcess/ShapeProcess.hxx
@@ -112,8 +112,8 @@ private:
   //! Returns operators to be performed according to the specified flags.
   //! @param theFlags Bitset of operations flags.
   //! @return List of operators to perform: pairs of operator name and operator handle.
-  static NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>> getOperators(
-    const OperationsFlags& theFlags);
+  static NCollection_LinearVector<std::pair<const char*, occ::handle<ShapeProcess_Operator>>>
+    getOperators(const OperationsFlags& theFlags);
 
   //! Converts operation flag to its name.
   //! @param theOperation Operation flag.

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepClass3d/BRepClass3d_SClassifier.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepClass3d/BRepClass3d_SClassifier.cxx
@@ -31,8 +31,7 @@
 #include <TopExp.hxx>
 #include <BRepAdaptor_Surface.hxx>
 #include <Extrema_ExtPS.hxx>
-
-#include <vector>
+#include <NCollection_LinearVector.hxx>
 
 // modified by NIZHNY-MKK  Mon Jun 21 15:13:40 2004
 static bool FaceNormal(const TopoDS_Face& aF, const double U, const double V, gp_Dir& aDN);
@@ -112,12 +111,12 @@ void BRepClass3d_SClassifier::PerformInfinitePoint(BRepClass3d_SolidExplorer& aS
   myState = 2;
 
   // Collect faces in sequence to iterate
-  std::vector<TopoDS_Face> aFaces;
+  NCollection_LinearVector<TopoDS_Face> aFaces;
   for (aSE.InitShell(); aSE.MoreShell(); aSE.NextShell())
   {
     for (aSE.InitFace(); aSE.MoreFace(); aSE.NextFace())
     {
-      aFaces.push_back(aSE.CurrentFace());
+      aFaces.Append(aSE.CurrentFace());
     }
   }
 
@@ -125,9 +124,9 @@ void BRepClass3d_SClassifier::PerformInfinitePoint(BRepClass3d_SolidExplorer& aS
   const int NB_MAX_POINTS_PER_FACE = 10;
   for (int itry = 0; itry < NB_MAX_POINTS_PER_FACE; itry++)
   {
-    for (std::vector<TopoDS_Face>::iterator iFace = aFaces.begin(); iFace != aFaces.end(); ++iFace)
+    for (size_t iFace = 0; iFace < aFaces.Size(); ++iFace)
     {
-      TopoDS_Face aF = *iFace;
+      TopoDS_Face aF = aFaces[iFace];
 
       TopAbs_State                      aState      = TopAbs_OUT;
       IntCurveSurface_TransitionOnCurve aTransition = IntCurveSurface_Tangent;

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_ProximityDistTool.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_ProximityDistTool.cxx
@@ -104,7 +104,7 @@ void BRepExtrema_ProximityDistTool::LoadAdditionalPointsFirstSet(
 void BRepExtrema_ProximityDistTool::goThroughtSet1(const BVH_Array3d& theVertices1,
                                                    const bool         theIsAdditionalSet)
 {
-  int aVtxSize = (int)theVertices1.size();
+  int aVtxSize = (int)theVertices1.Size();
   int aVtxStep = std::max(myNbSamples1 <= 0 ? 1 : aVtxSize / myNbSamples1, 1);
   for (int aVtxIdx = 0; aVtxIdx < aVtxSize; aVtxIdx += aVtxStep)
   {
@@ -373,7 +373,7 @@ void BRepExtrema_ProximityDistTool::defineStatusProxPnt1()
   if (myShapeList1(aFaceID1).ShapeType() == TopAbs_EDGE)
   {
     const BVH_Array3d& aVertices1 = mySet1->GetVertices();
-    int                aVtxSize   = (int)aVertices1.size();
+    int                aVtxSize   = (int)aVertices1.Size();
     int                aLastIdx   = aVtxSize - 1;
 
     if ((aVertices1[0] - aVertices1[aLastIdx]).Modulus() < Precision::Confusion()) // if closed
@@ -428,7 +428,7 @@ void BRepExtrema_ProximityDistTool::defineStatusProxPnt2()
     else
     {
       const BVH_Array3d& aVertices2 = mySet2->GetVertices();
-      int                aVtxSize   = (int)aVertices2.size();
+      int                aVtxSize   = (int)aVertices2.Size();
       int                aLastIdx   = aVtxSize - 1;
 
       if ((aVertices2[0] - aVertices2[aLastIdx]).Modulus() < Precision::Confusion()) // if closed

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_ProximityValueTool.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_ProximityValueTool.cxx
@@ -258,7 +258,7 @@ bool BRepExtrema_ProximityValueTool::getEdgeAdditionalVertices(
     double aPar = aGCPnts.Parameter(aVertIdx);
     gp_Pnt aP   = aBAC.Value(aPar);
 
-    theAddVertices.emplace_back(aP.X(), aP.Y(), aP.Z());
+    theAddVertices.EmplaceAppend(aP.X(), aP.Y(), aP.Z());
     theAddStatuses.Append(ProxPnt_Status::ProxPnt_Status_MIDDLE);
   }
 
@@ -308,10 +308,10 @@ void BRepExtrema_ProximityValueTool::doRecurTrgSplit(
   if (myInspector.IsNeedAdd()) // is point aCenterOfMaxSide unique
   {
     BVH_Vec3d aBisectingPnt(aCenterOfMaxSide.X(), aCenterOfMaxSide.Y(), aCenterOfMaxSide.Z());
-    theAddVertices.push_back(aBisectingPnt);
+    theAddVertices.Append(aBisectingPnt);
     theAddStatuses.Append(theEdgesStatus[aBisectedEdgeIdx]);
     myInspector.Add(aCenterOfMaxSide.Coord());
-    myCells.Add(static_cast<BRepExtrema_VertexInspector::Target>(theAddVertices.size()),
+    myCells.Add(static_cast<BRepExtrema_VertexInspector::Target>(theAddVertices.Size()),
                 aBox.CornerMin().XYZ(),
                 aBox.CornerMax().XYZ());
   }

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_SelfIntersection.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_SelfIntersection.cxx
@@ -265,10 +265,10 @@ BRepExtrema_ElementFilter::FilterResult BRepExtrema_SelfIntersection::PreCheckEl
                                aTrng0Vtxs[3 - aSharedVtxs[0].first - aSharedVtxs[1].first],
                                aTrng1Vtxs[3 - aSharedVtxs[0].second - aSharedVtxs[1].second]);
   }
-  else if (aSharedVtxs.size() == 1) // check shared vertex
+  else if (aSharedVtxs.Size() == 1) // check shared vertex
   {
-    std::swap(*aTrng0Vtxs, aTrng0Vtxs[aSharedVtxs.front().first]);
-    std::swap(*aTrng1Vtxs, aTrng1Vtxs[aSharedVtxs.front().second]);
+    std::swap(*aTrng0Vtxs, aTrng0Vtxs[aSharedVtxs.First().first]);
+    std::swap(*aTrng1Vtxs, aTrng1Vtxs[aSharedVtxs.First().second]);
 
     return isRegularSharedVertex(aTrng0Vtxs[0],
                                  aTrng0Vtxs[1],

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_SelfIntersection.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_SelfIntersection.cxx
@@ -15,6 +15,7 @@
 
 #include <BRepExtrema_SelfIntersection.hxx>
 
+#include <NCollection_LinearVector.hxx>
 #include <Precision.hxx>
 #include <TopExp_Explorer.hxx>
 
@@ -241,7 +242,7 @@ BRepExtrema_ElementFilter::FilterResult BRepExtrema_SelfIntersection::PreCheckEl
 
   myElementSet->GetVertices(theIndex2, aTrng1Vtxs[0], aTrng1Vtxs[1], aTrng1Vtxs[2]);
 
-  std::vector<std::pair<int, int>> aSharedVtxs;
+  NCollection_LinearVector<std::pair<int, int>> aSharedVtxs;
 
   for (int aVertIdx1 = 0; aVertIdx1 < 3; ++aVertIdx1)
   {
@@ -250,14 +251,14 @@ BRepExtrema_ElementFilter::FilterResult BRepExtrema_SelfIntersection::PreCheckEl
       if ((aTrng0Vtxs[aVertIdx1] - aTrng1Vtxs[aVertIdx2]).SquareModulus()
           < Precision::SquareConfusion())
       {
-        aSharedVtxs.emplace_back(aVertIdx1, aVertIdx2);
+        aSharedVtxs.EmplaceAppend(aVertIdx1, aVertIdx2);
 
         break; // go to next vertex of the 1st triangle
       }
     }
   }
 
-  if (aSharedVtxs.size() == 2) // check shared edge
+  if (aSharedVtxs.Size() == 2) // check shared edge
   {
     return isRegularSharedEdge(aTrng0Vtxs[aSharedVtxs[0].first],
                                aTrng0Vtxs[aSharedVtxs[1].first],

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_TriangleSet.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepExtrema/BRepExtrema_TriangleSet.cxx
@@ -57,7 +57,7 @@ BRepExtrema_TriangleSet::~BRepExtrema_TriangleSet() = default;
 //=======================================================================
 int BRepExtrema_TriangleSet::Size() const
 {
-  return static_cast<int>(myTriangles.size());
+  return static_cast<int>(myTriangles.Size());
 }
 
 //=======================================================================
@@ -206,11 +206,8 @@ void BRepExtrema_TriangleSet::GetVtxIndices(const int                theIndex,
 
 void BRepExtrema_TriangleSet::Clear()
 {
-  BVH_Array4i anEmptyTriangles;
-  myTriangles.swap(anEmptyTriangles);
-
-  BVH_Array3d anEmptyVertexArray;
-  myVertexArray.swap(anEmptyVertexArray);
+  myTriangles.Clear(true);
+  myVertexArray.Clear(true);
 }
 
 //=================================================================================================
@@ -228,7 +225,7 @@ bool BRepExtrema_TriangleSet::Init(const NCollection_DynamicArray<TopoDS_Shape>&
       isOK = initEdge(TopoDS::Edge(theShapes(aShapeIdx)), aShapeIdx);
   }
 
-  int aNumTrg = static_cast<int>(myTriangles.size());
+  int aNumTrg = static_cast<int>(myTriangles.Size());
   myTrgIdxMap.Clear();
   myTrgIdxMap.ReSize(aNumTrg);
 
@@ -256,7 +253,7 @@ bool BRepExtrema_TriangleSet::initFace(const TopoDS_Face& theFace, const int the
     return false;
   }
 
-  const int aVertOffset = static_cast<int>(myVertexArray.size()) - 1;
+  const int aVertOffset = static_cast<int>(myVertexArray.Size()) - 1;
 
   initNodes(aTriangulation->MapNodeArray()->ChangeArray1(), aLocation.Transformation(), theIndex);
 
@@ -268,10 +265,10 @@ bool BRepExtrema_TriangleSet::initFace(const TopoDS_Face& theFace, const int the
 
     aTriangulation->Triangle(aTriIdx).Get(aVertex1, aVertex2, aVertex3);
 
-    myTriangles.emplace_back(aVertex1 + aVertOffset,
-                             aVertex2 + aVertOffset,
-                             aVertex3 + aVertOffset,
-                             theIndex);
+    myTriangles.EmplaceAppend(aVertex1 + aVertOffset,
+                              aVertex2 + aVertOffset,
+                              aVertex3 + aVertOffset,
+                              theIndex);
   }
 
   myNumTrgInShapeVec.SetValue(theIndex, aTriangulation->NbTriangles());
@@ -291,17 +288,17 @@ bool BRepExtrema_TriangleSet::initEdge(const TopoDS_Edge& theEdge, const int the
     return false;
   }
 
-  const int aVertOffset = static_cast<int>(myVertexArray.size()) - 1;
+  const int aVertOffset = static_cast<int>(myVertexArray.Size()) - 1;
 
   initNodes(aPolygon->Nodes(), aLocation.Transformation(), theIndex);
 
   for (int aVertIdx = 1; aVertIdx < aPolygon->NbNodes(); ++aVertIdx)
   {
     // segment as degenerate triangle
-    myTriangles.emplace_back(aVertIdx + aVertOffset,
-                             aVertIdx + aVertOffset + 1,
-                             aVertIdx + aVertOffset + 1,
-                             theIndex);
+    myTriangles.EmplaceAppend(aVertIdx + aVertOffset,
+                              aVertIdx + aVertOffset + 1,
+                              aVertIdx + aVertOffset + 1,
+                              theIndex);
   }
   return true;
 }
@@ -318,7 +315,7 @@ void BRepExtrema_TriangleSet::initNodes(const NCollection_Array1<gp_Pnt>& theNod
 
     aVertex.Transform(theTrsf);
 
-    myVertexArray.emplace_back(aVertex.X(), aVertex.Y(), aVertex.Z());
+    myVertexArray.EmplaceAppend(aVertex.X(), aVertex.Y(), aVertex.Z());
     myShapeIdxOfVtxVec.Append(theIndex);
   }
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_HaltonSampler.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_HaltonSampler.hxx
@@ -21,7 +21,7 @@
 #ifndef _OpenGl_HaltonSampler_H
 #define _OpenGl_HaltonSampler_H
 
-#include <vector>
+#include <NCollection_LinearVector.hxx>
 
 //! Compute points of the Halton sequence with digit-permutations for different bases.
 class OpenGl_HaltonSampler
@@ -55,10 +55,10 @@ private:
   //! Init the permutation arrays using Faure-permutations.
   void initFaure();
 
-  static unsigned short invert(unsigned short                     theBase,
-                               unsigned short                     theDigits,
-                               unsigned short                     theIndex,
-                               const std::vector<unsigned short>& thePerm)
+  static unsigned short invert(unsigned short                                  theBase,
+                               unsigned short                                  theDigits,
+                               unsigned short                                  theIndex,
+                               const NCollection_LinearVector<unsigned short>& thePerm)
   {
     unsigned short aResult = 0;
     for (unsigned short i = 0; i < theDigits; ++i)
@@ -69,7 +69,7 @@ private:
     return aResult;
   }
 
-  void initTables(const std::vector<std::vector<unsigned short>>& thePerm)
+  void initTables(const NCollection_LinearVector<NCollection_LinearVector<unsigned short>>& thePerm)
   {
     for (unsigned short i = 0; i < 243; ++i)
     {
@@ -119,11 +119,12 @@ private:
 
 inline void OpenGl_HaltonSampler::initFaure()
 {
-  const unsigned                           THE_MAX_BASE = 5u;
-  std::vector<std::vector<unsigned short>> aPerms(THE_MAX_BASE + 1);
+  const unsigned                                              THE_MAX_BASE = 5u;
+  NCollection_LinearVector<NCollection_LinearVector<unsigned short>> aPerms;
+  aPerms.Resize(THE_MAX_BASE + 1);
   for (unsigned k = 1; k <= 3; ++k) // Keep identity permutations for base 1, 2, 3.
   {
-    aPerms[k].resize(k);
+    aPerms[k].Resize(k);
     for (unsigned i = 0; i < k; ++i)
     {
       aPerms[k][i] = static_cast<unsigned short>(i);
@@ -132,7 +133,7 @@ inline void OpenGl_HaltonSampler::initFaure()
 
   for (unsigned aBase = 4; aBase <= THE_MAX_BASE; ++aBase)
   {
-    aPerms[aBase].resize(aBase);
+    aPerms[aBase].Resize(aBase);
     const unsigned b = aBase / 2;
     if (aBase & 1) // odd
     {

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_HaltonSampler.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_HaltonSampler.hxx
@@ -119,7 +119,7 @@ private:
 
 inline void OpenGl_HaltonSampler::initFaure()
 {
-  const unsigned                                              THE_MAX_BASE = 5u;
+  const unsigned                                                     THE_MAX_BASE = 5u;
   NCollection_LinearVector<NCollection_LinearVector<unsigned short>> aPerms;
   aPerms.Resize(THE_MAX_BASE + 1);
   for (unsigned k = 1; k <= 3; ++k) // Keep identity permutations for base 1, 2, 3.

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.cxx
@@ -144,14 +144,8 @@ void OpenGl_RaytraceGeometry::Clear()
 {
   BVH_Geometry<float, 3>::BVH_Geometry::Clear();
 
-  std::vector<OpenGl_RaytraceLight, NCollection_OccAllocator<OpenGl_RaytraceLight>> anEmptySources;
-
-  Sources.swap(anEmptySources);
-
-  std::vector<OpenGl_RaytraceMaterial, NCollection_OccAllocator<OpenGl_RaytraceMaterial>>
-    anEmptyMaterials;
-
-  Materials.swap(anEmptyMaterials);
+  Sources.Clear(true);
+  Materials.Clear(true);
 }
 
 struct OpenGL_BVHParallelBuilder
@@ -446,7 +440,7 @@ bool OpenGl_RaytraceGeometry::ReleaseTextures(const occ::handle<OpenGl_Context>&
     return true;
   }
 
-  for (size_t aTexIter = 0; aTexIter < myTextureHandles.size(); ++aTexIter)
+  for (size_t aTexIter = 0; aTexIter < myTextureHandles.Size(); ++aTexIter)
   {
     theContext->arbTexBindless->glMakeTextureHandleNonResidentARB(myTextureHandles[aTexIter]);
     const GLenum anErr = theContext->core11fwd->glGetError();

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.cxx
@@ -142,7 +142,7 @@ OpenGl_TriangleSet::OpenGl_TriangleSet(const size_t                             
 
 void OpenGl_RaytraceGeometry::Clear()
 {
-  BVH_Geometry<float, 3>::BVH_Geometry::Clear();
+  BVH_ObjectSet<float, 3>::Clear();
 
   Sources.Clear(true);
   Materials.Clear(true);
@@ -273,8 +273,8 @@ bool OpenGl_RaytraceGeometry::ProcessAcceleration()
                                                    aVerticesOffset,
                                                    aElementsOffset);
 
-      aVerticesOffset += static_cast<int>(aTriangleSet->Vertices.size());
-      aElementsOffset += static_cast<int>(aTriangleSet->Elements.size());
+      aVerticesOffset += static_cast<int>(aTriangleSet->Vertices.Size());
+      aElementsOffset += static_cast<int>(aTriangleSet->Elements.Size());
 
       aBvhNodesOffset += aTriangleSet->QuadBVH()->Length();
     }
@@ -314,7 +314,7 @@ int OpenGl_RaytraceGeometry::AccelerationOffset(int theNodeIdx)
   if (theNodeIdx >= aBVH->Length() || !aBVH->IsOuter(theNodeIdx))
     return INVALID_OFFSET;
 
-  return aBVH->NodeInfoBuffer().at(theNodeIdx).y();
+  return aBVH->NodeInfoBuffer().Value(theNodeIdx).y();
 }
 
 // =======================================================================
@@ -328,7 +328,7 @@ int OpenGl_RaytraceGeometry::VerticesOffset(int theNodeIdx)
   if (theNodeIdx >= aBVH->Length() || !aBVH->IsOuter(theNodeIdx))
     return INVALID_OFFSET;
 
-  return aBVH->NodeInfoBuffer().at(theNodeIdx).z();
+  return aBVH->NodeInfoBuffer().Value(theNodeIdx).z();
 }
 
 // =======================================================================
@@ -342,7 +342,7 @@ int OpenGl_RaytraceGeometry::ElementsOffset(int theNodeIdx)
   if (theNodeIdx >= aBVH->Length() || !aBVH->IsOuter(theNodeIdx))
     return INVALID_OFFSET;
 
-  return aBVH->NodeInfoBuffer().at(theNodeIdx).w();
+  return aBVH->NodeInfoBuffer().Value(theNodeIdx).w();
 }
 
 // =======================================================================
@@ -356,11 +356,11 @@ OpenGl_TriangleSet* OpenGl_RaytraceGeometry::TriangleSet(int theNodeIdx)
   if (theNodeIdx >= aBVH->Length() || !aBVH->IsOuter(theNodeIdx))
     return nullptr;
 
-  if (aBVH->NodeInfoBuffer().at(theNodeIdx).x() > myObjects.Length())
+  if (aBVH->NodeInfoBuffer().Value(theNodeIdx).x() > myObjects.Length())
     return nullptr;
 
   return dynamic_cast<OpenGl_TriangleSet*>(
-    myObjects(aBVH->NodeInfoBuffer().at(theNodeIdx).x() - 1).get());
+    myObjects(aBVH->NodeInfoBuffer().Value(theNodeIdx).x() - 1).get());
 }
 
 // =======================================================================
@@ -406,7 +406,7 @@ bool OpenGl_RaytraceGeometry::AcquireTextures(const occ::handle<OpenGl_Context>&
           GL_DEBUG_SEVERITY_HIGH,
           TCollection_AsciiString("Error: Failed to get 64-bit handle of OpenGL texture ")
             + OpenGl_Context::FormatGlError(anErr));
-        myTextureHandles.clear();
+        myTextureHandles.Clear();
         return false;
       }
     }
@@ -498,8 +498,8 @@ bool OpenGl_RaytraceGeometry::UpdateTextureHandles(const occ::handle<OpenGl_Cont
     return false;
   }
 
-  myTextureHandles.clear();
-  myTextureHandles.resize(myTextures.Size());
+  myTextureHandles.Clear();
+  myTextureHandles.Resize(myTextures.Size());
 
   int aTexIter = 0;
   for (NCollection_DynamicArray<occ::handle<OpenGl_Texture>>::Iterator aTexSrcIter(myTextures);
@@ -531,7 +531,7 @@ bool OpenGl_RaytraceGeometry::UpdateTextureHandles(const occ::handle<OpenGl_Cont
         GL_DEBUG_SEVERITY_HIGH,
         TCollection_AsciiString("Error: Failed to get 64-bit handle of OpenGL texture ")
           + OpenGl_Context::FormatGlError(anErr));
-      myTextureHandles.clear();
+      myTextureHandles.Clear();
       return false;
     }
   }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.hxx
@@ -19,7 +19,7 @@
 #include <BVH_Geometry.hxx>
 #include <BVH_Triangulation.hxx>
 #include <BVH_BinnedBuilder.hxx>
-#include <NCollection_OccAllocator.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <OpenGl_Texture.hxx>
 #include <OpenGl_Sampler.hxx>
 
@@ -167,10 +167,10 @@ public:
 
 public:
   //! Array of properties of light sources.
-  std::vector<OpenGl_RaytraceLight, NCollection_OccAllocator<OpenGl_RaytraceLight>> Sources;
+  NCollection_LinearVector<OpenGl_RaytraceLight> Sources;
 
   //! Array of 'front' material properties.
-  std::vector<OpenGl_RaytraceMaterial, NCollection_OccAllocator<OpenGl_RaytraceMaterial>> Materials;
+  NCollection_LinearVector<OpenGl_RaytraceMaterial> Materials;
 
   //! Global ambient from all light sources.
   BVH_Vec4f Ambient;
@@ -193,11 +193,7 @@ public:
   //! Clears only ray-tracing materials.
   void ClearMaterials()
   {
-    std::vector<OpenGl_RaytraceMaterial, NCollection_OccAllocator<OpenGl_RaytraceMaterial>>
-      anEmptyMaterials;
-
-    Materials.swap(anEmptyMaterials);
-
+    Materials.Clear(true);
     myTextures.Clear();
   }
 
@@ -248,7 +244,7 @@ public: //! @name methods related to texture management
   Standard_EXPORT bool ReleaseTextures(const occ::handle<OpenGl_Context>& theContext) const;
 
   //! Returns array of texture handles.
-  const std::vector<GLuint64>& TextureHandles() const { return myTextureHandles; }
+  const NCollection_LinearVector<GLuint64>& TextureHandles() const { return myTextureHandles; }
 
   //! Releases OpenGL resources.
   void ReleaseResources(const occ::handle<OpenGl_Context>&)
@@ -266,7 +262,7 @@ public: //! @name auxiliary methods
 protected:
   // clang-format off
   NCollection_DynamicArray<occ::handle<OpenGl_Texture>> myTextures;           //!< Array of texture maps shared between rendered objects
-  std::vector<GLuint64>                      myTextureHandles;     //!< Array of unique 64-bit texture handles obtained from OpenGL
+  NCollection_LinearVector<GLuint64>                    myTextureHandles;     //!< Array of unique 64-bit texture handles obtained from OpenGL
   int                           myTopLevelTreeDepth;  //!< Depth of high-level scene BVH from last build
   int                           myBotLevelTreeDepth;  //!< Maximum depth of bottom-level scene BVHs from last build
   // clang-format on

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_SceneGeometry.hxx
@@ -113,18 +113,18 @@ public:
   //! Returns material index of triangle set.
   int MaterialIndex() const
   {
-    if (Elements.empty())
+    if (Elements.IsEmpty())
     {
       return INVALID_MATERIAL;
     }
 
-    return Elements.front().w();
+    return Elements.First().w();
   }
 
   //! Sets material index for entire triangle set.
   void SetMaterialIndex(int theMatID)
   {
-    for (size_t anIdx = 0; anIdx < Elements.size(); ++anIdx)
+    for (size_t anIdx = 0; anIdx < Elements.Size(); ++anIdx)
     {
       Elements[anIdx].w() = theMatID;
     }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.cxx
@@ -15,6 +15,7 @@
 
 #include <OSD_File.hxx>
 #include <OSD_Environment.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include <OpenGl_Context.hxx>
 #include <OpenGl_ShaderProgram.hxx>
@@ -662,13 +663,14 @@ bool OpenGl_ShaderProgram::Initialize(
   if (const OpenGl_ShaderUniformLocation aLocSampler =
         GetUniformLocation(theCtx, "occShadowMapSamplers"))
   {
-    std::vector<GLint> aShadowSamplers(myNbShadowMaps);
-    const GLint        aSamplFrom = GLint(theCtx->ShadowMapTexUnit()) - myNbShadowMaps + 1;
+    NCollection_LinearVector<GLint> aShadowSamplers;
+    aShadowSamplers.Resize(myNbShadowMaps);
+    const GLint                     aSamplFrom = GLint(theCtx->ShadowMapTexUnit()) - myNbShadowMaps + 1;
     for (int aSamplerIter = 0; aSamplerIter < myNbShadowMaps; ++aSamplerIter)
     {
       aShadowSamplers[aSamplerIter] = aSamplFrom + aSamplerIter;
     }
-    SetUniform(theCtx, aLocSampler, myNbShadowMaps, &aShadowSamplers.front());
+    SetUniform(theCtx, aLocSampler, myNbShadowMaps, &aShadowSamplers[0]);
   }
 
   if (const OpenGl_ShaderUniformLocation aLocSampler =

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.cxx
@@ -665,7 +665,7 @@ bool OpenGl_ShaderProgram::Initialize(
   {
     NCollection_LinearVector<GLint> aShadowSamplers;
     aShadowSamplers.Resize(myNbShadowMaps);
-    const GLint                     aSamplFrom = GLint(theCtx->ShadowMapTexUnit()) - myNbShadowMaps + 1;
+    const GLint aSamplFrom = GLint(theCtx->ShadowMapTexUnit()) - myNbShadowMaps + 1;
     for (int aSamplerIter = 0; aSamplerIter < myNbShadowMaps; ++aSamplerIter)
     {
       aShadowSamplers[aSamplerIter] = aSamplFrom + aSamplerIter;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_TileSampler.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_TileSampler.cxx
@@ -122,8 +122,8 @@ void OpenGl_TileSampler::dumpMap(std::ostream&                     theStream,
 NCollection_Vec2<int> OpenGl_TileSampler::nextTileToSample()
 {
   NCollection_Vec2<int> aTile(0, 0);
-  const float           aKsiX = mySampler.sample(0, myLastSample) * myMarginalMap.back();
-  for (; (size_t)aTile.x() < myMarginalMap.size() - 1; ++aTile.x())
+  const float           aKsiX = mySampler.sample(0, myLastSample) * myMarginalMap.Last();
+  for (; (size_t)aTile.x() < myMarginalMap.Size() - 1; ++aTile.x())
   {
     if (aKsiX <= myMarginalMap[aTile.x()])
     {
@@ -189,8 +189,7 @@ void OpenGl_TileSampler::SetSize(const Graphic3d_RenderingParams& theParams,
     myOffsets.Init(myTiles.Allocator(), myTiles.SizeX, myTiles.SizeY);
     myOffsets.Init(NCollection_Vec2<int>(-1, -1));
 
-    myMarginalMap.resize(myTiles.SizeX);
-    myMarginalMap.assign(myMarginalMap.size(), 0.0f);
+    myMarginalMap.Resize(myTiles.SizeX, 0.0f);
   }
 
   // calculate a size of compact offsets texture optimal for rendering reduced number of tiles

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_TileSampler.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_TileSampler.hxx
@@ -20,8 +20,7 @@
 #include <OpenGl_HaltonSampler.hxx>
 
 #include <Image_PixMapTypedData.hxx>
-
-#include <vector>
+#include <NCollection_LinearVector.hxx>
 
 class Graphic3d_RenderingParams;
 
@@ -153,7 +152,7 @@ protected:
   Image_PixMapTypedData<int>             myVarianceRaw;   //!< Estimation of visual error per tile (raw data)
   Image_PixMapTypedData<NCollection_Vec2<int>> myOffsets;       //!< 2D array of tiles redirecting to another tile
   Image_PixMapTypedData<NCollection_Vec2<int>> myOffsetsShrunk; //!< 2D array of tiles redirecting to another tile (shrunk)
-  std::vector<float>                     myMarginalMap;   //!< Marginal distribution of 2D error map
+  NCollection_LinearVector<float>                myMarginalMap;   //!< Marginal distribution of 2D error map
   OpenGl_HaltonSampler                   mySampler;       //!< Halton sequence generator
   unsigned int                           myLastSample;    //!< Index of generated sample
   float                                  myScaleFactor;   //!< scale factor for quantization of visual error (float) into signed integer

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -16,6 +16,8 @@
 #include <OpenGl_View.hxx>
 
 #include <cmath>
+#include <NCollection_LinearVector.hxx>
+#include <Standard_OutOfMemory.hxx>
 
 #include <Aspect_NeutralWindow.hxx>
 #include <Aspect_RenderingContext.hxx>
@@ -534,12 +536,12 @@ bool OpenGl_View::BufferDump(Image_PixMap& theImage, const Graphic3d_BufferType&
     return false;
   }
 
-  std::vector<GLfloat> aValues;
+  NCollection_LinearVector<GLfloat> aValues;
   try
   {
-    aValues.resize(aW * aH);
+    aValues.Resize(aW * aH);
   }
-  catch (const std::bad_alloc&)
+  catch (const Standard_OutOfMemory&)
   {
     return false;
   }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
@@ -527,8 +527,8 @@ bool OpenGl_View::addRaytraceGroups(const OpenGl_Structure*            theStruct
     int aMatID = static_cast<int>(myRaytraceGeometry.Materials.Size());
 
     // Use group material if available, otherwise use structure material
-    myRaytraceGeometry.Materials.Append(
-      aGroupIter.Value()->GlAspects() != nullptr ? aGroupMaterial : theStructMat);
+    myRaytraceGeometry.Materials.Append(aGroupIter.Value()->GlAspects() != nullptr ? aGroupMaterial
+                                                                                   : theStructMat);
 
     // Add OpenGL elements from group (extract primitives arrays and aspects)
     for (const OpenGl_ElementNode* aNode = aGroupIter.Value()->FirstNode(); aNode != nullptr;
@@ -808,9 +808,9 @@ bool OpenGl_View::addRaytraceTriangleArray(OpenGl_TriangleSet&                  
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; aVert += 3)
     {
       theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
-                                   theIndices->Index(aVert + 1),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + 1),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
     }
   }
   else
@@ -846,9 +846,9 @@ bool OpenGl_View::addRaytraceTriangleFanArray(OpenGl_TriangleSet&               
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; ++aVert)
     {
       theSet.Elements.EmplaceAppend(theIndices->Index(theOffset),
-                                   theIndices->Index(aVert + 1),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + 1),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
     }
   }
   else
@@ -886,9 +886,9 @@ bool OpenGl_View::addRaytraceTriangleStripArray(
          ++aVert, aCW               = (aCW + 1) % 2)
     {
       theSet.Elements.EmplaceAppend(theIndices->Index(aVert + (aCW ? 1 : 0)),
-                                   theIndices->Index(aVert + (aCW ? 0 : 1)),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + (aCW ? 0 : 1)),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
     }
   }
   else
@@ -897,9 +897,9 @@ bool OpenGl_View::addRaytraceTriangleStripArray(
          ++aVert, aCW               = (aCW + 1) % 2)
     {
       theSet.Elements.EmplaceAppend(aVert + (aCW ? 1 : 0),
-                                   aVert + (aCW ? 0 : 1),
-                                   aVert + 2,
-                                   theMatID);
+                                    aVert + (aCW ? 0 : 1),
+                                    aVert + 2,
+                                    theMatID);
     }
   }
 
@@ -928,13 +928,13 @@ bool OpenGl_View::addRaytraceQuadrangleArray(OpenGl_TriangleSet&                
     for (int aVert = theOffset; aVert < theOffset + theCount - 3; aVert += 4)
     {
       theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
-                                   theIndices->Index(aVert + 1),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + 1),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
       theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
-                                   theIndices->Index(aVert + 2),
-                                   theIndices->Index(aVert + 3),
-                                   theMatID);
+                                    theIndices->Index(aVert + 2),
+                                    theIndices->Index(aVert + 3),
+                                    theMatID);
     }
   }
   else
@@ -972,14 +972,14 @@ bool OpenGl_View::addRaytraceQuadrangleStripArray(
     for (int aVert = theOffset; aVert < theOffset + theCount - 3; aVert += 2)
     {
       theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
-                                   theIndices->Index(aVert + 1),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + 1),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
 
       theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 1),
-                                   theIndices->Index(aVert + 3),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + 3),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
     }
   }
   else
@@ -1017,9 +1017,9 @@ bool OpenGl_View::addRaytracePolygonArray(OpenGl_TriangleSet&                   
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; ++aVert)
     {
       theSet.Elements.EmplaceAppend(theIndices->Index(theOffset),
-                                   theIndices->Index(aVert + 1),
-                                   theIndices->Index(aVert + 2),
-                                   theMatID);
+                                    theIndices->Index(aVert + 1),
+                                    theIndices->Index(aVert + 2),
+                                    theMatID);
     }
   }
   else
@@ -2572,7 +2572,7 @@ bool OpenGl_View::updateRaytraceLightSources(const NCollection_Mat4<float>&     
                                              const occ::handle<OpenGl_Context>& theGlContext)
 {
   NCollection_LinearVector<occ::handle<Graphic3d_CLight>> aLightSources;
-  NCollection_Vec4<float>                    aNewAmbient(0.0f);
+  NCollection_Vec4<float>                                 aNewAmbient(0.0f);
   if (myRenderParams.ShadingModel != Graphic3d_TypeOfShadingModel_Unlit && !myLights.IsNull())
   {
     aNewAmbient.SetValues(myLights->AmbientColor().rgb(), 0.0f);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
@@ -28,6 +28,7 @@
 #include <OSD_File.hxx>
 #include <NCollection_MapAlgo.hxx>
 #include <NCollection_DynamicArray.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include "../../TKService/Shaders/Shaders_RaytraceBase_vs.pxx"
 #include "../../TKService/Shaders/Shaders_RaytraceBase_fs.pxx"
@@ -523,10 +524,10 @@ bool OpenGl_View::addRaytraceGroups(const OpenGl_Structure*            theStruct
       aGroupMaterial = convertMaterial(aGroupIter.Value()->GlAspects(), theGlContext);
     }
 
-    int aMatID = static_cast<int>(myRaytraceGeometry.Materials.size());
+    int aMatID = static_cast<int>(myRaytraceGeometry.Materials.Size());
 
     // Use group material if available, otherwise use structure material
-    myRaytraceGeometry.Materials.push_back(
+    myRaytraceGeometry.Materials.Append(
       aGroupIter.Value()->GlAspects() != nullptr ? aGroupMaterial : theStructMat);
 
     // Add OpenGL elements from group (extract primitives arrays and aspects)
@@ -537,11 +538,11 @@ bool OpenGl_View::addRaytraceGroups(const OpenGl_Structure*            theStruct
 
       if (anAspect != nullptr)
       {
-        aMatID = static_cast<int>(myRaytraceGeometry.Materials.size());
+        aMatID = static_cast<int>(myRaytraceGeometry.Materials.Size());
 
         OpenGl_RaytraceMaterial aMaterial = convertMaterial(anAspect, theGlContext);
 
-        myRaytraceGeometry.Materials.push_back(aMaterial);
+        myRaytraceGeometry.Materials.Append(aMaterial);
       }
       else
       {
@@ -679,7 +680,7 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
     {
       for (int aVertIter = 0; aVertIter < anAttribs->NbElements; ++aVertIter)
       {
-        aSet->Normals.emplace_back();
+        aSet->Normals.EmplaceAppend();
       }
     }
 
@@ -687,7 +688,7 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
     {
       for (int aVertIter = 0; aVertIter < anAttribs->NbElements; ++aVertIter)
       {
-        aSet->TexCrds.emplace_back();
+        aSet->TexCrds.EmplaceAppend();
       }
     }
 
@@ -806,7 +807,7 @@ bool OpenGl_View::addRaytraceTriangleArray(OpenGl_TriangleSet&                  
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; aVert += 3)
     {
-      theSet.Elements.emplace_back(theIndices->Index(aVert + 0),
+      theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
                                    theIndices->Index(aVert + 1),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
@@ -816,7 +817,7 @@ bool OpenGl_View::addRaytraceTriangleArray(OpenGl_TriangleSet&                  
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; aVert += 3)
     {
-      theSet.Elements.emplace_back(aVert + 0, aVert + 1, aVert + 2, theMatID);
+      theSet.Elements.EmplaceAppend(aVert + 0, aVert + 1, aVert + 2, theMatID);
     }
   }
 
@@ -844,7 +845,7 @@ bool OpenGl_View::addRaytraceTriangleFanArray(OpenGl_TriangleSet&               
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; ++aVert)
     {
-      theSet.Elements.emplace_back(theIndices->Index(theOffset),
+      theSet.Elements.EmplaceAppend(theIndices->Index(theOffset),
                                    theIndices->Index(aVert + 1),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
@@ -854,7 +855,7 @@ bool OpenGl_View::addRaytraceTriangleFanArray(OpenGl_TriangleSet&               
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; ++aVert)
     {
-      theSet.Elements.emplace_back(theOffset, aVert + 1, aVert + 2, theMatID);
+      theSet.Elements.EmplaceAppend(theOffset, aVert + 1, aVert + 2, theMatID);
     }
   }
 
@@ -884,7 +885,7 @@ bool OpenGl_View::addRaytraceTriangleStripArray(
     for (int aVert = theOffset, aCW = 0; aVert < theOffset + theCount - 2;
          ++aVert, aCW               = (aCW + 1) % 2)
     {
-      theSet.Elements.emplace_back(theIndices->Index(aVert + (aCW ? 1 : 0)),
+      theSet.Elements.EmplaceAppend(theIndices->Index(aVert + (aCW ? 1 : 0)),
                                    theIndices->Index(aVert + (aCW ? 0 : 1)),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
@@ -895,7 +896,7 @@ bool OpenGl_View::addRaytraceTriangleStripArray(
     for (int aVert = theOffset, aCW = 0; aVert < theOffset + theCount - 2;
          ++aVert, aCW               = (aCW + 1) % 2)
     {
-      theSet.Elements.emplace_back(aVert + (aCW ? 1 : 0),
+      theSet.Elements.EmplaceAppend(aVert + (aCW ? 1 : 0),
                                    aVert + (aCW ? 0 : 1),
                                    aVert + 2,
                                    theMatID);
@@ -926,11 +927,11 @@ bool OpenGl_View::addRaytraceQuadrangleArray(OpenGl_TriangleSet&                
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 3; aVert += 4)
     {
-      theSet.Elements.emplace_back(theIndices->Index(aVert + 0),
+      theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
                                    theIndices->Index(aVert + 1),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
-      theSet.Elements.emplace_back(theIndices->Index(aVert + 0),
+      theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
                                    theIndices->Index(aVert + 2),
                                    theIndices->Index(aVert + 3),
                                    theMatID);
@@ -940,8 +941,8 @@ bool OpenGl_View::addRaytraceQuadrangleArray(OpenGl_TriangleSet&                
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 3; aVert += 4)
     {
-      theSet.Elements.emplace_back(aVert + 0, aVert + 1, aVert + 2, theMatID);
-      theSet.Elements.emplace_back(aVert + 0, aVert + 2, aVert + 3, theMatID);
+      theSet.Elements.EmplaceAppend(aVert + 0, aVert + 1, aVert + 2, theMatID);
+      theSet.Elements.EmplaceAppend(aVert + 0, aVert + 2, aVert + 3, theMatID);
     }
   }
 
@@ -970,12 +971,12 @@ bool OpenGl_View::addRaytraceQuadrangleStripArray(
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 3; aVert += 2)
     {
-      theSet.Elements.emplace_back(theIndices->Index(aVert + 0),
+      theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 0),
                                    theIndices->Index(aVert + 1),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
 
-      theSet.Elements.emplace_back(theIndices->Index(aVert + 1),
+      theSet.Elements.EmplaceAppend(theIndices->Index(aVert + 1),
                                    theIndices->Index(aVert + 3),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
@@ -985,9 +986,9 @@ bool OpenGl_View::addRaytraceQuadrangleStripArray(
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 3; aVert += 2)
     {
-      theSet.Elements.emplace_back(aVert + 0, aVert + 1, aVert + 2, theMatID);
+      theSet.Elements.EmplaceAppend(aVert + 0, aVert + 1, aVert + 2, theMatID);
 
-      theSet.Elements.emplace_back(aVert + 1, aVert + 3, aVert + 2, theMatID);
+      theSet.Elements.EmplaceAppend(aVert + 1, aVert + 3, aVert + 2, theMatID);
     }
   }
 
@@ -1015,7 +1016,7 @@ bool OpenGl_View::addRaytracePolygonArray(OpenGl_TriangleSet&                   
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; ++aVert)
     {
-      theSet.Elements.emplace_back(theIndices->Index(theOffset),
+      theSet.Elements.EmplaceAppend(theIndices->Index(theOffset),
                                    theIndices->Index(aVert + 1),
                                    theIndices->Index(aVert + 2),
                                    theMatID);
@@ -1025,7 +1026,7 @@ bool OpenGl_View::addRaytracePolygonArray(OpenGl_TriangleSet&                   
   {
     for (int aVert = theOffset; aVert < theOffset + theCount - 2; ++aVert)
     {
-      theSet.Elements.emplace_back(theOffset, aVert + 1, aVert + 2, theMatID);
+      theSet.Elements.EmplaceAppend(theOffset, aVert + 1, aVert + 2, theMatID);
     }
   }
 
@@ -2508,12 +2509,12 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
   /////////////////////////////////////////////////////////////////////////////
   // Write material buffer
 
-  if (!myRaytraceGeometry.Materials.empty())
+  if (!myRaytraceGeometry.Materials.IsEmpty())
   {
     aResult &= myRaytraceMaterialTexture->Init(theGlContext,
                                                4,
-                                               GLsizei(myRaytraceGeometry.Materials.size() * 19),
-                                               myRaytraceGeometry.Materials.front().Packed());
+                                               GLsizei(myRaytraceGeometry.Materials.Size() * 19),
+                                               myRaytraceGeometry.Materials[0].Packed());
 
     if (!aResult)
     {
@@ -2570,14 +2571,14 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
 bool OpenGl_View::updateRaytraceLightSources(const NCollection_Mat4<float>&     theInvModelView,
                                              const occ::handle<OpenGl_Context>& theGlContext)
 {
-  std::vector<occ::handle<Graphic3d_CLight>> aLightSources;
+  NCollection_LinearVector<occ::handle<Graphic3d_CLight>> aLightSources;
   NCollection_Vec4<float>                    aNewAmbient(0.0f);
   if (myRenderParams.ShadingModel != Graphic3d_TypeOfShadingModel_Unlit && !myLights.IsNull())
   {
     aNewAmbient.SetValues(myLights->AmbientColor().rgb(), 0.0f);
 
     // move positional light sources at the front of the list
-    aLightSources.reserve(myLights->Extent());
+    aLightSources.Reserve(myLights->Extent());
     for (Graphic3d_LightSet::Iterator aLightIter(
            myLights,
            Graphic3d_LightSet::IterationFilter_ExcludeDisabledAndAmbient);
@@ -2587,7 +2588,7 @@ bool OpenGl_View::updateRaytraceLightSources(const NCollection_Mat4<float>&     
       const Graphic3d_CLight& aLight = *aLightIter.Value();
       if (aLight.Type() != Graphic3d_TypeOfLightSource_Directional)
       {
-        aLightSources.push_back(aLightIter.Value());
+        aLightSources.Append(aLightIter.Value());
       }
     }
 
@@ -2599,7 +2600,7 @@ bool OpenGl_View::updateRaytraceLightSources(const NCollection_Mat4<float>&     
     {
       if (aLightIter.Value()->Type() == Graphic3d_TypeOfLightSource_Directional)
       {
-        aLightSources.push_back(aLightIter.Value());
+        aLightSources.Append(aLightIter.Value());
       }
     }
   }
@@ -2611,14 +2612,14 @@ bool OpenGl_View::updateRaytraceLightSources(const NCollection_Mat4<float>&     
   }
 
   // get number of 'real' (not ambient) light sources
-  const size_t aNbLights  = aLightSources.size();
-  bool         wasUpdated = myRaytraceGeometry.Sources.size() != aNbLights;
+  const size_t aNbLights  = aLightSources.Size();
+  bool         wasUpdated = myRaytraceGeometry.Sources.Size() != aNbLights;
   if (wasUpdated)
   {
-    myRaytraceGeometry.Sources.resize(aNbLights);
+    myRaytraceGeometry.Sources.Resize(aNbLights);
   }
 
-  for (size_t aLightIdx = 0, aRealIdx = 0; aLightIdx < aLightSources.size(); ++aLightIdx)
+  for (size_t aLightIdx = 0, aRealIdx = 0; aLightIdx < aLightSources.Size(); ++aLightIdx)
   {
     const Graphic3d_CLight&        aLight      = *aLightSources[aLightIdx];
     const NCollection_Vec4<float>& aLightColor = aLight.PackedColor();
@@ -2673,12 +2674,12 @@ bool OpenGl_View::updateRaytraceLightSources(const NCollection_Mat4<float>&     
     myRaytraceLightSrcTexture = new OpenGl_TextureBuffer();
   }
 
-  if (!myRaytraceGeometry.Sources.empty() && wasUpdated)
+  if (!myRaytraceGeometry.Sources.IsEmpty() && wasUpdated)
   {
-    const GLfloat* aDataPtr = myRaytraceGeometry.Sources.front().Packed();
+    const GLfloat* aDataPtr = myRaytraceGeometry.Sources[0].Packed();
     if (!myRaytraceLightSrcTexture->Init(theGlContext,
                                          4,
-                                         GLsizei(myRaytraceGeometry.Sources.size() * 2),
+                                         GLsizei(myRaytraceGeometry.Sources.Size() * 2),
                                          aDataPtr))
     {
       Message::SendTrace() << "Error: Failed to upload light source buffer";
@@ -2808,7 +2809,7 @@ bool OpenGl_View::setUniformState(const int                          theProgramI
                          myRaytraceSceneEpsilon);
 
   // Set light source parameters
-  const int aLightSourceBufferSize = static_cast<int>(myRaytraceGeometry.Sources.size());
+  const int aLightSourceBufferSize = static_cast<int>(myRaytraceGeometry.Sources.Size());
 
   theProgram->SetUniform(theGlContext,
                          myUniformLocations[theProgramId][OpenGl_RT_uLightCount],
@@ -2817,13 +2818,13 @@ bool OpenGl_View::setUniformState(const int                          theProgramI
   // Set array of 64-bit texture handles
   if (theGlContext->arbTexBindless != nullptr && myRaytraceGeometry.HasTextures())
   {
-    const std::vector<GLuint64>& aTextures = myRaytraceGeometry.TextureHandles();
+    const NCollection_LinearVector<GLuint64>& aTextures = myRaytraceGeometry.TextureHandles();
 
     theProgram->SetUniform(
       theGlContext,
       myUniformLocations[theProgramId][OpenGl_RT_uTexSamplersArray],
-      static_cast<GLsizei>(aTextures.size()),
-      reinterpret_cast<const NCollection_Vec2<unsigned int>*>(&aTextures.front()));
+      static_cast<GLsizei>(aTextures.Size()),
+      reinterpret_cast<const NCollection_Vec2<unsigned int>*>(aTextures.Data()));
   }
 
   // Set background colors (only vertical gradient background supported)

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View_Raytrace.cxx
@@ -624,11 +624,11 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
   occ::handle<OpenGl_TriangleSet> aSet =
     new OpenGl_TriangleSet(theArray->GetUID(), myRaytraceBVHBuilder);
   {
-    aSet->Vertices.reserve(anAttribs->NbElements);
-    aSet->Normals.reserve(anAttribs->NbElements);
-    aSet->TexCrds.reserve(anAttribs->NbElements);
+    aSet->Vertices.Reserve(anAttribs->NbElements);
+    aSet->Normals.Reserve(anAttribs->NbElements);
+    aSet->TexCrds.Reserve(anAttribs->NbElements);
 
-    const size_t aVertFrom = aSet->Vertices.size();
+    const size_t aVertFrom = aSet->Vertices.Size();
 
     int    anAttribIndex  = 0;
     size_t anAttribStride = 0;
@@ -643,9 +643,9 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
         {
           const float* aCoords =
             reinterpret_cast<const float*>(aPosData + anAttribStride * aVertIter);
-          aSet->Vertices.emplace_back(aCoords[0],
-                                      aCoords[1],
-                                      anAttrib.DataType != Graphic3d_TOD_VEC2 ? aCoords[2] : 0.0f);
+          aSet->Vertices.EmplaceAppend(aCoords[0],
+                                       aCoords[1],
+                                       anAttrib.DataType != Graphic3d_TOD_VEC2 ? aCoords[2] : 0.0f);
         }
       }
     }
@@ -657,7 +657,7 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
       {
         for (int aVertIter = 0; aVertIter < anAttribs->NbElements; ++aVertIter)
         {
-          aSet->Normals.push_back(*reinterpret_cast<const NCollection_Vec3<float>*>(
+          aSet->Normals.Append(*reinterpret_cast<const NCollection_Vec3<float>*>(
             aNormData + anAttribStride * aVertIter));
         }
       }
@@ -670,13 +670,13 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
       {
         for (int aVertIter = 0; aVertIter < anAttribs->NbElements; ++aVertIter)
         {
-          aSet->TexCrds.push_back(*reinterpret_cast<const NCollection_Vec2<float>*>(
+          aSet->TexCrds.Append(*reinterpret_cast<const NCollection_Vec2<float>*>(
             aTexData + anAttribStride * aVertIter));
         }
       }
     }
 
-    if (aSet->Normals.size() != aSet->Vertices.size())
+    if (aSet->Normals.Size() != aSet->Vertices.Size())
     {
       for (int aVertIter = 0; aVertIter < anAttribs->NbElements; ++aVertIter)
       {
@@ -684,7 +684,7 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
       }
     }
 
-    if (aSet->TexCrds.size() != aSet->Vertices.size())
+    if (aSet->TexCrds.Size() != aSet->Vertices.Size())
     {
       for (int aVertIter = 0; aVertIter < anAttribs->NbElements; ++aVertIter)
       {
@@ -694,7 +694,7 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
 
     if (theTransform != nullptr)
     {
-      for (size_t aVertIter = aVertFrom; aVertIter < aSet->Vertices.size(); ++aVertIter)
+      for (size_t aVertIter = aVertFrom; aVertIter < aSet->Vertices.Size(); ++aVertIter)
       {
         BVH_Vec3f& aVertex = aSet->Vertices[aVertIter];
 
@@ -703,7 +703,7 @@ occ::handle<OpenGl_TriangleSet> OpenGl_View::addRaytracePrimitiveArray(
 
         aVertex = BVH_Vec3f(aTransVertex.x(), aTransVertex.y(), aTransVertex.z());
       }
-      for (size_t aVertIter = aVertFrom; aVertIter < aSet->Normals.size(); ++aVertIter)
+      for (size_t aVertIter = aVertFrom; aVertIter < aSet->Normals.Size(); ++aVertIter)
       {
         BVH_Vec3f& aNormal = aSet->Normals[aVertIter];
 
@@ -801,7 +801,7 @@ bool OpenGl_View::addRaytraceTriangleArray(OpenGl_TriangleSet&                  
     return true;
   }
 
-  theSet.Elements.reserve(theSet.Elements.size() + theCount / 3);
+  theSet.Elements.Reserve(theSet.Elements.Size() + theCount / 3);
 
   if (!theIndices.IsNull())
   {
@@ -839,7 +839,7 @@ bool OpenGl_View::addRaytraceTriangleFanArray(OpenGl_TriangleSet&               
     return true;
   }
 
-  theSet.Elements.reserve(theSet.Elements.size() + theCount - 2);
+  theSet.Elements.Reserve(theSet.Elements.Size() + theCount - 2);
 
   if (!theIndices.IsNull())
   {
@@ -878,7 +878,7 @@ bool OpenGl_View::addRaytraceTriangleStripArray(
     return true;
   }
 
-  theSet.Elements.reserve(theSet.Elements.size() + theCount - 2);
+  theSet.Elements.Reserve(theSet.Elements.Size() + theCount - 2);
 
   if (!theIndices.IsNull())
   {
@@ -921,7 +921,7 @@ bool OpenGl_View::addRaytraceQuadrangleArray(OpenGl_TriangleSet&                
     return true;
   }
 
-  theSet.Elements.reserve(theSet.Elements.size() + theCount / 2);
+  theSet.Elements.Reserve(theSet.Elements.Size() + theCount / 2);
 
   if (!theIndices.IsNull())
   {
@@ -965,7 +965,7 @@ bool OpenGl_View::addRaytraceQuadrangleStripArray(
     return true;
   }
 
-  theSet.Elements.reserve(theSet.Elements.size() + 2 * theCount - 6);
+  theSet.Elements.Reserve(theSet.Elements.Size() + 2 * theCount - 6);
 
   if (!theIndices.IsNull())
   {
@@ -1010,7 +1010,7 @@ bool OpenGl_View::addRaytracePolygonArray(OpenGl_TriangleSet&                   
     return true;
   }
 
-  theSet.Elements.reserve(theSet.Elements.size() + theCount - 2);
+  theSet.Elements.Reserve(theSet.Elements.Size() + theCount - 2);
 
   if (!theIndices.IsNull())
   {
@@ -2328,17 +2328,17 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
                            "Error: Failed to get triangulation of OpenGL element",
                            false);
 
-    aTotalVerticesNb += aTriangleSet->Vertices.size();
-    aTotalElementsNb += aTriangleSet->Elements.size();
+    aTotalVerticesNb += aTriangleSet->Vertices.Size();
+    aTotalElementsNb += aTriangleSet->Elements.Size();
 
     Standard_ASSERT_RETURN(!aTriangleSet->QuadBVH().IsNull(),
                            "Error: Failed to get bottom-level BVH of OpenGL element",
                            false);
 
-    aTotalBVHNodesNb += aTriangleSet->QuadBVH()->NodeInfoBuffer().size();
+    aTotalBVHNodesNb += aTriangleSet->QuadBVH()->NodeInfoBuffer().Size();
   }
 
-  aTotalBVHNodesNb += myRaytraceGeometry.QuadBVH()->NodeInfoBuffer().size();
+  aTotalBVHNodesNb += myRaytraceGeometry.QuadBVH()->NodeInfoBuffer().Size();
 
   if (aTotalBVHNodesNb != 0)
   {
@@ -2400,17 +2400,17 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
       theGlContext,
       0,
       aBVH->Length(),
-      reinterpret_cast<const GLuint*>(&aBVH->NodeInfoBuffer().front()));
+      reinterpret_cast<const GLuint*>(aBVH->NodeInfoBuffer().Data()));
     aResult &= mySceneMinPointTexture->SubData(
       theGlContext,
       0,
       aBVH->Length(),
-      reinterpret_cast<const GLfloat*>(&aBVH->MinPointBuffer().front()));
+      reinterpret_cast<const GLfloat*>(aBVH->MinPointBuffer().Data()));
     aResult &= mySceneMaxPointTexture->SubData(
       theGlContext,
       0,
       aBVH->Length(),
-      reinterpret_cast<const GLfloat*>(&aBVH->MaxPointBuffer().front()));
+      reinterpret_cast<const GLfloat*>(aBVH->MaxPointBuffer().Data()));
   }
 
   for (int aNodeIdx = 0; aNodeIdx < aBVH->Length(); ++aNodeIdx)
@@ -2438,17 +2438,17 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
         theGlContext,
         aBVHOffset,
         aBvhBuffersSize,
-        reinterpret_cast<const GLuint*>(&aTriangleSet->QuadBVH()->NodeInfoBuffer().front()));
+        reinterpret_cast<const GLuint*>(aTriangleSet->QuadBVH()->NodeInfoBuffer().Data()));
       aResult &= mySceneMinPointTexture->SubData(
         theGlContext,
         aBVHOffset,
         aBvhBuffersSize,
-        reinterpret_cast<const GLfloat*>(&aTriangleSet->QuadBVH()->MinPointBuffer().front()));
+        reinterpret_cast<const GLfloat*>(aTriangleSet->QuadBVH()->MinPointBuffer().Data()));
       aResult &= mySceneMaxPointTexture->SubData(
         theGlContext,
         aBVHOffset,
         aBvhBuffersSize,
-        reinterpret_cast<const GLfloat*>(&aTriangleSet->QuadBVH()->MaxPointBuffer().front()));
+        reinterpret_cast<const GLfloat*>(aTriangleSet->QuadBVH()->MaxPointBuffer().Data()));
 
       if (!aResult)
       {
@@ -2464,23 +2464,23 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
       "Error: Failed to get offset for triangulation vertices of OpenGL element",
       false);
 
-    if (!aTriangleSet->Vertices.empty())
+    if (!aTriangleSet->Vertices.IsEmpty())
     {
       aResult &= myGeometryNormalTexture->SubData(
         theGlContext,
         aVerticesOffset,
-        GLsizei(aTriangleSet->Normals.size()),
-        reinterpret_cast<const GLfloat*>(&aTriangleSet->Normals.front()));
+        GLsizei(aTriangleSet->Normals.Size()),
+        reinterpret_cast<const GLfloat*>(aTriangleSet->Normals.Data()));
       aResult &= myGeometryTexCrdTexture->SubData(
         theGlContext,
         aVerticesOffset,
-        GLsizei(aTriangleSet->TexCrds.size()),
-        reinterpret_cast<const GLfloat*>(&aTriangleSet->TexCrds.front()));
+        GLsizei(aTriangleSet->TexCrds.Size()),
+        reinterpret_cast<const GLfloat*>(aTriangleSet->TexCrds.Data()));
       aResult &= myGeometryVertexTexture->SubData(
         theGlContext,
         aVerticesOffset,
-        GLsizei(aTriangleSet->Vertices.size()),
-        reinterpret_cast<const GLfloat*>(&aTriangleSet->Vertices.front()));
+        GLsizei(aTriangleSet->Vertices.Size()),
+        reinterpret_cast<const GLfloat*>(aTriangleSet->Vertices.Data()));
     }
 
     const int anElementsOffset = myRaytraceGeometry.ElementsOffset(aNodeIdx);
@@ -2490,13 +2490,13 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
       "Error: Failed to get offset for triangulation elements of OpenGL element",
       false);
 
-    if (!aTriangleSet->Elements.empty())
+    if (!aTriangleSet->Elements.IsEmpty())
     {
       aResult &= myGeometryTriangTexture->SubData(
         theGlContext,
         anElementsOffset,
-        GLsizei(aTriangleSet->Elements.size()),
-        reinterpret_cast<const GLuint*>(&aTriangleSet->Elements.front()));
+        GLsizei(aTriangleSet->Elements.Size()),
+        reinterpret_cast<const GLuint*>(aTriangleSet->Elements.Data()));
     }
 
     if (!aResult)
@@ -2535,25 +2535,25 @@ bool OpenGl_View::uploadRaytraceData(const occ::handle<OpenGl_Context>& theGlCon
     OpenGl_TriangleSet* aTriangleSet =
       dynamic_cast<OpenGl_TriangleSet*>(myRaytraceGeometry.Objects()(anElemIdx).get());
 
-    aMemTrgUsed += static_cast<float>(aTriangleSet->Vertices.size() * sizeof(BVH_Vec3f));
-    aMemTrgUsed += static_cast<float>(aTriangleSet->Normals.size() * sizeof(BVH_Vec3f));
-    aMemTrgUsed += static_cast<float>(aTriangleSet->TexCrds.size() * sizeof(BVH_Vec2f));
-    aMemTrgUsed += static_cast<float>(aTriangleSet->Elements.size() * sizeof(BVH_Vec4i));
+    aMemTrgUsed += static_cast<float>(aTriangleSet->Vertices.Size() * sizeof(BVH_Vec3f));
+    aMemTrgUsed += static_cast<float>(aTriangleSet->Normals.Size() * sizeof(BVH_Vec3f));
+    aMemTrgUsed += static_cast<float>(aTriangleSet->TexCrds.Size() * sizeof(BVH_Vec2f));
+    aMemTrgUsed += static_cast<float>(aTriangleSet->Elements.Size() * sizeof(BVH_Vec4i));
 
     aMemBvhUsed +=
-      static_cast<float>(aTriangleSet->QuadBVH()->NodeInfoBuffer().size() * sizeof(BVH_Vec4i));
+      static_cast<float>(aTriangleSet->QuadBVH()->NodeInfoBuffer().Size() * sizeof(BVH_Vec4i));
     aMemBvhUsed +=
-      static_cast<float>(aTriangleSet->QuadBVH()->MinPointBuffer().size() * sizeof(BVH_Vec3f));
+      static_cast<float>(aTriangleSet->QuadBVH()->MinPointBuffer().Size() * sizeof(BVH_Vec3f));
     aMemBvhUsed +=
-      static_cast<float>(aTriangleSet->QuadBVH()->MaxPointBuffer().size() * sizeof(BVH_Vec3f));
+      static_cast<float>(aTriangleSet->QuadBVH()->MaxPointBuffer().Size() * sizeof(BVH_Vec3f));
   }
 
   aMemBvhUsed +=
-    static_cast<float>(myRaytraceGeometry.QuadBVH()->NodeInfoBuffer().size() * sizeof(BVH_Vec4i));
+    static_cast<float>(myRaytraceGeometry.QuadBVH()->NodeInfoBuffer().Size() * sizeof(BVH_Vec4i));
   aMemBvhUsed +=
-    static_cast<float>(myRaytraceGeometry.QuadBVH()->MinPointBuffer().size() * sizeof(BVH_Vec3f));
+    static_cast<float>(myRaytraceGeometry.QuadBVH()->MinPointBuffer().Size() * sizeof(BVH_Vec3f));
   aMemBvhUsed +=
-    static_cast<float>(myRaytraceGeometry.QuadBVH()->MaxPointBuffer().size() * sizeof(BVH_Vec3f));
+    static_cast<float>(myRaytraceGeometry.QuadBVH()->MaxPointBuffer().Size() * sizeof(BVH_Vec3f));
 
   std::cout << "GPU Memory Used (Mb):\n"
             << "\tFor mesh: " << aMemTrgUsed / 1048576 << "\n"

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_FrameStatsData.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_FrameStatsData.cxx
@@ -13,6 +13,8 @@
 
 #include <Graphic3d_FrameStatsData.hxx>
 
+#include <algorithm>
+
 //=================================================================================================
 
 Graphic3d_FrameStatsData::Graphic3d_FrameStatsData()
@@ -21,10 +23,10 @@ Graphic3d_FrameStatsData::Graphic3d_FrameStatsData()
       myFpsImmediate(-1.0),
       myFpsCpuImmediate(-1.0)
 {
-  myCounters.resize(Graphic3d_FrameStatsCounter_NB, 0);
-  myTimers.resize(Graphic3d_FrameStatsTimer_NB, 0.0);
-  myTimersMin.resize(Graphic3d_FrameStatsTimer_NB, RealLast());
-  myTimersMax.resize(Graphic3d_FrameStatsTimer_NB, 0.0);
+  myCounters.Resize(Graphic3d_FrameStatsCounter_NB);
+  myTimers.Resize(Graphic3d_FrameStatsTimer_NB);
+  myTimersMin.Resize(Graphic3d_FrameStatsTimer_NB, RealLast());
+  myTimersMax.Resize(Graphic3d_FrameStatsTimer_NB);
   Reset();
 }
 
@@ -96,10 +98,10 @@ void Graphic3d_FrameStatsData::Reset()
   myFpsCpu          = -1.0;
   myFpsImmediate    = -1.0;
   myFpsCpuImmediate = -1.0;
-  myCounters.assign(myCounters.size(), 0);
-  myTimers.assign(myTimers.size(), 0.0);
-  myTimersMin.assign(myTimersMin.size(), RealLast());
-  myTimersMax.assign(myTimersMax.size(), 0.0);
+  std::fill(myCounters.begin(), myCounters.end(), (size_t)0);
+  std::fill(myTimers.begin(), myTimers.end(), 0.0);
+  std::fill(myTimersMin.begin(), myTimersMin.end(), RealLast());
+  std::fill(myTimersMax.begin(), myTimersMax.end(), 0.0);
 }
 
 //=================================================================================================
@@ -110,13 +112,13 @@ void Graphic3d_FrameStatsData::FillMax(const Graphic3d_FrameStatsData& theOther)
   myFpsCpu          = std::max(myFpsCpu, theOther.myFpsCpu);
   myFpsImmediate    = std::max(myFpsImmediate, theOther.myFpsImmediate);
   myFpsCpuImmediate = std::max(myFpsCpuImmediate, theOther.myFpsCpuImmediate);
-  for (size_t aCounterIter = 0; aCounterIter < myCounters.size(); ++aCounterIter)
+  for (size_t aCounterIter = 0; aCounterIter < myCounters.Size(); ++aCounterIter)
   {
     myCounters[aCounterIter] = myCounters[aCounterIter] > theOther.myCounters[aCounterIter]
                                  ? myCounters[aCounterIter]
                                  : theOther.myCounters[aCounterIter];
   }
-  for (size_t aTimerIter = 0; aTimerIter < myTimers.size(); ++aTimerIter)
+  for (size_t aTimerIter = 0; aTimerIter < myTimers.Size(); ++aTimerIter)
   {
     myTimersMax[aTimerIter] = std::max(myTimersMax[aTimerIter], theOther.myTimersMax[aTimerIter]);
     myTimersMin[aTimerIter] = std::min(myTimersMin[aTimerIter], theOther.myTimersMin[aTimerIter]);
@@ -128,15 +130,19 @@ void Graphic3d_FrameStatsData::FillMax(const Graphic3d_FrameStatsData& theOther)
 
 Graphic3d_FrameStatsDataTmp::Graphic3d_FrameStatsDataTmp()
 {
-  myOsdTimers.resize(Graphic3d_FrameStatsTimer_NB, OSD_Timer(true));
-  myTimersPrev.resize(Graphic3d_FrameStatsTimer_NB, 0.0);
+  myOsdTimers.Reserve(Graphic3d_FrameStatsTimer_NB);
+  for (int i = 0; i < Graphic3d_FrameStatsTimer_NB; ++i)
+  {
+    myOsdTimers.Append(OSD_Timer(true));
+  }
+  myTimersPrev.Resize(Graphic3d_FrameStatsTimer_NB);
 }
 
 //=================================================================================================
 
 void Graphic3d_FrameStatsDataTmp::FlushTimers(size_t theNbFrames, bool theIsFinal)
 {
-  for (size_t aTimerIter = 0; aTimerIter < myTimers.size(); ++aTimerIter)
+  for (size_t aTimerIter = 0; aTimerIter < myTimers.Size(); ++aTimerIter)
   {
     const double aFrameTime  = myTimers[aTimerIter] - myTimersPrev[aTimerIter];
     myTimersMax[aTimerIter]  = std::max(myTimersMax[aTimerIter], aFrameTime);
@@ -147,7 +153,7 @@ void Graphic3d_FrameStatsDataTmp::FlushTimers(size_t theNbFrames, bool theIsFina
   if (theIsFinal)
   {
     const double aNbFrames = (double)theNbFrames;
-    for (size_t aTimerIter = 0; aTimerIter < myTimers.size(); ++aTimerIter)
+    for (size_t aTimerIter = 0; aTimerIter < myTimers.Size(); ++aTimerIter)
     {
       myTimers[aTimerIter] /= aNbFrames;
     }
@@ -159,8 +165,8 @@ void Graphic3d_FrameStatsDataTmp::FlushTimers(size_t theNbFrames, bool theIsFina
 void Graphic3d_FrameStatsDataTmp::Reset()
 {
   Graphic3d_FrameStatsData::Reset();
-  myTimersPrev.assign(myTimersPrev.size(), 0.0);
-  for (size_t aTimerIter = 0; aTimerIter < myOsdTimers.size(); ++aTimerIter)
+  std::fill(myTimersPrev.begin(), myTimersPrev.end(), 0.0);
+  for (size_t aTimerIter = 0; aTimerIter < myOsdTimers.Size(); ++aTimerIter)
   {
     myOsdTimers[aTimerIter].Reset();
   }

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_FrameStatsData.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_FrameStatsData.hxx
@@ -18,8 +18,7 @@
 #include <Graphic3d_FrameStatsCounter.hxx>
 #include <Graphic3d_FrameStatsTimer.hxx>
 #include <OSD_Timer.hxx>
-
-#include <vector>
+#include <NCollection_LinearVector.hxx>
 
 //! Data frame definition.
 class Graphic3d_FrameStatsData
@@ -81,10 +80,10 @@ public:
   Standard_EXPORT void FillMax(const Graphic3d_FrameStatsData& theOther);
 
 protected:
-  std::vector<size_t> myCounters;        //!< counters
-  std::vector<double> myTimers;          //!< timers
-  std::vector<double> myTimersMin;       //!< minimal values of timers
-  std::vector<double> myTimersMax;       //!< maximum values of timers
+  NCollection_LinearVector<size_t> myCounters;        //!< counters
+  NCollection_LinearVector<double> myTimers;          //!< timers
+  NCollection_LinearVector<double> myTimersMin;       //!< minimal values of timers
+  NCollection_LinearVector<double> myTimersMax;       //!< maximum values of timers
   double              myFps;             //!< FPS     meter (frames per seconds, elapsed time)
   double              myFpsCpu;          //!< CPU FPS meter (frames per seconds, CPU time)
   double              myFpsImmediate;    //!< FPS     meter for immediate redraws
@@ -138,8 +137,8 @@ public:
   double& operator[](Graphic3d_FrameStatsTimer theIndex) { return ChangeTimerValue(theIndex); }
 
 protected:
-  std::vector<OSD_Timer> myOsdTimers;  //!< precise timers for time measurements
-  std::vector<double>    myTimersPrev; //!< previous timers values
+  NCollection_LinearVector<OSD_Timer> myOsdTimers;  //!< precise timers for time measurements
+  NCollection_LinearVector<double>    myTimersPrev; //!< previous timers values
 };
 
 #endif // _Graphic3d_FrameStatsData_HeaderFile

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_FrameStatsData.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_FrameStatsData.hxx
@@ -80,14 +80,14 @@ public:
   Standard_EXPORT void FillMax(const Graphic3d_FrameStatsData& theOther);
 
 protected:
-  NCollection_LinearVector<size_t> myCounters;        //!< counters
-  NCollection_LinearVector<double> myTimers;          //!< timers
-  NCollection_LinearVector<double> myTimersMin;       //!< minimal values of timers
-  NCollection_LinearVector<double> myTimersMax;       //!< maximum values of timers
-  double              myFps;             //!< FPS     meter (frames per seconds, elapsed time)
-  double              myFpsCpu;          //!< CPU FPS meter (frames per seconds, CPU time)
-  double              myFpsImmediate;    //!< FPS     meter for immediate redraws
-  double              myFpsCpuImmediate; //!< CPU FPS meter for immediate redraws
+  NCollection_LinearVector<size_t> myCounters;  //!< counters
+  NCollection_LinearVector<double> myTimers;    //!< timers
+  NCollection_LinearVector<double> myTimersMin; //!< minimal values of timers
+  NCollection_LinearVector<double> myTimersMax; //!< maximum values of timers
+  double                           myFps;    //!< FPS     meter (frames per seconds, elapsed time)
+  double                           myFpsCpu; //!< CPU FPS meter (frames per seconds, CPU time)
+  double                           myFpsImmediate;    //!< FPS     meter for immediate redraws
+  double                           myFpsCpuImmediate; //!< CPU FPS meter for immediate redraws
 };
 
 //! Temporary data frame definition.

--- a/src/Visualization/TKV3d/SelectBasics/SelectBasics_SelectingVolumeManager.hxx
+++ b/src/Visualization/TKV3d/SelectBasics/SelectBasics_SelectingVolumeManager.hxx
@@ -19,6 +19,7 @@
 #include <BVH_Box.hxx>
 #include <gp_Pnt.hxx>
 #include <NCollection_Array1.hxx>
+#include <NCollection_DynamicArray.hxx>
 #include <NCollection_HArray1.hxx>
 #include <SelectBasics_PickResult.hxx>
 #include <SelectMgr_SelectionType.hxx>

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewClipRange.cxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewClipRange.cxx
@@ -107,7 +107,7 @@ void SelectMgr_ViewClipRange::DumpJson(Standard_OStream& theOStream, int theDept
 {
   OCCT_DUMP_CLASS_BEGIN(theOStream, SelectMgr_ViewClipRange)
 
-  for (size_t aRangeIter = 0; aRangeIter < myClipRanges.size(); ++aRangeIter)
+  for (size_t aRangeIter = 0; aRangeIter < myClipRanges.Size(); ++aRangeIter)
   {
     Bnd_Range aClipRange = myClipRanges[aRangeIter];
     OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, &aClipRange)

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewClipRange.hxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewClipRange.hxx
@@ -20,8 +20,7 @@
 #include <Standard_TypeDef.hxx>
 #include <Standard_OStream.hxx>
 #include <Standard_Dump.hxx>
-
-#include <vector>
+#include <NCollection_LinearVector.hxx>
 
 class gp_Ax1;
 class Graphic3d_SequenceOfHClipPlane;
@@ -43,7 +42,7 @@ public:
     {
       return true;
     }
-    for (size_t aRangeIter = 0; aRangeIter < myClipRanges.size(); ++aRangeIter)
+    for (size_t aRangeIter = 0; aRangeIter < myClipRanges.Size(); ++aRangeIter)
     {
       if (!myClipRanges[aRangeIter].IsOut(theDepth))
       {
@@ -70,7 +69,7 @@ public:
       myUnclipRange.GetMin(theDepth);
     }
 
-    for (size_t aRangeIter = 0; aRangeIter < myClipRanges.size(); ++aRangeIter)
+    for (size_t aRangeIter = 0; aRangeIter < myClipRanges.Size(); ++aRangeIter)
     {
       if (!myClipRanges[aRangeIter].IsOut(theDepth))
       {
@@ -84,7 +83,7 @@ public:
       return true;
     }
 
-    for (size_t aRangeIter = 0; aRangeIter < myClipRanges.size(); ++aRangeIter)
+    for (size_t aRangeIter = 0; aRangeIter < myClipRanges.Size(); ++aRangeIter)
     {
       if (!aCommonClipRange.IsOut(myClipRanges[aRangeIter]))
       {
@@ -101,7 +100,7 @@ public:
   //! Clears clipping range.
   void SetVoid()
   {
-    myClipRanges.resize(0);
+    myClipRanges.Clear();
     myUnclipRange = Bnd_Range(RealFirst(), RealLast());
   }
 
@@ -113,13 +112,13 @@ public:
   Bnd_Range& ChangeUnclipRange() { return myUnclipRange; }
 
   //! Adds a clipping sub-range (for clipping chains).
-  void AddClipSubRange(const Bnd_Range& theRange) { myClipRanges.push_back(theRange); }
+  void AddClipSubRange(const Bnd_Range& theRange) { myClipRanges.Append(theRange); }
 
   //! Dumps the content of me into the stream
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const;
 
 private:
-  std::vector<Bnd_Range> myClipRanges;
+  NCollection_LinearVector<Bnd_Range> myClipRanges;
   Bnd_Range              myUnclipRange;
 };
 

--- a/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewClipRange.hxx
+++ b/src/Visualization/TKV3d/SelectMgr/SelectMgr_ViewClipRange.hxx
@@ -119,7 +119,7 @@ public:
 
 private:
   NCollection_LinearVector<Bnd_Range> myClipRanges;
-  Bnd_Range              myUnclipRange;
+  Bnd_Range                           myUnclipRange;
 };
 
 #endif // _SelectMgr_ViewClipRange_HeaderFile

--- a/src/Visualization/TKV3d/StdPrs/StdPrs_WFShape.cxx
+++ b/src/Visualization/TKV3d/StdPrs/StdPrs_WFShape.cxx
@@ -32,6 +32,7 @@
 #include <gp_Pnt.hxx>
 #include <NCollection_Sequence.hxx>
 #include <NCollection_HSequence.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Standard_Integer.hxx>
 #include <NCollection_Array1.hxx>
 #include <TopoDS_Edge.hxx>
@@ -50,7 +51,7 @@ public:
   StdPrs_WFShape_IsoFunctor(
     NCollection_List<occ::handle<NCollection_HSequence<gp_Pnt>>>& thePolylinesU,
     NCollection_List<occ::handle<NCollection_HSequence<gp_Pnt>>>& thePolylinesV,
-    const std::vector<TopoDS_Face>&                               theFaces,
+    const NCollection_LinearVector<TopoDS_Face>&                  theFaces,
     const occ::handle<Prs3d_Drawer>&                              theDrawer,
     double                                                        theShapeDeflection)
       : myPolylinesU(thePolylinesU),
@@ -80,7 +81,7 @@ private:
 private:
   NCollection_List<occ::handle<NCollection_HSequence<gp_Pnt>>>& myPolylinesU;
   NCollection_List<occ::handle<NCollection_HSequence<gp_Pnt>>>& myPolylinesV;
-  const std::vector<TopoDS_Face>&                               myFaces;
+  const NCollection_LinearVector<TopoDS_Face>&                  myFaces;
   const occ::handle<Prs3d_Drawer>&                              myDrawer;
   mutable std::mutex                                            myMutex;
   const double                                                  myShapeDeflection;
@@ -149,7 +150,8 @@ void StdPrs_WFShape::Add(const occ::handle<Prs3d_Presentation>& thePresentation,
       if (aNbFaces > 1)
       {
         isParallelIso = true;
-        std::vector<TopoDS_Face> aFaces(aNbFaces);
+        NCollection_LinearVector<TopoDS_Face> aFaces;
+        aFaces.Resize(aNbFaces);
         aNbFaces = 0;
         for (TopExp_Explorer aFaceExplorer(theShape, TopAbs_FACE); aFaceExplorer.More();
              aFaceExplorer.Next())


### PR DESCRIPTION
- Replaced std::vector with NCollection_LinearVector in various files to enhance efficiency.
- Updated methods to use EmplaceAppend and Resize for better memory handling.
- Adjusted logic in OpenGl_View, OpenGl_HaltonSampler, and other classes to accommodate new vector type.
- Improved memory allocation and initialization patterns across the visualization module.