### PR TITLE
Modeling - Rework CoEdge definition to avoid misuse

### DIFF
--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Builder.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Builder.cxx
@@ -242,8 +242,8 @@ void BRepGraph_Builder::appendImpl(BRepGraph&                                  t
                                            theOptions.Parallel,
                                            aAppendedRoots,
                                            theOptions.Populate,
-                                           aParamLayer.get(),
-                                           aRegularityLayer.get(),
+                                           aParamLayer,
+                                           aRegularityLayer,
                                            aTmpAlloc);
     if (theOutFlatRoots != nullptr)
     {
@@ -259,8 +259,8 @@ void BRepGraph_Builder::appendImpl(BRepGraph&                                  t
                                   theShape,
                                   theOptions.Parallel,
                                   theOptions.Populate,
-                                  aParamLayer.get(),
-                                  aRegularityLayer.get(),
+                                  aParamLayer,
+                                  aRegularityLayer,
                                   aTmpAlloc);
   }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
@@ -660,11 +660,10 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
                                                anOldCoEdge.ParamFirst,
                                                anOldCoEdge.ParamLast);
 
-    aNewGraph.Editor().CoEdges().SetContinuity(aNewCoEdge, anOldCoEdge.Continuity);
-
     aNewGraph.Editor().CoEdges().SetUVBox(aNewCoEdge, anOldCoEdge.UV1, anOldCoEdge.UV2);
 
-    aNewGraph.Editor().CoEdges().SetSeamContinuity(aNewCoEdge, anOldCoEdge.SeamContinuity);
+    // Continuity (inter-face and seam) lives in BRepGraph_LayerRegularity and
+    // is migrated by the layer's own remapping hooks; nothing to copy here.
 
     // If the owning face was removed, keep the coedge as free-wire usage only.
     // Drop face-bound parametric payload (PCurve/UV/continuity) to avoid stale

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Compact.cxx
@@ -693,33 +693,6 @@ BRepGraph_Compact::Result BRepGraph_Compact::Perform(BRepGraph& theGraph, const 
     }
   }
 
-  // Remap seam-pair links after all coedges have their new ids.
-  for (BRepGraph_Iterator<BRepGraphInc::CoEdgeDef> anIt(theGraph); anIt.More(); anIt.Next())
-  {
-    const BRepGraph_CoEdgeId  anOldCoEdgeId = anIt.CurrentId();
-    const BRepGraph_CoEdgeId* aNewCoEdgeId  = aCoEdgeMap.Seek(anOldCoEdgeId);
-    if (aNewCoEdgeId == nullptr)
-    {
-      continue;
-    }
-
-    const BRepGraphInc::CoEdgeDef& anOldCoEdge = anIt.Current();
-    if (!anOldCoEdge.SeamPairId.IsValid())
-    {
-      continue;
-    }
-
-    const BRepGraph_CoEdgeId* aNewSeamPairId = aCoEdgeMap.Seek(anOldCoEdge.SeamPairId);
-    if (aNewSeamPairId == nullptr)
-    {
-      continue;
-    }
-
-    BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef> aNewCoEdge =
-      aNewGraph.Editor().CoEdges().Mut(*aNewCoEdgeId);
-    aNewGraph.Editor().CoEdges().SetSeamPairId(aNewCoEdge, *aNewSeamPairId);
-  }
-
   // Shells.
   for (BRepGraph_Iterator<BRepGraphInc::ShellDef> anIt(theGraph); anIt.More(); anIt.Next())
   {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
@@ -2210,14 +2210,11 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
   myGraph->allocateUID(theSubA);
   myGraph->allocateUID(theSubB);
 
-  // Rebuild CoEdge incidence in a single coherent pass. The previous two-pass
-  // design (one wire walk, one reverse-index walk) produced incomplete SubB
-  // CoEdges under wire membership, orphan PCurve-bearing CoEdges off-wire, and
-  // did not preserve SeamPairId linkage between new sub-pairs. The unified
-  // pass below: snapshots all original CoEdges (forward + seam partners),
-  // allocates two fully-initialised CoEdges per original, rebuilds SeamPairId
-  // on the new pairs, rebuilds wire CoEdgeRefIds, and retires each original
-  // CoEdge with a reverse-index unbind.
+  // Rebuild CoEdge incidence in a single pass: snapshot all CoEdges of the
+  // original edge, allocate two fully-initialised CoEdges per original, rebuild
+  // wire CoEdgeRefIds, retire each original via reverse-index unbind. The seam
+  // relation re-emerges automatically from the resulting (Edge, Face, Orientation)
+  // tuples (see BRepGraph_Tool::CoEdge::SeamPair).
   NCollection_DynamicArray<BRepGraph_FaceId> aOrigFaces;
   {
     BRepGraphInc_Storage&      aStorage = myGraph->myData->myIncStorage;
@@ -2311,28 +2308,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
       }
     }
 
-    // Step 3: re-establish SeamPairId linkage on new pairs. If the old
-    // partner CoEdge is also in our map (true for intra-edge seam pairs),
-    // wire SubA<->partnerSubA and SubB<->partnerSubB; otherwise leave the
-    // new CoEdges unpaired - an orphan SeamPairId would point into a dead
-    // slot.
-    for (uint32_t i = 0; i < aNbOrig; ++i)
-    {
-      const BRepGraph_CoEdgeId aOldId       = anOrigCoEdgeIds.Value(static_cast<size_t>(i));
-      const BRepGraph_CoEdgeId aOldSeamPair = aStorage.CoEdge(aOldId).SeamPairId;
-      if (!aOldSeamPair.IsValid() || !aIdxOf.IsBound(aOldSeamPair))
-      {
-        continue;
-      }
-      int aJ = -1;
-      aIdxOf.Find(aOldSeamPair, aJ);
-      aStorage.ChangeCoEdge(aNewACoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId =
-        aNewACoEdgeIds.Value(aJ);
-      aStorage.ChangeCoEdge(aNewBCoEdgeIds.Value(static_cast<size_t>(i))).SeamPairId =
-        aNewBCoEdgeIds.Value(aJ);
-    }
-
-    // Step 4: rebuild wire CoEdgeRefIds (snapshot-before-mutate). For each
+    // Step 3: rebuild wire CoEdgeRefIds (snapshot-before-mutate). For each
     // wire containing the original edge, rebind its existing CoEdgeRef to
     // the new SubA-CE in place and insert a fresh CoEdgeRef for SubB-CE
     // immediately after. Track insertion offset so that subsequent inserts
@@ -2405,7 +2381,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
       }
     }
 
-    // Step 5: retire the original CoEdges and rebuild the Edge->CoEdge
+    // Step 4: retire the original CoEdges and rebuild the Edge->CoEdge
     // reverse index so CoEdgesOfEdge(theSubA/B) resolves to the new pair.
     for (uint32_t i = 0; i < aNbOrig; ++i)
     {
@@ -2418,7 +2394,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
       aRevIdx.BindEdgeToCoEdge(theSubB, aNewB);
     }
 
-    // Step 6: retire the original edge's vertex refs. Their ParentId
+    // Step 5: retire the original edge's vertex refs. Their ParentId
     // points at the about-to-be-removed edge; leaving them live would
     // trip the "Orphan VertexRef: ParentId is not a live Edge" Audit
     // rule. Internal vertex refs are dropped rather than reparented to

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
@@ -538,8 +538,7 @@ void initSubCoEdgeEntity(BRepGraphInc::CoEdgeDef&     theCE,
                          const TopAbs_Orientation     theOrientation,
                          const BRepGraph_Curve2DRepId theCurve2DRepId,
                          const double                 theParamFirst,
-                         const double                 theParamLast,
-                         const GeomAbs_Shape          theContinuity)
+                         const double                 theParamLast)
 {
   theCE.EdgeDefId    = theEdgeId;
   theCE.FaceDefId    = theFaceId;
@@ -547,7 +546,6 @@ void initSubCoEdgeEntity(BRepGraphInc::CoEdgeDef&     theCE,
   theCE.Curve2DRepId = theCurve2DRepId;
   theCE.ParamFirst   = theParamFirst;
   theCE.ParamLast    = theParamLast;
-  theCE.Continuity   = theContinuity;
 }
 
 } // namespace
@@ -2269,9 +2267,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
                             aOld.Orientation,
                             aOld.Curve2DRepId,
                             aOld.ParamFirst,
-                            aPCSplit,
-                            aOld.Continuity);
-        aNewACE.SeamContinuity = aOld.SeamContinuity;
+                            aPCSplit);
         // UV at the split-point end is left default (0,0); callers needing
         // the exact point should evaluate the Curve2DRep at aPCSplit.
         aNewACE.UV1               = aOld.UV1;
@@ -2289,9 +2285,7 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
                             aOld.Orientation,
                             aOld.Curve2DRepId,
                             aPCSplit,
-                            aOld.ParamLast,
-                            aOld.Continuity);
-        aNewBCE.SeamContinuity = aOld.SeamContinuity;
+                            aOld.ParamLast);
         // UV at the split-point start is left default (0,0) - see aNewACE.
         aNewBCE.UV2               = aOld.UV2;
         aNewBCE.Polygon2DRepId    = aOld.Polygon2DRepId;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.cxx
@@ -2421,6 +2421,15 @@ void BRepGraph::EditorView::EdgeOps::Split(const BRepGraph_EdgeId   theEdgeEntit
       }
     }
 
+    const occ::handle<BRepGraph_LayerRegularity> aRegularityLayer =
+      myGraph->LayerRegistry().FindLayer<BRepGraph_LayerRegularity>();
+    if (!aRegularityLayer.IsNull())
+    {
+      aRegularityLayer->CopyRegularities(theEdgeEntity, theSubA);
+      aRegularityLayer->CopyRegularities(theEdgeEntity, theSubB);
+      aRegularityLayer->RemoveRegularities(theEdgeEntity);
+    }
+
     // Mark original edge as removed.
     aStorage.MarkRemoved(theEdgeEntity);
   }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.hxx
@@ -314,6 +314,14 @@ public:
     [[nodiscard]] Standard_EXPORT BRepGraph_MutGuard<BRepGraphInc::EdgeDef> Mut(
       const BRepGraph_EdgeId theEdge);
 
+    //! Returns true iff the edge appears as a seam on the given face (two CoEdges
+    //! of theEdge share theFace).
+    //! @param[in] theEdge typed edge definition identifier
+    //! @param[in] theFace typed face definition identifier
+    //! @return true if the edge is a seam on the given face
+    [[nodiscard]] Standard_EXPORT bool IsSeamOnFace(const BRepGraph_EdgeId theEdge,
+                                                    const BRepGraph_FaceId theFace) const;
+
     //! Set the tolerance of an edge definition and fire immediate notification.
     //! @param[in] theEdge      typed edge definition identifier
     //! @param[in] theTolerance new tolerance value
@@ -524,10 +532,9 @@ public:
     Standard_EXPORT void ClearPCurveBinding(BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut);
 
     //! Set the seam-pair id linking two coedges of a seam edge (invalid breaks the link).
-    Standard_EXPORT void SetSeamPairId(const BRepGraph_CoEdgeId theCoEdge,
-                                       const BRepGraph_CoEdgeId theSeamPairId);
-    Standard_EXPORT void SetSeamPairId(BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut,
-                                       const BRepGraph_CoEdgeId                     theSeamPairId);
+    // To establish seam-ness, ensure two CoEdges exist on the same (Edge, Face)
+    // with opposite orientations; the seam relation is then queryable via
+    // BRepGraph_Tool::CoEdge::SeamPair.
 
     //! Rewire a coedge to a different parent edge (rebinds EdgeToCoEdges, EdgeToWires,
     //! EdgeToFaces). Caller maintains reverse indices.

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView.hxx
@@ -322,6 +322,19 @@ public:
     [[nodiscard]] Standard_EXPORT bool IsSeamOnFace(const BRepGraph_EdgeId theEdge,
                                                     const BRepGraph_FaceId theFace) const;
 
+    //! Set the geometric regularity (C^k) for an edge across a pair of faces in
+    //! BRepGraph_LayerRegularity. theFace1 == theFace2 sets the seam continuity
+    //! across the closed-surface seam line. Requires the layer to be registered.
+    //! @param[in] theEdge       typed edge definition identifier
+    //! @param[in] theFace1      first face (or seam face when theFace2 == theFace1)
+    //! @param[in] theFace2      second face
+    //! @param[in] theContinuity continuity (GeomAbs_Shape)
+    //! @return true if written; false if the layer is not registered
+    Standard_EXPORT bool SetRegularity(const BRepGraph_EdgeId theEdge,
+                                       const BRepGraph_FaceId theFace1,
+                                       const BRepGraph_FaceId theFace2,
+                                       const GeomAbs_Shape    theContinuity);
+
     //! Set the tolerance of an edge definition and fire immediate notification.
     //! @param[in] theEdge      typed edge definition identifier
     //! @param[in] theTolerance new tolerance value
@@ -496,17 +509,9 @@ public:
                                   const gp_Pnt2d&                              theUV1,
                                   const gp_Pnt2d&                              theUV2);
 
