### PR TITLE
Visualization - Restore CPU grid path alongside shader grid

### DIFF
--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -14259,11 +14259,17 @@ vgrid [off] [-type {rect|circ|inf}] [-mode {line|point}] [-origin X Y] [-rotAngl
       [-step StepRadius NbDivisions] [-radius Radius] [-arc AngleStart AngleEnd]
       [-color R G B] [-tenthColor R G B] [-scale N] [-lineThickness T]
       [-background {0|1}] [-drawAxis {0|1}] [-inf {0|1}]
-'-type inf' activates a shader-rendered infinite (or bounded) grid; combine
-with '-size DX DY' for a rectangle, '-radius R' for a disc, '-arc S E' for a
-wedge. '-color', '-tenthColor', '-scale', '-lineThickness' drive every grid
-since rendering is shader-based. '-background', '-drawAxis', '-inf {0|1}' are
-inf-mode only. 'off' deactivates the grid and cannot be combined with '-type inf'.
+Two render backends are available:
+  - '-type rect' / '-type circ' (default) draws the legacy CPU grid into a
+    bounded Graphic3d_Structure shared by every active view.
+  - '-type inf' activates the shader-rendered infinite (or bounded) grid on
+    the active view; combine with '-size DX DY' for a rectangle, '-radius R'
+    for a disc, '-arc S E' for a wedge.
+'-color', '-tenthColor' apply to both backends. '-scale', '-lineThickness',
+'-background', '-drawAxis', '-inf {0|1}' are inf-mode only. Switching to
+'-type inf' hides the CPU grid in the viewer; switching back to a non-inf
+type erases the shader grid in the active view. 'off' deactivates whichever
+grid is currently visible.
 )" /* [vgrid] */);
 
   addCmd("vpriviledgedplane", VPriviledgedPlane, /* [vpriviledgedplane] */ R"(

--- a/src/Visualization/TKService/Aspect/Aspect_GridParams.hxx
+++ b/src/Visualization/TKService/Aspect/Aspect_GridParams.hxx
@@ -22,16 +22,10 @@
 #include <Quantity_Color.hxx>
 #include <gp_Pnt.hxx>
 
-//! Render-only appearance parameters for a shader-rendered grid.
-//!
-//! Drives a screen-space quad intersected with a grid plane in the fragment
-//! shader (see Graphic3d_ShaderManager::getGridProgram). This is a pure value
-//! struct; it does NOT own any snap state. The authoritative grid geometry for
-//! snap selection still lives on Aspect_RectangularGrid / Aspect_CircularGrid,
-//! and V3d_{Rectangular,Circular}Grid::syncViews produces an Aspect_GridParams
-//! from the grid on every display. If you introduce a new field here that has
-//! a matching concept on Aspect_Grid, update syncViews too so both layers stay
-//! in sync.
+//! Shader grid appearance (color, scale, bounds, arc, draw mode, background / inf flags).
+//! Consumed only by the GPU path: V3d_View::GridDisplay -> OpenGl_View::renderGrid.
+//! No effect on the CPU path (V3d_Viewer::ActivateGrid). Snap math is independent and
+//! lives on Aspect_RectangularGrid / Aspect_CircularGrid.
 class Aspect_GridParams
 {
 public:
@@ -77,10 +71,10 @@ public:
   //! Set local offset of the grid origin within the plane.
   void SetOrigin(const gp_Pnt& theOrigin) { myOrigin = theOrigin; }
 
-  //! Return accent color used by the classical V3d grid emulation path.
+  //! Return every-tenth-line / accent colour rendered by the shader.
   const Quantity_Color& AccentColor() const { return myAccentColor; }
 
-  //! Set accent color used by the classical V3d grid emulation path.
+  //! Set every-tenth-line / accent colour rendered by the shader.
   void SetAccentColor(const Quantity_Color& theColor) { myAccentColor = theColor; }
 
   //! Return accent overlay scale along the plane X/radial direction.

--- a/src/Visualization/TKV3d/V3d/V3d_CircularGrid.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_CircularGrid.cxx
@@ -13,12 +13,17 @@
 
 #include <V3d_CircularGrid.hxx>
 
-#include <Aspect_GridParams.hxx>
+#include <Graphic3d_ArrayOfPoints.hxx>
+#include <Graphic3d_ArrayOfPolylines.hxx>
+#include <Graphic3d_ArrayOfSegments.hxx>
+#include <Graphic3d_AspectLine3d.hxx>
+#include <Graphic3d_AspectMarker3d.hxx>
+#include <Graphic3d_Group.hxx>
+#include <Message.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Quantity_Color.hxx>
 #include <Standard_Type.hxx>
-#include <V3d_View.hxx>
 #include <V3d_Viewer.hxx>
-#include <gp_Ax3.hxx>
 #include <gp_Pnt.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(V3d_CircularGrid, Aspect_CircularGrid)
@@ -30,6 +35,28 @@ constexpr int    THE_DEFAULT_DIVISION  = 8;
 constexpr double THE_MYFACTOR          = 50.0;
 } // namespace
 
+class V3d_CircularGrid::CircularGridStructure : public Graphic3d_Structure
+{
+public:
+  CircularGridStructure(const occ::handle<Graphic3d_StructureManager>& theManager,
+                        V3d_CircularGrid*                              theGrid)
+      : Graphic3d_Structure(theManager),
+        myGrid(theGrid)
+  {
+  }
+
+  void Compute() override
+  {
+    GraphicClear(false);
+    myGrid->myGroup         = NewGroup();
+    myGrid->myCurAreDefined = false;
+    myGrid->UpdateDisplay();
+  }
+
+private:
+  V3d_CircularGrid* myGrid;
+};
+
 //=================================================================================================
 
 V3d_CircularGrid::V3d_CircularGrid(const V3d_ViewerPointer& aViewer,
@@ -37,10 +64,24 @@ V3d_CircularGrid::V3d_CircularGrid(const V3d_ViewerPointer& aViewer,
                                    const Quantity_Color&    aTenthColor)
     : Aspect_CircularGrid(1., THE_DEFAULT_DIVISION),
       myViewer(aViewer),
-      myIsDisplayed(false)
+      myCurAreDefined(false),
+      myToComputePrs(false),
+      myCurDrawMode(Aspect_GDM_Lines),
+      myCurXo(0.0),
+      myCurYo(0.0),
+      myCurAngle(0.0),
+      myCurStep(0.0),
+      myCurDivi(0),
+      myCurRadius(0.0),
+      myCurOffSet(0.0),
+      myArcWarned(false)
 {
   myColor      = aColor;
   myTenthColor = aTenthColor;
+
+  myStructure = new CircularGridStructure(aViewer->StructureManager(), this);
+  myGroup     = myStructure->NewGroup();
+  myStructure->SetInfiniteState(true);
 
   SetRadiusStep(THE_DEFAULT_GRID_STEP);
   Aspect_CircularGrid::SetRadius(0.5 * aViewer->DefaultViewSize());
@@ -51,9 +92,10 @@ V3d_CircularGrid::V3d_CircularGrid(const V3d_ViewerPointer& aViewer,
 
 V3d_CircularGrid::~V3d_CircularGrid()
 {
-  if (myIsDisplayed)
+  myGroup.Nullify();
+  if (!myStructure.IsNull())
   {
-    syncViews(false);
+    myStructure->Erase();
   }
 }
 
@@ -63,8 +105,9 @@ void V3d_CircularGrid::SetColors(const Quantity_Color& aColor, const Quantity_Co
 {
   if (myColor != aColor || myTenthColor != aTenthColor)
   {
-    myColor      = aColor;
-    myTenthColor = aTenthColor;
+    myColor         = aColor;
+    myTenthColor    = aTenthColor;
+    myCurAreDefined = false;
     UpdateDisplay();
   }
 }
@@ -73,33 +116,285 @@ void V3d_CircularGrid::SetColors(const Quantity_Color& aColor, const Quantity_Co
 
 void V3d_CircularGrid::Display()
 {
-  myIsDisplayed = true;
-  syncViews(true);
+  myStructure->SetDisplayPriority(Graphic3d_DisplayPriority_AlmostBottom);
+  myStructure->Display();
+  UpdateDisplay();
 }
 
 //=================================================================================================
 
 void V3d_CircularGrid::Erase() const
 {
-  myIsDisplayed = false;
-  syncViews(false);
+  myStructure->Erase();
 }
 
 //=================================================================================================
 
 bool V3d_CircularGrid::IsDisplayed() const
 {
-  return myIsDisplayed;
+  return myStructure->IsDisplayed();
 }
 
 //=================================================================================================
 
 void V3d_CircularGrid::UpdateDisplay()
 {
-  if (myIsDisplayed)
+  if (IsArc() && !myArcWarned)
   {
-    syncViews(true);
+    Message::SendWarning() << "V3d_CircularGrid: arc range (AngleStart/AngleEnd) is not "
+                              "supported by the CPU rendering path and will be ignored. "
+                              "Use V3d_View::GridDisplay with Aspect_GridParams::SetArcRange "
+                              "for arc rendering.";
+    myArcWarned = true;
   }
+
+  const gp_Ax3 aPlane = myViewer->PrivilegedPlane();
+
+  double xl, yl, zl;
+  double xdx, xdy, xdz;
+  double ydx, ydy, ydz;
+  double dx, dy, dz;
+  aPlane.Location().Coord(xl, yl, zl);
+  aPlane.XDirection().Coord(xdx, xdy, xdz);
+  aPlane.YDirection().Coord(ydx, ydy, ydz);
+  aPlane.Direction().Coord(dx, dy, dz);
+
+  bool MakeTransform = !myCurAreDefined;
+  if (!MakeTransform)
+  {
+    MakeTransform = (RotationAngle() != myCurAngle || XOrigin() != myCurXo || YOrigin() != myCurYo);
+    if (!MakeTransform)
+    {
+      double curxl, curyl, curzl;
+      double curxdx, curxdy, curxdz;
+      double curydx, curydy, curydz;
+      double curdx, curdy, curdz;
+      myCurViewPlane.Location().Coord(curxl, curyl, curzl);
+      myCurViewPlane.XDirection().Coord(curxdx, curxdy, curxdz);
+      myCurViewPlane.YDirection().Coord(curydx, curydy, curydz);
+      myCurViewPlane.Direction().Coord(curdx, curdy, curdz);
+      if (xl != curxl || yl != curyl || zl != curzl || xdx != curxdx || xdy != curxdy
+          || xdz != curxdz || ydx != curydx || ydy != curydy || ydz != curydz || dx != curdx
+          || dy != curdy || dz != curdz)
+      {
+        MakeTransform = true;
+      }
+    }
+  }
+
+  if (MakeTransform)
+  {
+    const double CosAlpha = std::cos(RotationAngle());
+    const double SinAlpha = std::sin(RotationAngle());
+
+    gp_Trsf aTrsf;
+    aTrsf.SetValues(xdx, ydx, dx, xl, xdy, ydy, dy, yl, xdz, ydz, dz, zl);
+
+    gp_Trsf aTrsf2;
+    aTrsf2.SetValues(CosAlpha,
+                     SinAlpha,
+                     0.0,
+                     -XOrigin(),
+                     -SinAlpha,
+                     CosAlpha,
+                     0.0,
+                     -YOrigin(),
+                     0.0,
+                     0.0,
+                     1.0,
+                     0.0);
+    aTrsf.Multiply(aTrsf2);
+    myStructure->SetTransformation(new TopLoc_Datum3D(aTrsf));
+
+    myCurAngle     = RotationAngle();
+    myCurXo        = XOrigin();
+    myCurYo        = YOrigin();
+    myCurViewPlane = aPlane;
+  }
+
+  switch (myDrawMode)
+  {
+    case Aspect_GDM_Points:
+      DefinePoints();
+      myCurDrawMode = Aspect_GDM_Points;
+      break;
+    case Aspect_GDM_Lines:
+      DefineLines();
+      myCurDrawMode = Aspect_GDM_Lines;
+      break;
+    case Aspect_GDM_None:
+      myCurDrawMode = Aspect_GDM_None;
+      break;
+  }
+  myCurAreDefined = true;
+}
+
+//=================================================================================================
+
+void V3d_CircularGrid::DefineLines()
+{
+  const double aStep      = RadiusStep();
+  const double aDivision  = DivisionNumber();
+  const double aRadius    = Radius();
+  const double aOffSet    = ZOffset();
+  const bool   toUpdate   = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Lines
+                          || aDivision != myCurDivi || aStep != myCurStep
+                          || aRadius != myCurRadius || aOffSet != myCurOffSet;
+  if (!toUpdate && !myToComputePrs)
+  {
+    return;
+  }
+  else if (!myStructure->IsDisplayed())
+  {
+    myToComputePrs = true;
+    return;
+  }
+
+  myToComputePrs = false;
+  myGroup->Clear();
+
+  const int Division =
+    (int)((aDivision >= THE_DEFAULT_DIVISION ? aDivision : THE_DEFAULT_DIVISION));
+
+  int    nbpnts = 2 * Division;
+  double alpha  = M_PI / aDivision;
+
+  myGroup->SetGroupPrimitivesAspect(
+    new Graphic3d_AspectLine3d(myTenthColor, Aspect_TOL_SOLID, 1.0));
+  occ::handle<Graphic3d_ArrayOfSegments> aPrims1 = new Graphic3d_ArrayOfSegments(2 * nbpnts);
+  const gp_Pnt                           p0(0., 0., -aOffSet);
+  for (int i = 1; i <= nbpnts; i++)
+  {
+    aPrims1->AddVertex(p0);
+    aPrims1->AddVertex(std::cos(alpha * i) * aRadius, std::sin(alpha * i) * aRadius, -aOffSet);
+  }
+  myGroup->AddPrimitiveArray(aPrims1, false);
+
+  nbpnts                                   = 2 * Division + 1;
+  alpha                                    = M_PI / Division;
+  int                              nblines = 0;
+  const size_t                     aNbR  = aStep > 0.0 ? static_cast<size_t>(aRadius / aStep) + 1 : 1;
+  const size_t                     aResv = aNbR * static_cast<size_t>(nbpnts);
+  NCollection_LinearVector<gp_Pnt> aSeqLines(aResv), aSeqTenth(aResv);
+  for (double r = aStep; r <= aRadius; r += aStep, nblines++)
+  {
+    const bool isTenth = (Modulus(nblines, 10) == 0);
+    for (int i = 0; i < nbpnts; i++)
+    {
+      (isTenth ? aSeqTenth : aSeqLines)
+        .EmplaceAppend(std::cos(alpha * i) * r, std::sin(alpha * i) * r, -aOffSet);
+    }
+  }
+  if (!aSeqTenth.IsEmpty())
+  {
+    myGroup->SetGroupPrimitivesAspect(
+      new Graphic3d_AspectLine3d(myTenthColor, Aspect_TOL_SOLID, 1.0));
+    const int                               aSize = static_cast<int>(aSeqTenth.Size());
+    const int                               nbl   = aSize / nbpnts;
+    occ::handle<Graphic3d_ArrayOfPolylines> aPrims2 =
+      new Graphic3d_ArrayOfPolylines(aSize, nbl);
+    int np = 0;
+    for (int n = 0; n < nbl; n++)
+    {
+      aPrims2->AddBound(nbpnts);
+      for (int i = 0; i < nbpnts; i++, np++)
+      {
+        aPrims2->AddVertex(aSeqTenth[np]);
+      }
+    }
+    myGroup->AddPrimitiveArray(aPrims2, false);
+  }
+  if (!aSeqLines.IsEmpty())
+  {
+    myGroup->SetPrimitivesAspect(new Graphic3d_AspectLine3d(myColor, Aspect_TOL_SOLID, 1.0));
+    const int                               aSize = static_cast<int>(aSeqLines.Size());
+    const int                               nbl   = aSize / nbpnts;
+    occ::handle<Graphic3d_ArrayOfPolylines> aPrims3 =
+      new Graphic3d_ArrayOfPolylines(aSize, nbl);
+    int np = 0;
+    for (int n = 0; n < nbl; n++)
+    {
+      aPrims3->AddBound(nbpnts);
+      for (int i = 0; i < nbpnts; i++, np++)
+      {
+        aPrims3->AddVertex(aSeqLines[np]);
+      }
+    }
+    myGroup->AddPrimitiveArray(aPrims3, false);
+  }
+
+  myGroup->SetMinMaxValues(-aRadius, -aRadius, -aOffSet, aRadius, aRadius, -aOffSet);
+  myCurStep   = aStep;
+  myCurDivi   = (int)aDivision;
+  myCurRadius = aRadius;
+  myCurOffSet = aOffSet;
+
+  myStructure->CalculateBoundBox();
+  myViewer->StructureManager()->Update(myStructure->GetZLayer());
+}
+
+//=================================================================================================
+
+void V3d_CircularGrid::DefinePoints()
+{
+  const double aStep      = RadiusStep();
+  const double aDivision  = DivisionNumber();
+  const double aRadius    = Radius();
+  const double aOffSet    = ZOffset();
+  const bool   toUpdate   = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Points
+                          || aDivision != myCurDivi || aStep != myCurStep
+                          || aRadius != myCurRadius || aOffSet != myCurOffSet;
+  if (!toUpdate && !myToComputePrs)
+  {
+    return;
+  }
+  else if (!myStructure->IsDisplayed())
+  {
+    myToComputePrs = true;
+    return;
+  }
+
+  myToComputePrs = false;
+  myGroup->Clear();
+
+  occ::handle<Graphic3d_AspectMarker3d> MarkerAttrib = new Graphic3d_AspectMarker3d();
+  MarkerAttrib->SetColor(myColor);
+  MarkerAttrib->SetType(Aspect_TOM_POINT);
+  MarkerAttrib->SetScale(3.);
+
+  const int nbpnts = int(2 * aDivision);
+  double    r, alpha = M_PI / aDivision;
+
+  const size_t                     aNbR = aStep > 0.0 ? static_cast<size_t>(aRadius / aStep) + 1 : 1;
+  NCollection_LinearVector<gp_Pnt> aSeqPnts(aNbR * static_cast<size_t>(nbpnts) + 1);
+  aSeqPnts.EmplaceAppend(0.0, 0.0, -aOffSet);
+  for (r = aStep; r <= aRadius; r += aStep)
+  {
+    for (int i = 0; i < nbpnts; i++)
+    {
+      aSeqPnts.EmplaceAppend(std::cos(alpha * i) * r, std::sin(alpha * i) * r, -aOffSet);
+    }
+  }
+  myGroup->SetGroupPrimitivesAspect(MarkerAttrib);
+  if (!aSeqPnts.IsEmpty())
+  {
+    const int                            nbv    = static_cast<int>(aSeqPnts.Size());
+    occ::handle<Graphic3d_ArrayOfPoints> Cercle = new Graphic3d_ArrayOfPoints(nbv);
+    for (const gp_Pnt& aPnt : aSeqPnts)
+    {
+      Cercle->AddVertex(aPnt);
+    }
+    myGroup->AddPrimitiveArray(Cercle, false);
+  }
+  myGroup->SetMinMaxValues(-aRadius, -aRadius, -aOffSet, aRadius, aRadius, -aOffSet);
+
+  myCurStep   = aStep;
+  myCurDivi   = (int)aDivision;
+  myCurRadius = aRadius;
+  myCurOffSet = aOffSet;
+
+  myStructure->CalculateBoundBox();
+  myViewer->StructureManager()->Update(myStructure->GetZLayer());
 }
 
 //=================================================================================================
@@ -114,68 +409,8 @@ void V3d_CircularGrid::GraphicValues(double& theRadius, double& theOffSet) const
 
 void V3d_CircularGrid::SetGraphicValues(const double theRadius, const double theOffSet)
 {
-  // Base-class setters each trigger UpdateDisplay only on real change.
   SetRadius(theRadius);
   SetZOffset(theOffSet);
-}
-
-//=================================================================================================
-
-void V3d_CircularGrid::syncViews(const bool theDoDisplay) const
-{
-  if (myViewer == nullptr)
-  {
-    return;
-  }
-
-  const double aRadiusStep = RadiusStep() > 0.0 ? RadiusStep() : THE_DEFAULT_GRID_STEP;
-  const int    aDivisions  = DivisionNumber() > 0 ? DivisionNumber() : THE_DEFAULT_DIVISION;
-
-  const gp_Ax3 aPlane = myViewer->PrivilegedPlane();
-
-  // Same convention as V3d_RectangularGrid::syncViews: origin is a world-space
-  // offset aligned with the plane basis so the shader's aPlaneOrigin matches
-  // V3d_View::Compute's aPnt0 used for snap selection.
-  const gp_XYZ aOriginOffset =
-    aPlane.XDirection().XYZ() * -XOrigin() + aPlane.YDirection().XYZ() * -YOrigin();
-
-  Aspect_GridParams aParams;
-  aParams.SetColor(myColor);
-  aParams.SetAccentColor(myTenthColor);
-  aParams.SetOrigin(gp_Pnt(aOriginOffset));
-  aParams.SetScale(1.0 / aRadiusStep);
-  aParams.SetScaleY(0.0); // unused in circular mode
-  aParams.SetAccentScaleX(0.1 / aRadiusStep);
-  // Angular accent defaults OFF: classical OCCT circular grids have no
-  // "tenth spoke" concept. Spokes come from DivisionNumber and are already
-  // drawn by the base layer at full count. Setting this to a positive value
-  // (e.g. aDivisions / (k * M_PI) for k > 1) would highlight every k-th spoke.
-  aParams.SetAccentAngularScale(0.0);
-  aParams.SetRotationAngle(RotationAngle());
-  aParams.SetAngularDivisions(aDivisions);
-  aParams.SetDrawMode(DrawMode());
-  aParams.SetRadius(Radius());
-  aParams.SetZOffset(ZOffset());
-  aParams.SetArcRange(AngleStart(), AngleEnd());
-  aParams.SetIsBackground(false);
-  aParams.SetIsDrawAxis(false);
-  aParams.SetIsInfinity(false);
-
-  for (const occ::handle<V3d_View>& aView : myViewer->DefinedViews())
-  {
-    if (aView.IsNull())
-    {
-      continue;
-    }
-    if (theDoDisplay)
-    {
-      aView->GridDisplay(aParams, aPlane);
-    }
-    else
-    {
-      aView->GridErase();
-    }
-  }
 }
 
 //=================================================================================================
@@ -185,6 +420,19 @@ void V3d_CircularGrid::DumpJson(Standard_OStream& theOStream, int theDepth) cons
   OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
   OCCT_DUMP_BASE_CLASS(theOStream, theDepth, Aspect_CircularGrid)
 
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, myStructure.get())
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, myGroup.get())
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, &myCurViewPlane)
   OCCT_DUMP_FIELD_VALUE_POINTER(theOStream, myViewer)
-  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myIsDisplayed)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurAreDefined)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToComputePrs)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurDrawMode)
+
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurXo)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurYo)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurAngle)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurStep)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurDivi)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurRadius)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurOffSet)
 }

