### PR TITLE
Data Exchange - Make STEP read/write pipelines thread-safer

### DIFF
--- a/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Controller.cxx
+++ b/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Controller.cxx
@@ -26,6 +26,8 @@
 #include "../RWStepAP214/RWStepAP214.pxx"
 #include <Standard_Type.hxx>
 #include <Standard_Version.hxx>
+#include <DESTEP_Parameters.hxx>
+#include <ShapeProcess.hxx>
 #include <STEPControl_ActorRead.hxx>
 #include <STEPControl_ActorWrite.hxx>
 #include <STEPControl_Controller.hxx>
@@ -342,6 +344,13 @@ STEPControl_Controller::STEPControl_Controller()
 
   occ::handle<STEPControl_ActorWrite> ActWrite = new STEPControl_ActorWrite;
   myAdaptorWrite                               = ActWrite;
+
+  ActWrite->SetShapeFixParameters(DESTEP_Parameters::GetDefaultShapeFixParameters(),
+                                  XSAlgo_ShapeProcessor::ParameterMap{});
+  ShapeProcess::OperationsFlags aDefaultProcFlags;
+  aDefaultProcFlags.set(ShapeProcess::Operation::SplitCommonVertex);
+  aDefaultProcFlags.set(ShapeProcess::Operation::DirectFaces);
+  ActWrite->SetShapeProcessFlags(aDefaultProcFlags);
 
   occ::handle<StepSelect_WorkLibrary> swl = new StepSelect_WorkLibrary;
   swl->SetDumpLabel(1);

--- a/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.cxx
+++ b/src/DataExchange/TKDESTEP/STEPControl/STEPControl_Writer.cxx
@@ -155,7 +155,6 @@ IFSelect_ReturnStatus STEPControl_Writer::Transfer(const TopoDS_Shape&          
     occ::down_cast<STEPControl_ActorWrite>(WS()->NormAdaptor()->ActorWrite());
   ActWrite->SetGroupMode(
     occ::down_cast<StepData_StepModel>(thesession->Model())->InternalParameters.WriteAssembly);
-  InitializeMissingParameters();
   return thesession->TransferWriteShape(sh, compgraph, theProgress);
 }
 

--- a/src/DataExchange/TKXSBase/LibCtl/LibCtl_Library.gxx
+++ b/src/DataExchange/TKXSBase/LibCtl/LibCtl_Library.gxx
@@ -15,86 +15,79 @@
 // #include <LibCtl_Library.ixx>
 #include <Standard_NoSuchObject.hxx>
 
-//  Global List of Modules, from which we will be served
+#include <mutex>
 
-static occ::handle<LibCtl_GlobalNode> theglobal;
+namespace
+{
+//  Global registry of (Module, Protocol) pairs. SetGlobal / AddProtocol are
+//  expected to run only during one-time controller initialization, before any
+//  parallel work. Writers serialize against each other; readers traverse
+//  without locking and rely on this register-before-parallel-use contract.
+static occ::handle<LibCtl_GlobalNode> THE_GLOBAL;
 
-//  Data for optimization (last Protocol requested)
+static std::mutex& LibCtl_TheWriterLock()
+{
+  static std::mutex aMutex;
+  return aMutex;
+}
 
-static occ::handle<TheProtocol> theprotocol;
-static occ::handle<LibCtl_Node> thelast;
+//  Build/extend `theTargetList` for `theProtocol`, recursing into Resources.
+static void LibCtl_AddProtocolImpl(occ::handle<LibCtl_Node>&              theTargetList,
+                                   const occ::handle<Standard_Transient>& theProtocol)
+{
+  occ::handle<TheProtocol> aProtocol = occ::down_cast<TheProtocol>(theProtocol);
+  if (aProtocol.IsNull())
+    return;
+
+  for (occ::handle<LibCtl_GlobalNode> aCurrent = THE_GLOBAL; !aCurrent.IsNull();)
+  {
+    const occ::handle<TheProtocol>& aNodeProto = aCurrent->Protocol();
+    if (!aNodeProto.IsNull() && aNodeProto->DynamicType() == aProtocol->DynamicType())
+    {
+      if (theTargetList.IsNull())
+        theTargetList = new LibCtl_Node;
+      theTargetList->AddNode(aCurrent);
+      break;
+    }
+    aCurrent = aCurrent->Next();
+  }
+
+  const int aNbResources = aProtocol->NbResources();
+  for (int anInd = 1; anInd <= aNbResources; anInd++)
+  {
+    LibCtl_AddProtocolImpl(theTargetList, aProtocol->Resource(anInd));
+  }
+}
+} // namespace
 
 //  Feeding the global list
 //  WARNING: SetGlobal performs substitution, i.e. it's the last one
 //   that is right for a given Protocol