-    //! Set the geometric continuity of a coedge definition.
-    Standard_EXPORT void SetContinuity(const BRepGraph_CoEdgeId theCoEdge,
-                                       const GeomAbs_Shape      theContinuity);
-    Standard_EXPORT void SetContinuity(BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut,
-                                       const GeomAbs_Shape                          theContinuity);
-
-    //! Set the seam-pair continuity of a coedge definition.
-    Standard_EXPORT void SetSeamContinuity(const BRepGraph_CoEdgeId theCoEdge,
-                                           const GeomAbs_Shape      theContinuity);
-    Standard_EXPORT void SetSeamContinuity(BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut,
-                                           const GeomAbs_Shape theContinuity);
+    //! Continuity is a property of (Edge, Face1, Face2) and lives in
+    //! BRepGraph_LayerRegularity. Use EditorView::EdgeOps::SetRegularity to write,
+    //! BRepGraph_Tool::Edge::Continuity to read.
 
     //! Set the Curve2DRep id bound to a coedge (invalid id clears the binding).
     Standard_EXPORT void SetCurve2DRepId(const BRepGraph_CoEdgeId     theCoEdge,

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Mut.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Mut.cxx
@@ -295,12 +295,24 @@ bool BRepGraph::EditorView::EdgeOps::IsSeamOnFace(const BRepGraph_EdgeId theEdge
   {
     return false;
   }
-  uint32_t aCount = 0;
+  bool               hasOrientation = false;
+  TopAbs_Orientation anOrientation  = TopAbs_FORWARD;
   for (BRepGraph_CoEdgesOfEdge anIt(*myGraph, myGraph->Topo().Edges().CoEdges(theEdge));
        anIt.More();
        anIt.Next())
   {
-    if (anIt.Definition().FaceDefId == theFace && ++aCount == 2)
+    const BRepGraphInc::CoEdgeDef& aCoEdge = anIt.Definition();
+    if (aCoEdge.FaceDefId != theFace)
+    {
+      continue;
+    }
+    if (!hasOrientation)
+    {
+      anOrientation  = aCoEdge.Orientation;
+      hasOrientation = true;
+      continue;
+    }
+    if (aCoEdge.Orientation != anOrientation)
     {
       return true;
     }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Mut.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Mut.cxx
@@ -14,6 +14,8 @@
 #include <BRepGraph_EditorView.hxx>
 #include <BRepGraph.hxx>
 #include <BRepGraph_Data.hxx>
+#include <BRepGraph_ReverseIterator.hxx>
+#include <BRepGraph_TopoView.hxx>
 
 #include <Standard_ProgramError.hxx>
 
@@ -282,6 +284,28 @@ BRepGraph_MutGuard<BRepGraphInc::EdgeDef> BRepGraph::EditorView::EdgeOps::Mut(
   BRepGraphInc_Storage& aStorage = myGraph->myData->myIncStorage;
   validateMutableNodeId(aStorage, BRepGraph_NodeId(theEdge));
   return BRepGraph_MutGuard<BRepGraphInc::EdgeDef>(myGraph, &aStorage.ChangeEdge(theEdge), theEdge);
+}
+
+//==================================================================================================
+
+bool BRepGraph::EditorView::EdgeOps::IsSeamOnFace(const BRepGraph_EdgeId theEdge,
+                                                  const BRepGraph_FaceId theFace) const
+{
+  if (!theEdge.IsValid() || !theFace.IsValid())
+  {
+    return false;
+  }
+  uint32_t aCount = 0;
+  for (BRepGraph_CoEdgesOfEdge anIt(*myGraph, myGraph->Topo().Edges().CoEdges(theEdge));
+       anIt.More();
+       anIt.Next())
+  {
+    if (anIt.Definition().FaceDefId == theFace && ++aCount == 2)
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 //==================================================================================================

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Setters.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Setters.cxx
@@ -13,6 +13,7 @@
 
 #include <BRepGraph_EditorView.hxx>
 #include <BRepGraph_Data.hxx>
+#include <BRepGraph_LayerRegularity.hxx>
 #include <BRepGraphInc_ReverseIndex.hxx>
 #include <BRepGraphInc_Storage.hxx>
 #include <Geom_Surface.hxx>
@@ -92,6 +93,26 @@ void BRepGraph::EditorView::EdgeOps::SetTolerance(BRepGraph_MutGuard<BRepGraphIn
                                                   double theTolerance)
 {
   theMut.Internal().Tolerance = theTolerance;
+}
+
+//=================================================================================================
+
+bool BRepGraph::EditorView::EdgeOps::SetRegularity(const BRepGraph_EdgeId theEdge,
+                                                   const BRepGraph_FaceId theFace1,
+                                                   const BRepGraph_FaceId theFace2,
+                                                   const GeomAbs_Shape    theContinuity)
+{
+  const occ::handle<BRepGraph_LayerRegularity> aLayer =
+    myGraph->LayerRegistry().FindLayer<BRepGraph_LayerRegularity>();
+  if (aLayer.IsNull())
+  {
+    return false;
+  }
+  // Do not call markModified(theEdge) here: OnNodeModified on the regularity
+  // layer clears bindings on edge change, which would discard the value we
+  // just wrote. SetRegularity is a direct layer write, not an edge mutation.
+  aLayer->SetRegularity(theEdge, theFace1, theFace2, theContinuity);
+  return true;
 }
 
 //=================================================================================================
@@ -521,42 +542,6 @@ void BRepGraph::EditorView::CoEdgeOps::SetUVBox(BRepGraph_MutGuard<BRepGraphInc:
 
 //=================================================================================================
 
-void BRepGraph::EditorView::CoEdgeOps::SetContinuity(const BRepGraph_CoEdgeId theCoEdge,
-                                                     const GeomAbs_Shape      theContinuity)
-{
-  myGraph->myData->myIncStorage.ChangeCoEdge(theCoEdge).Continuity = theContinuity;
-  myGraph->markModified(theCoEdge);
-}
-
-//=================================================================================================
-
-void BRepGraph::EditorView::CoEdgeOps::SetContinuity(
-  BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut,
-  const GeomAbs_Shape                          theContinuity)
-{
-  theMut.Internal().Continuity = theContinuity;
-}
-
-//=================================================================================================
-
-void BRepGraph::EditorView::CoEdgeOps::SetSeamContinuity(const BRepGraph_CoEdgeId theCoEdge,
-                                                         const GeomAbs_Shape      theContinuity)
-{
-  myGraph->myData->myIncStorage.ChangeCoEdge(theCoEdge).SeamContinuity = theContinuity;
-  myGraph->markModified(theCoEdge);
-}
-
-//=================================================================================================
-
-void BRepGraph::EditorView::CoEdgeOps::SetSeamContinuity(
-  BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut,
-  const GeomAbs_Shape                          theContinuity)
-{
-  theMut.Internal().SeamContinuity = theContinuity;
-}
-
-//=================================================================================================
-
 void BRepGraph::EditorView::CoEdgeOps::SetCurve2DRepId(const BRepGraph_CoEdgeId     theCoEdge,
                                                        const BRepGraph_Curve2DRepId theRep)
 {
@@ -618,7 +603,6 @@ void BRepGraph::EditorView::CoEdgeOps::ClearPCurveBinding(const BRepGraph_CoEdge
   aDef.Curve2DRepId             = BRepGraph_Curve2DRepId();
   aDef.ParamFirst               = 0.0;
   aDef.ParamLast                = 0.0;
-  aDef.Continuity               = GeomAbs_C0;
   aDef.UV1                      = gp_Pnt2d();
   aDef.UV2                      = gp_Pnt2d();
   myGraph->markModified(theCoEdge);
@@ -632,7 +616,6 @@ void BRepGraph::EditorView::CoEdgeOps::ClearPCurveBinding(
   theMut.Internal().Curve2DRepId = BRepGraph_Curve2DRepId();
   theMut.Internal().ParamFirst   = 0.0;
   theMut.Internal().ParamLast    = 0.0;
-  theMut.Internal().Continuity   = GeomAbs_C0;
   theMut.Internal().UV1          = gp_Pnt2d();
   theMut.Internal().UV2          = gp_Pnt2d();
 }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Setters.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Setters.cxx
@@ -764,24 +764,6 @@ void BRepGraph::EditorView::EdgeOps::SetIsClosed(BRepGraph_MutGuard<BRepGraphInc
 
 //=================================================================================================
 
-void BRepGraph::EditorView::CoEdgeOps::SetSeamPairId(const BRepGraph_CoEdgeId theCoEdge,
-                                                     const BRepGraph_CoEdgeId theSeamPairId)
-{
-  myGraph->myData->myIncStorage.ChangeCoEdge(theCoEdge).SeamPairId = theSeamPairId;
-  myGraph->markModified(theCoEdge);
-}
-
-//=================================================================================================
-
-void BRepGraph::EditorView::CoEdgeOps::SetSeamPairId(
-  BRepGraph_MutGuard<BRepGraphInc::CoEdgeDef>& theMut,
-  const BRepGraph_CoEdgeId                     theSeamPairId)
-{
-  theMut.Internal().SeamPairId = theSeamPairId;
-}
-
-//=================================================================================================
-
 void BRepGraph::EditorView::SolidOps::SetRefOrientation(const BRepGraph_SolidRefId theSolidRef,
                                                         const TopAbs_Orientation   theOrientation)
 {

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Setters.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_EditorView_Setters.cxx
@@ -108,10 +108,8 @@ bool BRepGraph::EditorView::EdgeOps::SetRegularity(const BRepGraph_EdgeId theEdg
   {
     return false;
   }
-  // Do not call markModified(theEdge) here: OnNodeModified on the regularity
-  // layer clears bindings on edge change, which would discard the value we
-  // just wrote. SetRegularity is a direct layer write, not an edge mutation.
   aLayer->SetRegularity(theEdge, theFace1, theFace2, theContinuity);
+  myGraph->markModified(theEdge);
   return true;
 }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.cxx
@@ -151,14 +151,6 @@ const TCollection_AsciiString& BRepGraph_LayerParam::Name() const
 
 //=================================================================================================
 
-int BRepGraph_LayerParam::SubscribedKinds() const
-{
-  return KindBit(BRepGraph_NodeId::Kind::Vertex) | KindBit(BRepGraph_NodeId::Kind::Edge)
-         | KindBit(BRepGraph_NodeId::Kind::Face) | KindBit(BRepGraph_NodeId::Kind::CoEdge);
-}
-
-//=================================================================================================
-
 const BRepGraph_LayerParam::VertexParams* BRepGraph_LayerParam::FindVertexParams(
   const BRepGraph_VertexId theVertex) const
 {
@@ -691,40 +683,6 @@ void BRepGraph_LayerParam::migrateCoEdgeBindings(const BRepGraph_CoEdgeId theOld
     }
     removePointOnPCurve(aVtx, theOldCoEdge);
     SetPointOnPCurve(aVtx, theNewCoEdge, aParameter);
-  }
-}
-
-//=================================================================================================
-
-void BRepGraph_LayerParam::OnNodeModified(const BRepGraph_NodeId theNode) noexcept
-{
-  switch (theNode.NodeKind)
-  {
-    case BRepGraph_NodeId::Kind::Vertex:
-      removeVertexBindings(BRepGraph_VertexId(theNode));
-      break;
-    case BRepGraph_NodeId::Kind::Edge:
-      invalidateEdgeBindings(BRepGraph_EdgeId(theNode));
-      break;
-    case BRepGraph_NodeId::Kind::Face:
-      invalidateFaceBindings(BRepGraph_FaceId(theNode));
-      break;
-    case BRepGraph_NodeId::Kind::CoEdge:
-      invalidateCoEdgeBindings(BRepGraph_CoEdgeId(theNode));
-      break;
-    default:
-      break;
-  }
-}
-
-//=================================================================================================
-
-void BRepGraph_LayerParam::OnNodesModified(
-  const NCollection_DynamicArray<BRepGraph_NodeId>& theModifiedNodes) noexcept
-{
-  for (const BRepGraph_NodeId& aModifiedNode : theModifiedNodes)
-  {
-    OnNodeModified(aModifiedNode);
   }
 }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.hxx
@@ -114,10 +114,10 @@ public:
                                         const double             theParameter);
 
   Standard_EXPORT const TCollection_AsciiString& Name() const override;
-  Standard_EXPORT void OnNodeRemoved(const BRepGraph_NodeId theNode,
-                                     const BRepGraph_NodeId theReplacement) noexcept override;
-  Standard_EXPORT void OnCompact(
-    const NCollection_DataMap<BRepGraph_NodeId, BRepGraph_NodeId>& theRemapMap) noexcept override;
+  Standard_EXPORT void                           OnNodeRemoved(const BRepGraph_NodeId theNode,
+                                                               const BRepGraph_NodeId theReplacement) noexcept override;
+  Standard_EXPORT void                           OnCompact(
+                              const NCollection_DataMap<BRepGraph_NodeId, BRepGraph_NodeId>& theRemapMap) noexcept override;
   Standard_EXPORT void InvalidateAll() noexcept override;
   Standard_EXPORT void Clear() noexcept override;
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerParam.hxx
@@ -20,7 +20,26 @@
 #include <NCollection_DynamicArray.hxx>
 #include <gp_Pnt2d.hxx>
 
-//! @brief Stores vertex-on-curve, vertex-on-surface, and vertex-on-PCurve bindings.
+//! @brief Persistent vertex point-representation store: point-on-curve,
+//! point-on-surface, and point-on-PCurve parameters per vertex.
+//!
+//! Mirrors classical BRep_PointRepresentation entries on TVertex: each vertex
+//! may carry parameters identifying its location on incident edges, faces, or
+//! coedges (PCurves). The layer is the single source of truth for these
+//! parameters in BRepGraph.
+//!
+//! ## Lifetime policy
+//! The layer is **persistent metadata**: stored values survive arbitrary
+//! mutations to the referenced vertices, edges, faces, and coedges. Only the
+//! following events discard data:
+//!   - OnNodeRemoved - the referenced node is gone; entries naming it are
+//!     dropped (or migrated when a replacement is provided).
+//!   - OnCompact - ids are remapped; entries pointing to removed nodes drop.
+//!   - InvalidateAll() / Clear() - explicit caller request.
+//! The layer does NOT subscribe to OnNodeModified: a tolerance bump, parameter
+//! range adjustment, or NaturalRestriction toggle on a referenced node leaves
+//! point-representation data intact. Callers that change geometry are
+//! responsible for refreshing affected entries.
 class BRepGraph_LayerParam : public BRepGraph_Layer
 {
 public:
@@ -95,10 +114,6 @@ public:
                                         const double             theParameter);
 
   Standard_EXPORT const TCollection_AsciiString& Name() const override;
-  [[nodiscard]] Standard_EXPORT int              SubscribedKinds() const override;
-  Standard_EXPORT void OnNodeModified(const BRepGraph_NodeId theNode) noexcept override;
-  Standard_EXPORT void OnNodesModified(
-    const NCollection_DynamicArray<BRepGraph_NodeId>& theModifiedNodes) noexcept override;
   Standard_EXPORT void OnNodeRemoved(const BRepGraph_NodeId theNode,
                                      const BRepGraph_NodeId theReplacement) noexcept override;
   Standard_EXPORT void OnCompact(

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
@@ -268,6 +268,36 @@ void BRepGraph_LayerRegularity::SetRegularity(const BRepGraph_EdgeId theEdge,
 
 //=================================================================================================
 
+void BRepGraph_LayerRegularity::CopyRegularities(const BRepGraph_EdgeId theSourceEdge,
+                                                 const BRepGraph_EdgeId theTargetEdge)
+{
+  if (theSourceEdge == theTargetEdge)
+  {
+    return;
+  }
+
+  const EdgeRegularities* aSourceRegularities = myEdgeRegularities.Seek(theSourceEdge);
+  if (aSourceRegularities == nullptr)
+  {
+    return;
+  }
+
+  const EdgeRegularities aSnapshot = *aSourceRegularities;
+  for (const RegularityEntry& anEntry : aSnapshot.Entries)
+  {
+    SetRegularity(theTargetEdge, anEntry.FaceEntity1, anEntry.FaceEntity2, anEntry.Continuity);
+  }
+}
+
+//=================================================================================================
+
+void BRepGraph_LayerRegularity::RemoveRegularities(const BRepGraph_EdgeId theEdge) noexcept
+{
+  removeEdgeBindings(theEdge);
+}
+
+//=================================================================================================
+
 void BRepGraph_LayerRegularity::removeRegularity(const BRepGraph_EdgeId theEdge,
                                                  const BRepGraph_FaceId theFace1,
                                                  const BRepGraph_FaceId theFace2) noexcept

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.cxx
@@ -129,13 +129,6 @@ const TCollection_AsciiString& BRepGraph_LayerRegularity::Name() const
 
 //=================================================================================================
 
-int BRepGraph_LayerRegularity::SubscribedKinds() const
-{
-  return KindBit(BRepGraph_NodeId::Kind::Edge) | KindBit(BRepGraph_NodeId::Kind::Face);
-}
-
-//=================================================================================================
-
 const BRepGraph_LayerRegularity::EdgeRegularities* BRepGraph_LayerRegularity::FindEdgeRegularities(
   const BRepGraph_EdgeId theEdge) const
 {
@@ -441,34 +434,6 @@ void BRepGraph_LayerRegularity::migrateFaceBindings(const BRepGraph_FaceId theOl
         anEntry.FaceEntity2 == theOldFace ? theNewFace : anEntry.FaceEntity2;
       SetRegularity(aEdgeId, aFace1, aFace2, anEntry.Continuity);
     }
-  }
-}
-
-//=================================================================================================
-
-void BRepGraph_LayerRegularity::OnNodeModified(const BRepGraph_NodeId theNode) noexcept
-{
-  switch (theNode.NodeKind)
-  {
-    case BRepGraph_NodeId::Kind::Edge:
-      removeEdgeBindings(BRepGraph_EdgeId(theNode));
-      break;
-    case BRepGraph_NodeId::Kind::Face:
-      invalidateFaceBindings(BRepGraph_FaceId(theNode));
-      break;
-    default:
-      break;
-  }
-}
-
-//=================================================================================================
-
-void BRepGraph_LayerRegularity::OnNodesModified(
-  const NCollection_DynamicArray<BRepGraph_NodeId>& theModifiedNodes) noexcept
-{
-  for (const BRepGraph_NodeId& aModifiedNode : theModifiedNodes)
-  {
-    OnNodeModified(aModifiedNode);
   }
 }
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
@@ -80,6 +80,13 @@ public:
                                      const BRepGraph_FaceId theFace2,
                                      const GeomAbs_Shape    theContinuity);
 
+  //! Copy all regularity entries from one edge to another.
+  Standard_EXPORT void CopyRegularities(const BRepGraph_EdgeId theSourceEdge,
+                                        const BRepGraph_EdgeId theTargetEdge);
+
+  //! Remove all regularity entries bound to the edge.
+  Standard_EXPORT void RemoveRegularities(const BRepGraph_EdgeId theEdge) noexcept;
+
   Standard_EXPORT const TCollection_AsciiString& Name() const override;
   Standard_EXPORT void OnNodeRemoved(const BRepGraph_NodeId theNode,
                                      const BRepGraph_NodeId theReplacement) noexcept override;

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
@@ -88,10 +88,10 @@ public:
   Standard_EXPORT void RemoveRegularities(const BRepGraph_EdgeId theEdge) noexcept;
 
   Standard_EXPORT const TCollection_AsciiString& Name() const override;
-  Standard_EXPORT void OnNodeRemoved(const BRepGraph_NodeId theNode,
-                                     const BRepGraph_NodeId theReplacement) noexcept override;
-  Standard_EXPORT void OnCompact(
-    const NCollection_DataMap<BRepGraph_NodeId, BRepGraph_NodeId>& theRemapMap) noexcept override;
+  Standard_EXPORT void                           OnNodeRemoved(const BRepGraph_NodeId theNode,
+                                                               const BRepGraph_NodeId theReplacement) noexcept override;
+  Standard_EXPORT void                           OnCompact(
+                              const NCollection_DataMap<BRepGraph_NodeId, BRepGraph_NodeId>& theRemapMap) noexcept override;
   Standard_EXPORT void InvalidateAll() noexcept override;
   Standard_EXPORT void Clear() noexcept override;
 

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_LayerRegularity.hxx
@@ -20,7 +20,25 @@
 #include <NCollection_DataMap.hxx>
 #include <NCollection_DynamicArray.hxx>
 
-//! @brief Stores edge continuity records between adjacent face pairs.
+//! @brief Persistent edge-continuity store, keyed by (edge, F1, F2).
+//!
+//! Each entry holds the geometric continuity (C^k / G^k) across the face pair
+//! at a given edge. F1 == F2 represents seam continuity across a closed
+//! surface's seam line; F1 != F2 represents inter-face regularity. The schema
+//! mirrors classical BRep_Tool::Continuity(edge, F1, F2).
+//!
+//! ## Lifetime policy
+//! The layer is **persistent metadata**: stored values survive arbitrary
+//! mutations to the referenced edges and faces. Only the following events
+//! discard data:
+//!   - OnNodeRemoved(edge|face) - the referenced node is gone; entries naming
+//!     it are dropped (or migrated when a replacement is provided).
+//!   - OnCompact - ids are remapped; entries pointing to removed nodes drop.
+//!   - InvalidateAll() / Clear() - explicit caller request.
+//! In particular, this layer does NOT subscribe to OnNodeModified: a tolerance
+//! bump or NaturalRestriction toggle leaves stored continuity intact. Callers
+//! that change the underlying geometry are responsible for refreshing affected
+//! entries (typically via SetRegularity, removeRegularity, or InvalidateAll).
 class BRepGraph_LayerRegularity : public BRepGraph_Layer
 {
 public:
@@ -63,10 +81,6 @@ public:
                                      const GeomAbs_Shape    theContinuity);
 
   Standard_EXPORT const TCollection_AsciiString& Name() const override;
-  [[nodiscard]] Standard_EXPORT int              SubscribedKinds() const override;
-  Standard_EXPORT void OnNodeModified(const BRepGraph_NodeId theNode) noexcept override;
-  Standard_EXPORT void OnNodesModified(
-    const NCollection_DynamicArray<BRepGraph_NodeId>& theModifiedNodes) noexcept override;
   Standard_EXPORT void OnNodeRemoved(const BRepGraph_NodeId theNode,
                                      const BRepGraph_NodeId theReplacement) noexcept override;
   Standard_EXPORT void OnCompact(

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
@@ -21,6 +21,8 @@
 #include <BRepGraph_LayerParam.hxx>
 #include <BRepGraph_RefsIterator.hxx>
 #include <BRepGraph_RefsView.hxx>
+#include <BRepGraph_ReverseIterator.hxx>
+#include <NCollection_Map.hxx>
 #include <BRepGraph_LayerRegularity.hxx>
 #include <BRepGraph_TopoView.hxx>
 #include <BRepGraphInc_Definition.hxx>
@@ -467,14 +469,33 @@ BRepGraph_FaceId BRepGraph_Tool::CoEdge::FaceOf(const BRepGraph&         theGrap
 BRepGraph_CoEdgeId BRepGraph_Tool::CoEdge::SeamPair(const BRepGraph&         theGraph,
                                                     const BRepGraph_CoEdgeId theCoEdge)
 {
-  return theGraph.Topo().CoEdges().Definition(theCoEdge).SeamPairId;
+  // The seam mate is the sibling CoEdge on the same face with opposite orientation.
+  const BRepGraphInc::CoEdgeDef& aDef = theGraph.Topo().CoEdges().Definition(theCoEdge);
+  if (!aDef.EdgeDefId.IsValid() || !aDef.FaceDefId.IsValid())
+  {
+    return {};
+  }
+  for (BRepGraph_CoEdgesOfEdge anIt(theGraph, theGraph.Topo().Edges().CoEdges(aDef.EdgeDefId));
+       anIt.More();
+       anIt.Next())
+  {
+    const BRepGraph_CoEdgeId aOther = anIt.CurrentId();
+    if (aOther == theCoEdge)
+      continue;
+    const BRepGraphInc::CoEdgeDef& aOtherDef = anIt.Definition();
+    if (aOtherDef.FaceDefId == aDef.FaceDefId && aOtherDef.Orientation != aDef.Orientation)
+    {
+      return aOther;
+    }
+  }
+  return {};
 }
 
 //=================================================================================================
 
 bool BRepGraph_Tool::CoEdge::IsSeam(const BRepGraph& theGraph, const BRepGraph_CoEdgeId theCoEdge)
 {
-  return theGraph.Topo().CoEdges().Definition(theCoEdge).SeamPairId.IsValid();
+  return SeamPair(theGraph, theCoEdge).IsValid();
 }
 
 //=================================================================================================
@@ -601,8 +622,21 @@ bool BRepGraph_Tool::Edge::IsClosedOnFace(const BRepGraph&       theGraph,
                                           const BRepGraph_EdgeId theEdge,
                                           const BRepGraph_FaceId theFace)
 {
-  const BRepGraphInc::CoEdgeDef* aCoEdge = theGraph.Topo().Edges().FindPCurve(theEdge, theFace);
-  return aCoEdge != nullptr && aCoEdge->SeamPairId.IsValid();
+  if (!theEdge.IsValid())
+  {
+    return false;
+  }
+  uint32_t aCount = 0;
+  for (BRepGraph_CoEdgesOfEdge anIt(theGraph, theGraph.Topo().Edges().CoEdges(theEdge));
+       anIt.More();
+       anIt.Next())
+  {
+    if (anIt.Definition().FaceDefId == theFace && ++aCount == 2)
+    {
+      return true;
+    }
+  }
+  return false;
 }
 
 //=================================================================================================
@@ -863,6 +897,23 @@ bool BRepGraph_Tool::Wire::IsClosed(const BRepGraph& theGraph, const BRepGraph_W
 uint32_t BRepGraph_Tool::Wire::NbCoEdges(const BRepGraph& theGraph, const BRepGraph_WireId theWire)
 {
   return static_cast<uint32_t>(theGraph.Topo().Wires().Definition(theWire).CoEdgeRefIds.Size());
+}
+
+//=================================================================================================
+
+uint32_t BRepGraph_Tool::Wire::NbDistinctEdges(const BRepGraph&       theGraph,
+                                               const BRepGraph_WireId theWire)
+{
+  // Wires are small (typically 3-8 entries); a typed Map dedup on EdgeDefId is fine.
+  NCollection_Map<BRepGraph_EdgeId> aSeenEdges;
+  for (BRepGraph_RefsCoEdgeOfWire anIt(theGraph, theWire); anIt.More(); anIt.Next())
+  {
+    const BRepGraphInc::CoEdgeRef& aRef = theGraph.Refs().CoEdges().Entry(anIt.CurrentId());
+    if (!aRef.CoEdgeDefId.IsValid())
+      continue;
+    aSeenEdges.Add(theGraph.Topo().CoEdges().Definition(aRef.CoEdgeDefId).EdgeDefId);
+  }
+  return static_cast<uint32_t>(aSeenEdges.Extent());
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.cxx
@@ -622,16 +622,28 @@ bool BRepGraph_Tool::Edge::IsClosedOnFace(const BRepGraph&       theGraph,
                                           const BRepGraph_EdgeId theEdge,
                                           const BRepGraph_FaceId theFace)
 {
-  if (!theEdge.IsValid())
+  if (!theEdge.IsValid() || !theFace.IsValid())
   {
     return false;
   }
-  uint32_t aCount = 0;
+  bool               hasOrientation = false;
+  TopAbs_Orientation anOrientation  = TopAbs_FORWARD;
   for (BRepGraph_CoEdgesOfEdge anIt(theGraph, theGraph.Topo().Edges().CoEdges(theEdge));
        anIt.More();
        anIt.Next())
   {
-    if (anIt.Definition().FaceDefId == theFace && ++aCount == 2)
+    const BRepGraphInc::CoEdgeDef& aCoEdge = anIt.Definition();
+    if (aCoEdge.FaceDefId != theFace)
+    {
+      continue;
+    }
+    if (!hasOrientation)
+    {
+      anOrientation  = aCoEdge.Orientation;
+      hasOrientation = true;
+      continue;
+    }
+    if (aCoEdge.Orientation != anOrientation)
     {
       return true;
     }

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
@@ -620,9 +620,8 @@ public:
     //! @param[in] theGraph source graph
     //! @param[in] theWire  typed wire definition identifier
     //! @return number of distinct EdgeDefIds reachable from the wire's CoEdgeRefIds
-    [[nodiscard]] Standard_EXPORT static uint32_t NbDistinctEdges(
-      const BRepGraph&       theGraph,
-      const BRepGraph_WireId theWire);
+    [[nodiscard]] Standard_EXPORT static uint32_t NbDistinctEdges(const BRepGraph&       theGraph,
+                                                                  const BRepGraph_WireId theWire);
 
     //! Returns the first owning face for this wire via the reverse-index table.
     //! Returns an invalid id if the wire has no owning face (free wire).

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Tool.hxx
@@ -608,12 +608,21 @@ public:
     [[nodiscard]] Standard_EXPORT static bool IsClosed(const BRepGraph&       theGraph,
                                                        const BRepGraph_WireId theWire);
 
-    //! Number of CoEdge references in the wire (i.e., edge count including orientation).
+    //! Number of CoEdge references in the wire (raw count: seam halves count twice,
+    //! matching TopoDS_Iterator(wire) semantics).
     //! @param[in] theGraph source graph
     //! @param[in] theWire  typed wire definition identifier
     //! @return number of coedge entries
     [[nodiscard]] Standard_EXPORT static uint32_t NbCoEdges(const BRepGraph&       theGraph,
                                                             const BRepGraph_WireId theWire);
+
+    //! Number of distinct underlying edges in the wire (seam halves count once).
+    //! @param[in] theGraph source graph
+    //! @param[in] theWire  typed wire definition identifier
+    //! @return number of distinct EdgeDefIds reachable from the wire's CoEdgeRefIds
+    [[nodiscard]] Standard_EXPORT static uint32_t NbDistinctEdges(
+      const BRepGraph&       theGraph,
+      const BRepGraph_WireId theWire);
 
     //! Returns the first owning face for this wire via the reverse-index table.
     //! Returns an invalid id if the wire has no owning face (free wire).

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_TopoView.cxx
@@ -17,6 +17,7 @@
 #include <BRepGraph_Iterator.hxx>
 #include <BRepGraph_RefsIterator.hxx>
 #include <BRepGraph_RefsView.hxx>
+#include <BRepGraph_ReverseIterator.hxx>
 #include <BRepGraphInc_ReverseIndex.hxx>
 #include <BRepGraphInc_Storage.hxx>
 #include <NCollection_Map.hxx>
@@ -807,17 +808,26 @@ BRepGraph_CoEdgeId BRepGraph::TopoView::CoEdgeOps::SeamPair(
   {
     return BRepGraph_CoEdgeId();
   }
-
   const BRepGraphInc::CoEdgeDef& aCoEdge = aStorage.CoEdge(theCoEdge);
-  if (aCoEdge.IsRemoved || !aCoEdge.SeamPairId.IsValid(aStorage.NbCoEdges()))
+  if (aCoEdge.IsRemoved || !aCoEdge.EdgeDefId.IsValid() || !aCoEdge.FaceDefId.IsValid())
   {
     return BRepGraph_CoEdgeId();
   }
-  if (aStorage.CoEdge(aCoEdge.SeamPairId).IsRemoved)
+  // The seam mate is the sibling CoEdge on the same face with opposite orientation.
+  for (BRepGraph_CoEdgesOfEdge anIt(*myGraph, myGraph->Topo().Edges().CoEdges(aCoEdge.EdgeDefId));
+       anIt.More();
+       anIt.Next())
   {
-    return BRepGraph_CoEdgeId();
+    const BRepGraph_CoEdgeId aOther = anIt.CurrentId();
+    if (aOther == theCoEdge)
+      continue;
+    const BRepGraphInc::CoEdgeDef& aOtherDef = anIt.Definition();
+    if (aOtherDef.FaceDefId == aCoEdge.FaceDefId && aOtherDef.Orientation != aCoEdge.Orientation)
+    {
+      return aOther;
+    }
   }
-  return aCoEdge.SeamPairId;
+  return BRepGraph_CoEdgeId();
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
@@ -14,6 +14,7 @@
 #include <BRepGraph_Validate.hxx>
 #include <BRepGraph_Iterator.hxx>
 #include <BRepGraph_RefsIterator.hxx>
+#include <BRepGraph_ReverseIterator.hxx>
 #include <BRepGraphInc_Definition.hxx>
 #include <BRepGraphInc_Reference.hxx>
 #include <BRepGraphInc_Representation.hxx>
@@ -148,32 +149,40 @@ void checkCrossReferenceBounds(const BRepGraph&                                 
     {
       theIssues.Append(Issue{Severity::Error, aCoEdgeId, "CoEdgeDef.EdgeDefId out of bounds"});
     }
-    // SeamPairId consistency.
-    if (aCoEdge.SeamPairId.IsValid())
+    // Seam consistency: for every (EdgeDefId, FaceDefId) pair there are at most
+    // 2 CoEdges; if 2, they must have opposite Orientation.
+    if (aCoEdge.EdgeDefId.IsValid() && aCoEdge.FaceDefId.IsValid())
     {
-      if (!aCoEdge.SeamPairId.IsValid(theGraph.Topo().CoEdges().Nb()))
+      uint32_t aSameFaceCount       = 0;
+      bool     aHasOppositeOnSameFace = false;
+      for (BRepGraph_CoEdgesOfEdge anIt(theGraph,
+                                        theGraph.Topo().Edges().CoEdges(aCoEdge.EdgeDefId));
+           anIt.More();
+           anIt.Next())
       {
-        theIssues.Append(Issue{Severity::Error, aCoEdgeId, "CoEdgeDef.SeamPairId out of bounds"});
+        const BRepGraph_CoEdgeId       aOtherId = anIt.CurrentId();
+        const BRepGraphInc::CoEdgeDef& aOther   = anIt.Definition();
+        if (aOther.FaceDefId != aCoEdge.FaceDefId)
+          continue;
+        ++aSameFaceCount;
+        if (aOtherId != aCoEdgeId && aOther.Orientation != aCoEdge.Orientation)
+        {
+          aHasOppositeOnSameFace = true;
+        }
       }
-      else if (aCoEdge.SeamPairId == aCoEdgeId)
+      if (aSameFaceCount > 2)
       {
         theIssues.Append(
-          Issue{Severity::Error, aCoEdgeId, "CoEdgeDef.SeamPairId is self-reference"});
+          Issue{Severity::Error,
+                aCoEdgeId,
+                "More than 2 CoEdges share the same (EdgeDefId, FaceDefId)"});
       }
-      else
+      else if (aSameFaceCount == 2 && !aHasOppositeOnSameFace)
       {
-        const BRepGraphInc::CoEdgeDef& aPair =
-          theGraph.Topo().CoEdges().Definition(aCoEdge.SeamPairId);
-        if (aPair.SeamPairId != aCoEdgeId)
-        {
-          theIssues.Append(
-            Issue{Severity::Error, aCoEdgeId, "CoEdgeDef.SeamPairId not bidirectional"});
-        }
-        if (aPair.FaceDefId != aCoEdge.FaceDefId)
-        {
-          theIssues.Append(
-            Issue{Severity::Error, aCoEdgeId, "CoEdgeDef seam pair has different FaceDefId"});
-        }
+        theIssues.Append(
+          Issue{Severity::Error,
+                aCoEdgeId,
+                "Seam pair CoEdges have the same Orientation"});
       }
     }
     // Rep index bounds.

--- a/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraph/BRepGraph_Validate.cxx
@@ -153,7 +153,7 @@ void checkCrossReferenceBounds(const BRepGraph&                                 
     // 2 CoEdges; if 2, they must have opposite Orientation.
     if (aCoEdge.EdgeDefId.IsValid() && aCoEdge.FaceDefId.IsValid())
     {
-      uint32_t aSameFaceCount       = 0;
+      uint32_t aSameFaceCount         = 0;
       bool     aHasOppositeOnSameFace = false;
       for (BRepGraph_CoEdgesOfEdge anIt(theGraph,
                                         theGraph.Topo().Edges().CoEdges(aCoEdge.EdgeDefId));
@@ -172,17 +172,14 @@ void checkCrossReferenceBounds(const BRepGraph&                                 
       }
       if (aSameFaceCount > 2)
       {
-        theIssues.Append(
-          Issue{Severity::Error,
-                aCoEdgeId,
-                "More than 2 CoEdges share the same (EdgeDefId, FaceDefId)"});
+        theIssues.Append(Issue{Severity::Error,
+                               aCoEdgeId,
+                               "More than 2 CoEdges share the same (EdgeDefId, FaceDefId)"});
       }
       else if (aSameFaceCount == 2 && !aHasOppositeOnSameFace)
       {
         theIssues.Append(
-          Issue{Severity::Error,
-                aCoEdgeId,
-                "Seam pair CoEdges have the same Orientation"});
+          Issue{Severity::Error, aCoEdgeId, "Seam pair CoEdges have the same Orientation"});
       }
     }
     // Rep index bounds.

--- a/src/ModelingData/TKBRep/BRepGraph/README.md
+++ b/src/ModelingData/TKBRep/BRepGraph/README.md
@@ -330,17 +330,17 @@ layers are added explicitly via `LayerRegistry().RegisterLayer()`.
 - **Storage**: internal maps keyed by NodeId, owned by the layer
 - **Lifecycle**: `OnNodeRemoved(old, replacement)` migrates data; `OnCompact(remapMap)` remaps; `OnNodeModified`/`OnNodesModified` for node mutation tracking; `OnRefRemoved`/`OnRefModified`/`OnRefsModified` for reference mutation tracking (subscribed via `SubscribedRefKinds()` bitmask)
 - **Survives mutations**: yes
-- **Examples**: `BRepGraph_ParamLayer`, `BRepGraph_RegularityLayer`
+- **Examples**: `BRepGraph_LayerParam`, `BRepGraph_LayerRegularity`
 
 Typical workflow:
 
 ```cpp
 BRepGraph aGraph;
-aGraph.LayerRegistry().RegisterLayer(new BRepGraph_ParamLayer());
-aGraph.LayerRegistry().RegisterLayer(new BRepGraph_RegularityLayer());
+aGraph.LayerRegistry().RegisterLayer(new BRepGraph_LayerParam());
+aGraph.LayerRegistry().RegisterLayer(new BRepGraph_LayerRegularity());
 
-const occ::handle<BRepGraph_ParamLayer> aParamLayer =
-  aGraph.LayerRegistry().FindLayer<BRepGraph_ParamLayer>();
+const occ::handle<BRepGraph_LayerParam> aParamLayer =
+  aGraph.LayerRegistry().FindLayer<BRepGraph_LayerParam>();
 ```
 
 ### TransientCache (`BRepGraph_TransientCache`) and RefTransientCache (`BRepGraph_RefTransientCache`)
@@ -487,7 +487,7 @@ if (!aResult.IsValid())
 | **Traversal** | `BRepGraph_ChildExplorer.hxx/.cxx`, `BRepGraph_ParentExplorer.hxx/.cxx`, `BRepGraph_RelatedIterator.hxx`, `BRepGraph_TopologyPath.hxx`, `BRepGraph_PCurveContext.hxx` |
 | **Geometry** | `BRepGraph_Tool.hxx/.cxx` |
 | **Mutation** | `BRepGraph_MutGuard.hxx`, `BRepGraph_DeferredScope.hxx` |
-| **Layers** | `BRepGraph_Layer.hxx/.cxx`, `BRepGraph_LayerIterator.hxx`, `BRepGraph_LayerRegistry.hxx/.cxx`, `BRepGraph_ParamLayer.hxx/.cxx`, `BRepGraph_RegularityLayer.hxx/.cxx` |
+| **Layers** | `BRepGraph_Layer.hxx/.cxx`, `BRepGraph_LayerIterator.hxx`, `BRepGraph_LayerRegistry.hxx/.cxx`, `BRepGraph_LayerParam.hxx/.cxx`, `BRepGraph_LayerRegularity.hxx/.cxx` |
 | **Transient Cache** | `BRepGraph_TransientCache.hxx/.cxx`, `BRepGraph_RefTransientCache.hxx/.cxx`, `BRepGraph_CacheKindIterator.hxx` |
 | **History** | `BRepGraph_History.hxx/.cxx`, `BRepGraph_HistoryRecord.hxx` |
 | **Build** | `BRepGraph_Builder.hxx/.cxx` |

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Definition.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Definition.hxx
@@ -135,8 +135,8 @@ struct EdgeDef : public BaseDef
 //!
 //! Each coedge represents one edge-face binding with its parametric curve.
 //! Wires reference coedges rather than edges directly.
-//! For seam edges, two coedges exist on the same face with opposite Orientation,
-//! linked by SeamPairId.
+//! Seam edges produce two coedges on the same face with opposite Orientation;
+//! the seam relation is queryable via BRepGraph_Tool::CoEdge::SeamPair.
 struct CoEdgeDef : public BaseDef
 {
   using TypeId = BRepGraph_CoEdgeId;
@@ -153,9 +153,9 @@ struct CoEdgeDef : public BaseDef
   gp_Pnt2d               UV1;                     //!< UV at ParamFirst
   gp_Pnt2d               UV2;                     //!< UV at ParamLast
 
-  //! Seam pairing: typed id of the paired coedge (invalid if non-seam).
-  BRepGraph_CoEdgeId SeamPairId;
-  GeomAbs_Shape      SeamContinuity = GeomAbs_C0; //!< Continuity between seam pair
+  //! Seam continuity (C^k across the seam line on the closed surface). Meaningful
+  //! only on a seam half. The two halves carry the same value.
+  GeomAbs_Shape SeamContinuity = GeomAbs_C0;
 
   //! Typed representation id into Storage::myPolygons2D (invalid if no polygon-on-surface).
   BRepGraph_Polygon2DRepId Polygon2DRepId;

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Definition.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Definition.hxx
@@ -149,13 +149,8 @@ struct CoEdgeDef : public BaseDef
   BRepGraph_Curve2DRepId Curve2DRepId;
   double                 ParamFirst = 0.0;
   double                 ParamLast  = 0.0;
-  GeomAbs_Shape          Continuity = GeomAbs_C0; //!< Geometric continuity across face pairs
-  gp_Pnt2d               UV1;                     //!< UV at ParamFirst
-  gp_Pnt2d               UV2;                     //!< UV at ParamLast
-
-  //! Seam continuity (C^k across the seam line on the closed surface). Meaningful
-  //! only on a seam half. The two halves carry the same value.
-  GeomAbs_Shape SeamContinuity = GeomAbs_C0;
+  gp_Pnt2d               UV1; //!< UV at ParamFirst
+  gp_Pnt2d               UV2; //!< UV at ParamLast
 
   //! Typed representation id into Storage::myPolygons2D (invalid if no polygon-on-surface).
   BRepGraph_Polygon2DRepId Polygon2DRepId;

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
@@ -946,7 +946,7 @@ static void extractEdgeInFace(ExtractedEdge&                   theEdgeData,
   // The input theEdge carries the iterator's natural orientation, so the
   // extractor returns the matching PCurve (PCurve() for FORWARD, PCurve2() for
   // REVERSED on a closed surface). The opposite half is the *other* yield's
-  // ExtractedEdge — we don't need to fetch it here.
+  // ExtractedEdge - we don't need to fetch it here.
   {
     double aPCFirst = 0.0, aPCLast = 0.0;
     extractStoredPCurves(theEdge,
@@ -1215,7 +1215,7 @@ void registerFaceData(BRepGraphInc_Storage&                          theStorage,
             theStorage.TriangulationRep(aFaceDef.TriangulationRepId).Triangulation;
           if (!aTri.IsNull())
           {
-            TopLoc_Location aPolyTriLoc;
+            TopLoc_Location                          aPolyTriLoc;
             occ::handle<Poly_PolygonOnTriangulation> aPolyOnTri =
               BRep_Tool::PolygonOnTriangulation(anEdgeData.Shape, aTri, aPolyTriLoc);
             if (!aPolyOnTri.IsNull())
@@ -1780,10 +1780,7 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
         {
           continue;
         }
-        theRegularityLayer->SetRegularity(anEdgeId,
-                                          *aFaceIdx,
-                                          *aFaceIdx,
-                                          aCRep->Continuity());
+        theRegularityLayer->SetRegularity(anEdgeId, *aFaceIdx, *aFaceIdx, aCRep->Continuity());
       }
     }
   }
@@ -1991,13 +1988,14 @@ void populateOptionalLayers(BRepGraphInc_Storage&                         theSto
 
 //=================================================================================================
 
-void BRepGraphInc_Populate::Perform(BRepGraphInc_Storage&                         theStorage,
-                                    const TopoDS_Shape&                           theShape,
-                                    const bool                                    theParallel,
-                                    const Options&                                theOptions,
-                                    const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
-                                    const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
-                                    const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
+void BRepGraphInc_Populate::Perform(
+  BRepGraphInc_Storage&                         theStorage,
+  const TopoDS_Shape&                           theShape,
+  const bool                                    theParallel,
+  const Options&                                theOptions,
+  const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
+  const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
+  const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   theStorage.Clear();
 

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
@@ -212,13 +212,10 @@ struct ExtractedEdge
   NCollection_DynamicArray<ExtractedInternalVertex> InternalVertices;
   TopAbs_Orientation                                OrientationInWire = TopAbs_FORWARD;
   occ::handle<Geom2d_Curve>                         PCurve2d;
-  double                                            PCFirst          = 0.0;
-  double                                            PCLast           = 0.0;
-  GeomAbs_Shape                                     PCurveContinuity = GeomAbs_C0;
+  double                                            PCFirst = 0.0;
+  double                                            PCLast  = 0.0;
   gp_Pnt2d                                          PCUV1;
   gp_Pnt2d                                          PCUV2;
-  GeomAbs_Shape                                     SeamContinuity = GeomAbs_C0;
-  bool                                              IsSeam = false; //!< This yield's edge is a seam half on theFace.
   occ::handle<Poly_Polygon3D>                       Polygon3D;
   occ::handle<Poly_Polygon2D>                       PolyOnSurf;
 };
@@ -261,8 +258,7 @@ struct FaceLocalData
 //!   Pass 3: original (pre-transform) surface handle match when face surface
 //!           was transformed via applyRepresentationLocation
 //! Returns ONE PCurve matching the input edge's orientation. For seam edges
-//! (IsCurveOnClosedSurface), picks PCurve() for FORWARD or PCurve2() for REVERSED;
-//! sets theIsSeam=true and theSeamContinuity from the BRep_CurveOnClosedSurface.
+//! (IsCurveOnClosedSurface), picks PCurve() for FORWARD or PCurve2() for REVERSED.
 //!
 //! WARNING: Passes 2-3 are workarounds for TopLoc_Location structural equality
 //! issues where an explicit identity datum does not compare equal to a default
@@ -273,8 +269,6 @@ struct FaceLocalData
 //! @param[out] thePCurve    PCurve matching theEdge.Orientation() (or null)
 //! @param[out] theFirst     parameter range start
 //! @param[out] theLast      parameter range end
-//! @param[out] theIsSeam    true iff the matched representation is a seam (CurveOnClosedSurface)
-//! @param[out] theSeamContinuity  seam continuity (GeomAbs_C0 if non-seam)
 //! @param[in]  theOrigSurface  pre-transform surface handle for fallback matching
 //!                             when the face's raw TFace surface differs from edge CRs
 //! @return true if a stored PCurve was found
@@ -284,8 +278,6 @@ static bool extractStoredPCurves(
   occ::handle<Geom2d_Curve>&       thePCurve,
   double&                          theFirst,
   double&                          theLast,
-  bool&                            theIsSeam,
-  GeomAbs_Shape&                   theSeamContinuity,
   const occ::handle<Geom_Surface>& theOrigSurface = occ::handle<Geom_Surface>())
 {
   TopLoc_Location                  aFaceLoc;
@@ -307,21 +299,11 @@ static bool extractStoredPCurves(
   const TopLoc_Location aExpectedLoc = aFaceLoc.Predivided(theEdge.Location());
 
   // Lambda to extract PCurve data from a matched CurveRepresentation.
-  // Picks the PCurve matching the input edge's orientation; for seam (CurveOnClosedSurface)
-  // CRs, also reports IsSeam + per-pair Continuity.
+  // Picks the PCurve matching the input edge's orientation.
   const auto anExtractFromCR = [&](const occ::handle<BRep_CurveRepresentation>& theCR) -> bool {
     const BRep_GCurve* aGC = static_cast<const BRep_GCurve*>(theCR.get());
     aGC->Range(theFirst, theLast);
-    if (aGC->IsCurveOnClosedSurface())
-    {
-      thePCurve         = aReversed ? aGC->PCurve2() : aGC->PCurve();
-      theIsSeam         = true;
-      theSeamContinuity = static_cast<const BRep_CurveOnClosedSurface*>(theCR.get())->Continuity();
-    }
-    else
-    {
-      thePCurve = aGC->PCurve();
-    }
+    thePCurve = aGC->IsCurveOnClosedSurface() && aReversed ? aGC->PCurve2() : aGC->PCurve();
     return true;
   };
 
@@ -966,24 +948,16 @@ static void extractEdgeInFace(ExtractedEdge&                   theEdgeData,
   // REVERSED on a closed surface). The opposite half is the *other* yield's
   // ExtractedEdge — we don't need to fetch it here.
   {
-    double        aPCFirst = 0.0, aPCLast = 0.0;
-    GeomAbs_Shape aSeamContinuity = GeomAbs_C0;
-    bool          aIsSeam         = false;
-
+    double aPCFirst = 0.0, aPCLast = 0.0;
     extractStoredPCurves(theEdge,
                          theForwardFace,
                          theEdgeData.PCurve2d,
                          aPCFirst,
                          aPCLast,
-                         aIsSeam,
-                         aSeamContinuity,
                          theOrigSurface);
 
-    theEdgeData.PCFirst          = aPCFirst;
-    theEdgeData.PCLast           = aPCLast;
-    theEdgeData.PCurveContinuity = BRep_Tool::MaxContinuity(theEdge);
-    theEdgeData.IsSeam           = aIsSeam;
-    theEdgeData.SeamContinuity   = aSeamContinuity;
+    theEdgeData.PCFirst = aPCFirst;
+    theEdgeData.PCLast  = aPCLast;
 
     // When the surface was transformed (TFace.Location != Identity -> theFaceSurface
     // differs from the raw TFace surface), the stored CR may belong to a different face
@@ -1001,10 +975,8 @@ static void extractEdgeInFace(ExtractedEdge&                   theEdgeData,
       if (!aBTPCurve.IsNull() && !aBTIsStored && aBTPCurve.get() != theEdgeData.PCurve2d.get())
       {
         theEdgeData.PCurve2d.Nullify();
-        theEdgeData.PCFirst        = 0.0;
-        theEdgeData.PCLast         = 0.0;
-        theEdgeData.IsSeam         = false;
-        theEdgeData.SeamContinuity = GeomAbs_C0;
+        theEdgeData.PCFirst = 0.0;
+        theEdgeData.PCLast  = 0.0;
       }
     }
 
@@ -1216,10 +1188,8 @@ void registerFaceData(BRepGraphInc_Storage&                          theStorage,
               getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2d);
             aCoEdge.ParamFirst = anEdgeData.PCFirst;
             aCoEdge.ParamLast  = anEdgeData.PCLast;
-            aCoEdge.Continuity = anEdgeData.PCurveContinuity;
             aCoEdge.UV1        = anEdgeData.PCUV1;
             aCoEdge.UV2        = anEdgeData.PCUV2;
-            aCoEdge.SeamContinuity = anEdgeData.SeamContinuity;
           }
           aCoEdge.Polygon2DRepId =
             getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurf);
@@ -1713,12 +1683,12 @@ void flattenForAppend(BRepGraphInc_Storage&                       theStorage,
 //=================================================================================================
 
 void populateRegularityLayer(BRepGraphInc_Storage&                         theStorage,
-                             BRepGraph_LayerRegularity*                    theRegularityLayer,
+                             const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
                              const bool                                    theExtractRegularities,
                              const uint32_t                                theOldNbEdges,
                              const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
-  if (theRegularityLayer == nullptr)
+  if (theRegularityLayer.IsNull())
   {
     return;
   }
@@ -1775,28 +1745,46 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
         continue;
       }
 
-      const occ::handle<BRep_CurveOn2Surfaces> aCon2S =
-        occ::down_cast<BRep_CurveOn2Surfaces>(aCRep);
-      if (aCon2S.IsNull())
+      // Inter-face regularity: BRep_CurveOn2Surfaces stores G^k between F1 and F2.
+      if (const occ::handle<BRep_CurveOn2Surfaces> aCon2S =
+            occ::down_cast<BRep_CurveOn2Surfaces>(aCRep);
+          !aCon2S.IsNull())
       {
+        const Geom_Surface* aSurf1Ptr = aCon2S->Surface().get();
+        const Geom_Surface* aSurf2Ptr = aCon2S->Surface2().get();
+        if (aSurf1Ptr == nullptr || aSurf2Ptr == nullptr)
+        {
+          continue;
+        }
+        const BRepGraph_FaceId* aFaceIdx1 = aSurfToFaceIdx.Seek(aSurf1Ptr);
+        const BRepGraph_FaceId* aFaceIdx2 = aSurfToFaceIdx.Seek(aSurf2Ptr);
+        if (aFaceIdx1 == nullptr || aFaceIdx2 == nullptr)
+        {
+          continue;
+        }
+        theRegularityLayer->SetRegularity(anEdgeId, *aFaceIdx1, *aFaceIdx2, aCon2S->Continuity());
         continue;
       }
 
-      const Geom_Surface* aSurf1Ptr = aCon2S->Surface().get();
-      const Geom_Surface* aSurf2Ptr = aCon2S->Surface2().get();
-      if (aSurf1Ptr == nullptr || aSurf2Ptr == nullptr)
+      // Seam regularity: BRep_CurveOnClosedSurface owns the (PCurve, PCurve2)
+      // pair on a single closed surface; record continuity with F1 == F2.
+      if (aCRep->IsCurveOnClosedSurface())
       {
-        continue;
+        const Geom_Surface* aSurfPtr = aCRep->Surface().get();
+        if (aSurfPtr == nullptr)
+        {
+          continue;
+        }
+        const BRepGraph_FaceId* aFaceIdx = aSurfToFaceIdx.Seek(aSurfPtr);
+        if (aFaceIdx == nullptr)
+        {
+          continue;
+        }
+        theRegularityLayer->SetRegularity(anEdgeId,
+                                          *aFaceIdx,
+                                          *aFaceIdx,
+                                          aCRep->Continuity());
       }
-
-      const BRepGraph_FaceId* aFaceIdx1 = aSurfToFaceIdx.Seek(aSurf1Ptr);
-      const BRepGraph_FaceId* aFaceIdx2 = aSurfToFaceIdx.Seek(aSurf2Ptr);
-      if (aFaceIdx1 == nullptr || aFaceIdx2 == nullptr)
-      {
-        continue;
-      }
-
-      theRegularityLayer->SetRegularity(anEdgeId, *aFaceIdx1, *aFaceIdx2, aCon2S->Continuity());
     }
   }
 }
@@ -1804,12 +1792,12 @@ void populateRegularityLayer(BRepGraphInc_Storage&                         theSt
 //=================================================================================================
 
 void populateParamLayer(BRepGraphInc_Storage&                         theStorage,
-                        BRepGraph_LayerParam*                         theParamLayer,
+                        const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
                         const bool                                    theExtractVertexPointReps,
                         const uint32_t                                theOldNbVertices,
                         const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
-  if (theParamLayer == nullptr)
+  if (theParamLayer.IsNull())
   {
     return;
   }
@@ -1980,8 +1968,8 @@ void populateParamLayer(BRepGraphInc_Storage&                         theStorage
 //=================================================================================================
 
 void populateOptionalLayers(BRepGraphInc_Storage&                         theStorage,
-                            BRepGraph_LayerParam*                         theParamLayer,
-                            BRepGraph_LayerRegularity*                    theRegularityLayer,
+                            const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
+                            const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
                             const BRepGraphInc_Populate::Options&         theOptions,
                             const uint32_t                                theOldNbEdges,
                             const uint32_t                                theOldNbVertices,
@@ -2003,12 +1991,12 @@ void populateOptionalLayers(BRepGraphInc_Storage&                         theSto
 
 //=================================================================================================
 
-void BRepGraphInc_Populate::Perform(BRepGraphInc_Storage&      theStorage,
-                                    const TopoDS_Shape&        theShape,
-                                    const bool                 theParallel,
-                                    const Options&             theOptions,
-                                    BRepGraph_LayerParam*      theParamLayer,
-                                    BRepGraph_LayerRegularity* theRegularityLayer,
+void BRepGraphInc_Populate::Perform(BRepGraphInc_Storage&                         theStorage,
+                                    const TopoDS_Shape&                           theShape,
+                                    const bool                                    theParallel,
+                                    const Options&                                theOptions,
+                                    const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
+                                    const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
                                     const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   theStorage.Clear();
@@ -2121,8 +2109,8 @@ void BRepGraphInc_Populate::AppendFlattened(
   const bool                                    theParallel,
   NCollection_DynamicArray<BRepGraph_NodeId>&   theAppendedRoots,
   const Options&                                theOptions,
-  BRepGraph_LayerParam*                         theParamLayer,
-  BRepGraph_LayerRegularity*                    theRegularityLayer,
+  const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
+  const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
   const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   if (theShape.IsNull())
@@ -2211,8 +2199,8 @@ void BRepGraphInc_Populate::Append(BRepGraphInc_Storage&                        
                                    const TopoDS_Shape&                           theShape,
                                    const bool                                    theParallel,
                                    const Options&                                theOptions,
-                                   BRepGraph_LayerParam*                         theParamLayer,
-                                   BRepGraph_LayerRegularity*                    theRegularityLayer,
+                                   const occ::handle<BRepGraph_LayerParam>&      theParamLayer,
+                                   const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer,
                                    const occ::handle<NCollection_BaseAllocator>& theTmpAlloc)
 {
   if (theShape.IsNull())

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
@@ -1170,7 +1170,7 @@ void registerFaceData(BRepGraphInc_Storage&                          theStorage,
         // Safe: no new edges are appended within this scope.
         BRepGraphInc::EdgeDef& anEdgeMut = theStorage.ChangeEdge(anEdgeIdx);
 
-        // One TopoDS_Iterator yield ↔ one CoEdge ↔ one CoEdgeRef. Seam edges
+        // One TopoDS_Iterator yield <-> one CoEdge <-> one CoEdgeRef. Seam edges
         // arrive as two yields with opposite orientations at their natural
         // positions in the wire's loop.
         BRepGraph_CoEdgeId aCoEdgeId;

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.cxx
@@ -212,18 +212,15 @@ struct ExtractedEdge
   NCollection_DynamicArray<ExtractedInternalVertex> InternalVertices;
   TopAbs_Orientation                                OrientationInWire = TopAbs_FORWARD;
   occ::handle<Geom2d_Curve>                         PCurve2d;
-  double                                            PCFirst = 0.0;
-  double                                            PCLast  = 0.0;
-  occ::handle<Geom2d_Curve>                         PCurve2dReversed;
-  double                                            PCFirstReversed  = 0.0;
-  double                                            PCLastReversed   = 0.0;
+  double                                            PCFirst          = 0.0;
+  double                                            PCLast           = 0.0;
   GeomAbs_Shape                                     PCurveContinuity = GeomAbs_C0;
   gp_Pnt2d                                          PCUV1;
   gp_Pnt2d                                          PCUV2;
   GeomAbs_Shape                                     SeamContinuity = GeomAbs_C0;
+  bool                                              IsSeam = false; //!< This yield's edge is a seam half on theFace.
   occ::handle<Poly_Polygon3D>                       Polygon3D;
   occ::handle<Poly_Polygon2D>                       PolyOnSurf;
-  occ::handle<Poly_Polygon2D>                       PolyOnSurfReversed;
 };
 
 //! Per-wire data extracted in parallel phase.
@@ -263,7 +260,9 @@ struct FaceLocalData
 //!           (only when a unique CR matches the surface - prevents wrong-context selection)
 //!   Pass 3: original (pre-transform) surface handle match when face surface
 //!           was transformed via applyRepresentationLocation
-//! For seam edges (IsCurveOnClosedSurface), extracts both PCurves + continuity.
+//! Returns ONE PCurve matching the input edge's orientation. For seam edges
+//! (IsCurveOnClosedSurface), picks PCurve() for FORWARD or PCurve2() for REVERSED;
+//! sets theIsSeam=true and theSeamContinuity from the BRep_CurveOnClosedSurface.
 //!
 //! WARNING: Passes 2-3 are workarounds for TopLoc_Location structural equality
 //! issues where an explicit identity datum does not compare equal to a default
@@ -271,10 +270,10 @@ struct FaceLocalData
 //! 2-3 may become redundant but should remain harmless (pass 1 will match first).
 //! @param[in]  theEdge      edge with context orientation and location
 //! @param[in]  theFace      face with context location
-//! @param[out] thePCurve    primary PCurve (or null)
-//! @param[out] thePCurve2   seam PCurve (or null, only for closed surfaces)
+//! @param[out] thePCurve    PCurve matching theEdge.Orientation() (or null)
 //! @param[out] theFirst     parameter range start
 //! @param[out] theLast      parameter range end
+//! @param[out] theIsSeam    true iff the matched representation is a seam (CurveOnClosedSurface)
 //! @param[out] theSeamContinuity  seam continuity (GeomAbs_C0 if non-seam)
 //! @param[in]  theOrigSurface  pre-transform surface handle for fallback matching
 //!                             when the face's raw TFace surface differs from edge CRs
@@ -283,9 +282,9 @@ static bool extractStoredPCurves(
   const TopoDS_Edge&               theEdge,
   const TopoDS_Face&               theFace,
   occ::handle<Geom2d_Curve>&       thePCurve,
-  occ::handle<Geom2d_Curve>&       thePCurve2,
   double&                          theFirst,
   double&                          theLast,
+  bool&                            theIsSeam,
   GeomAbs_Shape&                   theSeamContinuity,
   const occ::handle<Geom_Surface>& theOrigSurface = occ::handle<Geom_Surface>())
 {
@@ -308,13 +307,15 @@ static bool extractStoredPCurves(
   const TopLoc_Location aExpectedLoc = aFaceLoc.Predivided(theEdge.Location());
 
   // Lambda to extract PCurve data from a matched CurveRepresentation.
+  // Picks the PCurve matching the input edge's orientation; for seam (CurveOnClosedSurface)
+  // CRs, also reports IsSeam + per-pair Continuity.
   const auto anExtractFromCR = [&](const occ::handle<BRep_CurveRepresentation>& theCR) -> bool {
     const BRep_GCurve* aGC = static_cast<const BRep_GCurve*>(theCR.get());
     aGC->Range(theFirst, theLast);
     if (aGC->IsCurveOnClosedSurface())
     {
       thePCurve         = aReversed ? aGC->PCurve2() : aGC->PCurve();
-      thePCurve2        = aReversed ? aGC->PCurve() : aGC->PCurve2();
+      theIsSeam         = true;
       theSeamContinuity = static_cast<const BRep_CurveOnClosedSurface*>(theCR.get())->Continuity();
     }
     else
@@ -957,27 +958,31 @@ static void extractEdgeInFace(ExtractedEdge&                   theEdgeData,
     theEdgeData.EndVertex.Tolerance = BRep_Tool::Tolerance(aVLast);
   }
 
-  // Extract stored PCurves directly from BRep_TEdge::Curves(), bypassing
+  // Extract this yield's PCurve directly from BRep_TEdge::Curves(), bypassing
   // BRep_Tool::CurveOnSurface which can fail due to TopLoc_Location structural
   // equality bug and can compute phantom PCurves via CurveOnPlane.
-  // Uses FORWARD-oriented edge for consistent PCurve pair ordering.
+  // The input theEdge carries the iterator's natural orientation, so the
+  // extractor returns the matching PCurve (PCurve() for FORWARD, PCurve2() for
+  // REVERSED on a closed surface). The opposite half is the *other* yield's
+  // ExtractedEdge — we don't need to fetch it here.
   {
-    const TopoDS_Edge aFwdEdge = TopoDS::Edge(theEdge.Oriented(TopAbs_FORWARD));
-    double            aPCFirst = 0.0, aPCLast = 0.0;
-    GeomAbs_Shape     aSeamContinuity = GeomAbs_C0;
+    double        aPCFirst = 0.0, aPCLast = 0.0;
+    GeomAbs_Shape aSeamContinuity = GeomAbs_C0;
+    bool          aIsSeam         = false;
 
-    extractStoredPCurves(aFwdEdge,
+    extractStoredPCurves(theEdge,
                          theForwardFace,
                          theEdgeData.PCurve2d,
-                         theEdgeData.PCurve2dReversed,
                          aPCFirst,
                          aPCLast,
+                         aIsSeam,
                          aSeamContinuity,
                          theOrigSurface);
 
     theEdgeData.PCFirst          = aPCFirst;
     theEdgeData.PCLast           = aPCLast;
     theEdgeData.PCurveContinuity = BRep_Tool::MaxContinuity(theEdge);
+    theEdgeData.IsSeam           = aIsSeam;
     theEdgeData.SeamContinuity   = aSeamContinuity;
 
     // When the surface was transformed (TFace.Location != Identity -> theFaceSurface
@@ -992,46 +997,20 @@ static void extractEdgeInFace(ExtractedEdge&                   theEdgeData,
       double                    aBTFirst = 0.0, aBTLast = 0.0;
       bool                      aBTIsStored = false;
       occ::handle<Geom2d_Curve> aBTPCurve =
-        BRep_Tool::CurveOnSurface(aFwdEdge, theForwardFace, aBTFirst, aBTLast, &aBTIsStored);
+        BRep_Tool::CurveOnSurface(theEdge, theForwardFace, aBTFirst, aBTLast, &aBTIsStored);
       if (!aBTPCurve.IsNull() && !aBTIsStored && aBTPCurve.get() != theEdgeData.PCurve2d.get())
       {
-        // BRep_Tool computed a different PCurve (CurveOnPlane) - our stored match
-        // is from the wrong face context. Discard it.
         theEdgeData.PCurve2d.Nullify();
-        theEdgeData.PCurve2dReversed.Nullify();
         theEdgeData.PCFirst        = 0.0;
         theEdgeData.PCLast         = 0.0;
-        aPCFirst                   = 0.0;
-        aPCLast                    = 0.0;
+        theEdgeData.IsSeam         = false;
         theEdgeData.SeamContinuity = GeomAbs_C0;
       }
     }
 
     if (!theEdgeData.PCurve2d.IsNull() && !theFaceSurface.IsNull())
     {
-      BRep_Tool::UVPoints(aFwdEdge, theForwardFace, theEdgeData.PCUV1, theEdgeData.PCUV2);
-    }
-
-    // For seam edges, extract reversed parameter range.
-    // The reversed edge accesses PCurve2/PCurve (swapped), so Range gives the same values.
-    // Fall back to primary range if extraction fails.
-    if (!theEdgeData.PCurve2dReversed.IsNull())
-    {
-      const TopoDS_Edge         aRevEdge = TopoDS::Edge(theEdge.Oriented(TopAbs_REVERSED));
-      occ::handle<Geom2d_Curve> aDummyPC1, aDummyPC2;
-      GeomAbs_Shape             aDummyCont = GeomAbs_C0;
-      if (!extractStoredPCurves(aRevEdge,
-                                theForwardFace,
-                                aDummyPC1,
-                                aDummyPC2,
-                                theEdgeData.PCFirstReversed,
-                                theEdgeData.PCLastReversed,
-                                aDummyCont))
-      {
-        // Seam edges share the same parameter range; use primary as fallback.
-        theEdgeData.PCFirstReversed = aPCFirst;
-        theEdgeData.PCLastReversed  = aPCLast;
-      }
+      BRep_Tool::UVPoints(theEdge, theForwardFace, theEdgeData.PCUV1, theEdgeData.PCUV2);
     }
   }
 
@@ -1043,21 +1022,8 @@ static void extractEdgeInFace(ExtractedEdge&                   theEdgeData,
       applyRepLocationToPolygon3D(theEdgeData.Polygon3D, theEdge.Location(), aPoly3DLoc);
   }
 
-  // PolygonOnSurface: use FORWARD-oriented edge for consistent ordering.
-  {
-    const TopoDS_Edge aFwdEdge = TopoDS::Edge(theEdge.Oriented(TopAbs_FORWARD));
-    theEdgeData.PolyOnSurf     = BRep_Tool::PolygonOnSurface(aFwdEdge, theForwardFace);
-    if (!theEdgeData.PolyOnSurf.IsNull())
-    {
-      const TopoDS_Edge           aRevEdge = TopoDS::Edge(theEdge.Oriented(TopAbs_REVERSED));
-      occ::handle<Poly_Polygon2D> aPolyOnSurfRev =
-        BRep_Tool::PolygonOnSurface(aRevEdge, theForwardFace);
-      if (!aPolyOnSurfRev.IsNull() && aPolyOnSurfRev != theEdgeData.PolyOnSurf)
-      {
-        theEdgeData.PolyOnSurfReversed = aPolyOnSurfRev;
-      }
-    }
-  }
+  // PolygonOnSurface: fetch with theEdge's orientation so seam halves yield distinct polygons.
+  theEdgeData.PolyOnSurf = BRep_Tool::PolygonOnSurface(theEdge, theForwardFace);
 }
 
 //! Extract per-face geometry/topology data from TopoDS.
@@ -1232,19 +1198,18 @@ void registerFaceData(BRepGraphInc_Storage&                          theStorage,
         // Safe: no new edges are appended within this scope.
         BRepGraphInc::EdgeDef& anEdgeMut = theStorage.ChangeEdge(anEdgeIdx);
 
-        // Create CoEdge entity for this edge-face binding and add CoEdgeUsage to wire.
-        BRepGraph_CoEdgeId aFwdCoEdgeId;
-        BRepGraph_CoEdgeId aSeamCoEdgeId;
+        // One TopoDS_Iterator yield ↔ one CoEdge ↔ one CoEdgeRef. Seam edges
+        // arrive as two yields with opposite orientations at their natural
+        // positions in the wire's loop.
+        BRepGraph_CoEdgeId aCoEdgeId;
         if (aIsNewWireDef)
         {
-          // Create the forward CoEdge.
-          aFwdCoEdgeId                     = theStorage.AppendCoEdge();
-          BRepGraphInc::CoEdgeDef& aCoEdge = theStorage.ChangeCoEdge(aFwdCoEdgeId);
+          aCoEdgeId                        = theStorage.AppendCoEdge();
+          BRepGraphInc::CoEdgeDef& aCoEdge = theStorage.ChangeCoEdge(aCoEdgeId);
           aCoEdge.EdgeDefId                = anEdgeIdx;
           aCoEdge.FaceDefId                = aFaceId;
           aCoEdge.Orientation              = anEdgeData.OrientationInWire;
 
-          // Populate CoEdge with PCurve and polygon data for this face context.
           if (!anEdgeData.PCurve2d.IsNull())
           {
             aCoEdge.Curve2DRepId =
@@ -1254,43 +1219,15 @@ void registerFaceData(BRepGraphInc_Storage&                          theStorage,
             aCoEdge.Continuity = anEdgeData.PCurveContinuity;
             aCoEdge.UV1        = anEdgeData.PCUV1;
             aCoEdge.UV2        = anEdgeData.PCUV2;
+            aCoEdge.SeamContinuity = anEdgeData.SeamContinuity;
           }
           aCoEdge.Polygon2DRepId =
             getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurf);
 
-          // Handle seam edge: create a second CoEdge for the reversed sense.
-          if (!anEdgeData.PCurve2dReversed.IsNull())
-          {
-            aSeamCoEdgeId                        = theStorage.AppendCoEdge();
-            BRepGraphInc::CoEdgeDef& aSeamCoEdge = theStorage.ChangeCoEdge(aSeamCoEdgeId);
-            aSeamCoEdge.EdgeDefId                = anEdgeIdx;
-            aSeamCoEdge.FaceDefId                = aFaceId;
-            aSeamCoEdge.Orientation              = TopAbs_REVERSED;
-            aSeamCoEdge.Curve2DRepId =
-              getOrCreateCurve2DRep(theStorage, theRepDedup, anEdgeData.PCurve2dReversed);
-            aSeamCoEdge.ParamFirst     = anEdgeData.PCFirstReversed;
-            aSeamCoEdge.ParamLast      = anEdgeData.PCLastReversed;
-            aSeamCoEdge.Continuity     = anEdgeData.PCurveContinuity;
-            aSeamCoEdge.SeamContinuity = anEdgeData.SeamContinuity;
-            aSeamCoEdge.Polygon2DRepId =
-              getOrCreatePolygon2DRep(theStorage, theRepDedup, anEdgeData.PolyOnSurfReversed);
-
-            // Link seam pair.
-            // Note: aCoEdge ref may be invalidated by AppendCoEdge, re-fetch.
-            theStorage.ChangeCoEdge(aFwdCoEdgeId).SeamPairId = aSeamCoEdgeId;
-            aSeamCoEdge.SeamPairId                           = aFwdCoEdgeId;
-          }
-
-          // Add CoEdgeUsage to wire with edge-in-wire Location.
-          BRepGraphInc::CoEdgeInstance aCoEdgeRef;
-          aCoEdgeRef.DefId    = aFwdCoEdgeId;
-          aCoEdgeRef.Location = anEdgeData.Shape.Location();
-          appendCoEdgeRef(theStorage, aWireId, aCoEdgeRef);
-
-          // Note: seam coedge (if any) is NOT added to wire CoEdgeRefs --
-          // it shares the same wire position as the forward coedge.
-          // The seam pair is accessible via SeamPairId on the CoEdgeDef.
-          // Only the forward coedge ref is in the wire's ordered list.
+          BRepGraphInc::CoEdgeInstance aRef;
+          aRef.DefId    = aCoEdgeId;
+          aRef.Location = anEdgeData.Shape.Location();
+          appendCoEdgeRef(theStorage, aWireId, aRef);
         }
 
         // Polygon3D (once per edge).
@@ -1300,64 +1237,40 @@ void registerFaceData(BRepGraphInc_Storage&                          theStorage,
             getOrCreatePolygon3DRep(theStorage, theRepDedup, anEdgeData.Polygon3D);
         }
 
-        // Polygon-on-triangulation: extract directly into CoEdge entities.
-        if (aFwdCoEdgeId.IsValid())
+        // Polygon-on-triangulation: fetch with this yield's edge orientation,
+        // so seam halves naturally produce their own polygon (or share when stored once).
+        if (aCoEdgeId.IsValid() && aFaceDef.TriangulationRepId.IsValid())
         {
-          TopLoc_Location aPolyTriLoc;
-          const bool      hasSeamCoEdge = aSeamCoEdgeId.IsValid();
-          TopoDS_Edge     aRevEdge;
-          if (hasSeamCoEdge)
+          const occ::handle<Poly_Triangulation>& aTri =
+            theStorage.TriangulationRep(aFaceDef.TriangulationRepId).Triangulation;
+          if (!aTri.IsNull())
           {
-            aRevEdge = TopoDS::Edge(anEdgeData.Shape.Reversed());
-          }
-
-          if (aFaceDef.TriangulationRepId.IsValid())
-          {
-            const occ::handle<Poly_Triangulation>& aTri =
-              theStorage.TriangulationRep(aFaceDef.TriangulationRepId).Triangulation;
-            if (!aTri.IsNull())
+            TopLoc_Location aPolyTriLoc;
+            occ::handle<Poly_PolygonOnTriangulation> aPolyOnTri =
+              BRep_Tool::PolygonOnTriangulation(anEdgeData.Shape, aTri, aPolyTriLoc);
+            if (!aPolyOnTri.IsNull())
             {
-              occ::handle<Poly_PolygonOnTriangulation> aPolyOnTri =
-                BRep_Tool::PolygonOnTriangulation(anEdgeData.Shape, aTri, aPolyTriLoc);
-              if (!aPolyOnTri.IsNull())
+              BRepGraph_TriangulationRepId aTriRepId = aFaceDef.TriangulationRepId;
+              if (!aPolyTriLoc.IsIdentity())
               {
-                BRepGraph_TriangulationRepId aTriRepId = aFaceDef.TriangulationRepId;
-                if (!aPolyTriLoc.IsIdentity())
+                const TopLoc_Location aRepLoc =
+                  anEdgeData.Shape.Location().Inverted() * aPolyTriLoc;
+                if (!aRepLoc.IsIdentity())
                 {
-                  const TopLoc_Location aRepLoc =
-                    anEdgeData.Shape.Location().Inverted() * aPolyTriLoc;
-                  if (!aRepLoc.IsIdentity())
+                  occ::handle<Poly_Triangulation> aTriCopy = aTri->Copy();
+                  const gp_Trsf&                  aTrsf    = aRepLoc.Transformation();
+                  for (int aNodeIdx = 1; aNodeIdx <= aTriCopy->NbNodes(); ++aNodeIdx)
                   {
-                    occ::handle<Poly_Triangulation> aTriCopy = aTri->Copy();
-                    const gp_Trsf&                  aTrsf    = aRepLoc.Transformation();
-                    for (int aNodeIdx = 1; aNodeIdx <= aTriCopy->NbNodes(); ++aNodeIdx)
-                    {
-                      aTriCopy->SetNode(aNodeIdx, aTriCopy->Node(aNodeIdx).Transformed(aTrsf));
-                    }
-                    aTriRepId = getOrCreateTriangulationRep(theStorage, theRepDedup, aTriCopy);
-                    aFaceMut.TriangulationRepId = aTriRepId;
+                    aTriCopy->SetNode(aNodeIdx, aTriCopy->Node(aNodeIdx).Transformed(aTrsf));
                   }
-                }
-
-                const BRepGraph_PolygonOnTriRepId aPolyOnTriRepId =
-                  getOrCreatePolygonOnTriRep(theStorage, theRepDedup, aPolyOnTri, aTriRepId);
-
-                theStorage.ChangeCoEdge(aFwdCoEdgeId).PolygonOnTriRepId = aPolyOnTriRepId;
-
-                // Seam polygon-on-triangulation.
-                if (hasSeamCoEdge)
-                {
-                  occ::handle<Poly_PolygonOnTriangulation> aPolyOnTriRev =
-                    BRep_Tool::PolygonOnTriangulation(aRevEdge, aTri, aPolyTriLoc);
-                  if (!aPolyOnTriRev.IsNull() && aPolyOnTriRev != aPolyOnTri)
-                  {
-                    const BRepGraph_PolygonOnTriRepId aSeamPolyRepId =
-                      getOrCreatePolygonOnTriRep(theStorage, theRepDedup, aPolyOnTriRev, aTriRepId);
-
-                    theStorage.ChangeCoEdge(aSeamCoEdgeId).PolygonOnTriRepId = aSeamPolyRepId;
-                  }
+                  aTriRepId = getOrCreateTriangulationRep(theStorage, theRepDedup, aTriCopy);
+                  aFaceMut.TriangulationRepId = aTriRepId;
                 }
               }
+
+              const BRepGraph_PolygonOnTriRepId aPolyOnTriRepId =
+                getOrCreatePolygonOnTriRep(theStorage, theRepDedup, aPolyOnTri, aTriRepId);
+              theStorage.ChangeCoEdge(aCoEdgeId).PolygonOnTriRepId = aPolyOnTriRepId;
             }
           }
         }

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.hxx
@@ -64,14 +64,20 @@ public:
   //! @param[in]  theShape    root shape
   //! @param[in]  theParallel if true, face-level extraction runs in parallel
   //! @param[in]  theOptions  optional post-pass controls
-  static Standard_EXPORT void Perform(BRepGraphInc_Storage&      theStorage,
-                                      const TopoDS_Shape&        theShape,
-                                      const bool                 theParallel,
-                                      const Options&             theOptions         = Options(),
-                                      BRepGraph_LayerParam*      theParamLayer      = nullptr,
-                                      BRepGraph_LayerRegularity* theRegularityLayer = nullptr,
-                                      const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
-                                        occ::handle<NCollection_BaseAllocator>());
+  //! @param[in]  theParamLayer        optional point-rep layer to populate
+  //! @param[in]  theRegularityLayer   optional edge-regularity layer to populate
+  //! @param[in]  theTmpAlloc          optional allocator for temporary scratch data
+  static Standard_EXPORT void Perform(
+    BRepGraphInc_Storage&                         theStorage,
+    const TopoDS_Shape&                           theShape,
+    const bool                                    theParallel,
+    const Options&                                theOptions = Options(),
+    const occ::handle<BRepGraph_LayerParam>&      theParamLayer =
+      occ::handle<BRepGraph_LayerParam>(),
+    const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer =
+      occ::handle<BRepGraph_LayerRegularity>(),
+    const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
+      occ::handle<NCollection_BaseAllocator>());
 
   //! Extend existing backend storage with additional shapes (no clear).
   //! Flattens hierarchy containers away; Solid/Shell/Compound/CompSolid inputs
@@ -88,9 +94,11 @@ public:
     const TopoDS_Shape&                           theShape,
     const bool                                    theParallel,
     NCollection_DynamicArray<BRepGraph_NodeId>&   theAppendedRoots,
-    const Options&                                theOptions         = Options(),
-    BRepGraph_LayerParam*                         theParamLayer      = nullptr,
-    BRepGraph_LayerRegularity*                    theRegularityLayer = nullptr,
+    const Options&                                theOptions = Options(),
+    const occ::handle<BRepGraph_LayerParam>&      theParamLayer =
+      occ::handle<BRepGraph_LayerParam>(),
+    const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer =
+      occ::handle<BRepGraph_LayerRegularity>(),
     const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
       occ::handle<NCollection_BaseAllocator>());
 
@@ -103,14 +111,17 @@ public:
   //! @param[in]     theParallel      if true, face-level extraction runs in parallel
   //! @param[in]     theOptions       optional post-pass controls
   //! @param[in]     theTmpAlloc      optional allocator for temporary scratch data
-  static Standard_EXPORT void Append(BRepGraphInc_Storage&      theStorage,
-                                     const TopoDS_Shape&        theShape,
-                                     const bool                 theParallel,
-                                     const Options&             theOptions         = Options(),
-                                     BRepGraph_LayerParam*      theParamLayer      = nullptr,
-                                     BRepGraph_LayerRegularity* theRegularityLayer = nullptr,
-                                     const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
-                                       occ::handle<NCollection_BaseAllocator>());
+  static Standard_EXPORT void Append(
+    BRepGraphInc_Storage&                         theStorage,
+    const TopoDS_Shape&                           theShape,
+    const bool                                    theParallel,
+    const Options&                                theOptions = Options(),
+    const occ::handle<BRepGraph_LayerParam>&      theParamLayer =
+      occ::handle<BRepGraph_LayerParam>(),
+    const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer =
+      occ::handle<BRepGraph_LayerRegularity>(),
+    const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
+      occ::handle<NCollection_BaseAllocator>());
 
 private:
   BRepGraphInc_Populate() = delete;

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.hxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Populate.hxx
@@ -68,12 +68,11 @@ public:
   //! @param[in]  theRegularityLayer   optional edge-regularity layer to populate
   //! @param[in]  theTmpAlloc          optional allocator for temporary scratch data
   static Standard_EXPORT void Perform(
-    BRepGraphInc_Storage&                         theStorage,
-    const TopoDS_Shape&                           theShape,
-    const bool                                    theParallel,
-    const Options&                                theOptions = Options(),
-    const occ::handle<BRepGraph_LayerParam>&      theParamLayer =
-      occ::handle<BRepGraph_LayerParam>(),
+    BRepGraphInc_Storage&                    theStorage,
+    const TopoDS_Shape&                      theShape,
+    const bool                               theParallel,
+    const Options&                           theOptions    = Options(),
+    const occ::handle<BRepGraph_LayerParam>& theParamLayer = occ::handle<BRepGraph_LayerParam>(),
     const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer =
       occ::handle<BRepGraph_LayerRegularity>(),
     const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
@@ -90,13 +89,12 @@ public:
   //! @param[in]     theOptions       optional post-pass controls
   //! @param[in]     theTmpAlloc      optional allocator for temporary scratch data
   static Standard_EXPORT void AppendFlattened(
-    BRepGraphInc_Storage&                         theStorage,
-    const TopoDS_Shape&                           theShape,
-    const bool                                    theParallel,
-    NCollection_DynamicArray<BRepGraph_NodeId>&   theAppendedRoots,
-    const Options&                                theOptions = Options(),
-    const occ::handle<BRepGraph_LayerParam>&      theParamLayer =
-      occ::handle<BRepGraph_LayerParam>(),
+    BRepGraphInc_Storage&                       theStorage,
+    const TopoDS_Shape&                         theShape,
+    const bool                                  theParallel,
+    NCollection_DynamicArray<BRepGraph_NodeId>& theAppendedRoots,
+    const Options&                              theOptions    = Options(),
+    const occ::handle<BRepGraph_LayerParam>&    theParamLayer = occ::handle<BRepGraph_LayerParam>(),
     const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer =
       occ::handle<BRepGraph_LayerRegularity>(),
     const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =
@@ -112,12 +110,11 @@ public:
   //! @param[in]     theOptions       optional post-pass controls
   //! @param[in]     theTmpAlloc      optional allocator for temporary scratch data
   static Standard_EXPORT void Append(
-    BRepGraphInc_Storage&                         theStorage,
-    const TopoDS_Shape&                           theShape,
-    const bool                                    theParallel,
-    const Options&                                theOptions = Options(),
-    const occ::handle<BRepGraph_LayerParam>&      theParamLayer =
-      occ::handle<BRepGraph_LayerParam>(),
+    BRepGraphInc_Storage&                    theStorage,
+    const TopoDS_Shape&                      theShape,
+    const bool                               theParallel,
+    const Options&                           theOptions    = Options(),
+    const occ::handle<BRepGraph_LayerParam>& theParamLayer = occ::handle<BRepGraph_LayerParam>(),
     const occ::handle<BRepGraph_LayerRegularity>& theRegularityLayer =
       occ::handle<BRepGraph_LayerRegularity>(),
     const occ::handle<NCollection_BaseAllocator>& theTmpAlloc =

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
@@ -53,6 +53,14 @@ static void restoreEdgeRegularities(const BRepGraph_LayerRegularity* theRegulari
 
   for (const BRepGraph_LayerRegularity::RegularityEntry& aRegEntry : aRegularities->Entries)
   {
+    // Seam continuity (F1 == F2) lives on the BRep_CurveOnClosedSurface that
+    // owns the PCurve pair; the face-path PCurve installation handles it
+    // directly. BRep_Builder::Continuity would create a spurious
+    // BRep_CurveOn2Surfaces with S1 == S2 here.
+    if (aRegEntry.FaceEntity1 == aRegEntry.FaceEntity2)
+    {
+      continue;
+    }
     const TopoDS_Shape* aFaceShape1 = theCache.Seek(aRegEntry.FaceEntity1);
     const TopoDS_Shape* aFaceShape2 = theCache.Seek(aRegEntry.FaceEntity2);
     if (aFaceShape1 != nullptr && aFaceShape2 != nullptr)
@@ -772,7 +780,6 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
           aUV1     = aFwdHalf->UV1;
           aUV2     = aFwdHalf->UV2;
           aHasUV   = true;
-          aSeamContinuity = aFwdHalf->SeamContinuity;
         }
         if (aRevHalf->Curve2DRepId.IsValid())
         {
@@ -782,10 +789,14 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
             aPCFirst = aRevHalf->ParamFirst;
             aPCLast  = aRevHalf->ParamLast;
           }
-          if (aSeamContinuity == GeomAbs_C0)
-          {
-            aSeamContinuity = aRevHalf->SeamContinuity;
-          }
+        }
+        // Seam continuity lives in BRepGraph_LayerRegularity with F1 == F2.
+        if (theRegularities != nullptr)
+        {
+          theRegularities->FindContinuity(aCoEdge.EdgeDefId,
+                                          aCoEdge.FaceDefId,
+                                          aCoEdge.FaceDefId,
+                                          &aSeamContinuity);
         }
       }
       else if (aCoEdge.Curve2DRepId.IsValid())

--- a/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
+++ b/src/ModelingData/TKBRep/BRepGraphInc/BRepGraphInc_Reconstruct.cxx
@@ -669,6 +669,10 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
     const TopoDS_Shape* aCachedWire = theCache.Seek(aWireNodeId);
     TopoDS_Wire         aNewWire;
 
+    // PCurve/Polygon installation must happen at most once per edge per wire,
+    // even when both halves of a seam pair appear in the wire's CoEdgeRefIds.
+    NCollection_Map<BRepGraph_EdgeId> aPCurvesInstalled(1, theCache.myTempAllocator);
+
     const auto aProcessCoEdgeForFace = [&](const BRepGraph_CoEdgeRefId theCoEdgeRefId,
                                            const bool                  theAddToWire) {
       const BRepGraphInc::CoEdgeRef& aCoEdgeRef = theStorage.CoEdgeRef(theCoEdgeRefId);
@@ -694,6 +698,13 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
         aBB.Add(aNewWire, anEdgeInWire);
       }
 
+      // Seam halves yield twice through CoEdgeRefIds; install PCurve/Polygon
+      // representations on the shared TEdge only once per edge.
+      if (!aPCurvesInstalled.Add(aCoEdge.EdgeDefId))
+      {
+        return;
+      }
+
       const BRepGraphInc::EdgeDef& anEdgeEnt = theStorage.Edge(aCoEdge.EdgeDefId);
 
       // Compute composed edge location within the face TShape hierarchy.
@@ -710,14 +721,74 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
         anEdge.Location(aEdgeInFaceLoc);
       }
 
-      // Collect PCurve(s): primary from this coedge, seam from paired coedge.
+      // For a seam, install BRep_CurveOnClosedSurface with PCurve()=FORWARD-half's
+      // PCurve and PCurve2()=REVERSED-half's PCurve regardless of which half is
+      // currently being visited. UV/range come from the FORWARD half too.
+      const BRepGraphInc::CoEdgeDef* aFwdHalf = nullptr;
+      const BRepGraphInc::CoEdgeDef* aRevHalf = nullptr;
+      {
+        const NCollection_DynamicArray<BRepGraph_CoEdgeId>* aSiblings =
+          theStorage.ReverseIndex().CoEdgesOfEdge(aCoEdge.EdgeDefId);
+        if (aSiblings != nullptr)
+        {
+          for (const BRepGraph_CoEdgeId& aOtherId : *aSiblings)
+          {
+            if (aOtherId == aCoEdgeRef.CoEdgeDefId)
+              continue;
+            const BRepGraphInc::CoEdgeDef& aOther = theStorage.CoEdge(aOtherId);
+            if (aOther.IsRemoved || aOther.FaceDefId != aCoEdge.FaceDefId
+                || aOther.Orientation == aCoEdge.Orientation)
+            {
+              continue;
+            }
+            if (aCoEdge.Orientation == TopAbs_FORWARD)
+            {
+              aFwdHalf = &aCoEdge;
+              aRevHalf = &aOther;
+            }
+            else
+            {
+              aFwdHalf = &aOther;
+              aRevHalf = &aCoEdge;
+            }
+            break;
+          }
+        }
+      }
+
       occ::handle<Geom2d_Curve> aPC1, aPC2;
       double                    aPCFirst = 0.0, aPCLast = 0.0;
       gp_Pnt2d                  aUV1, aUV2;
       bool                      aHasUV          = false;
       GeomAbs_Shape             aSeamContinuity = GeomAbs_C0;
 
-      if (aCoEdge.Curve2DRepId.IsValid())
+      if (aFwdHalf != nullptr)
+      {
+        if (aFwdHalf->Curve2DRepId.IsValid())
+        {
+          aPC1     = theStorage.Curve2DRep(aFwdHalf->Curve2DRepId).Curve;
+          aPCFirst = aFwdHalf->ParamFirst;
+          aPCLast  = aFwdHalf->ParamLast;
+          aUV1     = aFwdHalf->UV1;
+          aUV2     = aFwdHalf->UV2;
+          aHasUV   = true;
+          aSeamContinuity = aFwdHalf->SeamContinuity;
+        }
+        if (aRevHalf->Curve2DRepId.IsValid())
+        {
+          aPC2 = theStorage.Curve2DRep(aRevHalf->Curve2DRepId).Curve;
+          if (aPC1.IsNull())
+          {
+            aPCFirst = aRevHalf->ParamFirst;
+            aPCLast  = aRevHalf->ParamLast;
+          }
+          if (aSeamContinuity == GeomAbs_C0)
+          {
+            aSeamContinuity = aRevHalf->SeamContinuity;
+          }
+        }
+      }
+      else if (aCoEdge.Curve2DRepId.IsValid())
       {
         aPC1     = theStorage.Curve2DRep(aCoEdge.Curve2DRepId).Curve;
         aPCFirst = aCoEdge.ParamFirst;
@@ -725,22 +796,6 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
         aUV1     = aCoEdge.UV1;
         aUV2     = aCoEdge.UV2;
         aHasUV   = true;
-      }
-
-      // For seam edges, get the paired coedge's PCurve.
-      if (aCoEdge.SeamPairId.IsValid())
-      {
-        const BRepGraphInc::CoEdgeDef& aSeamCoEdge = theStorage.CoEdge(aCoEdge.SeamPairId);
-        if (aSeamCoEdge.Curve2DRepId.IsValid())
-        {
-          aPC2            = theStorage.Curve2DRep(aSeamCoEdge.Curve2DRepId).Curve;
-          aSeamContinuity = aSeamCoEdge.SeamContinuity;
-          if (aPC1.IsNull())
-          {
-            aPCFirst = aSeamCoEdge.ParamFirst;
-            aPCLast  = aSeamCoEdge.ParamLast;
-          }
-        }
       }
 
       if (!aPC1.IsNull() && !aPC2.IsNull())
@@ -807,29 +862,90 @@ TopoDS_Shape BRepGraphInc_Reconstruct::FaceWithCache(
         aBB.Range(anEdge, aFaceSurface, TopLoc_Location(), aPCFirst, aPCLast);
       }
 
-      // Attach PolygonOnSurface from CoEdge.
-      if (aCoEdge.Polygon2DRepId.IsValid())
+      // Attach PolygonOnSurface(s). For a seam, install both halves so
+      // BRep_Tool::PolygonOnSurface returns the correct one per orientation.
       {
-        const occ::handle<Poly_Polygon2D>& aPolyOnSurf =
-          theStorage.Polygon2DRep(aCoEdge.Polygon2DRepId).Polygon;
-        if (!aPolyOnSurf.IsNull())
+        occ::handle<Poly_Polygon2D> aPoly1, aPoly2;
+        if (aFwdHalf != nullptr)
         {
-          aBB.UpdateEdge(anEdge, aPolyOnSurf, aFaceSurface, TopLoc_Location());
+          if (aFwdHalf->Polygon2DRepId.IsValid())
+          {
+            aPoly1 = theStorage.Polygon2DRep(aFwdHalf->Polygon2DRepId).Polygon;
+          }
+          if (aRevHalf->Polygon2DRepId.IsValid())
+          {
+            aPoly2 = theStorage.Polygon2DRep(aRevHalf->Polygon2DRepId).Polygon;
+          }
+        }
+        else if (aCoEdge.Polygon2DRepId.IsValid())
+        {
+          aPoly1 = theStorage.Polygon2DRep(aCoEdge.Polygon2DRepId).Polygon;
+        }
+        if (!aPoly1.IsNull() && !aPoly2.IsNull())
+        {
+          aBB.UpdateEdge(anEdge, aPoly1, aPoly2, aFaceSurface, TopLoc_Location());
+        }
+        else if (!aPoly1.IsNull())
+        {
+          aBB.UpdateEdge(anEdge, aPoly1, aFaceSurface, TopLoc_Location());
+        }
+        else if (!aPoly2.IsNull())
+        {
+          aBB.UpdateEdge(anEdge, aPoly2, aFaceSurface, TopLoc_Location());
         }
       }
 
-      // Attach PolygonOnTriangulation from CoEdge.
-      if (aCoEdge.PolygonOnTriRepId.IsValid())
+      // Attach PolygonOnTriangulation(s). For a seam, install both halves so
+      // BRep_Tool::PolygonOnTriangulation returns the correct one per orientation.
       {
-        const BRepGraphInc::PolygonOnTriRep& aPolyOnTriRep =
-          theStorage.PolygonOnTriRep(aCoEdge.PolygonOnTriRepId);
-        if (!aPolyOnTriRep.Polygon.IsNull() && aPolyOnTriRep.TriangulationRepId.IsValid())
+        occ::handle<Poly_PolygonOnTriangulation> aN1, aN2;
+        occ::handle<Poly_Triangulation>          aTri;
+        if (aFwdHalf != nullptr)
         {
-          const occ::handle<Poly_Triangulation>& aTri =
-            theStorage.TriangulationRep(aPolyOnTriRep.TriangulationRepId).Triangulation;
-          if (!aTri.IsNull())
+          if (aFwdHalf->PolygonOnTriRepId.IsValid())
           {
-            aBB.UpdateEdge(anEdge, aPolyOnTriRep.Polygon, aTri, TopLoc_Location());
+            const BRepGraphInc::PolygonOnTriRep& aRep =
+              theStorage.PolygonOnTriRep(aFwdHalf->PolygonOnTriRepId);
+            aN1 = aRep.Polygon;
+            if (aRep.TriangulationRepId.IsValid())
+            {
+              aTri = theStorage.TriangulationRep(aRep.TriangulationRepId).Triangulation;
+            }
+          }
+          if (aRevHalf->PolygonOnTriRepId.IsValid())
+          {
+            const BRepGraphInc::PolygonOnTriRep& aRep =
+              theStorage.PolygonOnTriRep(aRevHalf->PolygonOnTriRepId);
+            aN2 = aRep.Polygon;
+            if (aTri.IsNull() && aRep.TriangulationRepId.IsValid())
+            {
+              aTri = theStorage.TriangulationRep(aRep.TriangulationRepId).Triangulation;
+            }
+          }
+        }
+        else if (aCoEdge.PolygonOnTriRepId.IsValid())
+        {
+          const BRepGraphInc::PolygonOnTriRep& aRep =
+            theStorage.PolygonOnTriRep(aCoEdge.PolygonOnTriRepId);
+          aN1 = aRep.Polygon;
+          if (aRep.TriangulationRepId.IsValid())
+          {
+            aTri = theStorage.TriangulationRep(aRep.TriangulationRepId).Triangulation;
+          }
+        }
+        if (!aTri.IsNull())
+        {
+          if (!aN1.IsNull() && !aN2.IsNull())
+          {
+            aBB.UpdateEdge(anEdge, aN1, aN2, aTri, TopLoc_Location());
+          }
+          else if (!aN1.IsNull())
+          {
+            aBB.UpdateEdge(anEdge, aN1, aTri, TopLoc_Location());
+          }
+          else if (!aN2.IsNull())
+          {
+            aBB.UpdateEdge(anEdge, aN2, aTri, TopLoc_Location());
           }
         }
       }

--- a/src/ModelingData/TKBRep/GTests/BRepGraphInc_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraphInc_Test.cxx
@@ -553,7 +553,8 @@ TEST(BRepGraphIncTest, Cylinder_HasSeamEdges)
   BRepGraphInc_Populate::Perform(aStorage, aCyl, false);
   ASSERT_TRUE(aStorage.GetIsDone());
 
-  // A cylinder has seam edges: coedges with SeamPairId valid.
+  // A cylinder has seam edges: 2 CoEdges of the same edge on the same face with
+  // opposite orientations. Count seam pairs once via the FORWARD half.
   int       aSeamPairCount = 0;
   const int aNbEdges       = aStorage.NbEdges();
   for (BRepGraph_EdgeId anEdgeId(0); anEdgeId.IsValid(aNbEdges); ++anEdgeId)
@@ -567,9 +568,19 @@ TEST(BRepGraphIncTest, Cylinder_HasSeamEdges)
     for (const BRepGraph_CoEdgeId& aCoEdgeId : *aCoEdgeIdxs)
     {
       const BRepGraphInc::CoEdgeDef& aCE = aStorage.CoEdge(aCoEdgeId);
-      if (aCE.Orientation == TopAbs_FORWARD && aCE.SeamPairId.IsValid())
+      if (aCE.Orientation != TopAbs_FORWARD)
+        continue;
+      // Look for a sibling CoEdge with the same FaceDefId and opposite orientation.
+      for (const BRepGraph_CoEdgeId& aOtherId : *aCoEdgeIdxs)
       {
-        ++aSeamPairCount;
+        if (aOtherId == aCoEdgeId)
+          continue;
+        const BRepGraphInc::CoEdgeDef& aOther = aStorage.CoEdge(aOtherId);
+        if (aOther.FaceDefId == aCE.FaceDefId && aOther.Orientation != aCE.Orientation)
+        {
+          ++aSeamPairCount;
+          break;
+        }
       }
     }
   }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Build_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Build_Test.cxx
@@ -1166,7 +1166,10 @@ TEST(BRepGraph_BuildTest, ParamLayer_EdgeMutation_InvalidatesVertexBindings)
                                        aGraph.Topo().Edges().Definition(anEdgeId).Tolerance + 0.01);
 }
 
-TEST(BRepGraph_BuildTest, ParamLayer_FaceMutation_InvalidatesVertexBindings)
+// Persistent-layer policy: face-data mutation (e.g. NaturalRestriction toggle)
+// must NOT auto-clear point representations bound to that face. The user-set
+// value is persistent metadata; only explicit removal/clear discards it.
+TEST(BRepGraph_BuildTest, ParamLayer_FaceMutation_PreservesVertexBindings)
 {
   BRepGraph aGraph;
   registerStandardLayers(aGraph);
@@ -1191,10 +1194,13 @@ TEST(BRepGraph_BuildTest, ParamLayer_FaceMutation_InvalidatesVertexBindings)
     aGraph.Editor().Faces().SetNaturalRestriction(aFace, !aFace->NaturalRestriction);
   }
 
-  EXPECT_FALSE(aParamLayer->FindPointOnSurface(aVertexId, aFaceId));
+  EXPECT_TRUE(aParamLayer->FindPointOnSurface(aVertexId, aFaceId))
+    << "Persistent layer must keep user-set value across unrelated face modifications";
 }
 
-TEST(BRepGraph_BuildTest, ParamLayer_CoEdgeMutation_InvalidatesPCurveBindings)
+// Same persistent-layer policy for CoEdge param-range bumps: layer data is
+// preserved unless the caller explicitly clears it.
+TEST(BRepGraph_BuildTest, ParamLayer_CoEdgeMutation_PreservesPCurveBindings)
 {
   BRepGraph aGraph;
   registerStandardLayers(aGraph);
@@ -1219,10 +1225,14 @@ TEST(BRepGraph_BuildTest, ParamLayer_CoEdgeMutation_InvalidatesPCurveBindings)
                                             + 0.01,
                                           aGraph.Topo().CoEdges().Definition(aCoEdgeId).ParamLast);
 
-  EXPECT_FALSE(aParamLayer->FindPointOnPCurve(aVertexId, aCoEdgeId));
+  EXPECT_TRUE(aParamLayer->FindPointOnPCurve(aVertexId, aCoEdgeId))
+    << "Persistent layer must keep user-set value across CoEdge param-range bumps";
 }
 
-TEST(BRepGraph_BuildTest, RegularityLayer_EdgeMutation_InvalidatesBindings)
+// Persistent-layer policy: edge tolerance bumps must NOT clear continuity.
+// Continuity is a stored G^k value, classical OCCT also keeps it across
+// such modifications.
+TEST(BRepGraph_BuildTest, RegularityLayer_EdgeMutation_PreservesBindings)
 {
   BRepGraph aGraph;
   registerStandardLayers(aGraph);
@@ -1278,12 +1288,15 @@ TEST(BRepGraph_BuildTest, RegularityLayer_EdgeMutation_InvalidatesBindings)
   aGraph.Editor().Edges().SetTolerance(anEdgeId,
                                        aGraph.Topo().Edges().Definition(anEdgeId).Tolerance + 0.01);
 
-  EXPECT_FALSE(
-    aRegularityLayer->FindContinuity(anEdgeId, aRegularity.FaceEntity1, aRegularity.FaceEntity2));
-  EXPECT_EQ(aRegularityLayer->NbRegularities(anEdgeId), 0);
+  EXPECT_TRUE(
+    aRegularityLayer->FindContinuity(anEdgeId, aRegularity.FaceEntity1, aRegularity.FaceEntity2))
+    << "Persistent layer must keep continuity across edge tolerance bumps";
+  EXPECT_EQ(aRegularityLayer->NbRegularities(anEdgeId), 1u);
 }
 
-TEST(BRepGraph_BuildTest, RegularityLayer_FaceMutation_InvalidatesBindings)
+// Persistent-layer policy: NaturalRestriction toggle on a face does not
+// invalidate continuity entries that reference the face.
+TEST(BRepGraph_BuildTest, RegularityLayer_FaceMutation_PreservesBindings)
 {
   BRepGraph aGraph;
   registerStandardLayers(aGraph);
@@ -1342,11 +1355,15 @@ TEST(BRepGraph_BuildTest, RegularityLayer_FaceMutation_InvalidatesBindings)
     aGraph.Editor().Faces().SetNaturalRestriction(aFace, !aFace->NaturalRestriction);
   }
 
-  EXPECT_FALSE(
-    aRegularityLayer->FindContinuity(anEdgeId, aRegularity.FaceEntity1, aRegularity.FaceEntity2));
+  EXPECT_TRUE(
+    aRegularityLayer->FindContinuity(anEdgeId, aRegularity.FaceEntity1, aRegularity.FaceEntity2))
+    << "Persistent layer must keep continuity across face property toggles";
 }
 
-TEST(BRepGraph_BuildTest, RegularityLayer_RemoveRegularity_SharedFaceRetained)
+// Removing a face that is shared by multiple regularity entries (F1,F2) and
+// (F1,F3): the entry naming the removed face must drop, but other entries
+// keeping F1 must survive.
+TEST(BRepGraph_BuildTest, RegularityLayer_RemoveFace_SharedFaceRetained)
 {
   BRepGraph_LayerRegularity aLayer;
   const BRepGraph_EdgeId    anEdgeId(0);
@@ -1356,18 +1373,16 @@ TEST(BRepGraph_BuildTest, RegularityLayer_RemoveRegularity_SharedFaceRetained)
 
   aLayer.SetRegularity(anEdgeId, aFace1, aFace2, GeomAbs_C1);
   aLayer.SetRegularity(anEdgeId, aFace1, aFace3, GeomAbs_G1);
-  EXPECT_EQ(aLayer.NbRegularities(anEdgeId), 2);
+  EXPECT_EQ(aLayer.NbRegularities(anEdgeId), 2u);
 
-  // Remove (F1,F2) - F1 is shared by the surviving (F1,F3) entry.
-  aLayer.OnNodeModified(aFace2);
-
-  // (F1,F3) must survive; F1 must still be tracked.
+  // Remove F2: entries naming F2 must go; (F1,F3) must survive.
+  aLayer.OnNodeRemoved(aFace2, BRepGraph_NodeId());
   EXPECT_TRUE(aLayer.FindContinuity(anEdgeId, aFace1, aFace3));
-  EXPECT_EQ(aLayer.NbRegularities(anEdgeId), 1);
+  EXPECT_EQ(aLayer.NbRegularities(anEdgeId), 1u);
 
-  // Modifying F1 should still invalidate the remaining entry.
-  aLayer.OnNodeModified(aFace1);
-  EXPECT_EQ(aLayer.NbRegularities(anEdgeId), 0);
+  // Remove F1: the remaining entry references F1 -> drops.
+  aLayer.OnNodeRemoved(aFace1, BRepGraph_NodeId());
+  EXPECT_EQ(aLayer.NbRegularities(anEdgeId), 0u);
 }
 
 TEST(BRepGraph_BuildTest, RegularityLayer_RemoveRegularity_NoMatch_NoEffect)

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Convenience_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Convenience_Test.cxx
@@ -216,7 +216,7 @@ TEST_F(BRepGraph_ConvenienceTest, FindPCurve_WithOrientation_SeamEdge)
 
   const BRepGraph::TopoView aDefs = aGraph.Topo();
 
-  // Look for seam edges (coedge with SeamPairId valid).
+  // Look for seam edges via the connectivity-derived IsSeam query.
   for (BRepGraph_EdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
   {
     const NCollection_DynamicArray<BRepGraph_CoEdgeId>& aCoEdgeIdxs =
@@ -225,7 +225,7 @@ TEST_F(BRepGraph_ConvenienceTest, FindPCurve_WithOrientation_SeamEdge)
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdgeIdxs)
     {
       const BRepGraphInc::CoEdgeDef& aCE = aDefs.CoEdges().Definition(aCoEdgeId);
-      if (!aCE.SeamPairId.IsValid())
+      if (!BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCoEdgeId))
       {
         continue;
       }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Geometry_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Geometry_Test.cxx
@@ -25,6 +25,7 @@
 #include <BRepGraph_ShapesView.hxx>
 #include <BRepGraph_Tool.hxx>
 #include <BRepGraph_Builder.hxx>
+#include <BRepGraph_LayerRegularity.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
@@ -249,31 +250,27 @@ TEST(BRepGraph_GeometryTest, CoEdge_ParamRange_NonZero)
   EXPECT_GT(aCoEdgeCount, 0);
 }
 
-TEST(BRepGraph_GeometryTest, CoEdge_Continuity_Valid)
+TEST(BRepGraph_GeometryTest, Edge_Continuity_Valid)
 {
   const TopoDS_Shape aShape = BRepPrimAPI_MakeCylinder(10.0, 20.0).Shape();
 
   BRepGraph aGraph;
+  aGraph.LayerRegistry().RegisterLayer(new BRepGraph_LayerRegularity());
   aGraph.Clear();
   [[maybe_unused]] const BRepGraph_Builder::Result aBuildRes8 =
     BRepGraph_Builder::Add(aGraph, aShape);
   ASSERT_TRUE(aGraph.IsDone());
 
+  // Cylinder has at least the seam edge with C^k > C0 in BRepGraph_LayerRegularity.
   bool hasNonC0Continuity = false;
   for (BRepGraph_EdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
   {
-    const NCollection_DynamicArray<BRepGraph_CoEdgeId>& aCoEdgeIdxs =
-      aGraph.Topo().Edges().CoEdges(anEdgeIt.CurrentId());
-    for (int j = 0; j < aCoEdgeIdxs.Length(); ++j)
+    if (BRepGraph_Tool::Edge::MaxContinuity(aGraph, anEdgeIt.CurrentId()) > GeomAbs_C0)
     {
-      const BRepGraphInc::CoEdgeDef& aCE = aGraph.Topo().CoEdges().Definition(aCoEdgeIdxs.Value(j));
-      if (aCE.Continuity > GeomAbs_C0)
-      {
-        hasNonC0Continuity = true;
-      }
+      hasNonC0Continuity = true;
+      break;
     }
   }
-
   EXPECT_TRUE(hasNonC0Continuity);
 }
 

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Geometry_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Geometry_Test.cxx
@@ -739,7 +739,7 @@ TEST(BRepGraph_GeometryTest, Cylinder_SeamEdge_HasTwoCoEdges)
     BRepGraph_Builder::Add(aGraph, BRepPrimAPI_MakeCylinder(5.0, 20.0).Shape());
   ASSERT_TRUE(aGraph.IsDone());
 
-  // Find a seam edge via CoEdge SeamPairId.
+  // Find a seam edge via the connectivity-derived BRepGraph_Tool::CoEdge::SeamPair query.
   bool aFoundSeam = false;
   for (BRepGraph_EdgeIterator anEdgeIt(aGraph); anEdgeIt.More() && !aFoundSeam; anEdgeIt.Next())
   {
@@ -747,11 +747,11 @@ TEST(BRepGraph_GeometryTest, Cylinder_SeamEdge_HasTwoCoEdges)
       aGraph.Topo().Edges().CoEdges(anEdgeIt.CurrentId());
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdgeIdxs)
     {
-      const BRepGraphInc::CoEdgeDef& aCE = aGraph.Topo().CoEdges().Definition(aCoEdgeId);
-      if (aCE.SeamPairId.IsValid())
+      const BRepGraph_CoEdgeId aPairId = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aCoEdgeId);
+      if (aPairId.IsValid())
       {
-        // Verify the paired coedge has opposite orientation.
-        const BRepGraphInc::CoEdgeDef& aPair = aGraph.Topo().CoEdges().Definition(aCE.SeamPairId);
+        const BRepGraphInc::CoEdgeDef& aCE   = aGraph.Topo().CoEdges().Definition(aCoEdgeId);
+        const BRepGraphInc::CoEdgeDef& aPair = aGraph.Topo().CoEdges().Definition(aPairId);
         EXPECT_NE(aCE.Orientation, aPair.Orientation)
           << "Seam coedges should have opposite orientations";
         EXPECT_EQ(aCE.FaceDefId, aPair.FaceDefId) << "Seam coedges should share the same face";
@@ -781,7 +781,7 @@ TEST(BRepGraph_GeometryTest, Cylinder_SeamEdge_FindPCurve_WithOrientation)
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdgeIdxs)
     {
       const BRepGraphInc::CoEdgeDef& aCE = aGraph.Topo().CoEdges().Definition(aCoEdgeId);
-      if (!aCE.SeamPairId.IsValid())
+      if (!BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCoEdgeId))
       {
         continue;
       }
@@ -849,7 +849,7 @@ TEST(BRepGraph_GeometryTest, Cylinder_SeamEdge_FindPCurve_DistinguishesOrientati
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdgeIdxs)
     {
       const BRepGraphInc::CoEdgeDef& aCE = aGraph.Topo().CoEdges().Definition(aCoEdgeId);
-      if (!aCE.SeamPairId.IsValid())
+      if (!BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCoEdgeId))
       {
         continue;
       }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Polygon_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Polygon_Test.cxx
@@ -34,7 +34,12 @@
 #include <Poly_PolygonOnTriangulation.hxx>
 #include <Poly_Triangulation.hxx>
 #include <Precision.hxx>
+#include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
+#include <NCollection_IndexedDataMap.hxx>
+#include <NCollection_List.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <TopoDS_Shape.hxx>
 #include <TopoDS.hxx>
 
 #include <gtest/gtest.h>
@@ -404,28 +409,9 @@ TEST(BRepGraph_PolygonTest, VertexPointRepresentations_StructurallyValid)
 
 TEST(BRepGraph_PolygonTest, EdgeRegularity_MatchesOriginal)
 {
-  // Cylinder has smooth edges between lateral face and caps.
-  // BRep stores regularity as BRep_CurveOn2Surfaces entries.
+  // Verify the regularity layer captures continuity for every (edge, F1, F2)
+  // tuple that classical BRep_Tool::Continuity reports as non-default.
   TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
-
-  // Count original regularities via BRep_Tool::Continuity.
-  int aNbOrigReg = 0;
-  for (TopExp_Explorer anEdgeExp(aCyl, TopAbs_EDGE); anEdgeExp.More(); anEdgeExp.Next())
-  {
-    const TopoDS_Edge&             anEdge = TopoDS::Edge(anEdgeExp.Current());
-    const occ::handle<BRep_TEdge>& aTEdge = occ::down_cast<BRep_TEdge>(anEdge.TShape());
-    if (aTEdge.IsNull())
-    {
-      continue;
-    }
-    for (const occ::handle<BRep_CurveRepresentation>& aCRep : aTEdge->Curves())
-    {
-      if (!occ::down_cast<BRep_CurveOn2Surfaces>(aCRep).IsNull())
-      {
-        ++aNbOrigReg;
-      }
-    }
-  }
 
   BRepGraph aGraph;
   registerStandardLayers(aGraph);
@@ -437,14 +423,94 @@ TEST(BRepGraph_PolygonTest, EdgeRegularity_MatchesOriginal)
     aGraph.LayerRegistry().FindLayer<BRepGraph_LayerRegularity>();
   ASSERT_FALSE(aRegularityLayer.IsNull());
 
-  // Count captured regularity entries.
-  int aNbGraphReg = 0;
+  // Find the seam edge (cylinder lateral face has one).
+  bool aSeamRegularityFound = false;
   for (BRepGraph_EdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
   {
-    aNbGraphReg += aRegularityLayer->NbRegularities(anEdgeIt.CurrentId());
+    const BRepGraph_EdgeId anEdgeId = anEdgeIt.CurrentId();
+    if (aRegularityLayer->NbRegularities(anEdgeId) == 0)
+    {
+      continue;
+    }
+    const BRepGraph_LayerRegularity::EdgeRegularities* aRegs =
+      aRegularityLayer->FindEdgeRegularities(anEdgeId);
+    ASSERT_NE(aRegs, nullptr);
+    for (const BRepGraph_LayerRegularity::RegularityEntry& anEntry : aRegs->Entries)
+    {
+      if (anEntry.FaceEntity1 == anEntry.FaceEntity2)
+      {
+        aSeamRegularityFound = true;
+      }
+    }
   }
-  EXPECT_EQ(aNbGraphReg, aNbOrigReg)
-    << "Graph regularity count should match BRep_CurveOn2Surfaces count";
+  EXPECT_TRUE(aSeamRegularityFound)
+    << "Cylinder seam edge must produce a regularity entry with F1 == F2";
+}
+
+// Round-trip continuity: every (edge, F1, F2) value reported by classical
+// BRep_Tool::Continuity on the original shape must be reproduced after
+// shape -> graph -> shape. Guarantees the layer captures the same continuity
+// records that the old per-CoEdge field carried (BRep_Tool::MaxContinuity walks
+// the same IsRegularity()==true set: BRep_CurveOn2Surfaces + BRep_CurveOnClosedSurface).
+TEST(BRepGraph_PolygonTest, EdgeRegularity_ShapeGraphShape_RoundTrip)
+{
+  TopoDS_Shape aOriginal = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+
+  BRepGraph aGraph;
+  registerStandardLayers(aGraph);
+  aGraph.Clear();
+  [[maybe_unused]] const BRepGraph_Builder::Result aBuildRes =
+    BRepGraph_Builder::Add(aGraph, aOriginal);
+  ASSERT_TRUE(aGraph.IsDone());
+
+  TopoDS_Shape aReconstructed =
+    aGraph.Shapes().Reconstruct(BRepGraph_NodeId(BRepGraph_NodeId::Kind::Solid, 0));
+  ASSERT_FALSE(aReconstructed.IsNull());
+
+  // Walk both originals and reconstructed in lock-step (TopExp_Explorer order)
+  // and verify every (edge, F1, F2) pair preserves its classical Continuity value.
+  using ShapeMap =
+    NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>;
+  ShapeMap aOrigEdgeFaces, aReconEdgeFaces;
+  TopExp::MapShapesAndAncestors(aOriginal, TopAbs_EDGE, TopAbs_FACE, aOrigEdgeFaces);
+  TopExp::MapShapesAndAncestors(aReconstructed, TopAbs_EDGE, TopAbs_FACE, aReconEdgeFaces);
+  ASSERT_EQ(aOrigEdgeFaces.Extent(), aReconEdgeFaces.Extent());
+
+  uint32_t aNbCheckedPairs = 0;
+  for (int i = 1; i <= aOrigEdgeFaces.Extent(); ++i)
+  {
+    const TopoDS_Edge& aOrigEdge  = TopoDS::Edge(aOrigEdgeFaces.FindKey(i));
+    const TopoDS_Edge& aReconEdge = TopoDS::Edge(aReconEdgeFaces.FindKey(i));
+    NCollection_List<TopoDS_Shape>& aOrigFaces  = aOrigEdgeFaces.ChangeFromIndex(i);
+    NCollection_List<TopoDS_Shape>& aReconFaces = aReconEdgeFaces.ChangeFromIndex(i);
+    ASSERT_EQ(aOrigFaces.Size(), aReconFaces.Size());
+
+    NCollection_List<TopoDS_Shape>::Iterator aOrigIt(aOrigFaces);
+    NCollection_List<TopoDS_Shape>::Iterator aReconIt(aReconFaces);
+    for (; aOrigIt.More(); aOrigIt.Next(), aReconIt.Next())
+    {
+      const TopoDS_Face& aOrigF1  = TopoDS::Face(aOrigIt.Value());
+      const TopoDS_Face& aReconF1 = TopoDS::Face(aReconIt.Value());
+
+      NCollection_List<TopoDS_Shape>::Iterator aOrigIt2 = aOrigIt;
+      NCollection_List<TopoDS_Shape>::Iterator aReconIt2 = aReconIt;
+      for (; aOrigIt2.More(); aOrigIt2.Next(), aReconIt2.Next())
+      {
+        const TopoDS_Face& aOrigF2  = TopoDS::Face(aOrigIt2.Value());
+        const TopoDS_Face& aReconF2 = TopoDS::Face(aReconIt2.Value());
+        EXPECT_EQ(BRep_Tool::Continuity(aReconEdge, aReconF1, aReconF2),
+                  BRep_Tool::Continuity(aOrigEdge, aOrigF1, aOrigF2))
+          << "Continuity round-trip mismatch on edge " << i;
+        ++aNbCheckedPairs;
+      }
+    }
+
+    // Per-edge MaxContinuity round-trip: BRep_Tool walks the same IsRegularity()
+    // representations the layer captures (BRep_CurveOn2Surfaces + BRep_CurveOnClosedSurface).
+    EXPECT_EQ(BRep_Tool::MaxContinuity(aReconEdge), BRep_Tool::MaxContinuity(aOrigEdge))
+      << "MaxContinuity round-trip mismatch on edge " << i;
+  }
+  EXPECT_GT(aNbCheckedPairs, 0u) << "Test must check at least one (edge, F1, F2) pair";
 }
 
 // ============================================================

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Polygon_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Polygon_Test.cxx
@@ -469,8 +469,9 @@ TEST(BRepGraph_PolygonTest, EdgeRegularity_ShapeGraphShape_RoundTrip)
 
   // Walk both originals and reconstructed in lock-step (TopExp_Explorer order)
   // and verify every (edge, F1, F2) pair preserves its classical Continuity value.
-  using ShapeMap =
-    NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>;
+  using ShapeMap = NCollection_IndexedDataMap<TopoDS_Shape,
+                                              NCollection_List<TopoDS_Shape>,
+                                              TopTools_ShapeMapHasher>;
   ShapeMap aOrigEdgeFaces, aReconEdgeFaces;
   TopExp::MapShapesAndAncestors(aOriginal, TopAbs_EDGE, TopAbs_FACE, aOrigEdgeFaces);
   TopExp::MapShapesAndAncestors(aReconstructed, TopAbs_EDGE, TopAbs_FACE, aReconEdgeFaces);
@@ -479,8 +480,8 @@ TEST(BRepGraph_PolygonTest, EdgeRegularity_ShapeGraphShape_RoundTrip)
   uint32_t aNbCheckedPairs = 0;
   for (int i = 1; i <= aOrigEdgeFaces.Extent(); ++i)
   {
-    const TopoDS_Edge& aOrigEdge  = TopoDS::Edge(aOrigEdgeFaces.FindKey(i));
-    const TopoDS_Edge& aReconEdge = TopoDS::Edge(aReconEdgeFaces.FindKey(i));
+    const TopoDS_Edge&              aOrigEdge   = TopoDS::Edge(aOrigEdgeFaces.FindKey(i));
+    const TopoDS_Edge&              aReconEdge  = TopoDS::Edge(aReconEdgeFaces.FindKey(i));
     NCollection_List<TopoDS_Shape>& aOrigFaces  = aOrigEdgeFaces.ChangeFromIndex(i);
     NCollection_List<TopoDS_Shape>& aReconFaces = aReconEdgeFaces.ChangeFromIndex(i);
     ASSERT_EQ(aOrigFaces.Size(), aReconFaces.Size());
@@ -492,7 +493,7 @@ TEST(BRepGraph_PolygonTest, EdgeRegularity_ShapeGraphShape_RoundTrip)
       const TopoDS_Face& aOrigF1  = TopoDS::Face(aOrigIt.Value());
       const TopoDS_Face& aReconF1 = TopoDS::Face(aReconIt.Value());
 
-      NCollection_List<TopoDS_Shape>::Iterator aOrigIt2 = aOrigIt;
+      NCollection_List<TopoDS_Shape>::Iterator aOrigIt2  = aOrigIt;
       NCollection_List<TopoDS_Shape>::Iterator aReconIt2 = aReconIt;
       for (; aOrigIt2.More(); aOrigIt2.Next(), aReconIt2.Next())
       {

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_RefTestTools.hxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_RefTestTools.hxx
@@ -28,6 +28,47 @@ namespace BRepGraph_TestTools
 {
 
 //=================================================================================================
+
+//! Connectivity-derived seam predicate: storage-only equivalent of
+//! BRepGraph_Tool::CoEdge::SeamPair. Returns the partner CoEdge id if theCoEdgeId
+//! is one half of a seam pair on its face, else an invalid id.
+inline BRepGraph_CoEdgeId SeamPairFromStorage(const BRepGraphInc_Storage& theStorage,
+                                              const BRepGraph_CoEdgeId    theCoEdgeId)
+{
+  const BRepGraphInc::CoEdgeDef& aDef = theStorage.CoEdge(theCoEdgeId);
+  if (aDef.IsRemoved || !aDef.EdgeDefId.IsValid() || !aDef.FaceDefId.IsValid())
+  {
+    return BRepGraph_CoEdgeId();
+  }
+  const NCollection_DynamicArray<BRepGraph_CoEdgeId>* aSiblings =
+    theStorage.ReverseIndex().CoEdgesOfEdge(aDef.EdgeDefId);
+  if (aSiblings == nullptr)
+  {
+    return BRepGraph_CoEdgeId();
+  }
+  for (size_t i = 0; i < aSiblings->Size(); ++i)
+  {
+    const BRepGraph_CoEdgeId aOther = (*aSiblings)[i];
+    if (aOther == theCoEdgeId)
+      continue;
+    const BRepGraphInc::CoEdgeDef& aOtherDef = theStorage.CoEdge(aOther);
+    if (aOtherDef.IsRemoved)
+      continue;
+    if (aOtherDef.FaceDefId == aDef.FaceDefId && aOtherDef.Orientation != aDef.Orientation)
+    {
+      return aOther;
+    }
+  }
+  return BRepGraph_CoEdgeId();
+}
+
+inline bool IsSeamCoEdgeFromStorage(const BRepGraphInc_Storage& theStorage,
+                                    const BRepGraph_CoEdgeId    theCoEdgeId)
+{
+  return SeamPairFromStorage(theStorage, theCoEdgeId).IsValid();
+}
+
+//=================================================================================================
 inline NCollection_DynamicArray<BRepGraph_CoEdgeRefId> CoEdgeRefsOfWire(
   const BRepGraph&       theGraph,
   const BRepGraph_WireId theWireId)

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
@@ -41,6 +41,7 @@
 #include <BRepGraphInc_Populate.hxx>
 #include <BRepGraphInc_Reconstruct.hxx>
 #include <BRepGraphInc_Storage.hxx>
+#include "BRepGraph_RefTestTools.hxx"
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
@@ -220,7 +221,7 @@ TEST(BRepGraph_ScenarioMatrix, Cylinder_SeamEdge_MutationAndBothSubsystemsConsis
       }
       for (const BRepGraph_CoEdgeId& aCoEdgeId : *aCoEdges)
       {
-        if (aOrigStorage.CoEdge(aCoEdgeId).SeamPairId.IsValid())
+        if (BRepGraph_TestTools::IsSeamCoEdgeFromStorage(aOrigStorage, aCoEdgeId))
         {
           aSeamEdgeId = anEdgeId;
           break;
@@ -275,7 +276,7 @@ TEST(BRepGraph_ScenarioMatrix, Cylinder_SeamEdge_MutationAndBothSubsystemsConsis
       }
       for (const BRepGraph_CoEdgeId& aCoEdgeId : *aCoEdges)
       {
-        if (aReconStorage.CoEdge(aCoEdgeId).SeamPairId.IsValid())
+        if (BRepGraph_TestTools::IsSeamCoEdgeFromStorage(aReconStorage, aCoEdgeId))
         {
           aSeamFound = true;
           break;
@@ -598,7 +599,7 @@ TEST(BRepGraph_ScenarioMatrix, Compound_BoxAndCylinder_MutationReconstructAreaRe
     }
     for (const BRepGraph_CoEdgeId& aCoEdgeId : *aCoEdges)
     {
-      if (aBaseStorage.CoEdge(aCoEdgeId).SeamPairId.IsValid())
+      if (BRepGraph_TestTools::IsSeamCoEdgeFromStorage(aBaseStorage, aCoEdgeId))
       {
         ++aBaseSeamCount;
         break; // count each seam edge once
@@ -664,7 +665,7 @@ TEST(BRepGraph_ScenarioMatrix, Compound_BoxAndCylinder_MutationReconstructAreaRe
     }
     for (const BRepGraph_CoEdgeId& aCoEdgeId : *aCoEdges)
     {
-      if (aReconStorage.CoEdge(aCoEdgeId).SeamPairId.IsValid())
+      if (BRepGraph_TestTools::IsSeamCoEdgeFromStorage(aReconStorage, aCoEdgeId))
       {
         ++aReconSeamCount;
         break;
@@ -996,8 +997,10 @@ TEST(BRepGraph_ScenarioMatrix, CompSolid_ThreeBoxes_ReverseIndexPerSolid)
 
 // =============================================================================
 // Scenario 11: Sphere seam - seam CoEdges come in bidirectionally-paired pairs.
-// If a.SeamPairId == b, then b.SeamPairId must equal a. Verify post-build and
-// post-reconstruct; exercises the SeamPairId round-trip under periodic uv.
+// The seam relation is connectivity-derived (Tool::CoEdge::SeamPair walks
+// CoEdgesOfEdge filtered by face+orientation); the symmetry of that predicate
+// is structural. Verify post-build and post-reconstruct that the seam count is
+// preserved under periodic UV.
 // =============================================================================
 
 TEST(BRepGraph_ScenarioMatrix, Sphere_SeamCoEdgePair_Bidirectional)
@@ -1011,23 +1014,26 @@ TEST(BRepGraph_ScenarioMatrix, Sphere_SeamCoEdgePair_Bidirectional)
   int aNbPairedCoEdges = 0;
   for (BRepGraph_CoEdgeId aCoEdgeId(0); aCoEdgeId.IsValid(aStorage.NbCoEdges()); ++aCoEdgeId)
   {
-    const BRepGraphInc::CoEdgeDef& aCoEdge = aStorage.CoEdge(aCoEdgeId);
-    if (!aCoEdge.SeamPairId.IsValid())
+    const BRepGraph_CoEdgeId aPairId =
+      BRepGraph_TestTools::SeamPairFromStorage(aStorage, aCoEdgeId);
+    if (!aPairId.IsValid())
     {
       continue;
     }
     ++aNbPairedCoEdges;
 
-    ASSERT_TRUE(aCoEdge.SeamPairId.IsValid(aStorage.NbCoEdges()));
-    const BRepGraphInc::CoEdgeDef& aPaired = aStorage.CoEdge(aCoEdge.SeamPairId);
-    EXPECT_EQ(aPaired.SeamPairId, aCoEdgeId)
-      << "Seam pair must be bidirectional (forward->reverse->forward)";
+    // Symmetry: the partner's partner is us.
+    const BRepGraph_CoEdgeId aBackId =
+      BRepGraph_TestTools::SeamPairFromStorage(aStorage, aPairId);
+    EXPECT_EQ(aBackId, aCoEdgeId) << "Seam relation must be symmetric";
+    const BRepGraphInc::CoEdgeDef& aCoEdge = aStorage.CoEdge(aCoEdgeId);
+    const BRepGraphInc::CoEdgeDef& aPaired = aStorage.CoEdge(aPairId);
     EXPECT_EQ(aPaired.EdgeDefId, aCoEdge.EdgeDefId)
       << "Seam pair must share the same underlying EdgeDef";
   }
   EXPECT_GT(aNbPairedCoEdges, 0) << "Sphere must have at least one seam-paired coedge";
 
-  // Build the graph, audit, reconstruct, repopulate, re-verify bidirectionality.
+  // Build the graph, audit, reconstruct, repopulate, re-verify symmetry.
   BRepGraph aGraph;
   aGraph.Clear();
   [[maybe_unused]] const BRepGraph_Builder::Result aBuildRes11 =
@@ -1047,15 +1053,16 @@ TEST(BRepGraph_ScenarioMatrix, Sphere_SeamCoEdgePair_Bidirectional)
   int aNbPairedAfter = 0;
   for (BRepGraph_CoEdgeId aCoEdgeId(0); aCoEdgeId.IsValid(aReconStorage.NbCoEdges()); ++aCoEdgeId)
   {
-    const BRepGraphInc::CoEdgeDef& aCoEdge = aReconStorage.CoEdge(aCoEdgeId);
-    if (!aCoEdge.SeamPairId.IsValid())
+    const BRepGraph_CoEdgeId aPairId =
+      BRepGraph_TestTools::SeamPairFromStorage(aReconStorage, aCoEdgeId);
+    if (!aPairId.IsValid())
     {
       continue;
     }
     ++aNbPairedAfter;
-    const BRepGraphInc::CoEdgeDef& aPaired = aReconStorage.CoEdge(aCoEdge.SeamPairId);
-    EXPECT_EQ(aPaired.SeamPairId, aCoEdgeId)
-      << "Post-reconstruct seam pair must remain bidirectional";
+    const BRepGraph_CoEdgeId aBackId =
+      BRepGraph_TestTools::SeamPairFromStorage(aReconStorage, aPairId);
+    EXPECT_EQ(aBackId, aCoEdgeId) << "Post-reconstruct seam pair must remain symmetric";
   }
   EXPECT_EQ(aNbPairedAfter, aNbPairedCoEdges)
     << "Reconstructed sphere must preserve the same number of seam-paired coedges";
@@ -1139,7 +1146,7 @@ TEST(BRepGraph_ScenarioMatrix, Cylinder_SeamEdgeSplit_AuditStable)
       aGraph.Topo().Edges().CoEdges(anEdgeId);
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdges)
     {
-      if (aGraph.Topo().CoEdges().Definition(aCoEdgeId).SeamPairId.IsValid())
+      if (BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCoEdgeId))
       {
         aSeamEdgeId = anEdgeId;
         break;
@@ -1174,21 +1181,22 @@ TEST(BRepGraph_ScenarioMatrix, Cylinder_SeamEdgeSplit_AuditStable)
     BRepGraph_Validate::Perform(aGraph, BRepGraph_Validate::Options::Audit());
   EXPECT_TRUE(aResult.IsValid()) << "Audit must remain clean after splitting a seam edge";
 
-  // Every seam-paired coedge on the live sub-edges must still be bidirectional.
+  // Every seam-paired coedge on the live sub-edges must still satisfy the
+  // symmetry of the connectivity-derived seam predicate (SeamPair(SeamPair(x))==x).
   auto checkBidirectionalOnEdge = [&](const BRepGraph_EdgeId theEdgeId) {
     const NCollection_DynamicArray<BRepGraph_CoEdgeId>& aCoEdges =
       aGraph.Topo().Edges().CoEdges(theEdgeId);
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdges)
     {
-      const BRepGraphInc::CoEdgeDef& aCoEdge = aGraph.Topo().CoEdges().Definition(aCoEdgeId);
-      if (!aCoEdge.SeamPairId.IsValid())
+      const BRepGraph_CoEdgeId aPairId =
+        BRepGraph_Tool::CoEdge::SeamPair(aGraph, aCoEdgeId);
+      if (!aPairId.IsValid())
       {
         continue;
       }
-      const BRepGraphInc::CoEdgeDef& aPaired =
-        aGraph.Topo().CoEdges().Definition(aCoEdge.SeamPairId);
-      EXPECT_EQ(aPaired.SeamPairId, aCoEdgeId)
-        << "Seam pair must remain bidirectional after Split on edge " << theEdgeId.Index;
+      const BRepGraph_CoEdgeId aBackId = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aPairId);
+      EXPECT_EQ(aBackId, aCoEdgeId)
+        << "Seam pair must remain symmetric after Split on edge " << theEdgeId.Index;
     }
   };
 
@@ -1218,7 +1226,7 @@ TEST(BRepGraph_ScenarioMatrix, Cylinder_SeamEdgeSplit_CoEdgeFaceIncidence)
       aGraph.Topo().Edges().CoEdges(anEdgeId);
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdges)
     {
-      if (aGraph.Topo().CoEdges().Definition(aCoEdgeId).SeamPairId.IsValid())
+      if (BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCoEdgeId))
       {
         aSeamEdgeId = anEdgeId;
         break;

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_ScenarioMatrix_Test.cxx
@@ -1023,8 +1023,7 @@ TEST(BRepGraph_ScenarioMatrix, Sphere_SeamCoEdgePair_Bidirectional)
     ++aNbPairedCoEdges;
 
     // Symmetry: the partner's partner is us.
-    const BRepGraph_CoEdgeId aBackId =
-      BRepGraph_TestTools::SeamPairFromStorage(aStorage, aPairId);
+    const BRepGraph_CoEdgeId aBackId = BRepGraph_TestTools::SeamPairFromStorage(aStorage, aPairId);
     EXPECT_EQ(aBackId, aCoEdgeId) << "Seam relation must be symmetric";
     const BRepGraphInc::CoEdgeDef& aCoEdge = aStorage.CoEdge(aCoEdgeId);
     const BRepGraphInc::CoEdgeDef& aPaired = aStorage.CoEdge(aPairId);
@@ -1188,8 +1187,7 @@ TEST(BRepGraph_ScenarioMatrix, Cylinder_SeamEdgeSplit_AuditStable)
       aGraph.Topo().Edges().CoEdges(theEdgeId);
     for (const BRepGraph_CoEdgeId& aCoEdgeId : aCoEdges)
     {
-      const BRepGraph_CoEdgeId aPairId =
-        BRepGraph_Tool::CoEdge::SeamPair(aGraph, aCoEdgeId);
+      const BRepGraph_CoEdgeId aPairId = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aCoEdgeId);
       if (!aPairId.IsValid())
       {
         continue;

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_SeamRedesign_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_SeamRedesign_Test.cxx
@@ -1,0 +1,524 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+// Edge cases that the seam-redesign reachable only after:
+//   - Both seam halves placed in WireDef::CoEdgeRefIds at TopoDS_Iterator order
+//   - SeamPair derived from connectivity (CoEdgesOfEdge filtered by face+orientation)
+//   - Continuity stored in BRepGraph_LayerRegularity (per (edge, F1, F2) tuple)
+
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepGraph.hxx>
+#include <BRepGraph_Builder.hxx>
+#include <BRepGraph_EditorView.hxx>
+#include <BRepGraph_Iterator.hxx>
+#include <BRepGraph_LayerRegularity.hxx>
+#include <BRepGraph_RefsIterator.hxx>
+#include <BRepGraph_ReverseIterator.hxx>
+#include <BRepGraph_RefsView.hxx>
+#include <BRepGraph_ShapesView.hxx>
+#include <BRepGraph_TopoView.hxx>
+#include <BRepGraph_Tool.hxx>
+#include <BRepGraph_WireExplorer.hxx>
+#include <BRepGraphInc_Definition.hxx>
+#include <BRepGraphInc_Reference.hxx>
+#include <BRepGraphInc_Storage.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepPrimAPI_MakeSphere.hxx>
+#include <NCollection_LinearVector.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Iterator.hxx>
+#include <TopoDS_Wire.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+void registerLayers(BRepGraph& theGraph)
+{
+  theGraph.LayerRegistry().RegisterLayer(new BRepGraph_LayerRegularity());
+}
+
+//! Find any seam CoEdge on the cylinder lateral face.
+BRepGraph_CoEdgeId findSeamCoEdge(const BRepGraph& theGraph)
+{
+  for (BRepGraph_EdgeIterator anEdgeIt(theGraph); anEdgeIt.More(); anEdgeIt.Next())
+  {
+    for (BRepGraph_CoEdgesOfEdge aCEIt(theGraph,
+                                       theGraph.Topo().Edges().CoEdges(anEdgeIt.CurrentId()));
+         aCEIt.More();
+         aCEIt.Next())
+    {
+      if (BRepGraph_Tool::CoEdge::IsSeam(theGraph, aCEIt.CurrentId()))
+      {
+        return aCEIt.CurrentId();
+      }
+    }
+  }
+  return {};
+}
+
+} // namespace
+
+// ============================================================
+// Wire CoEdgeRefIds layout: seam halves at TopoDS_Iterator positions
+// ============================================================
+
+// Cylinder lateral wire must contain BOTH seam halves in CoEdgeRefIds at the
+// same positions TopoDS_Iterator yields them. This guarantees round-trip with
+// classical TopoDS_Wire iteration.
+TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_BothSeamHalvesInCoEdgeRefIds)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+  ASSERT_TRUE(aGraph.IsDone());
+
+  const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
+  ASSERT_TRUE(aSeamCoEdge.IsValid()) << "Cylinder must have a seam CoEdge";
+
+  const BRepGraph_CoEdgeId aSeamPair =
+    BRepGraph_Tool::CoEdge::SeamPair(aGraph, aSeamCoEdge);
+  ASSERT_TRUE(aSeamPair.IsValid());
+
+  // Find the wire containing the seam CoEdge.
+  BRepGraph_WireId aWireId;
+  for (BRepGraph_WiresOfCoEdge aWIt(aGraph, aGraph.Topo().CoEdges().Wires(aSeamCoEdge));
+       aWIt.More();
+       aWIt.Next())
+  {
+    aWireId = aWIt.CurrentId();
+    break;
+  }
+  ASSERT_TRUE(aWireId.IsValid());
+
+  // Walk the wire's CoEdgeRefIds; both seam halves must appear.
+  bool aFwdInWire = false, aRevInWire = false;
+  for (BRepGraph_RefsCoEdgeOfWire aRefIt(aGraph, aWireId); aRefIt.More(); aRefIt.Next())
+  {
+    const BRepGraphInc::CoEdgeRef& aRef = aGraph.Refs().CoEdges().Entry(aRefIt.CurrentId());
+    if (aRef.CoEdgeDefId == aSeamCoEdge)
+    {
+      aFwdInWire = true;
+    }
+    else if (aRef.CoEdgeDefId == aSeamPair)
+    {
+      aRevInWire = true;
+    }
+  }
+  EXPECT_TRUE(aFwdInWire) << "Forward seam half must appear in the wire's CoEdgeRefIds";
+  EXPECT_TRUE(aRevInWire) << "Reversed seam half must appear in the wire's CoEdgeRefIds";
+}
+
+// Cylinder lateral wire's NbCoEdges must equal the count of TopoDS_Iterator(wire)
+// yields on the same wire — i.e. the seam edge contributes 2 CoEdgeRefs.
+TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_NbCoEdges_MatchesTopoDSIterator)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+
+  // Locate the cylinder lateral face (the one with > 1 wire-edges and a seam).
+  TopoDS_Face aLateralFace;
+  for (TopExp_Explorer aFE(aCyl, TopAbs_FACE); aFE.More(); aFE.Next())
+  {
+    const TopoDS_Face& aF = TopoDS::Face(aFE.Current());
+    int                aNbEdges = 0;
+    for (TopExp_Explorer aEE(aF, TopAbs_EDGE); aEE.More(); aEE.Next())
+      ++aNbEdges;
+    if (aNbEdges == 4)
+    {
+      aLateralFace = aF;
+      break;
+    }
+  }
+  ASSERT_FALSE(aLateralFace.IsNull());
+
+  // Count TopoDS_Iterator yields per wire on the original.
+  uint32_t aClassicalCount = 0;
+  for (TopoDS_Iterator aWIt(aLateralFace, false, false); aWIt.More(); aWIt.Next())
+  {
+    const TopoDS_Shape& aChild = aWIt.Value();
+    if (aChild.ShapeType() != TopAbs_WIRE)
+      continue;
+    for (TopoDS_Iterator aEIt(aChild, false, false); aEIt.More(); aEIt.Next())
+    {
+      ++aClassicalCount;
+    }
+  }
+
+  // Sum NbCoEdges across all wires of the matching face in the graph.
+  uint32_t aGraphCount = 0;
+  for (BRepGraph_WireIterator aWIt(aGraph); aWIt.More(); aWIt.Next())
+  {
+    const BRepGraph_FaceId aFaceId =
+      BRepGraph_Tool::Wire::FaceOf(aGraph, aWIt.CurrentId());
+    if (!aFaceId.IsValid())
+      continue;
+    const TopoDS_Shape* aOrig = aGraph.Shapes().FindOriginal(aFaceId);
+    if (aOrig == nullptr || !aOrig->IsSame(aLateralFace))
+      continue;
+    aGraphCount += BRepGraph_Tool::Wire::NbCoEdges(aGraph, aWIt.CurrentId());
+  }
+  EXPECT_EQ(aGraphCount, aClassicalCount)
+    << "NbCoEdges must equal the count of TopoDS_Iterator yields";
+}
+
+// ============================================================
+// Derived SeamPair: symmetry, free wire, non-seam
+// ============================================================
+
+// SeamPair(SeamPair(c)) == c on every seam half — symmetry guaranteed by the
+// connectivity-derived implementation.
+TEST(BRepGraph_SeamRedesignTest, SeamPair_DerivedQuery_IsSymmetric)
+{
+  const TopoDS_Shape aSph = BRepPrimAPI_MakeSphere(10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aSph).Ok);
+
+  uint32_t aSeamCount = 0;
+  for (BRepGraph_CoEdgeId aCEId(0); aCEId.IsValid(aGraph.Topo().CoEdges().Nb()); ++aCEId)
+  {
+    const BRepGraph_CoEdgeId aPair = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aCEId);
+    if (!aPair.IsValid())
+      continue;
+    ++aSeamCount;
+    const BRepGraph_CoEdgeId aBack = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aPair);
+    EXPECT_EQ(aBack, aCEId) << "SeamPair must be symmetric: SeamPair(SeamPair(c)) == c";
+  }
+  EXPECT_GT(aSeamCount, 0u) << "Sphere must have at least one seam CoEdge";
+}
+
+// Box has no seams: every CoEdge returns invalid SeamPair.
+TEST(BRepGraph_SeamRedesignTest, SeamPair_BoxHasNoSeams)
+{
+  const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(1., 1., 1.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aBox).Ok);
+
+  for (BRepGraph_CoEdgeId aCEId(0); aCEId.IsValid(aGraph.Topo().CoEdges().Nb()); ++aCEId)
+  {
+    EXPECT_FALSE(BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCEId))
+      << "Box CoEdge " << aCEId.Index << " must not be a seam half";
+  }
+}
+
+// Free-wire CoEdge (no FaceDefId) cannot be a seam — derived query handles invalid face.
+TEST(BRepGraph_SeamRedesignTest, SeamPair_FreeWireHasNoSeams)
+{
+  // Build a free wire: an edge between two vertices, not bound to any face.
+  TopoDS_Vertex aV1, aV2;
+  BRep_Builder  aBB;
+  aBB.MakeVertex(aV1, gp_Pnt(0, 0, 0), 1.0e-7);
+  aBB.MakeVertex(aV2, gp_Pnt(1, 0, 0), 1.0e-7);
+  BRepBuilderAPI_MakeEdge aMkEdge(aV1, aV2);
+  ASSERT_TRUE(aMkEdge.IsDone());
+  BRepBuilderAPI_MakeWire aMkWire(aMkEdge.Edge());
+  ASSERT_TRUE(aMkWire.IsDone());
+
+  BRepGraph aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aMkWire.Wire()).Ok);
+
+  for (BRepGraph_CoEdgeId aCEId(0); aCEId.IsValid(aGraph.Topo().CoEdges().Nb()); ++aCEId)
+  {
+    EXPECT_FALSE(BRepGraph_Tool::CoEdge::IsSeam(aGraph, aCEId))
+      << "Free-wire CoEdge has no face; cannot be a seam";
+  }
+}
+
+// ============================================================
+// EditorView::EdgeOps::IsSeamOnFace API
+// ============================================================
+
+TEST(BRepGraph_SeamRedesignTest, EdgeOps_IsSeamOnFace_DerivedFromConnectivity)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+
+  const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
+  ASSERT_TRUE(aSeamCoEdge.IsValid());
+  const BRepGraphInc::CoEdgeDef& aSeamDef =
+    aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
+  EXPECT_TRUE(aGraph.Editor().Edges().IsSeamOnFace(aSeamDef.EdgeDefId, aSeamDef.FaceDefId));
+
+  // A box edge (any) must NOT be a seam on its face.
+  const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(1., 1., 1.).Shape();
+  BRepGraph          aBoxGraph;
+  registerLayers(aBoxGraph);
+  aBoxGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aBoxGraph, aBox).Ok);
+  for (BRepGraph_CoEdgeId aCEId(0); aCEId.IsValid(aBoxGraph.Topo().CoEdges().Nb()); ++aCEId)
+  {
+    const BRepGraphInc::CoEdgeDef& aDef = aBoxGraph.Topo().CoEdges().Definition(aCEId);
+    if (!aDef.FaceDefId.IsValid())
+      continue;
+    EXPECT_FALSE(aBoxGraph.Editor().Edges().IsSeamOnFace(aDef.EdgeDefId, aDef.FaceDefId))
+      << "Box edge cannot be a seam";
+  }
+}
+
+// ============================================================
+// Tool::Wire::NbDistinctEdges
+// ============================================================
+
+TEST(BRepGraph_SeamRedesignTest, NbDistinctEdges_AccountsForSeamHalves)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+
+  uint32_t aWiresWithSeams = 0;
+  for (BRepGraph_WireIterator aWIt(aGraph); aWIt.More(); aWIt.Next())
+  {
+    const BRepGraph_WireId aWireId  = aWIt.CurrentId();
+    const uint32_t         aRawCnt  = BRepGraph_Tool::Wire::NbCoEdges(aGraph, aWireId);
+    const uint32_t         aDistinct = BRepGraph_Tool::Wire::NbDistinctEdges(aGraph, aWireId);
+    EXPECT_LE(aDistinct, aRawCnt)
+      << "Distinct edges <= raw CoEdge count";
+    if (aRawCnt > aDistinct)
+    {
+      ++aWiresWithSeams;
+      // The difference equals the number of seam pairs in the wire.
+      const uint32_t aDelta = aRawCnt - aDistinct;
+      EXPECT_GE(aDelta, 1u);
+    }
+  }
+  EXPECT_GE(aWiresWithSeams, 1u)
+    << "Cylinder must have at least one wire whose seam contributes a doubled edge";
+}
+
+// ============================================================
+// EditorView::EdgeOps::SetRegularity (writes through to layer)
+// ============================================================
+
+TEST(BRepGraph_SeamRedesignTest, EdgeOps_SetRegularity_RoundTripThroughLayer)
+{
+  const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(1., 1., 1.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aBox).Ok);
+
+  // Pick any edge with two faces.
+  BRepGraph_EdgeId aEdgeId;
+  BRepGraph_FaceId aFace1, aFace2;
+  for (BRepGraph_EdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
+  {
+    NCollection_LinearVector<BRepGraph_FaceId> aFaces;
+    for (BRepGraph_FacesOfEdge aFIt(aGraph, aGraph.Topo().Edges().Faces(anEdgeIt.CurrentId()));
+         aFIt.More();
+         aFIt.Next())
+    {
+      aFaces.Append(aFIt.CurrentId());
+    }
+    if (aFaces.Size() >= 2)
+    {
+      aEdgeId = anEdgeIt.CurrentId();
+      aFace1  = aFaces[0];
+      aFace2  = aFaces[1];
+      break;
+    }
+  }
+  ASSERT_TRUE(aEdgeId.IsValid());
+
+  // Initially C0.
+  EXPECT_EQ(BRepGraph_Tool::Edge::Continuity(aGraph, aEdgeId, aFace1, aFace2), GeomAbs_C0);
+
+  // Write G2.
+  EXPECT_TRUE(aGraph.Editor().Edges().SetRegularity(aEdgeId, aFace1, aFace2, GeomAbs_G2));
+
+  // Read back.
+  EXPECT_EQ(BRepGraph_Tool::Edge::Continuity(aGraph, aEdgeId, aFace1, aFace2), GeomAbs_G2);
+  EXPECT_TRUE(BRepGraph_Tool::Edge::HasContinuity(aGraph, aEdgeId, aFace1, aFace2));
+  EXPECT_EQ(BRepGraph_Tool::Edge::MaxContinuity(aGraph, aEdgeId), GeomAbs_G2);
+
+  // Symmetry: (F1, F2) == (F2, F1).
+  EXPECT_EQ(BRepGraph_Tool::Edge::Continuity(aGraph, aEdgeId, aFace2, aFace1), GeomAbs_G2);
+}
+
+// SetRegularity returns false when the layer is not registered.
+TEST(BRepGraph_SeamRedesignTest, EdgeOps_SetRegularity_FailsWithoutLayer)
+{
+  const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(1., 1., 1.).Shape();
+  BRepGraph          aGraph;
+  // Note: NOT calling registerLayers — layer absent.
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aBox).Ok);
+
+  ASSERT_GT(aGraph.Topo().Edges().Nb(), 0u);
+  ASSERT_GT(aGraph.Topo().Faces().Nb(), 1u);
+  EXPECT_FALSE(aGraph.Editor().Edges().SetRegularity(
+    BRepGraph_EdgeId::Start(),
+    BRepGraph_FaceId::Start(),
+    BRepGraph_FaceId(1),
+    GeomAbs_G1));
+}
+
+// ============================================================
+// Reconstruct: TopoDS_Iterator order preservation
+// ============================================================
+
+// After shape -> graph -> shape, TopoDS_Iterator on the lateral cylinder face's
+// outer wire must yield the same sequence of (TShape, orientation) tuples.
+TEST(BRepGraph_SeamRedesignTest, Reconstruct_CylinderWire_TopoDSIteratorOrder)
+{
+  const TopoDS_Shape aOriginal = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aOriginal).Ok);
+
+  TopoDS_Shape aRecon =
+    aGraph.Shapes().Reconstruct(BRepGraph_NodeId(BRepGraph_NodeId::Kind::Solid, 0));
+  ASSERT_FALSE(aRecon.IsNull());
+
+  // Compare wire-edge counts pairwise across all faces.
+  NCollection_LinearVector<int> aOrigCounts, aReconCounts;
+  for (TopExp_Explorer aFE(aOriginal, TopAbs_FACE); aFE.More(); aFE.Next())
+  {
+    for (TopoDS_Iterator aWIt(aFE.Current(), false, false); aWIt.More(); aWIt.Next())
+    {
+      if (aWIt.Value().ShapeType() != TopAbs_WIRE)
+        continue;
+      int aCount = 0;
+      for (TopoDS_Iterator aEIt(aWIt.Value(), false, false); aEIt.More(); aEIt.Next())
+        ++aCount;
+      aOrigCounts.Append(aCount);
+    }
+  }
+  for (TopExp_Explorer aFE(aRecon, TopAbs_FACE); aFE.More(); aFE.Next())
+  {
+    for (TopoDS_Iterator aWIt(aFE.Current(), false, false); aWIt.More(); aWIt.Next())
+    {
+      if (aWIt.Value().ShapeType() != TopAbs_WIRE)
+        continue;
+      int aCount = 0;
+      for (TopoDS_Iterator aEIt(aWIt.Value(), false, false); aEIt.More(); aEIt.Next())
+        ++aCount;
+      aReconCounts.Append(aCount);
+    }
+  }
+  ASSERT_EQ(aOrigCounts.Size(), aReconCounts.Size());
+  for (size_t i = 0; i < aOrigCounts.Size(); ++i)
+  {
+    EXPECT_EQ(aReconCounts[i], aOrigCounts[i])
+      << "Wire " << i << " edge count must match after reconstruct";
+  }
+}
+
+// ============================================================
+// LayerRegularity captures both inter-face and seam continuity
+// ============================================================
+
+TEST(BRepGraph_SeamRedesignTest, LayerRegularity_CapturesInterFaceAndSeam)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+
+  const occ::handle<BRepGraph_LayerRegularity> aLayer =
+    aGraph.LayerRegistry().FindLayer<BRepGraph_LayerRegularity>();
+  ASSERT_FALSE(aLayer.IsNull());
+
+  // Cylinder produces exactly one seam-style entry (F1 == F2, on the lateral face).
+  uint32_t aSeamEntries = 0;
+  for (BRepGraph_EdgeIterator anEdgeIt(aGraph); anEdgeIt.More(); anEdgeIt.Next())
+  {
+    const BRepGraph_LayerRegularity::EdgeRegularities* aRegs =
+      aLayer->FindEdgeRegularities(anEdgeIt.CurrentId());
+    if (aRegs == nullptr)
+      continue;
+    for (const BRepGraph_LayerRegularity::RegularityEntry& aE : aRegs->Entries)
+    {
+      if (aE.FaceEntity1 == aE.FaceEntity2)
+      {
+        ++aSeamEntries;
+        EXPECT_GT(aE.Continuity, GeomAbs_C0)
+          << "Cylinder seam BRep_CurveOnClosedSurface stores G^2";
+      }
+    }
+  }
+  EXPECT_EQ(aSeamEntries, 1u) << "Cylinder must produce exactly one seam regularity entry";
+}
+
+// ============================================================
+// Validator catches orphaned seam (one half missing from wire)
+// ============================================================
+
+// Manually break the wire-membership invariant: drop one seam half from the
+// wire's CoEdgeRefIds while keeping it as an active CoEdge. Validate must flag.
+TEST(BRepGraph_SeamRedesignTest, Validate_DetectsAsymmetricSeamPair)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+
+  // Locate a CoEdge with a seam pair.
+  const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
+  ASSERT_TRUE(aSeamCoEdge.IsValid());
+  const BRepGraph_CoEdgeId aSeamMate =
+    BRepGraph_Tool::CoEdge::SeamPair(aGraph, aSeamCoEdge);
+  ASSERT_TRUE(aSeamMate.IsValid());
+
+  // Forcibly assign the same orientation to both halves to break the
+  // "opposite-orientation" invariant. Validate must flag this.
+  const TopAbs_Orientation aOri =
+    aGraph.Topo().CoEdges().Definition(aSeamCoEdge).Orientation;
+  aGraph.Editor().CoEdges().SetOrientation(aSeamMate, aOri);
+
+  // Direct iteration check (analogous to Validate's logic): two CoEdges on
+  // (edge, face) with same orientation -> structural error.
+  const BRepGraphInc::CoEdgeDef& aDef = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
+  uint32_t aSameFaceCount = 0;
+  bool     aOpposite      = false;
+  for (BRepGraph_CoEdgesOfEdge aIt(aGraph, aGraph.Topo().Edges().CoEdges(aDef.EdgeDefId));
+       aIt.More();
+       aIt.Next())
+  {
+    if (aIt.Definition().FaceDefId != aDef.FaceDefId)
+      continue;
+    ++aSameFaceCount;
+    if (aIt.CurrentId() != aSeamCoEdge && aIt.Definition().Orientation != aDef.Orientation)
+    {
+      aOpposite = true;
+    }
+  }
+  EXPECT_EQ(aSameFaceCount, 2u);
+  EXPECT_FALSE(aOpposite) << "After injection, both halves should share orientation";
+}

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_SeamRedesign_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_SeamRedesign_Test.cxx
@@ -98,8 +98,7 @@ TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_BothSeamHalvesInCoEdgeRefId
   const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
   ASSERT_TRUE(aSeamCoEdge.IsValid()) << "Cylinder must have a seam CoEdge";
 
-  const BRepGraph_CoEdgeId aSeamPair =
-    BRepGraph_Tool::CoEdge::SeamPair(aGraph, aSeamCoEdge);
+  const BRepGraph_CoEdgeId aSeamPair = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aSeamCoEdge);
   ASSERT_TRUE(aSeamPair.IsValid());
 
   // Find the wire containing the seam CoEdge.
@@ -132,7 +131,7 @@ TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_BothSeamHalvesInCoEdgeRefId
 }
 
 // Cylinder lateral wire's NbCoEdges must equal the count of TopoDS_Iterator(wire)
-// yields on the same wire — i.e. the seam edge contributes 2 CoEdgeRefs.
+// yields on the same wire - i.e. the seam edge contributes 2 CoEdgeRefs.
 TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_NbCoEdges_MatchesTopoDSIterator)
 {
   const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
@@ -145,7 +144,7 @@ TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_NbCoEdges_MatchesTopoDSIter
   TopoDS_Face aLateralFace;
   for (TopExp_Explorer aFE(aCyl, TopAbs_FACE); aFE.More(); aFE.Next())
   {
-    const TopoDS_Face& aF = TopoDS::Face(aFE.Current());
+    const TopoDS_Face& aF       = TopoDS::Face(aFE.Current());
     int                aNbEdges = 0;
     for (TopExp_Explorer aEE(aF, TopAbs_EDGE); aEE.More(); aEE.Next())
       ++aNbEdges;
@@ -174,8 +173,7 @@ TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_NbCoEdges_MatchesTopoDSIter
   uint32_t aGraphCount = 0;
   for (BRepGraph_WireIterator aWIt(aGraph); aWIt.More(); aWIt.Next())
   {
-    const BRepGraph_FaceId aFaceId =
-      BRepGraph_Tool::Wire::FaceOf(aGraph, aWIt.CurrentId());
+    const BRepGraph_FaceId aFaceId = BRepGraph_Tool::Wire::FaceOf(aGraph, aWIt.CurrentId());
     if (!aFaceId.IsValid())
       continue;
     const TopoDS_Shape* aOrig = aGraph.Shapes().FindOriginal(aFaceId);
@@ -191,7 +189,7 @@ TEST(BRepGraph_SeamRedesignTest, CylinderLateralWire_NbCoEdges_MatchesTopoDSIter
 // Derived SeamPair: symmetry, free wire, non-seam
 // ============================================================
 
-// SeamPair(SeamPair(c)) == c on every seam half — symmetry guaranteed by the
+// SeamPair(SeamPair(c)) == c on every seam half - symmetry guaranteed by the
 // connectivity-derived implementation.
 TEST(BRepGraph_SeamRedesignTest, SeamPair_DerivedQuery_IsSymmetric)
 {
@@ -230,7 +228,7 @@ TEST(BRepGraph_SeamRedesignTest, SeamPair_BoxHasNoSeams)
   }
 }
 
-// Free-wire CoEdge (no FaceDefId) cannot be a seam — derived query handles invalid face.
+// Free-wire CoEdge (no FaceDefId) cannot be a seam - derived query handles invalid face.
 TEST(BRepGraph_SeamRedesignTest, SeamPair_FreeWireHasNoSeams)
 {
   // Build a free wire: an edge between two vertices, not bound to any face.
@@ -269,8 +267,7 @@ TEST(BRepGraph_SeamRedesignTest, EdgeOps_IsSeamOnFace_DerivedFromConnectivity)
 
   const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
   ASSERT_TRUE(aSeamCoEdge.IsValid());
-  const BRepGraphInc::CoEdgeDef& aSeamDef =
-    aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
+  const BRepGraphInc::CoEdgeDef& aSeamDef = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
   EXPECT_TRUE(aGraph.Editor().Edges().IsSeamOnFace(aSeamDef.EdgeDefId, aSeamDef.FaceDefId));
 
   // A box edge (any) must NOT be a seam on its face.
@@ -304,11 +301,10 @@ TEST(BRepGraph_SeamRedesignTest, NbDistinctEdges_AccountsForSeamHalves)
   uint32_t aWiresWithSeams = 0;
   for (BRepGraph_WireIterator aWIt(aGraph); aWIt.More(); aWIt.Next())
   {
-    const BRepGraph_WireId aWireId  = aWIt.CurrentId();
-    const uint32_t         aRawCnt  = BRepGraph_Tool::Wire::NbCoEdges(aGraph, aWireId);
+    const BRepGraph_WireId aWireId   = aWIt.CurrentId();
+    const uint32_t         aRawCnt   = BRepGraph_Tool::Wire::NbCoEdges(aGraph, aWireId);
     const uint32_t         aDistinct = BRepGraph_Tool::Wire::NbDistinctEdges(aGraph, aWireId);
-    EXPECT_LE(aDistinct, aRawCnt)
-      << "Distinct edges <= raw CoEdge count";
+    EXPECT_LE(aDistinct, aRawCnt) << "Distinct edges <= raw CoEdge count";
     if (aRawCnt > aDistinct)
     {
       ++aWiresWithSeams;
@@ -380,16 +376,14 @@ TEST(BRepGraph_SeamRedesignTest, EdgeOps_Split_PreservesSeamRegularityLayer)
 
   const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
   ASSERT_TRUE(aSeamCoEdge.IsValid());
-  const BRepGraphInc::CoEdgeDef& aSeamDef = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
+  const BRepGraphInc::CoEdgeDef& aSeamDef    = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
   const BRepGraph_EdgeId         aSeamEdgeId = aSeamDef.EdgeDefId;
   const BRepGraph_FaceId         aSeamFaceId = aSeamDef.FaceDefId;
   ASSERT_TRUE(aSeamEdgeId.IsValid());
   ASSERT_TRUE(aSeamFaceId.IsValid());
 
-  ASSERT_TRUE(aGraph.Editor().Edges().SetRegularity(aSeamEdgeId,
-                                                    aSeamFaceId,
-                                                    aSeamFaceId,
-                                                    GeomAbs_G2));
+  ASSERT_TRUE(
+    aGraph.Editor().Edges().SetRegularity(aSeamEdgeId, aSeamFaceId, aSeamFaceId, GeomAbs_G2));
   const occ::handle<BRepGraph_LayerRegularity> aLayer =
     aGraph.LayerRegistry().FindLayer<BRepGraph_LayerRegularity>();
   ASSERT_FALSE(aLayer.IsNull());
@@ -398,7 +392,7 @@ TEST(BRepGraph_SeamRedesignTest, EdgeOps_Split_PreservesSeamRegularityLayer)
   ASSERT_TRUE(aLayer->FindContinuity(aSeamEdgeId, aSeamFaceId, aSeamFaceId, &aContinuity));
   ASSERT_EQ(aContinuity, GeomAbs_G2);
 
-  const BRepGraphInc::EdgeDef& aEdgeDef = aGraph.Topo().Edges().Definition(aSeamEdgeId);
+  const BRepGraphInc::EdgeDef& aEdgeDef  = aGraph.Topo().Edges().Definition(aSeamEdgeId);
   const double                 aMidParam = 0.5 * (aEdgeDef.ParamFirst + aEdgeDef.ParamLast);
   const BRepGraph_VertexId     aSplitVertex =
     aGraph.Editor().Vertices().Add(gp_Pnt(5.0, 0.0, 5.0), aEdgeDef.Tolerance);
@@ -427,17 +421,16 @@ TEST(BRepGraph_SeamRedesignTest, EdgeOps_SetRegularity_FailsWithoutLayer)
 {
   const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(1., 1., 1.).Shape();
   BRepGraph          aGraph;
-  // Note: NOT calling registerLayers — layer absent.
+  // Note: NOT calling registerLayers - layer absent.
   aGraph.Clear();
   ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aBox).Ok);
 
   ASSERT_GT(aGraph.Topo().Edges().Nb(), 0u);
   ASSERT_GT(aGraph.Topo().Faces().Nb(), 1u);
-  EXPECT_FALSE(aGraph.Editor().Edges().SetRegularity(
-    BRepGraph_EdgeId::Start(),
-    BRepGraph_FaceId::Start(),
-    BRepGraph_FaceId(1),
-    GeomAbs_G1));
+  EXPECT_FALSE(aGraph.Editor().Edges().SetRegularity(BRepGraph_EdgeId::Start(),
+                                                     BRepGraph_FaceId::Start(),
+                                                     BRepGraph_FaceId(1),
+                                                     GeomAbs_G1));
 }
 
 // ============================================================
@@ -545,14 +538,12 @@ TEST(BRepGraph_SeamRedesignTest, Validate_DetectsAsymmetricSeamPair)
   // Locate a CoEdge with a seam pair.
   const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
   ASSERT_TRUE(aSeamCoEdge.IsValid());
-  const BRepGraph_CoEdgeId aSeamMate =
-    BRepGraph_Tool::CoEdge::SeamPair(aGraph, aSeamCoEdge);
+  const BRepGraph_CoEdgeId aSeamMate = BRepGraph_Tool::CoEdge::SeamPair(aGraph, aSeamCoEdge);
   ASSERT_TRUE(aSeamMate.IsValid());
 
   // Forcibly assign the same orientation to both halves to break the
   // "opposite-orientation" invariant. Validate must flag this.
-  const TopAbs_Orientation aOri =
-    aGraph.Topo().CoEdges().Definition(aSeamCoEdge).Orientation;
+  const TopAbs_Orientation aOri = aGraph.Topo().CoEdges().Definition(aSeamCoEdge).Orientation;
   aGraph.Editor().CoEdges().SetOrientation(aSeamMate, aOri);
 
   const BRepGraphInc::CoEdgeDef& aDef = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_SeamRedesign_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_SeamRedesign_Test.cxx
@@ -31,6 +31,7 @@
 #include <BRepGraph_ShapesView.hxx>
 #include <BRepGraph_TopoView.hxx>
 #include <BRepGraph_Tool.hxx>
+#include <BRepGraph_Validate.hxx>
 #include <BRepGraph_WireExplorer.hxx>
 #include <BRepGraphInc_Definition.hxx>
 #include <BRepGraphInc_Reference.hxx>
@@ -45,6 +46,7 @@
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Iterator.hxx>
 #include <TopoDS_Wire.hxx>
+#include <gp_Pnt.hxx>
 
 #include <gtest/gtest.h>
 
@@ -368,6 +370,58 @@ TEST(BRepGraph_SeamRedesignTest, EdgeOps_SetRegularity_RoundTripThroughLayer)
   EXPECT_EQ(BRepGraph_Tool::Edge::Continuity(aGraph, aEdgeId, aFace2, aFace1), GeomAbs_G2);
 }
 
+TEST(BRepGraph_SeamRedesignTest, EdgeOps_Split_PreservesSeamRegularityLayer)
+{
+  const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
+  BRepGraph          aGraph;
+  registerLayers(aGraph);
+  aGraph.Clear();
+  ASSERT_TRUE(BRepGraph_Builder::Add(aGraph, aCyl).Ok);
+
+  const BRepGraph_CoEdgeId aSeamCoEdge = findSeamCoEdge(aGraph);
+  ASSERT_TRUE(aSeamCoEdge.IsValid());
+  const BRepGraphInc::CoEdgeDef& aSeamDef = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
+  const BRepGraph_EdgeId         aSeamEdgeId = aSeamDef.EdgeDefId;
+  const BRepGraph_FaceId         aSeamFaceId = aSeamDef.FaceDefId;
+  ASSERT_TRUE(aSeamEdgeId.IsValid());
+  ASSERT_TRUE(aSeamFaceId.IsValid());
+
+  ASSERT_TRUE(aGraph.Editor().Edges().SetRegularity(aSeamEdgeId,
+                                                    aSeamFaceId,
+                                                    aSeamFaceId,
+                                                    GeomAbs_G2));
+  const occ::handle<BRepGraph_LayerRegularity> aLayer =
+    aGraph.LayerRegistry().FindLayer<BRepGraph_LayerRegularity>();
+  ASSERT_FALSE(aLayer.IsNull());
+
+  GeomAbs_Shape aContinuity = GeomAbs_C0;
+  ASSERT_TRUE(aLayer->FindContinuity(aSeamEdgeId, aSeamFaceId, aSeamFaceId, &aContinuity));
+  ASSERT_EQ(aContinuity, GeomAbs_G2);
+
+  const BRepGraphInc::EdgeDef& aEdgeDef = aGraph.Topo().Edges().Definition(aSeamEdgeId);
+  const double                 aMidParam = 0.5 * (aEdgeDef.ParamFirst + aEdgeDef.ParamLast);
+  const BRepGraph_VertexId     aSplitVertex =
+    aGraph.Editor().Vertices().Add(gp_Pnt(5.0, 0.0, 5.0), aEdgeDef.Tolerance);
+  ASSERT_TRUE(aSplitVertex.IsValid());
+
+  BRepGraph_EdgeId aSubA;
+  BRepGraph_EdgeId aSubB;
+  aGraph.Editor().Edges().Split(aSeamEdgeId, aSplitVertex, aMidParam, aSubA, aSubB);
+  ASSERT_TRUE(aSubA.IsValid());
+  ASSERT_TRUE(aSubB.IsValid());
+
+  EXPECT_FALSE(aLayer->FindContinuity(aSeamEdgeId, aSeamFaceId, aSeamFaceId))
+    << "Removed source edge must not keep stale regularity bindings";
+  EXPECT_TRUE(aLayer->FindContinuity(aSubA, aSeamFaceId, aSeamFaceId, &aContinuity));
+  EXPECT_EQ(aContinuity, GeomAbs_G2);
+  EXPECT_TRUE(aLayer->FindContinuity(aSubB, aSeamFaceId, aSeamFaceId, &aContinuity));
+  EXPECT_EQ(aContinuity, GeomAbs_G2);
+
+  const BRepGraph_Validate::Result aAudit =
+    BRepGraph_Validate::Perform(aGraph, BRepGraph_Validate::Options::Audit());
+  EXPECT_TRUE(aAudit.IsValid()) << "Audit must remain clean after seam split";
+}
+
 // SetRegularity returns false when the layer is not registered.
 TEST(BRepGraph_SeamRedesignTest, EdgeOps_SetRegularity_FailsWithoutLayer)
 {
@@ -476,11 +530,10 @@ TEST(BRepGraph_SeamRedesignTest, LayerRegularity_CapturesInterFaceAndSeam)
 }
 
 // ============================================================
-// Validator catches orphaned seam (one half missing from wire)
+// Validator catches invalid seam orientation
 // ============================================================
 
-// Manually break the wire-membership invariant: drop one seam half from the
-// wire's CoEdgeRefIds while keeping it as an active CoEdge. Validate must flag.
+// Manually break the opposite-orientation invariant. Validate must flag it.
 TEST(BRepGraph_SeamRedesignTest, Validate_DetectsAsymmetricSeamPair)
 {
   const TopoDS_Shape aCyl = BRepPrimAPI_MakeCylinder(5., 10.).Shape();
@@ -502,23 +555,24 @@ TEST(BRepGraph_SeamRedesignTest, Validate_DetectsAsymmetricSeamPair)
     aGraph.Topo().CoEdges().Definition(aSeamCoEdge).Orientation;
   aGraph.Editor().CoEdges().SetOrientation(aSeamMate, aOri);
 
-  // Direct iteration check (analogous to Validate's logic): two CoEdges on
-  // (edge, face) with same orientation -> structural error.
   const BRepGraphInc::CoEdgeDef& aDef = aGraph.Topo().CoEdges().Definition(aSeamCoEdge);
-  uint32_t aSameFaceCount = 0;
-  bool     aOpposite      = false;
-  for (BRepGraph_CoEdgesOfEdge aIt(aGraph, aGraph.Topo().Edges().CoEdges(aDef.EdgeDefId));
-       aIt.More();
-       aIt.Next())
+  EXPECT_FALSE(BRepGraph_Tool::Edge::IsClosedOnFace(aGraph, aDef.EdgeDefId, aDef.FaceDefId));
+  EXPECT_FALSE(aGraph.Editor().Edges().IsSeamOnFace(aDef.EdgeDefId, aDef.FaceDefId));
+
+  const BRepGraph_Validate::Result aResult =
+    BRepGraph_Validate::Perform(aGraph, BRepGraph_Validate::Options::Audit());
+  EXPECT_FALSE(aResult.IsValid());
+  EXPECT_GT(aResult.NbIssues(BRepGraph_Validate::Severity::Error), 0);
+
+  bool hasSameOrientationIssue = false;
+  for (const BRepGraph_Validate::Issue& anIssue : aResult.Issues)
   {
-    if (aIt.Definition().FaceDefId != aDef.FaceDefId)
-      continue;
-    ++aSameFaceCount;
-    if (aIt.CurrentId() != aSeamCoEdge && aIt.Definition().Orientation != aDef.Orientation)
+    if (anIssue.Sev == BRepGraph_Validate::Severity::Error
+        && anIssue.Description.Search("same Orientation") > 0)
     {
-      aOpposite = true;
+      hasSameOrientationIssue = true;
+      break;
     }
   }
-  EXPECT_EQ(aSameFaceCount, 2u);
-  EXPECT_FALSE(aOpposite) << "After injection, both halves should share orientation";
+  EXPECT_TRUE(hasSameOrientationIssue);
 }

--- a/src/ModelingData/TKBRep/GTests/BRepGraph_Views_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepGraph_Views_Test.cxx
@@ -445,7 +445,9 @@ TEST_F(BRepGraph_ViewsTest, TopoView_GroupedCoEdgeOps_Parity)
   EXPECT_EQ(myGraph.Topo().CoEdges().Definition(aCoEdgeId).FaceDefId, aCoEdge.FaceDefId);
   EXPECT_EQ(myGraph.Topo().CoEdges().Curve2DRepId(aCoEdgeId),
             myGraph.Topo().CoEdges().Definition(aCoEdgeId).Curve2DRepId);
-  EXPECT_EQ(myGraph.Topo().CoEdges().Definition(aCoEdgeId).SeamPairId, aCoEdge.SeamPairId);
+  // Verify TopoView::CoEdgeOps::SeamPair and Tool::CoEdge::SeamPair agree.
+  EXPECT_EQ(myGraph.Topo().CoEdges().SeamPair(aCoEdgeId),
+            BRepGraph_Tool::CoEdge::SeamPair(myGraph, aCoEdgeId));
 }
 
 TEST_F(BRepGraph_ViewsTest, TopoView_GroupedProductAndOccurrenceOps_Parity)

--- a/src/ModelingData/TKBRep/GTests/FILES.cmake
+++ b/src/ModelingData/TKBRep/GTests/FILES.cmake
@@ -46,6 +46,7 @@ set(OCCT_TKBRep_GTests_FILES
   BRepGraph_Transform_Test.cxx
   BRepGraph_Validate_Test.cxx
   BRepGraph_ScenarioMatrix_Test.cxx
+  BRepGraph_SeamRedesign_Test.cxx
   BRepGraph_Deduplicate_Test.cxx
   BRepTools_ReShape_Test.cxx
   TopExp_Test.cxx


### PR DESCRIPTION
Rework CoEdge to not store seam-edge id and continuity type.
In exchange Seam CoEdge is now part of Wire and can be explored as usually done by TopoDS.
The continuity is moved to RegularityLayer as it is done for FaceFace.