--- a/src/Visualization/TKV3d/V3d/V3d_CircularGrid.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_CircularGrid.cxx
@@ -355,10 +355,10 @@ void V3d_CircularGrid::DefinePoints()
   myToComputePrs = false;
   myGroup->Clear();
 
-  occ::handle<Graphic3d_AspectMarker3d> MarkerAttrib = new Graphic3d_AspectMarker3d();
-  MarkerAttrib->SetColor(myColor);
-  MarkerAttrib->SetType(Aspect_TOM_POINT);
-  MarkerAttrib->SetScale(3.);
+  occ::handle<Graphic3d_AspectMarker3d> aMarkerAttrib = new Graphic3d_AspectMarker3d();
+  aMarkerAttrib->SetColor(myColor);
+  aMarkerAttrib->SetType(Aspect_TOM_POINT);
+  aMarkerAttrib->SetScale(3.);
 
   const int nbpnts = int(2 * aDivision);
   double    r, alpha = M_PI / aDivision;
@@ -373,16 +373,16 @@ void V3d_CircularGrid::DefinePoints()
       aSeqPnts.EmplaceAppend(std::cos(alpha * i) * r, std::sin(alpha * i) * r, -aOffSet);
     }
   }
-  myGroup->SetGroupPrimitivesAspect(MarkerAttrib);
+  myGroup->SetGroupPrimitivesAspect(aMarkerAttrib);
   if (!aSeqPnts.IsEmpty())
   {
-    const int                            nbv    = static_cast<int>(aSeqPnts.Size());
-    occ::handle<Graphic3d_ArrayOfPoints> Cercle = new Graphic3d_ArrayOfPoints(nbv);
+    const int                            nbv     = static_cast<int>(aSeqPnts.Size());
+    occ::handle<Graphic3d_ArrayOfPoints> aPoints = new Graphic3d_ArrayOfPoints(nbv);
     for (const gp_Pnt& aPnt : aSeqPnts)
     {
-      Cercle->AddVertex(aPnt);
+      aPoints->AddVertex(aPnt);
     }
-    myGroup->AddPrimitiveArray(Cercle, false);
+    myGroup->AddPrimitiveArray(aPoints, false);
   }
   myGroup->SetMinMaxValues(-aRadius, -aRadius, -aOffSet, aRadius, aRadius, -aOffSet);
 