-void LibCtl_Library::SetGlobal(const occ::handle<TheModule>&   amodule,
-                               const occ::handle<TheProtocol>& aprotocol)
+void LibCtl_Library::SetGlobal(const occ::handle<TheModule>&   theModule,
+                               const occ::handle<TheProtocol>& theProtocol)
 {
-  if (theglobal.IsNull())
-    theglobal = new LibCtl_GlobalNode;
-  theglobal->Add(amodule, aprotocol);
+  std::lock_guard<std::mutex> aLock(LibCtl_TheWriterLock());
+  if (THE_GLOBAL.IsNull())
+    THE_GLOBAL = new LibCtl_GlobalNode;
+  THE_GLOBAL->Add(theModule, theProtocol);
 }
 
 // Constructor from Protocol
-LibCtl_Library::LibCtl_Library(const occ::handle<TheProtocol>& aprotocol)
+LibCtl_Library::LibCtl_Library(const occ::handle<TheProtocol>& theProtocol)
 {
-  bool last = false;
-  if (aprotocol.IsNull())
+  if (theProtocol.IsNull())
     return; // NO protocol = EMPTY Lib
-  if (!theprotocol.IsNull())
-    last = (theprotocol == aprotocol);
 
-  if (last)
-    thelist = thelast;
-  //  If no optimization available: build the list
-  else
-  {
-    AddProtocol(aprotocol);
-    //  This defines the optimization (for the next time)
-    thelast     = thelist;
-    theprotocol = aprotocol;
-  }
+  LibCtl_AddProtocolImpl(thelist, theProtocol);
 }
 
 //  Constructeur vide
 LibCtl_Library::LibCtl_Library() {}
 
-//  Adding a Protocol: beware, deoptimizes (otherwise risk of confusion!)
-void LibCtl_Library::AddProtocol(const occ::handle<Standard_Transient>& aprotocol)
+//  Adds a Protocol (and its Resources) to this Library's list.
+void LibCtl_Library::AddProtocol(const occ::handle<Standard_Transient>& theProtocol)
 {
-  //  DownCast because Protocol->Resources, even redefined and used in other
-  //  libraries, must always return the highest type
-  occ::handle<TheProtocol> aproto = occ::down_cast<TheProtocol>(aprotocol);
-  if (aproto.IsNull())
-    return;
-
-  //  First, add this one to the list: search for the Node
-  occ::handle<LibCtl_GlobalNode> curr;
-  for (curr = theglobal; !curr.IsNull();)
-  { // curr->Next : plus loin
-    const occ::handle<TheProtocol>& protocol = curr->Protocol();
-    if (!protocol.IsNull())
-    {
-      //  Match Protocol ?
-      if (protocol->DynamicType() == aprotocol->DynamicType())
-      {
-        if (thelist.IsNull())
-          thelist = new LibCtl_Node;
-        thelist->AddNode(curr);
-        break; // UN SEUL MODULE PAR PROTOCOLE
-      }
-    }
-    curr = curr->Next(); // this formula is refused in "for"
-  }
-  //  Then, process the resources
-  int nb = aproto->NbResources();
-  for (int i = 1; i <= nb; i++)
-  {
-    AddProtocol(aproto->Resource(i));
-  }
-  //  Don't forget to deoptimize
-  theprotocol.Nullify();
-  thelast.Nullify();
+  LibCtl_AddProtocolImpl(thelist, theProtocol);
 }
 
 void LibCtl_Library::Clear()
