### PR TITLE
Shape healing - crash in ShapeConstruct_ProjectCurveOnSurface::insertAdditionalPointOrAdjust()

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
@@ -258,16 +258,16 @@ void adjustSecondToFirstPoint(const gp_Pnt2d&                  theFirstPoint,
   {
     const double anUPeriod = theSurf->UPeriod();
     const double aNewU     = ElCLib::InPeriod(theSecondPoint.X(),
-                                              theFirstPoint.X() - anUPeriod / 2,
-                                              theFirstPoint.X() + anUPeriod / 2);
+                                          theFirstPoint.X() - anUPeriod / 2,
+                                          theFirstPoint.X() + anUPeriod / 2);
     theSecondPoint.SetX(aNewU);
   }
   if (theSurf->IsVPeriodic())
   {
     const double aVPeriod = theSurf->VPeriod();
     const double aNewV    = ElCLib::InPeriod(theSecondPoint.Y(),
-                                             theFirstPoint.Y() - aVPeriod / 2,
-                                             theFirstPoint.Y() + aVPeriod / 2);
+                                          theFirstPoint.Y() - aVPeriod / 2,
+                                          theFirstPoint.Y() + aVPeriod / 2);
     theSecondPoint.SetY(aNewV);
   }
 }

--- a/src/ModelingAlgorithms/TKShHealing/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeConstruct/ShapeConstruct_ProjectCurveOnSurface.cxx
@@ -258,16 +258,16 @@ void adjustSecondToFirstPoint(const gp_Pnt2d&                  theFirstPoint,
   {
     const double anUPeriod = theSurf->UPeriod();
     const double aNewU     = ElCLib::InPeriod(theSecondPoint.X(),
-                                          theFirstPoint.X() - anUPeriod / 2,
-                                          theFirstPoint.X() + anUPeriod / 2);
+                                              theFirstPoint.X() - anUPeriod / 2,
+                                              theFirstPoint.X() + anUPeriod / 2);
     theSecondPoint.SetX(aNewU);
   }
   if (theSurf->IsVPeriodic())
   {
     const double aVPeriod = theSurf->VPeriod();
     const double aNewV    = ElCLib::InPeriod(theSecondPoint.Y(),
-                                          theFirstPoint.Y() - aVPeriod / 2,
-                                          theFirstPoint.Y() + aVPeriod / 2);
+                                             theFirstPoint.Y() - aVPeriod / 2,
+                                             theFirstPoint.Y() + aVPeriod / 2);
     theSecondPoint.SetY(aNewV);
   }
 }
@@ -2129,9 +2129,9 @@ void ShapeConstruct_ProjectCurveOnSurface::insertAdditionalPointOrAdjust(
           aNewPoints2d.SetValue(i + 1, thePoints2d(i));
         }
 
-        thePoints   = aNewPoints;
-        theParams   = aNewParams;
-        thePoints2d = aNewPoints2d;
+        thePoints   = std::move(aNewPoints);
+        theParams   = std::move(aNewParams);
+        thePoints2d = std::move(aNewPoints2d);
         theIndex++;
       }
       else


### PR DESCRIPTION
To input parameters of ShapeConstruct_ProjectCurveOnSurface::insertAdditionalPointOrAdjust() new arrays were assigned. The size of new arrays are guaranteed to be 1 element larger that original array. NCollection_Array1::Assign() is guaranteed to throw exception when arrays size mismatch. So, given that assignment code is reached, function will always throw. Fixed by calling move assignment instead - size mismatch is allowed in this case. Also it is more optimal.