--- a/src/Visualization/TKV3d/V3d/V3d_CircularGrid.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_CircularGrid.cxx
@@ -233,13 +233,13 @@ void V3d_CircularGrid::UpdateDisplay()
 
 void V3d_CircularGrid::DefineLines()
 {
-  const double aStep      = RadiusStep();
-  const double aDivision  = DivisionNumber();
-  const double aRadius    = Radius();
-  const double aOffSet    = ZOffset();
-  const bool   toUpdate   = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Lines
-                          || aDivision != myCurDivi || aStep != myCurStep
-                          || aRadius != myCurRadius || aOffSet != myCurOffSet;
+  const double aStep     = RadiusStep();
+  const double aDivision = DivisionNumber();
+  const double aRadius   = Radius();
+  const double aOffSet   = ZOffset();
+  const bool   toUpdate  = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Lines
+                        || aDivision != myCurDivi || aStep != myCurStep || aRadius != myCurRadius
+                        || aOffSet != myCurOffSet;
   if (!toUpdate && !myToComputePrs)
   {
     return;
@@ -270,11 +270,11 @@ void V3d_CircularGrid::DefineLines()
   }
   myGroup->AddPrimitiveArray(aPrims1, false);
 
-  nbpnts                                   = 2 * Division + 1;
-  alpha                                    = M_PI / Division;
-  int                              nblines = 0;
-  const size_t                     aNbR  = aStep > 0.0 ? static_cast<size_t>(aRadius / aStep) + 1 : 1;
-  const size_t                     aResv = aNbR * static_cast<size_t>(nbpnts);
+  nbpnts               = 2 * Division + 1;
+  alpha                = M_PI / Division;
+  int          nblines = 0;
+  const size_t aNbR    = aStep > 0.0 ? static_cast<size_t>(aRadius / aStep) + 1 : 1;
+  const size_t aResv   = aNbR * static_cast<size_t>(nbpnts);
   NCollection_LinearVector<gp_Pnt> aSeqLines(aResv), aSeqTenth(aResv);
   for (double r = aStep; r <= aRadius; r += aStep, nblines++)
   {
@@ -289,11 +289,10 @@ void V3d_CircularGrid::DefineLines()
   {
     myGroup->SetGroupPrimitivesAspect(
       new Graphic3d_AspectLine3d(myTenthColor, Aspect_TOL_SOLID, 1.0));
-    const int                               aSize = static_cast<int>(aSeqTenth.Size());
-    const int                               nbl   = aSize / nbpnts;
-    occ::handle<Graphic3d_ArrayOfPolylines> aPrims2 =
-      new Graphic3d_ArrayOfPolylines(aSize, nbl);
-    int np = 0;
+    const int                               aSize   = static_cast<int>(aSeqTenth.Size());
+    const int                               nbl     = aSize / nbpnts;
+    occ::handle<Graphic3d_ArrayOfPolylines> aPrims2 = new Graphic3d_ArrayOfPolylines(aSize, nbl);
+    int                                     np      = 0;
     for (int n = 0; n < nbl; n++)
     {
       aPrims2->AddBound(nbpnts);
@@ -307,11 +306,10 @@ void V3d_CircularGrid::DefineLines()
   if (!aSeqLines.IsEmpty())
   {
     myGroup->SetPrimitivesAspect(new Graphic3d_AspectLine3d(myColor, Aspect_TOL_SOLID, 1.0));
-    const int                               aSize = static_cast<int>(aSeqLines.Size());
-    const int                               nbl   = aSize / nbpnts;
-    occ::handle<Graphic3d_ArrayOfPolylines> aPrims3 =
-      new Graphic3d_ArrayOfPolylines(aSize, nbl);
-    int np = 0;
+    const int                               aSize   = static_cast<int>(aSeqLines.Size());
+    const int                               nbl     = aSize / nbpnts;
+    occ::handle<Graphic3d_ArrayOfPolylines> aPrims3 = new Graphic3d_ArrayOfPolylines(aSize, nbl);
+    int                                     np      = 0;
     for (int n = 0; n < nbl; n++)
     {
       aPrims3->AddBound(nbpnts);
@@ -337,13 +335,13 @@ void V3d_CircularGrid::DefineLines()
 
 void V3d_CircularGrid::DefinePoints()
 {
-  const double aStep      = RadiusStep();
-  const double aDivision  = DivisionNumber();
-  const double aRadius    = Radius();
-  const double aOffSet    = ZOffset();
-  const bool   toUpdate   = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Points
-                          || aDivision != myCurDivi || aStep != myCurStep
-                          || aRadius != myCurRadius || aOffSet != myCurOffSet;
+  const double aStep     = RadiusStep();
+  const double aDivision = DivisionNumber();
+  const double aRadius   = Radius();
+  const double aOffSet   = ZOffset();
+  const bool   toUpdate  = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Points
+                        || aDivision != myCurDivi || aStep != myCurStep || aRadius != myCurRadius
+                        || aOffSet != myCurOffSet;
   if (!toUpdate && !myToComputePrs)
   {
     return;
@@ -365,7 +363,7 @@ void V3d_CircularGrid::DefinePoints()
   const int nbpnts = int(2 * aDivision);
   double    r, alpha = M_PI / aDivision;
 
-  const size_t                     aNbR = aStep > 0.0 ? static_cast<size_t>(aRadius / aStep) + 1 : 1;
+  const size_t aNbR = aStep > 0.0 ? static_cast<size_t>(aRadius / aStep) + 1 : 1;
   NCollection_LinearVector<gp_Pnt> aSeqPnts(aNbR * static_cast<size_t>(nbpnts) + 1);
   aSeqPnts.EmplaceAppend(0.0, 0.0, -aOffSet);
   for (r = aStep; r <= aRadius; r += aStep)

--- a/src/Visualization/TKV3d/V3d/V3d_CircularGrid.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_CircularGrid.hxx
@@ -21,47 +21,95 @@
 
 #include <Aspect_CircularGrid.hxx>
 #include <V3d_ViewerPointer.hxx>
+#include <gp_Ax3.hxx>
+class Graphic3d_Structure;
+class Graphic3d_Group;
 
-//! Circular grid bound to a V3d_Viewer. Snap math (Compute/Hit) is inherited
-//! from Aspect_CircularGrid; rendering goes through the shader-based infinite
-//! grid (OpenGl_View::renderGrid) with a polar branch.
+//! @deprecated Kept for backward compatibility. CPU-generated circular grid bound to a
+//! V3d_Viewer. New code should drive grids through V3d_View::GridDisplay(Aspect_GridParams,
+//! gp_Ax3), which renders an infinite, AA, shader-based grid and supports background mode,
+//! arc ranges and per-axis scales. This class consumes the same Aspect_CircularGrid
+//! parameters where the CPU path can render them; arc ranges (AngleStart/AngleEnd) are not
+//! supported by the CPU path and are reported via Message::SendWarning() and ignored.
 class V3d_CircularGrid : public Aspect_CircularGrid
 {
   DEFINE_STANDARD_RTTIEXT(V3d_CircularGrid, Aspect_CircularGrid)
 public:
+  //! Constructor. Builds a CPU-rendered circular grid bound to @p aViewer.
+  //! Default radius is 0.5 * Viewer->DefaultViewSize(); ZOffset defaults to step / 50.
+  //! @deprecated Prefer V3d_View::GridDisplay with Aspect_GridParams for shader-based
+  //!             infinite grids.
+  //! @param[in] aViewer     viewer that owns the grid (and provides DefaultViewSize)
+  //! @param[in] aColor      color of the regular rings / spokes
+  //! @param[in] aTenthColor color of every 10-th ring (and the diameter spokes)
   Standard_EXPORT V3d_CircularGrid(const V3d_ViewerPointer& aViewer,
                                    const Quantity_Color&    aColor,
                                    const Quantity_Color&    aTenthColor);
 
   Standard_EXPORT ~V3d_CircularGrid() override;
 
+  //! Updates the grid colors and triggers a re-display when they actually change.
+  //! @param[in] aColor      color of the regular rings / spokes
+  //! @param[in] aTenthColor color of every 10-th ring
   Standard_EXPORT void SetColors(const Quantity_Color& aColor,
                                  const Quantity_Color& aTenthColor) override;
 
+  //! Display the CPU grid in the owning viewer's structure manager.
   Standard_EXPORT void Display() override;
 
+  //! Erase the CPU grid (the underlying Graphic3d_Structure is hidden, not destroyed).
   Standard_EXPORT void Erase() const override;
 
+  //! Returns true if the grid structure is currently displayed.
   Standard_EXPORT bool IsDisplayed() const override;
 
+  //! Returns the grid extent and Z offset (alias for Radius/ZOffset).
+  //! @param[out] Radius outermost ring radius
+  //! @param[out] OffSet plane-normal displacement of the rendered grid
   Standard_EXPORT void GraphicValues(double& Radius, double& OffSet) const;
 
+  //! Sets the grid extent and Z offset (alias for SetRadius/SetZOffset).
+  //! @param[in] Radius outermost ring radius
+  //! @param[in] OffSet plane-normal displacement
   Standard_EXPORT void SetGraphicValues(const double Radius, const double OffSet);
 
-  //! Dumps the content of me into the stream
+  //! Dumps the content of me into the stream.
+  //! @param[in,out] theOStream destination stream
+  //! @param[in]     theDepth   recursion depth (-1 for full)
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const override;
 
 protected:
+  //! Recomputes the structure transformation and the ring / spoke primitive arrays
+  //! whenever a parameter or the privileged plane changes. Emits a one-shot
+  //! Message::SendWarning() when an arc range is set on the base class — the CPU
+  //! renderer cannot honor it and falls back to a full circle.
   Standard_EXPORT void UpdateDisplay() override;
 
 private:
-  //! Broadcast current parameters to every view owned by the viewer.
-  //! When theDoDisplay is false, erases the shader grid from each view instead.
-  void syncViews(const bool theDoDisplay) const;
+  Standard_EXPORT void DefineLines();
+
+  Standard_EXPORT void DefinePoints();
 
 private:
-  V3d_ViewerPointer myViewer;
-  mutable bool      myIsDisplayed;
+  //! Custom Graphic3d_Structure implementation.
+  class CircularGridStructure;
+
+private:
+  occ::handle<Graphic3d_Structure> myStructure;
+  occ::handle<Graphic3d_Group>     myGroup;
+  gp_Ax3                           myCurViewPlane;
+  V3d_ViewerPointer                myViewer;
+  bool                             myCurAreDefined;
+  bool                             myToComputePrs;
+  Aspect_GridDrawMode              myCurDrawMode;
+  double                           myCurXo;
+  double                           myCurYo;
+  double                           myCurAngle;
+  double                           myCurStep;
+  int                              myCurDivi;
+  double                           myCurRadius;
+  double                           myCurOffSet;
+  mutable bool                     myArcWarned;
 };
 
 #endif // _V3d_CircularGrid_HeaderFile

--- a/src/Visualization/TKV3d/V3d/V3d_CircularGrid.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_CircularGrid.hxx
@@ -81,7 +81,7 @@ public:
 protected:
   //! Recomputes the structure transformation and the ring / spoke primitive arrays
   //! whenever a parameter or the privileged plane changes. Emits a one-shot
-  //! Message::SendWarning() when an arc range is set on the base class — the CPU
+  //! Message::SendWarning() when an arc range is set on the base class - the CPU
   //! renderer cannot honor it and falls back to a full circle.
   Standard_EXPORT void UpdateDisplay() override;
 

--- a/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.cxx
@@ -240,9 +240,8 @@ void V3d_RectangularGrid::DefineLines()
   const double aYSize   = SizeY();
   const double aOffSet  = ZOffset();
   const bool   toUpdate = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Lines
-                          || aXStep != myCurXStep || aYStep != myCurYStep
-                          || aXSize != myCurXSize || aYSize != myCurYSize
-                          || aOffSet != myCurOffSet;
+                        || aXStep != myCurXStep || aYStep != myCurYStep || aXSize != myCurXSize
+                        || aYSize != myCurYSize || aOffSet != myCurOffSet;
   if (!toUpdate && !myToComputePrs)
   {
     return;
@@ -335,9 +334,8 @@ void V3d_RectangularGrid::DefinePoints()
   const double aYSize   = SizeY();
   const double aOffSet  = ZOffset();
   const bool   toUpdate = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Points
-                          || aXStep != myCurXStep || aYStep != myCurYStep
-                          || aXSize != myCurXSize || aYSize != myCurYSize
-                          || aOffSet != myCurOffSet;
+                        || aXStep != myCurXStep || aYStep != myCurYStep || aXSize != myCurXSize
+                        || aYSize != myCurYSize || aOffSet != myCurOffSet;
   if (!toUpdate && !myToComputePrs)
   {
     return;

--- a/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.cxx
@@ -13,12 +13,15 @@
 
 #include <V3d_RectangularGrid.hxx>
 
-#include <Aspect_GridParams.hxx>
+#include <Graphic3d_ArrayOfPoints.hxx>
+#include <Graphic3d_ArrayOfSegments.hxx>
+#include <Graphic3d_AspectLine3d.hxx>
+#include <Graphic3d_AspectMarker3d.hxx>
+#include <Graphic3d_Group.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Quantity_Color.hxx>
 #include <Standard_Type.hxx>
-#include <V3d_View.hxx>
 #include <V3d_Viewer.hxx>
-#include <gp_Ax3.hxx>
 #include <gp_Pnt.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(V3d_RectangularGrid, Aspect_RectangularGrid)
@@ -29,6 +32,30 @@ constexpr double THE_DEFAULT_GRID_STEP = 10.0;
 constexpr double THE_MYFACTOR          = 50.0;
 } // namespace
 
+//! Dummy implementation of Graphic3d_Structure overriding ::Compute() method for handling Device
+//! Lost.
+class V3d_RectangularGrid::RectangularGridStructure : public Graphic3d_Structure
+{
+public:
+  RectangularGridStructure(const occ::handle<Graphic3d_StructureManager>& theManager,
+                           V3d_RectangularGrid*                           theGrid)
+      : Graphic3d_Structure(theManager),
+        myGrid(theGrid)
+  {
+  }
+
+  void Compute() override
+  {
+    GraphicClear(false);
+    myGrid->myGroup         = NewGroup();
+    myGrid->myCurAreDefined = false;
+    myGrid->UpdateDisplay();
+  }
+
+private:
+  V3d_RectangularGrid* myGrid;
+};
+
 //=================================================================================================
 
 V3d_RectangularGrid::V3d_RectangularGrid(const V3d_ViewerPointer& aViewer,
@@ -36,15 +63,32 @@ V3d_RectangularGrid::V3d_RectangularGrid(const V3d_ViewerPointer& aViewer,
                                          const Quantity_Color&    aTenthColor)
     : Aspect_RectangularGrid(1., 1.),
       myViewer(aViewer),
-      myIsDisplayed(false)
+      myCurAreDefined(false),
+      myToComputePrs(true),
+      myCurDrawMode(Aspect_GDM_Lines),
+      myCurXo(0.0),
+      myCurYo(0.0),
+      myCurAngle(0.0),
+      myCurXStep(0.0),
+      myCurYStep(0.0),
+      myCurXSize(0.0),
+      myCurYSize(0.0),
+      myCurOffSet(0.0)
 {
   myColor      = aColor;
   myTenthColor = aTenthColor;
 
+  myStructure = new RectangularGridStructure(aViewer->StructureManager(), this);
+  myGroup     = myStructure->NewGroup();
+  myStructure->SetInfiniteState(true);
+
   SetXStep(THE_DEFAULT_GRID_STEP);
   SetYStep(THE_DEFAULT_GRID_STEP);
-  // Keep rectangular grid unbounded by default; explicit -size / viewer API
-  // requests set non-zero SizeX/SizeY and activate clipping in the shader.
+  // Aspect_RectangularGrid default-constructs SizeX/SizeY to 0; restore the historical
+  // CPU bound of half the default view size so existing ActivateGrid() users still see
+  // a bounded grid without needing an explicit SetGraphicValues call.
+  Aspect_RectangularGrid::SetSizeX(0.5 * aViewer->DefaultViewSize());
+  Aspect_RectangularGrid::SetSizeY(0.5 * aViewer->DefaultViewSize());
   Aspect_RectangularGrid::SetZOffset(THE_DEFAULT_GRID_STEP / THE_MYFACTOR);
 }
 
@@ -52,9 +96,10 @@ V3d_RectangularGrid::V3d_RectangularGrid(const V3d_ViewerPointer& aViewer,
 
 V3d_RectangularGrid::~V3d_RectangularGrid()
 {
-  if (myIsDisplayed)
+  myGroup.Nullify();
+  if (!myStructure.IsNull())
   {
-    syncViews(false);
+    myStructure->Erase();
   }
 }
 
@@ -64,8 +109,9 @@ void V3d_RectangularGrid::SetColors(const Quantity_Color& aColor, const Quantity
 {
   if (myColor != aColor || myTenthColor != aTenthColor)
   {
-    myColor      = aColor;
-    myTenthColor = aTenthColor;
+    myColor         = aColor;
+    myTenthColor    = aTenthColor;
+    myCurAreDefined = false;
     UpdateDisplay();
   }
 }
@@ -74,33 +120,278 @@ void V3d_RectangularGrid::SetColors(const Quantity_Color& aColor, const Quantity
 
 void V3d_RectangularGrid::Display()
 {
-  myIsDisplayed = true;
-  syncViews(true);
+  myStructure->SetDisplayPriority(Graphic3d_DisplayPriority_AlmostBottom);
+  myStructure->Display();
+  UpdateDisplay();
 }
 
 //=================================================================================================
 
 void V3d_RectangularGrid::Erase() const
 {
-  myIsDisplayed = false;
-  syncViews(false);
+  myStructure->Erase();
 }
 
 //=================================================================================================
 
 bool V3d_RectangularGrid::IsDisplayed() const
 {
-  return myIsDisplayed;
+  return myStructure->IsDisplayed();
 }
 
 //=================================================================================================
 
 void V3d_RectangularGrid::UpdateDisplay()
 {
-  if (myIsDisplayed)
+  const gp_Ax3 aPlane = myViewer->PrivilegedPlane();
+
+  bool   MakeTransform = false;
+  double xl, yl, zl;
+  double xdx, xdy, xdz;
+  double ydx, ydy, ydz;
+  double dx, dy, dz;
+  aPlane.Location().Coord(xl, yl, zl);
+  aPlane.XDirection().Coord(xdx, xdy, xdz);
+  aPlane.YDirection().Coord(ydx, ydy, ydz);
+  aPlane.Direction().Coord(dx, dy, dz);
+  if (!myCurAreDefined)
   {
-    syncViews(true);
+    MakeTransform = true;
   }
+  else
+  {
+    if (RotationAngle() != myCurAngle || XOrigin() != myCurXo || YOrigin() != myCurYo)
+    {
+      MakeTransform = true;
+    }
+    if (!MakeTransform)
+    {
+      double curxl, curyl, curzl;
+      double curxdx, curxdy, curxdz;
+      double curydx, curydy, curydz;
+      double curdx, curdy, curdz;
+      myCurViewPlane.Location().Coord(curxl, curyl, curzl);
+      myCurViewPlane.XDirection().Coord(curxdx, curxdy, curxdz);
+      myCurViewPlane.YDirection().Coord(curydx, curydy, curydz);
+      myCurViewPlane.Direction().Coord(curdx, curdy, curdz);
+      if (xl != curxl || yl != curyl || zl != curzl || xdx != curxdx || xdy != curxdy
+          || xdz != curxdz || ydx != curydx || ydy != curydy || ydz != curydz || dx != curdx
+          || dy != curdy || dz != curdz)
+      {
+        MakeTransform = true;
+      }
+    }
+  }
+
+  if (MakeTransform)
+  {
+    const double CosAlpha = std::cos(RotationAngle());
+    const double SinAlpha = std::sin(RotationAngle());
+
+    gp_Trsf aTrsf;
+    aTrsf.SetValues(xdx, ydx, dx, xl, xdy, ydy, dy, yl, xdz, ydz, dz, zl);
+
+    gp_Trsf aTrsf2;
+    aTrsf2.SetValues(CosAlpha,
+                     SinAlpha,
+                     0.0,
+                     -XOrigin(),
+                     -SinAlpha,
+                     CosAlpha,
+                     0.0,
+                     -YOrigin(),
+                     0.0,
+                     0.0,
+                     1.0,
+                     0.0);
+    aTrsf.Multiply(aTrsf2);
+    myStructure->SetTransformation(new TopLoc_Datum3D(aTrsf));
+
+    myCurAngle     = RotationAngle();
+    myCurXo        = XOrigin();
+    myCurYo        = YOrigin();
+    myCurViewPlane = aPlane;
+  }
+
+  switch (myDrawMode)
+  {
+    case Aspect_GDM_Points:
+      DefinePoints();
+      myCurDrawMode = Aspect_GDM_Points;
+      break;
+    case Aspect_GDM_Lines:
+      DefineLines();
+      myCurDrawMode = Aspect_GDM_Lines;
+      break;
+    case Aspect_GDM_None:
+      myCurDrawMode = Aspect_GDM_None;
+      break;
+  }
+  myCurAreDefined = true;
+}
+
+//=================================================================================================
+
+void V3d_RectangularGrid::DefineLines()
+{
+  const double aXStep   = XStep();
+  const double aYStep   = YStep();
+  const double aXSize   = SizeX();
+  const double aYSize   = SizeY();
+  const double aOffSet  = ZOffset();
+  const bool   toUpdate = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Lines
+                          || aXStep != myCurXStep || aYStep != myCurYStep
+                          || aXSize != myCurXSize || aYSize != myCurYSize
+                          || aOffSet != myCurOffSet;
+  if (!toUpdate && !myToComputePrs)
+  {
+    return;
+  }
+  else if (!myStructure->IsDisplayed())
+  {
+    myToComputePrs = true;
+    return;
+  }
+
+  myToComputePrs = false;
+  myGroup->Clear();
+
+  int          nblines;
+  double       xl, yl;
+  const double zl    = aOffSet;
+  const size_t aNbXc = aXStep > 0.0 ? static_cast<size_t>(aXSize / aXStep) + 1 : 1;
+  const size_t aNbYc = aYStep > 0.0 ? static_cast<size_t>(aYSize / aYStep) + 1 : 1;
+  const size_t aResv = 4 * (aNbXc + aNbYc) + 4;
+
+  NCollection_LinearVector<gp_Pnt> aSeqLines(aResv), aSeqTenth(aResv);
+
+  aSeqTenth.EmplaceAppend(0., -aYSize, -zl);
+  aSeqTenth.EmplaceAppend(0., aYSize, -zl);
+  for (nblines = 1, xl = aXStep; xl < aXSize; xl += aXStep, nblines++)
+  {
+    NCollection_LinearVector<gp_Pnt>& aSeq = (Modulus(nblines, 10) != 0) ? aSeqLines : aSeqTenth;
+    aSeq.EmplaceAppend(xl, -aYSize, -zl);
+    aSeq.EmplaceAppend(xl, aYSize, -zl);
+    aSeq.EmplaceAppend(-xl, -aYSize, -zl);
+    aSeq.EmplaceAppend(-xl, aYSize, -zl);
+  }
+
+  aSeqTenth.EmplaceAppend(-aXSize, 0., -zl);
+  aSeqTenth.EmplaceAppend(aXSize, 0., -zl);
+  for (nblines = 1, yl = aYStep; yl < aYSize; yl += aYStep, nblines++)
+  {
+    NCollection_LinearVector<gp_Pnt>& aSeq = (Modulus(nblines, 10) != 0) ? aSeqLines : aSeqTenth;
+    aSeq.EmplaceAppend(-aXSize, yl, -zl);
+    aSeq.EmplaceAppend(aXSize, yl, -zl);
+    aSeq.EmplaceAppend(-aXSize, -yl, -zl);
+    aSeq.EmplaceAppend(aXSize, -yl, -zl);
+  }
+
+  if (!aSeqLines.IsEmpty())
+  {
+    occ::handle<Graphic3d_AspectLine3d> aLineAspect =
+      new Graphic3d_AspectLine3d(myColor, Aspect_TOL_SOLID, 1.0);
+    myGroup->SetPrimitivesAspect(aLineAspect);
+    const int                              nbv    = static_cast<int>(aSeqLines.Size());
+    occ::handle<Graphic3d_ArrayOfSegments> aPrims = new Graphic3d_ArrayOfSegments(nbv);
+    for (const gp_Pnt& aPnt : aSeqLines)
+    {
+      aPrims->AddVertex(aPnt);
+    }
+    myGroup->AddPrimitiveArray(aPrims, false);
+  }
+  if (!aSeqTenth.IsEmpty())
+  {
+    occ::handle<Graphic3d_AspectLine3d> aLineAspect =
+      new Graphic3d_AspectLine3d(myTenthColor, Aspect_TOL_SOLID, 1.0);
+    myGroup->SetPrimitivesAspect(aLineAspect);
+    const int                              nbv    = static_cast<int>(aSeqTenth.Size());
+    occ::handle<Graphic3d_ArrayOfSegments> aPrims = new Graphic3d_ArrayOfSegments(nbv);
+    for (const gp_Pnt& aPnt : aSeqTenth)
+    {
+      aPrims->AddVertex(aPnt);
+    }
+    myGroup->AddPrimitiveArray(aPrims, false);
+  }
+
+  myGroup->SetMinMaxValues(-aXSize, -aYSize, -aOffSet, aXSize, aYSize, -aOffSet);
+  myCurXStep  = aXStep;
+  myCurYStep  = aYStep;
+  myCurXSize  = aXSize;
+  myCurYSize  = aYSize;
+  myCurOffSet = aOffSet;
+
+  myStructure->CalculateBoundBox();
+  myViewer->StructureManager()->Update(myStructure->GetZLayer());
+}
+
+//=================================================================================================
+
+void V3d_RectangularGrid::DefinePoints()
+{
+  const double aXStep   = XStep();
+  const double aYStep   = YStep();
+  const double aXSize   = SizeX();
+  const double aYSize   = SizeY();
+  const double aOffSet  = ZOffset();
+  const bool   toUpdate = !myCurAreDefined || myCurDrawMode != Aspect_GDM_Points
+                          || aXStep != myCurXStep || aYStep != myCurYStep
+                          || aXSize != myCurXSize || aYSize != myCurYSize
+                          || aOffSet != myCurOffSet;
+  if (!toUpdate && !myToComputePrs)
+  {
+    return;
+  }
+  else if (!myStructure->IsDisplayed())
+  {
+    myToComputePrs = true;
+    return;
+  }
+
+  myToComputePrs = false;
+  myGroup->Clear();
+
+  double       xl, yl;
+  const size_t aNbXc = aXStep > 0.0 ? static_cast<size_t>(aXSize / aXStep) + 1 : 1;
+  const size_t aNbYc = aYStep > 0.0 ? static_cast<size_t>(aYSize / aYStep) + 1 : 1;
+
+  NCollection_LinearVector<gp_Pnt> aSeqPnts((2 * aNbXc + 1) * (2 * aNbYc + 1));
+  for (xl = 0.0; xl <= aXSize; xl += aXStep)
+  {
+    aSeqPnts.EmplaceAppend(xl, 0.0, -aOffSet);
+    aSeqPnts.EmplaceAppend(-xl, 0.0, -aOffSet);
+    for (yl = aYStep; yl <= aYSize; yl += aYStep)
+    {
+      aSeqPnts.EmplaceAppend(xl, yl, -aOffSet);
+      aSeqPnts.EmplaceAppend(xl, -yl, -aOffSet);
+      aSeqPnts.EmplaceAppend(-xl, yl, -aOffSet);
+      aSeqPnts.EmplaceAppend(-xl, -yl, -aOffSet);
+    }
+  }
+  if (!aSeqPnts.IsEmpty())
+  {
+    const int                            nbv      = static_cast<int>(aSeqPnts.Size());
+    occ::handle<Graphic3d_ArrayOfPoints> Vertical = new Graphic3d_ArrayOfPoints(nbv);
+    for (const gp_Pnt& aPnt : aSeqPnts)
+    {
+      Vertical->AddVertex(aPnt);
+    }
+
+    occ::handle<Graphic3d_AspectMarker3d> aMarkerAspect =
+      new Graphic3d_AspectMarker3d(Aspect_TOM_POINT, myColor, 3.0);
+    myGroup->SetGroupPrimitivesAspect(aMarkerAspect);
+    myGroup->AddPrimitiveArray(Vertical, false);
+  }
+
+  myGroup->SetMinMaxValues(-aXSize, -aYSize, -aOffSet, aXSize, aYSize, -aOffSet);
+  myCurXStep  = aXStep;
+  myCurYStep  = aYStep;
+  myCurXSize  = aXSize;
+  myCurYSize  = aYSize;
+  myCurOffSet = aOffSet;
+
+  myStructure->CalculateBoundBox();
+  myViewer->StructureManager()->Update(myStructure->GetZLayer());
 }
 
 //=================================================================================================
@@ -118,69 +409,10 @@ void V3d_RectangularGrid::SetGraphicValues(const double theXSize,
                                            const double theYSize,
                                            const double theOffSet)
 {
-  // The Aspect_RectangularGrid setters each trigger UpdateDisplay() only when the
-  // value actually changes, so the final UpdateDisplay fires at most once.
+  // Aspect_RectangularGrid setters trigger UpdateDisplay() on real change only.
   SetSizeX(theXSize);
   SetSizeY(theYSize);
   SetZOffset(theOffSet);
-}
-
-//=================================================================================================
-
-void V3d_RectangularGrid::syncViews(const bool theDoDisplay) const
-{
-  if (myViewer == nullptr)
-  {
-    return;
-  }
-
-  // XStep/YStep carry world-unit spacing; the shader consumes cells-per-unit (1/step).
-  // Guard zero/negative step that could come from Aspect_RectangularGrid defaults.
-  const double aXStep = XStep() > 0.0 ? XStep() : THE_DEFAULT_GRID_STEP;
-  const double aYStep = YStep() > 0.0 ? YStep() : THE_DEFAULT_GRID_STEP;
-
-  const gp_Ax3 aPlane = myViewer->PrivilegedPlane();
-
-  // Pass the grid origin as a world-space offset from the plane origin, so the
-  // shader's aPlaneOrigin = planeLoc + Origin matches V3d_View::Compute's
-  // aPnt0 = planeLoc - XOrigin * planeX - YOrigin * planeY. Any other
-  // convention leaves selection snapping to a world point that doesn't line up
-  // with the drawn grid for tilted privileged planes.
-  const gp_XYZ aOriginOffset =
-    aPlane.XDirection().XYZ() * -XOrigin() + aPlane.YDirection().XYZ() * -YOrigin();
-
-  Aspect_GridParams aParams;
-  aParams.SetColor(myColor);
-  aParams.SetAccentColor(myTenthColor);
-  aParams.SetOrigin(gp_Pnt(aOriginOffset));
-  aParams.SetScale(1.0 / aXStep);
-  aParams.SetScaleY(1.0 / aYStep);
-  aParams.SetAccentScaleX(0.1 / aXStep);
-  aParams.SetAccentScaleY(0.1 / aYStep);
-  aParams.SetRotationAngle(RotationAngle());
-  aParams.SetDrawMode(DrawMode());
-  aParams.SetSizeX(SizeX());
-  aParams.SetSizeY(SizeY());
-  aParams.SetZOffset(ZOffset());
-  aParams.SetIsBackground(false);
-  aParams.SetIsDrawAxis(false);
-  aParams.SetIsInfinity(false);
-
-  for (const occ::handle<V3d_View>& aView : myViewer->DefinedViews())
-  {
-    if (aView.IsNull())
-    {
-      continue;
-    }
-    if (theDoDisplay)
-    {
-      aView->GridDisplay(aParams, aPlane);
-    }
-    else
-    {
-      aView->GridErase();
-    }
-  }
 }
 
 //=================================================================================================
@@ -190,6 +422,20 @@ void V3d_RectangularGrid::DumpJson(Standard_OStream& theOStream, int theDepth) c
   OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)
   OCCT_DUMP_BASE_CLASS(theOStream, theDepth, Aspect_RectangularGrid)
 
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, myStructure.get())
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, myGroup.get())
+  OCCT_DUMP_FIELD_VALUES_DUMPED(theOStream, theDepth, &myCurViewPlane)
   OCCT_DUMP_FIELD_VALUE_POINTER(theOStream, myViewer)
-  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myIsDisplayed)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurAreDefined)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToComputePrs)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurDrawMode)
+
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurXo)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurYo)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurAngle)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurXStep)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurYStep)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurXSize)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurYSize)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myCurOffSet)
 }