@@ -105,46 +98,43 @@ void LibCtl_Library::Clear()
 void LibCtl_Library::SetComplete()
 {
   thelist = new LibCtl_Node;
-  //    We take each of the Protocols from the Global List and add it
-  occ::handle<LibCtl_GlobalNode> curr;
-  for (curr = theglobal; !curr.IsNull();)
-  { // curr->Next : plus loin
-    const occ::handle<TheProtocol>& protocol = curr->Protocol();
-    //    Since we take everything, we don't worry about Resources!
-    if (!protocol.IsNull())
-      thelist->AddNode(curr);
-    curr = curr->Next(); // this formula is refused in "for"
+  for (occ::handle<LibCtl_GlobalNode> aCurrent = THE_GLOBAL; !aCurrent.IsNull();)
+  {
+    const occ::handle<TheProtocol>& aNodeProto = aCurrent->Protocol();
+    if (!aNodeProto.IsNull())
+      thelist->AddNode(aCurrent);
+    aCurrent = aCurrent->Next();
   }
 }
 
 //  Selection: Very powerful, we return the Module corresponding to a Type
 //  (as well as the CaseNumber returned by the corresponding protocol)
 
-bool LibCtl_Library::Select(const TheObject& obj, occ::handle<TheModule>& module, int& CN) const
+bool LibCtl_Library::Select(const TheObject&        theObj,
+                            occ::handle<TheModule>& theModule,
+                            int&                    theCN) const
 {
-  module.Nullify();
-  CN = 0; // Response "not found"
+  theModule.Nullify();
+  theCN = 0; // Response "not found"
   if (thelist.IsNull())
     return false;
-  occ::handle<LibCtl_Node> curr = thelist;
-  for (curr = thelist; !curr.IsNull();)
-  { // curr->Next : plus loin
-    const occ::handle<TheProtocol>& protocol = curr->Protocol();
+  occ::handle<LibCtl_Node> aCurrent = thelist;
+  for (aCurrent = thelist; !aCurrent.IsNull();)
+  { // aCurrent->Next : plus loin
+    const occ::handle<TheProtocol>& protocol = aCurrent->Protocol();
     if (!protocol.IsNull())
     {
-      CN = protocol->CaseNumber(obj);
-      if (CN > 0)
+      theCN = protocol->CaseNumber(theObj);
+      if (theCN > 0)
       {
-        module = curr->Module();
+        theModule = aCurrent->Module();
         return true;
       }
     }
-    curr = curr->Next(); // this formula is refused in "for"
+    aCurrent = aCurrent->Next(); // this formula is refused in "for"
   }
   return false; // here, not found
 }
-
-//  ....                        Iteration                        ....
 
 void LibCtl_Library::Start()
 {

--- a/src/DataExchange/TKXSBase/XSAlgo/XSAlgo_ShapeProcessor.cxx
+++ b/src/DataExchange/TKXSBase/XSAlgo/XSAlgo_ShapeProcessor.cxx
@@ -718,16 +718,12 @@ void XSAlgo_ShapeProcessor::SetShapeFixParameters(
   const XSAlgo_ShapeProcessor::ParameterMap& theAdditionalParameters,
   XSAlgo_ShapeProcessor::ParameterMap&       theTargetParameterMap)
 {
-  theTargetParameterMap.Clear();
   XSAlgo_ShapeProcessor::FillParameterMap(theParameters, true, theTargetParameterMap);
   for (XSAlgo_ShapeProcessor::ParameterMap::Iterator aParamIter(theAdditionalParameters);
        aParamIter.More();
        aParamIter.Next())
   {
-    if (!theTargetParameterMap.IsBound(aParamIter.Key()))
-    {
-      theTargetParameterMap.Bind(aParamIter.Key(), aParamIter.Value());
-    }
+    SetParameter(aParamIter.Key().ToCString(), aParamIter.Value(), false, theTargetParameterMap);
   }
 }
 
@@ -763,17 +759,15 @@ void XSAlgo_ShapeProcessor::SetParameter(const char*                          th
                                          const bool                           theIsReplace,
                                          XSAlgo_ShapeProcessor::ParameterMap& theMap)
 {
-  if (theIsReplace)
+  const TCollection_AsciiString* anExisting = theMap.Seek(theKey);
+  if (anExisting != nullptr)
   {
-    theMap.Bind(theKey, theValue);
-  }
-  else
-  {
-    if (!theMap.IsBound(theKey))
+    if (!theIsReplace || *anExisting == theValue)
     {
-      theMap.Bind(theKey, theValue);
+      return;
     }
   }
+  theMap.Bind(theKey, theValue);
 }
 
 //=============================================================================


### PR DESCRIPTION
Concurrent STEPControl_Writer::Transfer calls crashed inside TCollection_AsciiString::Move with a libmalloc double-free, and concurrent STEP/IGES readers occasionally crashed inside Interface_FileReaderTool::RecognizeByLib. Both originated in process-shared mutable state that every per-thread reader/writer silently mutated.

STEP write actor (writer-side race):
- Pre-populate the shared STEPControl_ActorWrite parameter map and processing flags inside STEPControl_Controller::Init under the existing one-time mutex, so concurrent STEPControl_Writer::Transfer calls no longer mutate the shared actor in the default path.
- Drop the per-Transfer call to STEPControl_Writer::InitializeMissingParameters; defaults are now in place from controller construction time.
- Make XSAlgo_ShapeProcessor::SetParameter idempotent: skip the destructive Bind when the existing entry already matches the new value, eliminating the TCollection_AsciiString::Move/Free path that was the immediate double-free site under concurrent writers.
- Stop clearing the target ParameterMap in XSAlgo_ShapeProcessor::SetShapeFixParameters before refilling it; rely on the idempotent SetParameter for in-place replacement.

LibCtl_Library (reader-side race):
- Drop the file-scope "last protocol" optimization cache (theprotocol/thelast) that raced between concurrent STEP/IGES readers in Interface_FileReaderTool::RecognizeByLib.
- Treat the global registry as immutable after one-time controller initialization: writers (SetGlobal) serialize against each other, readers traverse without locking. Move internal helper logic into an anonymous namespace.