--- a/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.cxx
@@ -368,17 +368,17 @@ void V3d_RectangularGrid::DefinePoints()
   }
   if (!aSeqPnts.IsEmpty())
   {
-    const int                            nbv      = static_cast<int>(aSeqPnts.Size());
-    occ::handle<Graphic3d_ArrayOfPoints> Vertical = new Graphic3d_ArrayOfPoints(nbv);
+    const int                            nbv     = static_cast<int>(aSeqPnts.Size());
+    occ::handle<Graphic3d_ArrayOfPoints> aPoints = new Graphic3d_ArrayOfPoints(nbv);
     for (const gp_Pnt& aPnt : aSeqPnts)
     {
-      Vertical->AddVertex(aPnt);
+      aPoints->AddVertex(aPnt);
     }
 
     occ::handle<Graphic3d_AspectMarker3d> aMarkerAspect =
       new Graphic3d_AspectMarker3d(Aspect_TOM_POINT, myColor, 3.0);
     myGroup->SetGroupPrimitivesAspect(aMarkerAspect);
-    myGroup->AddPrimitiveArray(Vertical, false);
+    myGroup->AddPrimitiveArray(aPoints, false);
   }
 
   myGroup->SetMinMaxValues(-aXSize, -aYSize, -aOffSet, aXSize, aYSize, -aOffSet);

--- a/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_RectangularGrid.hxx
@@ -21,49 +21,98 @@
 
 #include <Aspect_RectangularGrid.hxx>
 #include <V3d_ViewerPointer.hxx>
+#include <gp_Ax3.hxx>
+class Graphic3d_Structure;
+class Graphic3d_Group;
 
-//! Rectangular grid bound to a V3d_Viewer. Snap math (Compute/Hit) is inherited
-//! from Aspect_RectangularGrid; rendering goes through the shader-based infinite
-//! grid (OpenGl_View::renderGrid) instead of CPU-generated line segments.
+//! @deprecated Kept for backward compatibility. CPU-generated grid bound to a V3d_Viewer.
+//! New code should drive grids through V3d_View::GridDisplay(Aspect_GridParams, gp_Ax3),
+//! which renders an infinite, AA, shader-based grid and supports background mode, arc
+//! ranges and per-axis scales. This class consumes the same Aspect_RectangularGrid
+//! parameters where the CPU path can render them; unsupported parameters are reported
+//! via Message::SendWarning() and ignored.
 class V3d_RectangularGrid : public Aspect_RectangularGrid
 {
   DEFINE_STANDARD_RTTIEXT(V3d_RectangularGrid, Aspect_RectangularGrid)
 public:
+  //! Constructor. Builds a CPU-rendered rectangular grid bound to @p aViewer.
+  //! Default size is 0.5 * Viewer->DefaultViewSize() on each axis (bounded);
+  //! ZOffset defaults to step / 50.
+  //! @deprecated Prefer V3d_View::GridDisplay with Aspect_GridParams for shader-based
+  //!             infinite grids.
+  //! @param[in] aViewer     viewer that owns the grid (and provides DefaultViewSize)
+  //! @param[in] aColor      color of the regular grid lines / points
+  //! @param[in] aTenthColor color of every 10-th line (axis emphasis)
   Standard_EXPORT V3d_RectangularGrid(const V3d_ViewerPointer& aViewer,
                                       const Quantity_Color&    aColor,
                                       const Quantity_Color&    aTenthColor);
 
   Standard_EXPORT ~V3d_RectangularGrid() override;
 
+  //! Updates the grid colors and triggers a re-display when they actually change.
+  //! @param[in] aColor      color of the regular lines / points
+  //! @param[in] aTenthColor color of every 10-th line
   Standard_EXPORT void SetColors(const Quantity_Color& aColor,
                                  const Quantity_Color& aTenthColor) override;
 
+  //! Display the CPU grid in the owning viewer's structure manager.
   Standard_EXPORT void Display() override;
 
+  //! Erase the CPU grid (the underlying Graphic3d_Structure is hidden, not destroyed).
   Standard_EXPORT void Erase() const override;
 
+  //! Returns true if the grid structure is currently displayed.
   Standard_EXPORT bool IsDisplayed() const override;
 
+  //! Returns the grid bounds and Z offset (alias for SizeX/SizeY/ZOffset).
+  //! @param[out] XSize  width  along grid X
+  //! @param[out] YSize  height along grid Y
+  //! @param[out] OffSet plane-normal displacement of the rendered grid
   Standard_EXPORT void GraphicValues(double& XSize, double& YSize, double& OffSet) const;
 
+  //! Sets the grid bounds and Z offset (alias for SetSizeX/SetSizeY/SetZOffset).
+  //! @param[in] XSize  width  along grid X
+  //! @param[in] YSize  height along grid Y
+  //! @param[in] OffSet plane-normal displacement
   Standard_EXPORT void SetGraphicValues(const double XSize,
                                         const double YSize,
                                         const double OffSet);
 
-  //! Dumps the content of me into the stream
+  //! Dumps the content of me into the stream.
+  //! @param[in,out] theOStream destination stream
+  //! @param[in]     theDepth   recursion depth (-1 for full)
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const override;
 
 protected:
+  //! Recomputes the structure transformation and the line / point primitive arrays
+  //! whenever a parameter or the privileged plane changes.
   Standard_EXPORT void UpdateDisplay() override;
 
 private:
-  //! Broadcast current parameters to every view owned by the viewer.
-  //! When theDoDisplay is false, erases the shader grid from each view instead.
-  void syncViews(const bool theDoDisplay) const;
+  Standard_EXPORT void DefineLines();
+
+  Standard_EXPORT void DefinePoints();
 
 private:
-  V3d_ViewerPointer myViewer;
-  mutable bool      myIsDisplayed;
+  //! Custom Graphic3d_Structure implementation.
+  class RectangularGridStructure;
+
+private:
+  occ::handle<Graphic3d_Structure> myStructure;
+  occ::handle<Graphic3d_Group>     myGroup;
+  gp_Ax3                           myCurViewPlane;
+  V3d_ViewerPointer                myViewer;
+  bool                             myCurAreDefined;
+  bool                             myToComputePrs;
+  Aspect_GridDrawMode              myCurDrawMode;
+  double                           myCurXo;
+  double                           myCurYo;
+  double                           myCurAngle;
+  double                           myCurXStep;
+  double                           myCurYStep;
+  double                           myCurXSize;
+  double                           myCurYSize;
+  double                           myCurOffSet;
 };
 
 #endif // _V3d_RectangularGrid_HeaderFile

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -256,6 +256,11 @@ void V3d_View::Remove()
   {
     MyGrid->Erase();
   }
+  if (myShaderGridActive)
+  {
+    myView->GridErase();
+    myShaderGridActive = false;
+  }
   if (!myTrihedron.IsNull())
   {
     myTrihedron->Erase();
@@ -3453,6 +3458,12 @@ void V3d_View::Translate(const double theLength, const bool theStart)
 
 void V3d_View::SetGrid(const gp_Ax3& aPlane, const occ::handle<Aspect_Grid>& aGrid)
 {
+  if (myShaderGridActive)
+  {
+    myView->GridErase();
+    myShaderGridActive = false;
+  }
+
   MyPlane = aPlane;
   MyGrid  = aGrid;
 
@@ -3533,6 +3544,15 @@ void V3d_View::GridDisplay(const Aspect_GridParams& theParams)
 
 void V3d_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
 {
+  // Mutual exclusion: the CPU grid renders into a viewer-wide Graphic3d_Structure
+  // (visible in every active view), so enabling the per-view shader grid hides the
+  // CPU rendering at the viewer level. Snap geometry (Aspect_*Grid) is left alive
+  // and only the structure is erased; SetGrid / ActivateGrid restores it.
+  if (!MyGrid.IsNull() && MyGrid->IsDisplayed())
+  {
+    MyGrid->Erase();
+  }
+  myShaderGridActive = true;
   myView->GridDisplay(theParams, thePlane);
 }
 
@@ -3541,6 +3561,7 @@ void V3d_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& the
 void V3d_View::GridErase()
 {
   myView->GridErase();
+  myShaderGridActive = false;
 }
 
 //=================================================================================================

--- a/src/Visualization/TKV3d/V3d/V3d_View.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.hxx
@@ -924,8 +924,9 @@ public: //! @name CPU grid plumbing (deprecated, fed by V3d_Viewer::ActivateGrid
 
 public: //! @name GPU shader grid (recommended)
   //! Per-view immediate-mode shader; supports infinite, AA, background, arc range.
-  //! GridDisplay erases the viewer-wide CPU grid rendering (snap geometry is
-  //! preserved). GridErase or SetGrid restores the CPU grid via V3d_Viewer.
+  //! GridDisplay erases the viewer-wide CPU grid rendering on entry (snap geometry
+  //! on Aspect_*Grid is preserved). GridErase only tears down the shader grid on
+  //! this view; restoring the CPU rendering needs V3d_Viewer::ActivateGrid.
 
   //! Display a shader-rendered grid on the viewer's privileged plane.
   //! @param[in] theParams appearance: color, scale, bounds, arc, draw-mode, background / inf flags

--- a/src/Visualization/TKV3d/V3d/V3d_View.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.hxx
@@ -907,28 +907,37 @@ public:
                                  const double                         theResolution = 0.0,
                                  const bool theToEnlargeIfLine                      = true) const;
 
-  //! Defines or Updates the definition of the
-  //! grid in <me>
+public: //! @name CPU grid plumbing (deprecated, fed by V3d_Viewer::ActivateGrid)
+  //! Snap + CPU rendering. The CPU grid lives on the viewer's structure manager
+  //! and is visible in every active view; SetGrid on a view that has the shader
+  //! grid enabled erases the shader grid on this view, the CPU grid is left
+  //! intact (or re-displayed by V3d_Viewer::ActivateGrid).
+
+  //! Defines or updates the grid plane and snap object on this view.
+  //! @param[in] aPlane grid plane (origin + axes)
+  //! @param[in] aGrid  snap object (Aspect_RectangularGrid or Aspect_CircularGrid)
   Standard_EXPORT void SetGrid(const gp_Ax3& aPlane, const occ::handle<Aspect_Grid>& aGrid);
 
-  //! Defines or Updates the activity of the
-  //! grid in <me>
+  //! Activates / deactivates snap on this view.
+  //! @param[in] aFlag true to enable snap, false to disable
   Standard_EXPORT void SetGridActivity(const bool aFlag);
 
+public: //! @name GPU shader grid (recommended)
+  //! Per-view immediate-mode shader; supports infinite, AA, background, arc range.
+  //! GridDisplay erases the viewer-wide CPU grid rendering (snap geometry is
+  //! preserved). GridErase or SetGrid restores the CPU grid via V3d_Viewer.
+
   //! Display a shader-rendered grid on the viewer's privileged plane.
-  //! @param[in] theParams render-only appearance (color, scale, bounds, arc,
-  //!            draw-mode, background/inf flags); snap geometry still comes
-  //!            from the classical Aspect_*Grid on the viewer.
+  //! @param[in] theParams appearance: color, scale, bounds, arc, draw-mode, background / inf flags
   Standard_EXPORT void GridDisplay(const Aspect_GridParams& theParams);
 
-  //! Display a shader-rendered grid on an explicit plane (overrides the
-  //! viewer's privileged plane for this view only).
-  //! @param[in] theParams appearance parameters; see the single-argument overload.
-  //! @param[in] thePlane  world-space grid plane (origin + axes).
+  //! Display a shader-rendered grid on an explicit plane (overrides the viewer's
+  //! privileged plane for this view only).
+  //! @param[in] theParams appearance parameters; see the single-argument overload
+  //! @param[in] thePlane  world-space grid plane (origin + axes)
   Standard_EXPORT void GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane);
 
-  //! Erase the shader-rendered grid from this view. Does not touch the
-  //! viewer's classical grid activation used by snap.
+  //! Erase the shader-rendered grid from this view.
   Standard_EXPORT void GridErase();
 
   //! Dumps the full contents of the View into the image file. This is an alias for ToPixMap() with
@@ -1202,6 +1211,7 @@ private:
   occ::handle<Aspect_Grid>                                  MyGrid;
   gp_Ax3                                                    MyPlane;
   NCollection_Array2<double>                                MyTrsf;
+  bool                                                      myShaderGridActive = false;
   occ::handle<Graphic3d_Structure>                          MyGridEchoStructure;
   occ::handle<Graphic3d_Group>                              MyGridEchoGroup;
   gp_Vec                                                    myXscreenAxis;

--- a/src/Visualization/TKV3d/V3d/V3d_Viewer.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_Viewer.hxx
@@ -350,108 +350,134 @@ public: //! @name privileged plane management
 
   Standard_EXPORT void DisplayPrivilegedPlane(const bool theOnOff, const double theSize = 1);
 
-public: //! @name grid management
-  //! Activates the grid in all views of <me>.
+public: //! @name grid management (CPU rendering, deprecated)
+  //! GPU shader grid lives on V3d_View::GridDisplay (mutually exclusive with this path).
+  //! Arc range on circular grids is unsupported here: warning + ignored.
+
+  //! Activates the grid in all views of <me>. Lazily creates the V3d_RectangularGrid
+  //! / V3d_CircularGrid on first use and displays it.
+  //! @param[in] aGridType     rectangular or circular
+  //! @param[in] aGridDrawMode lines, points or none
   Standard_EXPORT void ActivateGrid(const Aspect_GridType     aGridType,
                                     const Aspect_GridDrawMode aGridDrawMode);
 
   //! Deactivates the grid in all views of <me>.
   Standard_EXPORT void DeactivateGrid();
 
-  //! Show/Don't show grid echo to the hit point.
-  //! If TRUE,the grid echo will be shown at ConvertToGrid() time.
-  Standard_EXPORT void SetGridEcho(const bool showGrid = true);
-
-  //! Show grid echo <aMarker> to the hit point.
-  //! Warning: When the grid echo marker is not set,
-  //! a default marker is build with the attributes:
-  //! marker type : Aspect_TOM_STAR
-  //! marker color : Quantity_NOC_GRAY90
-  //! marker size : 3.0
-  Standard_EXPORT void SetGridEcho(const occ::handle<Graphic3d_AspectMarker3d>& aMarker);
-
-  //! Returns TRUE when grid echo must be displayed at hit point.
-  bool GridEcho() const { return myGridEcho; }
-
-  //! Returns true if a grid is activated in <me>.
+  //! Returns true if a grid is currently active in <me>.
   Standard_EXPORT bool IsGridActive();
 
-  //! Returns the defined grid in <me>.
+  //! Returns the currently selected grid (rectangular / circular per GridType()).
+  //! @param[in] theToCreate when false, returns null instead of allocating
   occ::handle<Aspect_Grid> Grid(bool theToCreate = true) { return Grid(myGridType, theToCreate); }
 
-  //! Returns the defined grid in <me>.
+  //! Returns the grid of the requested type.
+  //! @param[in] theGridType rectangular or circular
+  //! @param[in] theToCreate when false, returns null instead of allocating
   Standard_EXPORT occ::handle<Aspect_Grid> Grid(Aspect_GridType theGridType,
                                                 bool            theToCreate = true);
 
-  //! Returns the current grid type defined in <me>.
+  //! Returns the currently selected grid type (rectangular / circular).
   Aspect_GridType GridType() const { return myGridType; }
 
-  //! Returns the current grid draw mode defined in <me>.
+  //! Returns the draw mode (lines / points / none) of the active grid.
   Standard_EXPORT Aspect_GridDrawMode GridDrawMode();
 
-  //! Returns the definition of the rectangular grid.
+  //! Returns the rectangular grid definition.
+  //! @param[out] theXOrigin       grid origin X (snap reference)
+  //! @param[out] theYOrigin       grid origin Y
+  //! @param[out] theXStep         interval between two vertical lines
+  //! @param[out] theYStep         interval between two horizontal lines
+  //! @param[out] theRotationAngle in-plane rotation angle, radians
   Standard_EXPORT void RectangularGridValues(double& theXOrigin,
                                              double& theYOrigin,
                                              double& theXStep,
                                              double& theYStep,
                                              double& theRotationAngle);
 
-  //! Sets the definition of the rectangular grid.
-  //! <XOrigin>, <YOrigin> defines the origin of the grid.
-  //! <XStep> defines the interval between 2 vertical lines.
-  //! <YStep> defines the interval between 2 horizontal lines.
-  //! <RotationAngle> defines the rotation angle of the grid.
+  //! Sets the rectangular grid definition.
+  //! @param[in] XOrigin       grid origin X
+  //! @param[in] YOrigin       grid origin Y
+  //! @param[in] XStep         interval between two vertical lines
+  //! @param[in] YStep         interval between two horizontal lines
+  //! @param[in] RotationAngle in-plane rotation angle, radians
   Standard_EXPORT void SetRectangularGridValues(const double XOrigin,
                                                 const double YOrigin,
                                                 const double XStep,
                                                 const double YStep,
                                                 const double RotationAngle);
 
-  //! Returns the definition of the circular grid.
+  //! Returns the rectangular grid extent.
+  //! @param[out] theXSize  width  along grid X
+  //! @param[out] theYSize  height along grid Y
+  //! @param[out] theOffSet plane-normal displacement of the rendered grid
+  Standard_EXPORT void RectangularGridGraphicValues(double& theXSize,
+                                                    double& theYSize,
+                                                    double& theOffSet);
+
+  //! Sets the rectangular grid extent.
+  //! @param[in] XSize  width  along grid X
+  //! @param[in] YSize  height along grid Y
+  //! @param[in] OffSet plane-normal displacement
+  Standard_EXPORT void SetRectangularGridGraphicValues(const double XSize,
+                                                       const double YSize,
+                                                       const double OffSet);
+
+  //! Returns the circular grid definition.
+  //! @param[out] theXOrigin        grid origin X (snap reference)
+  //! @param[out] theYOrigin        grid origin Y
+  //! @param[out] theRadiusStep     radial interval between two concentric circles
+  //! @param[out] theDivisionNumber number of sectors per half-circle
+  //! @param[out] theRotationAngle  in-plane rotation angle, radians
   Standard_EXPORT void CircularGridValues(double& theXOrigin,
                                           double& theYOrigin,
                                           double& theRadiusStep,
                                           int&    theDivisionNumber,
                                           double& theRotationAngle);
 
-  //! Sets the definition of the circular grid.
-  //! <XOrigin>, <YOrigin> defines the origin of the grid.
-  //! <RadiusStep> defines the interval between 2 circles.
-  //! <DivisionNumber> defines the section number of one half circle.
-  //! <RotationAngle> defines the rotation angle of the grid.
+  //! Sets the circular grid definition.
+  //! @param[in] XOrigin        grid origin X
+  //! @param[in] YOrigin        grid origin Y
+  //! @param[in] RadiusStep     radial interval between two concentric circles
+  //! @param[in] DivisionNumber number of sectors per half-circle (>= 1)
+  //! @param[in] RotationAngle  in-plane rotation angle, radians
   Standard_EXPORT void SetCircularGridValues(const double XOrigin,
                                              const double YOrigin,
                                              const double RadiusStep,
                                              const int    DivisionNumber,
                                              const double RotationAngle);
 
-  //! Returns the location and the size of the grid.
+  //! Returns the circular grid extent.
+  //! @param[out] theRadius outermost ring radius
+  //! @param[out] theOffSet plane-normal displacement of the rendered grid
   Standard_EXPORT void CircularGridGraphicValues(double& theRadius, double& theOffSet);
 
-  //! Sets the location and the size of the grid.
-  //! <XSize> defines the width of the grid.
-  //! <YSize> defines the height of the grid.
-  //! <OffSet> defines the displacement along the plane normal.
+  //! Sets the circular grid extent.
+  //! @param[in] Radius outermost ring radius
+  //! @param[in] OffSet plane-normal displacement
   Standard_EXPORT void SetCircularGridGraphicValues(const double Radius, const double OffSet);
 
-  //! Returns the location and the size of the grid.
-  Standard_EXPORT void RectangularGridGraphicValues(double& theXSize,
-                                                    double& theYSize,
-                                                    double& theOffSet);
+  //! Toggle the snap-hit echo marker drawn by ConvertToGrid() at the snapped point.
+  //! @param[in] showGrid when TRUE, the marker is shown on every snap hit
+  Standard_EXPORT void SetGridEcho(const bool showGrid = true);
 
-  //! Sets the location and the size of the grid.
-  //! <XSize> defines the width of the grid.
-  //! <YSize> defines the height of the grid.
-  //! <OffSet> defines the displacement along the plane normal.
-  Standard_EXPORT void SetRectangularGridGraphicValues(const double XSize,
-                                                       const double YSize,
-                                                       const double OffSet);
+  //! Replaces the default echo marker.
+  //! Default attributes when this overload is not called:
+  //! Aspect_TOM_STAR, Quantity_NOC_GRAY90, size 3.0.
+  //! @param[in] aMarker custom marker aspect to use for echo display
+  Standard_EXPORT void SetGridEcho(const occ::handle<Graphic3d_AspectMarker3d>& aMarker);
 
-  //! Display grid echo at requested point in the view.
+  //! Returns TRUE when the snap-hit echo marker is enabled.
+  bool GridEcho() const { return myGridEcho; }
+
+  //! Displays the echo marker in a single view.
+  //! @param[in] theView view in which to draw the echo
+  //! @param[in] thePoint world-space snapped point
   Standard_EXPORT void ShowGridEcho(const occ::handle<V3d_View>& theView,
                                     const Graphic3d_Vertex&      thePoint);
 
-  //! Temporarily hide grid echo.
+  //! Temporarily hides the echo marker in a single view (e.g. while not snapping).
+  //! @param[in] theView view in which to hide the echo
   Standard_EXPORT void HideGridEcho(const occ::handle<V3d_View>& theView);
 
 public: //! @name deprecated methods

--- a/tests/v3d/grid/circ_cpu
+++ b/tests/v3d/grid/circ_cpu
@@ -1,0 +1,35 @@
+puts "=================================================================="
+puts "Restored CPU circular grid path: V3d_CircularGrid + ActivateGrid"
+puts "=================================================================="
+# Exercises the legacy CPU circular grid (rings + spokes drawn into a
+# Graphic3d_Structure). The shader path with arc support is covered by
+# circ_shader and bounded_circ.
+
+pload MODELING VISUALIZATION
+
+vclear
+vinit View1
+vaxo
+
+box b 1 2 3
+vdisplay b -dispMode 1
+vfit
+vzoom 0.2
+
+# 8 divisions (22.5 deg spokes), radius step 0.5
+vgrid -type circ -step 0.5 8
+vdump $imagedir/${casename}_circ.png
+
+# Finer angular resolution, bigger radial spacing
+vgrid -type circ -step 1.0 24
+vdump $imagedir/${casename}_circ_fine.png
+
+# Rotated
+vgrid -type circ -step 0.5 12 -rotAngle 0.4
+vdump $imagedir/${casename}_circ_rotated.png
+
+# Points mode
+vgrid -type circ -step 0.5 8 -mode points
+vdump $imagedir/${casename}_circ_points.png
+
+vgrid off

--- a/tests/v3d/grid/circ_shader
+++ b/tests/v3d/grid/circ_shader
@@ -1,5 +1,5 @@
 puts "=================================================================="
-puts "0030979: V3d_CircularGrid now renders through the polar shader path"
+puts "0030979: vgrid -type inf with circular options uses the polar shader"
 puts "=================================================================="
 
 pload MODELING VISUALIZATION
@@ -13,16 +13,17 @@ vdisplay b -dispMode 1
 vfit
 vzoom 0.2
 
-# Classical circular grid: 8 divisions (22.5 deg spokes), radius step 0.5
-vgrid -type circ -step 0.5 8
+# Shader circular grid: -type inf with -step <radial> <divisions> picks the polar
+# branch. 8 divisions (22.5 deg spokes), radius step 0.5.
+vgrid -type inf -step 0.5 8 -radius 5
 vdump $imagedir/${casename}_circ.png
 
 # Finer angular resolution, bigger radial spacing
-vgrid -type circ -step 1.0 24
+vgrid -type inf -step 1.0 24 -radius 10
 vdump $imagedir/${casename}_circ_fine.png
 
 # Rotated
-vgrid -type circ -step 0.5 12 -rotAngle 0.4
+vgrid -type inf -step 0.5 12 -radius 5 -rotAngle 0.4
 vdump $imagedir/${casename}_circ_rotated.png
 
 vgrid off

--- a/tests/v3d/grid/mode_switch
+++ b/tests/v3d/grid/mode_switch
@@ -1,0 +1,35 @@
+puts "=================================================================="
+puts "Toggle between CPU grid and shader grid in the same view"
+puts "=================================================================="
+# Verifies that the two grid backends do not corrupt each other when toggled:
+#   1) CPU grid active             -> classical bounded grid visible
+#   2) switch to shader (-type inf) -> shader grid only on this view
+#   3) switch back to CPU           -> CPU grid visible again, shader gone
+# Regression for the per-view shader / viewer-wide CPU coexistence policy.
+
+pload MODELING VISUALIZATION
+
+vclear
+vinit View1 w=400 h=400
+vaxo
+
+box b 1 2 3
+vdisplay b -dispMode 1
+vfit
+vzoom 0.2
+
+# (1) Legacy CPU rectangular grid.
+vgrid -type rect -step 0.5 0.5
+vdump $imagedir/${casename}_cpu.png
+
+# (2) Switch the same view to the shader grid; vgrid -type inf calls
+# V3d_View::GridDisplay which only erases the shader grid on this view.
+vgrid -type inf -step 0.5 0.5
+vdump $imagedir/${casename}_shader.png
+
+# (3) Re-activate the classical CPU grid; SetGrid path must erase the shader
+# grid first via the myShaderGridActive guard.
+vgrid -type rect -step 0.5 0.5
+vdump $imagedir/${casename}_cpu_again.png
+
+vgrid off

--- a/tests/v3d/grid/mode_switch
+++ b/tests/v3d/grid/mode_switch
@@ -22,8 +22,9 @@ vzoom 0.2
 vgrid -type rect -step 0.5 0.5
 vdump $imagedir/${casename}_cpu.png
 
-# (2) Switch the same view to the shader grid; vgrid -type inf calls
-# V3d_View::GridDisplay which only erases the shader grid on this view.
+# (2) Switch the same view to the shader grid. vgrid -type inf calls
+# V3d_View::GridDisplay which erases the viewer-wide CPU grid rendering
+# (snap geometry on Aspect_*Grid is preserved) and enables the shader.
 vgrid -type inf -step 0.5 0.5
 vdump $imagedir/${casename}_shader.png
 

--- a/tests/v3d/grid/rect_cpu
+++ b/tests/v3d/grid/rect_cpu
@@ -1,0 +1,34 @@
+puts "=================================================================="
+puts "Restored CPU rectangular grid path: V3d_RectangularGrid + ActivateGrid"
+puts "=================================================================="
+# Exercises the legacy CPU grid that draws lines / points into a viewer-wide
+# Graphic3d_Structure. The shader (-type inf) path is covered by rect_shader.
+
+pload MODELING VISUALIZATION
+
+vclear
+vinit View1
+vaxo
+
+box b 1 2 3
+vdisplay b -dispMode 1
+vfit
+vzoom 0.2
+
+# Default rectangular CPU grid (no -type inf): bounded, half-default-view-size.
+vgrid -type rect -step 0.5 0.5 -rotAngle 0
+vdump $imagedir/${casename}_rect.png
+
+# Non-isotropic step (different X and Y spacing).
+vgrid -type rect -step 0.5 1.0
+vdump $imagedir/${casename}_rect_aniso.png
+
+# Switch to points draw-mode (still CPU path).
+vgrid -type rect -step 0.5 0.5 -mode points
+vdump $imagedir/${casename}_rect_points.png
+
+# In-plane rotation.
+vgrid -type rect -step 0.5 0.5 -mode lines -rotAngle 0.5
+vdump $imagedir/${casename}_rect_rotated.png
+
+vgrid off

--- a/tests/v3d/grid/rect_shader
+++ b/tests/v3d/grid/rect_shader
@@ -1,5 +1,5 @@
 puts "=================================================================="
-puts "0030979: classical vgrid -type rect now renders through the shader"
+puts "0030979: vgrid -type inf renders the rectangular grid via the shader"
 puts "=================================================================="
 
 pload MODELING VISUALIZATION
@@ -13,17 +13,17 @@ vdisplay b -dispMode 1
 vfit
 vzoom 0.2
 
-# Classical rectangular grid, routed through the infinite-grid shader:
+# Shader-rendered rectangular grid (-type inf opts into the GPU path):
 #   XStep/YStep map to Scale/ScaleY, RotationAngle rotates in-plane basis.
-vgrid -type rect -step 0.5 0.5 -rotAngle 0
+vgrid -type inf -step 0.5 0.5 -rotAngle 0
 vdump $imagedir/${casename}_rect.png
 
 # Non-isotropic step (different X and Y spacing)
-vgrid -type rect -step 0.5 1.0
+vgrid -type inf -step 0.5 1.0
 vdump $imagedir/${casename}_rect_aniso.png
 
 # In-plane rotation
-vgrid -type rect -step 0.5 0.5 -rotAngle 0.5
+vgrid -type inf -step 0.5 0.5 -rotAngle 0.5
 vdump $imagedir/${casename}_rect_rotated.png
 
 vgrid off


### PR DESCRIPTION
Commit a2e851b25 (#1223) replaced the classical Graphic3d_Structure-based grid rendering with a single shader path driven by Aspect_GridParams. This change brings the CPU rendering back as a coexisting backend so consumers can pick CPU or GPU per use case. Snap math on Aspect_Grid is unchanged; only the presentation layer is split.

V3d layer:
- V3d_RectangularGrid / V3d_CircularGrid restore the nested custom Graphic3d_Structure, myStructure / myGroup, DefineLines / DefinePoints and the myCur* change-detection cache. UpdateDisplay rebuilds the primitive arrays with the same SetTransformation + CalculateBoundBox flow as before #1223.
- DefineLines / DefinePoints use NCollection_LinearVector<gp_Pnt> pre-sized from XStep / YStep / Radius to avoid reallocations.
- V3d_CircularGrid emits a one-shot warning when an arc range is set (CPU cannot honor it; use the shader path for arcs).

V3d_View layer:
- V3d_View tracks myShaderGridActive. SetGrid erases the shader grid on this view before activating the CPU grid; GridDisplay erases the viewer-wide CPU rendering (snap geometry preserved) before enabling the shader grid. Remove tears both down.

Aspect / Viewer:
- Aspect_GridParams comment clarifies it is consumed only by the GPU path. V3d_Viewer.hxx grid block is annotated as the legacy CPU entry.