### PR TITLE
Documentation - Fix typos, naming, and snippet bugs in user guides

### DIFF
--- a/dox/build/build_occt/building_occt.md
+++ b/dox/build/build_occt/building_occt.md
@@ -303,7 +303,7 @@ Required tools (download and install if it is required):
   - For Linux/macOS: GNU Make 4.0+
 
 Run GUI tool provided by CMake and:
-  - Specify the root folder of OCCT (`$CASROOT`, which contains *CMakelists.txt* file) by clicking **Browse Source**.
+  - Specify the root folder of OCCT (`$CASROOT`, which contains *CMakeLists.txt* file) by clicking **Browse Source**.
   - Specify the location (build folder) for CMake generated project files by clicking **Browse Build**.
 
 @figure{/build/build_occt/images/android_image001.png}

--- a/dox/contribution/coding_rules.md
+++ b/dox/contribution/coding_rules.md
@@ -159,7 +159,7 @@ void Package_MyClass::MyFunction (const gp_Pnt& thePoint); // this is preferred
 
 ### Names of class member variables
 
-The name of a class member variable should start with prefix *my* followed by the meaningful of the name starting with a capital letter.
+The name of a class member variable should start with prefix *my* followed by the meaningful part of the name starting with a capital letter.
 
 See the following examples:
 
@@ -218,13 +218,13 @@ void Average (const double** theArray,
               double&        theResult)
 {
   theResult = 0.0;
-  for (int aRow = 0; aRow < aRowsNb; ++aRow)
+  for (int aRow = 0; aRow < theRowsNb; ++aRow)
   {
-    for (int aCol = 0; aCol < aRowLen; ++aCol)
+    for (int aCol = 0; aCol < theRowLen; ++aCol)
     {
       theResult += theArray[aRow][aCol];
     }
-    theResult /= double(aRowsNb * aRowLen);
+    theResult /= double(theRowsNb * theRowLen);
   }
 }
 ~~~~
@@ -318,7 +318,7 @@ void TellMeSmthBad()
 ~~~~
 
 ### Block layout [MANDATORY]
-Figure brackets <i>{ }</i> and each operator <i>(for, if, else, try, catch)</i> should be written on a dedicated line.
+Curly braces <i>{ }</i> and each operator <i>(for, if, else, try, catch)</i> should be written on a dedicated line.
 
 In general, the layout should be as follows:
 
@@ -492,7 +492,7 @@ Accepted style is:
 //! Method computes the square value.
 //! @param theValue the input value
 //! @return squared value
-Standard_Export double Square (double theValue);
+Standard_EXPORT double Square (double theValue);
 @endverbatim
 
 ### Documenting C/C++ sources
@@ -719,7 +719,7 @@ See the following example:
       }
     ...
     private:
-      occ::handle<Slave> theSlave; // smart pointer
+      occ::handle<Slave> mySlave; // smart pointer
     ...
     }
 
@@ -732,7 +732,7 @@ See the following example:
       }
     ...
     private:
-      Master* theMaster; // simple pointer
+      Master* myMaster; // simple pointer
     ...
     }
 ~~~~
@@ -998,7 +998,7 @@ public: //! @name public methods
   //! Method computes the square value.
   //! @param theValue the input value
   //! @return squared value
-  Standard_Export double Square (const double theValue);
+  Standard_EXPORT double Square (const double theValue);
 
 private: //! @name private methods
 

--- a/dox/contribution/tests/tests.md
+++ b/dox/contribution/tests/tests.md
@@ -1141,7 +1141,7 @@ The maximal tolerance of sub-shapes of each kind of the resulting shape can be e
 ~~~~
 set tolerance [tolerance result]
 regexp { *FACE +: +MAX=([-0-9.+eE]+)} $tolerance dummy max_face
-regexp { *EDGE +: +MAX=([-0-9.+eE]+)} $tolerance dummy max_edgee
+regexp { *EDGE +: +MAX=([-0-9.+eE]+)} $tolerance dummy max_edge
 regexp { *VERTEX +: +MAX=([-0-9.+eE]+)} $tolerance dummy max_vertex
 ~~~~
 

--- a/dox/debug/debug.md
+++ b/dox/debug/debug.md
@@ -174,18 +174,18 @@ Json output for Bnd_OBB (using command 'bounding v -obb -dumpJson'):
       "gp_XYZ": [1, 2, 3]
    },
    "Axes[0]": {
-       "gp_XYZ:" [1, 0, 0]
+       "gp_XYZ": [1, 0, 0]
    },
    "Axes[1]": {
-       "gp_XYZ:" [0, 1, 0]
+       "gp_XYZ": [0, 1, 0]
    },
    "Axes[2]": {
-       "gp_XYZ:" [0, 0, 1]
+       "gp_XYZ": [0, 0, 1]
    },
    "HDims[0]": 0,
    "HDims[1]": 0,
    "HDims[2]": 0,
-   "IsAABox": 1,
+   "IsAABox": 1
 }
 ~~~~
 

--- a/dox/introduction/introduction.md
+++ b/dox/introduction/introduction.md
@@ -52,7 +52,7 @@ In addition, @ref intro_overview_draw "Open CASCADE DRAW Test Harness", also cal
 
 **Foundation Classes** module contains data structures and services used by higher-level Open CASCADE Technology classes:
 
-  * Primitive types, such as Boolean, Character, Integer or Real;
+  * Standard C++ primitive types (`int`, `double`, `float`, `bool`, `char`);
   * String classes that handle Unicode strings;
   * Collection classes that handle statically or dynamically sized aggregates of data, such as arrays, lists, queues, sets and hash tables (data maps).
   * Classes providing commonly used numerical algorithms and basic linear algebra calculations (addition, multiplication, transposition of vectors and matrices, solving linear systems etc).

--- a/dox/samples/ais_object.md
+++ b/dox/samples/ais_object.md
@@ -64,7 +64,7 @@ void MyAisObject::Compute (const occ::handle<PrsMgr_PresentationManager>& thePrs
   StdPrs_ShadedShape::Add (thePrs, aShape, myDrawer);
 }
 ...
-occ::handle<AIS_InteractiveContext> aCtx;
+occ::handle<AIS_InteractiveContext> aCtx; // obtained from viewer setup
 occ::handle<MyAisObject> aPrs = new MyAisObject();
 aCtx->Display (aPrs, true);
 ~~~~
@@ -736,7 +736,7 @@ void MyAisOwner::HilightWithColor (const occ::handle<PrsMgr_PresentationManager>
     occ::handle<Graphic3d_Group> aGroup = aPrs->NewGroup();
     aGroup->SetGroupPrimitivesAspect (theStyle->ArrowAspect()->Aspect());
     gp_Trsf aTrsfInv = mySelectable->LocalTransformation().Inverted();
-    gp_Dir  aNorm (aPickPnt.Normal.x(), aPickPnt.Normal.y(), aPickPnt.Normal.z());
+    gp_Dir  aNorm (aPickPnt.Normal.X(), aPickPnt.Normal.Y(), aPickPnt.Normal.Z());
     occ::handle<Graphic3d_ArrayOfTriangles> aTris =
       Prs3d_Arrow::DrawShaded (gp_Ax1(aPickPnt.Point, aNorm).Transformed (aTrsfInv),
         1.0, 15.0,

--- a/dox/samples/ocaf.md
+++ b/dox/samples/ocaf.md
@@ -33,9 +33,9 @@ In the <i>Formats</i> method, add the format of the documents, which need to be 
 For example:
 
 ~~~~{.cpp}
-    void myApplication::Formats(NCollection_Sequence<TCollection_ExtendedString>& Formats)
+    void myApplication::Formats(NCollection_Sequence<TCollection_ExtendedString>& theFormats)
     {
-      Formats.Append(TCollection_ExtendedString ("OCAF-myApplication"));
+      theFormats.Append(TCollection_ExtendedString ("OCAF-myApplication"));
     }
 ~~~~
 
@@ -45,7 +45,7 @@ This file contains several definitions for the saving and opening mechanisms ass
 ~~~~{.cpp}
     const char* myApplication::ResourcesName()
     {
-      return const char* ("Resources");
+      return "Resources";
     }
 ~~~~
 
@@ -232,20 +232,20 @@ const Standard_GUID& MyPackage_Transformation::GetID()
 
 occ::handle<MyPackage_Transformation> MyPackage_Transformation::Set(const TDF_Label& theLabel)
 {
-  occ::handle<MyPackage_Transformation> T;
-  if (!theLabel.FindAttribute(MyPackage_Transformation::GetID(), T))
+  occ::handle<MyPackage_Transformation> aT;
+  if (!theLabel.FindAttribute(MyPackage_Transformation::GetID(), aT))
   {
-    T = new MyPackage_Transformation();
-    theLabel.AddAttribute(T);
+    aT = new MyPackage_Transformation();
+    theLabel.AddAttribute(aT);
   }
-  return T;
+  return aT;
 }
 
 //==================================================================================================
 
 gp_Trsf MyPackage_Transformation::Get() const
 {
-  gp_Trsf transformation;
+  gp_Trsf aTransformation;
   switch (myType)
   {
     case gp_Identity:
@@ -254,37 +254,37 @@ gp_Trsf MyPackage_Transformation::Get() const
     }
     case gp_Rotation:
     {
-      transformation.SetRotation(myAx1, myAngle);
+      aTransformation.SetRotation(myAx1, myAngle);
       break;
     }
     case gp_Translation:
     {
-      transformation.SetTranslation(myFirstPoint, mySecondPoint);
+      aTransformation.SetTranslation(myFirstPoint, mySecondPoint);
       break;
     }
     case gp_PntMirror:
     {
-      transformation.SetMirror(myFirstPoint);
+      aTransformation.SetMirror(myFirstPoint);
       break;
     }
     case gp_Ax1Mirror:
     {
-      transformation.SetMirror(myAx1);
+      aTransformation.SetMirror(myAx1);
       break;
     }
     case gp_Ax2Mirror:
     {
-      transformation.SetMirror(myAx2);
+      aTransformation.SetMirror(myAx2);
       break;
     }
     case gp_Scale:
     {
-      transformation.SetScale(myFirstPoint, myScale);
+      aTransformation.SetScale(myFirstPoint, myScale);
       break;
     }
     case gp_CompoundTrsf:
     {
-      transformation.SetTransformation(myFirstAx3, mySecondAx3);
+      aTransformation.SetTransformation(myFirstAx3, mySecondAx3);
       break;
     }
     case gp_Other:
@@ -292,12 +292,12 @@ gp_Trsf MyPackage_Transformation::Get() const
       break;
     }
   }
-  return transformation;
+  return aTransformation;
 }
 
 //==================================================================================================
 
-void MyPackage_Transformation::SetRotation(const gp_Ax1& theAxis, const double theAngle)
+void MyPackage_Transformation::SetRotation(const gp_Ax1& theAxis, double theAngle)
 {
   Backup();
   myType = gp_Rotation;
@@ -344,7 +344,7 @@ void MyPackage_Transformation::SetMirror(const gp_Ax2& thePlane)
 
 //==================================================================================================
 
-void MyPackage_Transformation::SetScale(const gp_Pnt& thePoint, const double theScale)
+void MyPackage_Transformation::SetScale(const gp_Pnt& thePoint, double theScale)
 {
   Backup();
   myType = gp_Scale;
@@ -373,16 +373,16 @@ const Standard_GUID& MyPackage_Transformation::ID() const
 
 void MyPackage_Transformation::Restore(const occ::handle<TDF_Attribute>& theAttribute)
 {
-  occ::handle<MyPackage_Transformation> theTransformation = occ::down_cast<MyPackage_Transformation>(theAttribute);
-  myType = theTransformation->myType;
-  myAx1 = theTransformation->myAx1;
-  myAx2 = theTransformation->myAx2;
-  myFirstAx3 = theTransformation->myFirstAx3;
-  mySecondAx3 = theTransformation->mySecondAx3;
-  myAngle = theTransformation->myAngle;
-  myScale = theTransformation->myScale;
-  myFirstPoint = theTransformation->myFirstPoint;
-  mySecondPoint = theTransformation->mySecondPoint;
+  occ::handle<MyPackage_Transformation> aTransformation = occ::down_cast<MyPackage_Transformation>(theAttribute);
+  myType = aTransformation->myType;
+  myAx1 = aTransformation->myAx1;
+  myAx2 = aTransformation->myAx2;
+  myFirstAx3 = aTransformation->myFirstAx3;
+  mySecondAx3 = aTransformation->mySecondAx3;
+  myAngle = aTransformation->myAngle;
+  myScale = aTransformation->myScale;
+  myFirstPoint = aTransformation->myFirstPoint;
+  mySecondPoint = aTransformation->mySecondPoint;
 }
 
 //==================================================================================================
@@ -397,16 +397,16 @@ occ::handle<TDF_Attribute> MyPackage_Transformation::NewEmpty() const
 void MyPackage_Transformation::Paste (const occ::handle<TDF_Attribute>& theAttribute,
                                       const occ::handle<TDF_RelocationTable>& ) const
 {
-  occ::handle<MyPackage_Transformation> theTransformation = occ::down_cast<MyPackage_Transformation>(theAttribute);
-  theTransformation->myType = myType;
-  theTransformation->myAx1 = myAx1;
-  theTransformation->myAx2 = myAx2;
-  theTransformation->myFirstAx3 = myFirstAx3;
-  theTransformation->mySecondAx3 = mySecondAx3;
-  theTransformation->myAngle = myAngle;
-  theTransformation->myScale = myScale;
-  theTransformation->myFirstPoint = myFirstPoint;
-  theTransformation->mySecondPoint = mySecondPoint;
+  occ::handle<MyPackage_Transformation> aTransformation = occ::down_cast<MyPackage_Transformation>(theAttribute);
+  aTransformation->myType = myType;
+  aTransformation->myAx1 = myAx1;
+  aTransformation->myAx2 = myAx2;
+  aTransformation->myFirstAx3 = myFirstAx3;
+  aTransformation->mySecondAx3 = mySecondAx3;
+  aTransformation->myAngle = myAngle;
+  aTransformation->myScale = myScale;
+  aTransformation->myFirstPoint = myFirstPoint;
+  aTransformation->mySecondPoint = mySecondPoint;
 }
 
 //==================================================================================================

--- a/dox/samples/ocaf_func.md
+++ b/dox/samples/ocaf_func.md
@@ -163,38 +163,38 @@ drivers for a function  driver table with the help of *TFunction_DriverTable* cl
 ~~~~{.cpp}
 
     // The scope of functions is defined.
-    occ::handle<TFunction_Scope> scope = TFunction_Scope::Set (anyLabel);
+    occ::handle<TFunction_Scope> aScope = TFunction_Scope::Set (anyLabel);
 
     // The information on modifications in the model is received.
-    occ::handle<TFunction_Logbook> log = scope->GetLogbook();
+    occ::handle<TFunction_Logbook> aLog = aScope->GetLogbook();
 
     // The iterator is initialized by the scope of functions.
-    TFunction_Iterator iterator (anyLabel);
-    iterator.SetUsageOfExecutionStatus (true);
+    TFunction_Iterator anIterator (anyLabel);
+    anIterator.SetUsageOfExecutionStatus (true);
 
     // The function is iterated, its dependency is checked on the modified data and executed if necessary.
-    for (; iterator.More(); iterator.Next())
+    for (; anIterator.More(); anIterator.Next())
     {
       // The function iterator may return a list of current functions for execution.
       // It might be useful for multi-threaded execution of functions.
-      const NCollection_List<TDF_Label>& currentFunctions = iterator.Current();
+      const NCollection_List<TDF_Label>& aCurrentFunctions = anIterator.Current();
 
       // The list of current functions is iterated.
-      NCollection_List<TDF_Label>::Iterator currentIterator (currentFunctions);
-      for (; currentIterator.More(); currentIterator.Next())
+      NCollection_List<TDF_Label>::Iterator aCurrentIterator (aCurrentFunctions);
+      for (; aCurrentIterator.More(); aCurrentIterator.Next())
       {
         // An interface for the function is created.
-        TFunction_IFunction interface (currentIterator.Value());
+        TFunction_IFunction anInterface (aCurrentIterator.Value());
 
         // The function driver is retrieved.
-        occ::handle<TFunction_Driver> driver = interface.GetDriver();
+        occ::handle<TFunction_Driver> aDriver = anInterface.GetDriver();
 
         // The dependency of the function on the modified data is checked.
-        if (driver->MustExecute (log))
+        if (aDriver->MustExecute (aLog))
         {
           // The function is executed.
-          int ret = driver->Execute (log);
-          if (ret)
+          int aRet = aDriver->Execute (aLog);
+          if (aRet)
             return false;
         } // end if check on modification
       } // end of iteration of current functions
@@ -213,18 +213,18 @@ drivers for a function  driver table with the help of *TFunction_DriverTable* cl
     void CylinderDriver::Arguments (NCollection_List<TDF_Label>& args) const
     {
       // The direct arguments, located at sub-leaves of the function, are collected (see picture 2).
-      TDF_ChildIterator cIterator (Label(), false);
-      for (; cIterator.More(); cIterator.Next())
+      TDF_ChildIterator aChildIterator (Label(), false);
+      for (; aChildIterator.More(); aChildIterator.Next())
       {
         // Direct argument.
-        TDF_Label sublabel = cIterator.Value();
-        args.Append (sublabel);
+        TDF_Label aSubLabel = aChildIterator.Value();
+        args.Append (aSubLabel);
 
         // The references to the external data are checked.
-        occ::handle<TDF_Reference> ref;
-        if (sublabel.FindAttribute (TDF_Reference::GetID(), ref))
+        occ::handle<TDF_Reference> aRef;
+        if (aSubLabel.FindAttribute (TDF_Reference::GetID(), aRef))
         {
-          args.Append (ref->Get());
+          args.Append (aRef->Get());
         }
       }
     }
@@ -237,51 +237,56 @@ drivers for a function  driver table with the help of *TFunction_DriverTable* cl
     }
 
     // Execution of the function driver.
-    int CylinderDriver::Execute (occ::handle<TFunction_Logbook>& log) const
+    int CylinderDriver::Execute (occ::handle<TFunction_Logbook>& aLog) const
     {
       // Position of the cylinder - position of the first function (cone)
       // is elevated along Z for height values of all previous functions.
-      gp_Ax2 axes = ...; // out of the scope of this guide.
+      gp_Ax2 anAxes = ...; // out of the scope of this guide.
 
       // The radius value is retrieved.
       // It is located at second child sub-leaf (see the picture 2).
-      TDF_Label radiusLabel = Label().FindChild (2);
+      TDF_Label aRadiusLabel = Label().FindChild (2);
 
       // The multiplicator of the radius is retrieved.
-      occ::handle<TDataStd_Real> radiusValue;
-      radiusLabel.FindAttribute (TDataStd_Real::GetID(), radiusValue);
+      occ::handle<TDataStd_Real> aRadiusValue;
+      aRadiusLabel.FindAttribute (TDataStd_Real::GetID(), aRadiusValue);
 
       // The reference to the radius is retrieved.
-      occ::handle<TDF_Reference> refRadius;
-      radiusLabel.FindAttribute (TDF_Reference::GetID(), refRadius);
+      occ::handle<TDF_Reference> aRefRadius;
+      aRadiusLabel.FindAttribute (TDF_Reference::GetID(), aRefRadius);
 
       // The radius value is calculated.
-      double radius = 0.0;
+      double aRadius = 0.0;
 
-      if (refRadius.IsNull())
+      if (aRefRadius.IsNull())
       {
-        radius = radiusValue->Get();
+        aRadius = aRadiusValue->Get();
       }
       else
       {
         // The referenced radius value is retrieved.
-        occ::handle<TDataStd_Real> referencedRadiusValue;
-        refRadius->Get().FindAttribute (TDataStd_Real::GetID(), referencedRadiusValue);
-        radius = referencedRadiusValue->Get() * radiusValue->Get();
+        occ::handle<TDataStd_Real> aReferencedRadiusValue;
+        aRefRadius->Get().FindAttribute (TDataStd_Real::GetID(), aReferencedRadiusValue);
+        aRadius = aReferencedRadiusValue->Get() * aRadiusValue->Get();
       }
 
       // The height value is retrieved.
-      double height = ...; // similar code to taking the radius value.
+      double aHeight = ...; // similar code to taking the radius value.
 
       // The cylinder is created.
-      TopoDS_Shape cylinder = BRepPrimAPI_MakeCylinder (axes, radius, height);
+      BRepPrimAPI_MakeCylinder aMkCylinder (anAxes, aRadius, aHeight);
+      TopoDS_Shape aCylinder;
+      if (aMkCylinder.IsDone())
+      {
+        aCylinder = aMkCylinder.Shape();
+      }
 
       // The result (cylinder) is set
-      TNaming_Builder builder (Label());
-      builder.Generated (cylinder);
+      TNaming_Builder aBuilder (Label());
+      aBuilder.Generated (aCylinder);
 
       // The modification of the result leaf is saved in the log.
-      log->SetImpacted (Label());
+      aLog->SetImpacted (Label());
 
       return 0;
     }

--- a/dox/specification/boolean_operations/boolean_operations.md
+++ b/dox/specification/boolean_operations/boolean_operations.md
@@ -648,7 +648,7 @@ The input data for this step is the DS after updating Pave Blocks.
 | 4	| Access to the pave blocks of interfered shapes: <i>(PBi1, PBi2…PBiNi)</i> for edge *Ei* and <i>(PBj1, PBj2…PBjNj)</i> for  edge *Ej* | *BOPAlgo_PaveFiller::PerformEE()* |
 | 5	| Compute shrunk data for pave blocks in terms of @ref specification__boolean_4_4 "Pave, PaveBlock and CommonBlock", if it is necessary. | *BOPAlgo_PaveFiller::FillShrunkData()* |
 | 6	| Compute Edge/Edge interference for pave blocks *PBix* and *PBiy*. The result of the computation is a set of objects of type *IntTools_CommonPart* | *IntTools_EdgeEdge* |
-| 7.1 | For each *CommonPart* of type *VERTEX:*	Create new vertices *VNi (i =1, 2…,NbVN),* where *NbVN* is the number of new vertices. Intersect the vertices *VNi* using the steps Initialization and compute Vertex/Vertex interferences as follows: a) create a new object *PFn* of type *BOPAlgo_PaveFiller* with its own DS; b) use new vertices *VNi (i=1, 2…,NbVN), NbVN* as arguments (in terms of *TopoDS_Shape*) of *PFn*; c) invoke method *Perform()* for *PFn*. The resulting vertices *VNXi (i=1, 2…,NbVNX)*, where *NbVNX* is the number of vertices, are obtained via mapping between *VNi* and the results of *PVn*. | *BOPTools_Tools::MakeNewVertex()* |
+| 7.1 | For each *CommonPart* of type *VERTEX:*	Create new vertices *VNi (i =1, 2…,NbVN),* where *NbVN* is the number of new vertices. Intersect the vertices *VNi* using the steps Initialization and compute Vertex/Vertex interferences as follows: a) create a new object *PFn* of type *BOPAlgo_PaveFiller* with its own DS; b) use new vertices *VNi (i=1, 2…,NbVN), NbVN* as arguments (in terms of *TopoDS_Shape*) of *PFn*; c) invoke method *Perform()* for *PFn*. The resulting vertices *VNXi (i=1, 2…,NbVNX)*, where *NbVNX* is the number of vertices, are obtained via mapping between *VNi* and the results of *PVn*. | *BOPTools_AlgoTools::MakeNewVertex()* |
 | 7.2 |	For each *CommonPart* of type *EDGE:*	Compute the coinciding connexity chains of  pave blocks <i>(PB1C, PB2C… PNnC)k, C=0, 1…nCs,</i> where *nCs* is the number of the connexity chains. Create common blocks <i>(CBc. C=0, 1…nCs)</i> from the chains. Attach the common blocks to the pave blocks. |	*BOPAlgo_Tools::PerformCommonBlocks()* |
 | 8	| Post-processing. Append the paves of *VNXi* into the corresponding pave blocks in terms of @ref specification__boolean_4_4 "Pave, PaveBlock and CommonBlock" | *BOPDS_PaveBlock:: AppendExtPave()* |
 | 9	| Split common blocks CBc by the paves. | *BOPDS_DS:: UpdateCommonBlock()* |
@@ -684,7 +684,7 @@ The input data for this step is the DS after computing Vertex/Face Interferences
 | 4	| Access to the pave blocks of interfered edge <i>(PBi1, PBi2…PBiNi)</i> for edge *Ei*	| *BOPAlgo_PaveFiller::PerformEF()* |
 | 5	| Compute shrunk data for pave blocks (in terms of @ref specification__boolean_4_4 "Pave, PaveBlock and CommonBlock") if it is necessary. |	*BOPAlgo_PaveFiller::FillShrunkData()* |
 | 6	| Compute Edge/Face interference for pave block *PBix*, and face *nFj*. The result of the computation is a set of objects of type *IntTools_CommonPart* | *IntTools_EdgeFace* |
-| 7.1 |	For each *CommonPart* of type *VERTEX:* Create new vertices *VNi (i=1, 2…,NbVN),* where *NbVN* is the number of new vertices. Merge vertices *VNi* as follows: a) create new object *PFn* of type *BOPAlgo_PaveFiller* with its own DS; b) use new vertices *VNi (i=1, 2…,NbVN), NbVN* as arguments (in terms of *TopoDS_Shape*) of *PFn*; c) invoke method *Perform()* for *PFn*. The resulting vertices *VNXi (i=1, 2…,NbVNX)*, where *NbVNX* is the number of vertices, are obtained via mapping between *VNi* and the results of *PVn*. | *BOPTools_Tools::MakeNewVertex()* and *BOPAlgo_PaveFiller::PerformVertices1()* |
+| 7.1 |	For each *CommonPart* of type *VERTEX:* Create new vertices *VNi (i=1, 2…,NbVN),* where *NbVN* is the number of new vertices. Merge vertices *VNi* as follows: a) create new object *PFn* of type *BOPAlgo_PaveFiller* with its own DS; b) use new vertices *VNi (i=1, 2…,NbVN), NbVN* as arguments (in terms of *TopoDS_Shape*) of *PFn*; c) invoke method *Perform()* for *PFn*. The resulting vertices *VNXi (i=1, 2…,NbVNX)*, where *NbVNX* is the number of vertices, are obtained via mapping between *VNi* and the results of *PVn*. | *BOPTools_AlgoTools::MakeNewVertex()* and *BOPAlgo_PaveFiller::PerformVertices1()* |
 | 7.2 | For each *CommonPart* of type *EDGE:* Create common blocks <i>(CBc. C=0, 1…nCs)</i> from pave blocks that lie on the faces. Attach the common blocks to the pave blocks. | *BOPAlgo_Tools::PerformCommonBlocks()* |
 | 8	| Post-processing. Append the paves of *VNXi* into the corresponding pave blocks in terms of @ref specification__boolean_4_4 "Pave, PaveBlock and CommonBlock". | *BOPDS_PaveBlock:: AppendExtPave()* |
 | 9	| Split pave blocks and common blocks *CBc* by the paves. |	*BOPAlgo_PaveFiller::PerformVertices1()*, *BOPDS_DS:: UpdatePaveBlock()* and *BOPDS_DS:: UpdateCommonBlock()* |
@@ -701,7 +701,7 @@ For each pave block *PB* take the following steps:
 | No | Contents | Implementation |
 | :--- | :--- | :--- | 
 | 1	| Get the real pave block *PBR*, which is equal to *PB* if *PB* is not a common block and to *PB<sub>1</sub>* if *PB* is a common block. *PB<sub>1</sub>* is the first pave block in the pave blocks list of the common block.  See  @ref specification__boolean_4_4 "Pave, PaveBlock and CommonBlock". | *BOPAlgo_PaveFiller::MakeSplitEdges()* | 
-| 2	| Build the split edge *Esp* using the information from *DS* and *PBR*.	| *BOPTools_Tools::MakeSplitEdge()* |
+| 2	| Build the split edge *Esp* using the information from *DS* and *PBR*.	| *BOPTools_AlgoTools::MakeSplitEdge()* |
 | 3	| Compute *BOPDS_ShapeInfo* contents for Esp | *BOPAlgo_PaveFiller::MakeSplitEdges()* |
 | 4	| Append *BOPDS_ShapeInfo* contents to the DS | *BOPDS_DS::Append()* |
 
@@ -727,7 +727,7 @@ The input data for this step is the DS after computing Face/Face interferences.
 | 2.1 | Create paves PVc for the curve using existing vertices, i.e. vertices On or In (in terms of *FaceInfo*) for faces *nFi* and *nFj*. Append the paves *PVc* | *BOPAlgo_PaveFiller::PutPaveOnCurve()* and *BOPDS_PaveBlock::AppendExtPave()* |
 | 2.2 |	Create technological vertices *Vt*, which are the bounding points of an intersection curve (with the value of tolerance *Tol(Cijk)*). Each vertex *Vt* with parameter *Tt* on curve *Cijk* forms pave *PVt* on curve *Cijk*. Append technological paves. | *BOPAlgo_PaveFiller::PutBoundPaveOnCurve()* |
 | 2.3 |	Create pave blocks *PBk* for the curve using paves <i>(k=1, 2…, NbPB)</i>, where *NbPB* is the number of pave blocks |	*BOPAlgo_PaveFiller::MakeBlocks()* |
-| 2.4 |	Build draft section edges *ESk* using the pave blocks <i>(k=1, 2…, NbES)</i>, where *NbES* is the number of draft section edges	The draft section edge is created from a pave block *PBk* if *PBk* has state *In* or *On* for both faces *nFi* and *nF,j* and *PBk ≠ PBm (m=0, 1, 2… NbPBm)*, where *PBm* is an existing pave block for faces *nFi* and *nF,j* (*On* or *In* in terms of *FaceInfo*), *NbVm* is the number of existing pave blocks for faces *nFi* and *nF,j* and ≠ -- means non-coincidence (in terms of @ref specification__boolean_3_1_3 "Vertex/Face interference"). | *BOPTools_Tools::MakeEdge()* |
+| 2.4 |	Build draft section edges *ESk* using the pave blocks <i>(k=1, 2…, NbES)</i>, where *NbES* is the number of draft section edges	The draft section edge is created from a pave block *PBk* if *PBk* has state *In* or *On* for both faces *nFi* and *nF,j* and *PBk ≠ PBm (m=0, 1, 2… NbPBm)*, where *PBm* is an existing pave block for faces *nFi* and *nF,j* (*On* or *In* in terms of *FaceInfo*), *NbVm* is the number of existing pave blocks for faces *nFi* and *nF,j* and ≠ -- means non-coincidence (in terms of @ref specification__boolean_3_1_3 "Vertex/Face interference"). | *BOPTools_AlgoTools::MakeEdge()* |
 | 3	| Intersect the draft vertices *VPk (k=1, 2…, NbVP)* and the draft section edges *ESk (k=1, 2…, NbES)*. For this: a) create new object *PFn* of type *BOPAlgo_PaveFiller* with its own DS; b) use vertices *VPk* and edges *ESk* as arguments (in terms of @ref specification__boolean_4_1 "Arguments") of *PFn*; c) invoke	method *Perform()* for *PFn*. Resulting vertices *VPXk (k=1, 2… NbVPX)* and edges *ESXk (k=1, 2… NbESX)* are obtained via mapping between *VPk, ESk* and the results of *PVn*. | *BOPAlgo_PaveFiller::PostTreatFF()* |
 | 4	| Update face info (sections about pave blocks and vertices) | *BOPAlgo_PaveFiller::PerformFF()* |
 
@@ -1075,7 +1075,7 @@ The input data for this step is:
 | No | Contents | Implementation |
 | :---- | :---- | :----- | 
 | 1	| For all arguments of the type *Type*. Create a container C of the type *Type*. | *BOPAlgo_Builder::FillImagesContainers()* |
-| 2	| Add to C the images or non-split parts of the *Original Shape*, taking into account its orientation. | *BOPAlgo_Builder::FillImagesContainers()* *BOPTools_Tools::IsSplitToReverse()* |
+| 2	| Add to C the images or non-split parts of the *Original Shape*, taking into account its orientation. | *BOPAlgo_Builder::FillImagesContainers()* *BOPTools_AlgoTools::IsSplitToReverse()* |
 | 3	| Fill *myImages*  for the *Original Shape* by the information above. | *BOPAlgo_Builder::FillImagesContainers()* | 
 
 @subsubsection specification__boolean_7_4_8	Build Result of Type Wire
@@ -1096,7 +1096,7 @@ The input data for this step is *BOPAlgo_Builder* object after building result o
 | 1.5 |	Impart to <i>(Fi1, Fi2…FiNbSp)</i> the orientation coherent with the original face *Fi*. | *BOPAlgo_Builder::BuildSplitFaces()* | 
 | 1.6 |	Fill the map mySplits with *Fi/(Fi1, Fi2…FiNbSp)* | *BOPAlgo_Builder::BuildSplitFaces()* |
 | 2 | Fill Same Domain faces | *BOPAlgo_Builder::FillSameDomainFaces* | 
-| 2.1 |  Find and collect in the contents of *mySplits* the pairs of same domain split faces <i>(Fij, Fkl)m</i>, where *m* is the number of pairs. | *BOPAlgo_Builder::FillSameDomainFaces* *BOPTools_Tools::AreFacesSameDomain()* |
+| 2.1 |  Find and collect in the contents of *mySplits* the pairs of same domain split faces <i>(Fij, Fkl)m</i>, where *m* is the number of pairs. | *BOPAlgo_Builder::FillSameDomainFaces* *BOPTools_AlgoTools::AreFacesSameDomain()* |
 | 2.2 |	Compute the connexity chains 1) of same domain faces <i>(F1C, F2C… FnC)k, C=0, 1…nCs,</i> where *nCs* is the number of connexity chains. | *BOPAlgo_Builder::FillSameDomainFaces()* | 
 | 2.3 |	Fill *myShapesSD* using the chains <i>(F1C, F2C… FnC)k</i> |	*BOPAlgo_Builder::FillSameDomainFaces()* |
 | 2.4 | Add internal vertices to split faces. | *BOPAlgo_Builder::FillSameDomainFaces()* |
@@ -1173,8 +1173,8 @@ The input data for this step is a *BOPAlgo_Builder* object after building result
 
 | No |	Contents | Implementation  |
 | :---- | :---- | :----- |
-| 1	| Correct tolerances of vertices on curves | *BOPTools_Tools::CorrectPointOnCurve()* |
-| 2	| Correct tolerances of edges on faces | *BOPTools_Tools::CorrectCurveOnSurface()* |
+| 1	| Correct tolerances of vertices on curves | *BOPTools_AlgoTools::CorrectPointOnCurve()* |
+| 2	| Correct tolerances of edges on faces | *BOPTools_AlgoTools::CorrectCurveOnSurface()* |
 
 
 @section specification__boolean_8  Splitter Algorithm
@@ -1599,7 +1599,7 @@ Let us consider two faces *F1* and *F2* that have a common part:
 @figure{/specification/boolean_operations/images/boolean_image031.png,"",230}
 
 * The result of *Fuse* operation is a compound containing split parts of arguments, i.e. 3 new faces: *F11*, *F12* and *F22*. These faces are shared through edges In this case: 
-	* the argument edge *F1* has resulting split faces *F11* and *F12* (image of *F1*)
+	* the argument face *F1* has resulting split faces *F11* and *F12* (image of *F1*)
 	* the argument face *F2* has resulting split faces *F12* and *F22* (image of *F2*)
 	* the face *F12* is common for the images of *F1* and *F2*.
 	
@@ -1722,7 +1722,7 @@ Let us consider face *F1* and solid *S2* that have overlapping vertices:
 
 * The result of *Fuse* operation is not defined because the dimension of the face (2) is not equal to the dimension of the solid (3).
 	
-* The result of *Common* operation is an empty compound because the dimension (1) of the common part between *F1* and *S2* (vertex) is less than the lower dimension of the arguments (2).
+* The result of *Common* operation is an empty compound because the dimension (0) of the common part between *F1* and *S2* (vertex) is less than the lower dimension of the arguments (2).
 
 * The result of *Cut12* operation is a compound containing split part of the argument *F1*. In this case  argument face *F1* has a common part with solid *S2* so the corresponding part is not included into the result. The yellow contour is not a part of the result. It only shows the place of *S2*.
   	
@@ -1888,7 +1888,7 @@ The input data for this step is as follows:
 | :---- | :---- | :------ |
 | 1 | For the Type of the Boolean operation Common, Cut with any dimension and operation Fuse with *myDim[0] < 3* | |
 | 1.1 |	Find containers (WIRE, SHELL, COMPSOLID) in the arguments | *BOPAlgo_BOP:: BuildShape()* |
-| 1.2 |	Make connexity blocks from splits of each container that are in *myRC* |	*BOPTools_Tools::MakeConnexityBlocks()* |
+| 1.2 |	Make connexity blocks from splits of each container that are in *myRC* |	*BOPTools_AlgoTools::MakeConnexityBlocks()* |
 | 1.3 |	Build the result from shapes made from the connexity blocks | *BOPAlgo_BOP:: BuildShape()* |
 | 1.4 |	Add the remaining shapes from *myRC* to the result | *BOPAlgo_BOP:: BuildShape()* |
 | 2	| For the Type of the Boolean operation Fuse with *myDim[0] = 3* | |	
@@ -2258,7 +2258,7 @@ Cells Builder is based on the General Fuse algorithm. Thus all options of the Ge
 
 The requirements for the input shapes are the same as for General Fuse - each argument should be valid in terms of *BRepCheck_Analyzer* and *BOPAlgo_ArgumentAnalyzer*.
 
-The result of the algorithm is a compound containing the selected parts of the basic type (VERTEX, EDGE, FACE or SOLID). The default result is an empty compound. It is possible to add any Cell by using the methods *AddToRessult()* and *AddAllToResult()*. It is also possible to remove any part from the result by using methods *RemoveFromResult()* and *RemoveAllFromResult()*. The method *RemoveAllFromResult()* is also suitable for clearing the result.
+The result of the algorithm is a compound containing the selected parts of the basic type (VERTEX, EDGE, FACE or SOLID). The default result is an empty compound. It is possible to add any Cell by using the methods *AddToResult()* and *AddAllToResult()*. It is also possible to remove any part from the result by using methods *RemoveFromResult()* and *RemoveAllFromResult()*. The method *RemoveAllFromResult()* is also suitable for clearing the result.
 
 The Cells that should be added/removed to/from the result are defined through the input shapes containing the parts that should be taken *(ShapesToTake)* and the ones containing parts that should be avoided (ShapesToAvoid).
 To be taken into the result the part must be IN all shapes from *ShapesToTake* and OUT of all shapes from *ShapesToAvoid*.
@@ -2771,7 +2771,7 @@ The Gluing option is an enumeration implemented in BOPAlgo_GlueEnum.hxx:
 * BOPAlgo_GlueFull - Glue option for shapes with full coincidence.
 
 #### API level
-For setting the Gluing options for the algorithm it is just necessary to call the SetGlue(const BOPAlgo_Glue) method with appropriate value:
+For setting the Gluing options for the algorithm it is just necessary to call the SetGlue(const BOPAlgo_GlueEnum) method with appropriate value:
 ~~~~
 BOPAlgo_Builder aGF;
 //
@@ -3148,7 +3148,7 @@ The package consists of the following classes:
 * *BRepAlgoAPI_Algo* -- the root class that provides the interface for algorithms. 
 * *BRepAlgoAPI_BuilderAlgo* -- the class API level of General Fuse algorithm.
 * *BRepAlgoAPI_Splitter* -- the class API level of the Splitter algorithm.
-* *BRepAlgoAPI_BooleanOperation* -- the root class for the classes *BRepAlgoAPI_Fuse*. *BRepAlgoAPI_Common*, *BRepAlgoAPI_Cut* and *BRepAlgoAPI_Section*.
+* *BRepAlgoAPI_BooleanOperation* -- the root class for the classes *BRepAlgoAPI_Fuse*, *BRepAlgoAPI_Common*, *BRepAlgoAPI_Cut* and *BRepAlgoAPI_Section*.
 * *BRepAlgoAPI_Fuse* -- the class provides Boolean fusion operation. 
 * *BRepAlgoAPI_Common* -- the class provides Boolean common operation.
 * *BRepAlgoAPI_Cut* -- the class provides Boolean cut operation.

--- a/dox/specification/brep_format.md
+++ b/dox/specification/brep_format.md
@@ -74,7 +74,7 @@ The following sample code reads a shape from ASCII file and writes it to a binar
   \<content type\> = "DBRep_DrawableShape" \<_\\n\>\<_\\n\>;  
   \<content type\> have other values [1].  
  
-  \<version\> = ("CASCADE Topology V1, (c)  Matra-Datavision" | "CASCADE Topology V2, (c) Matra-Datavision" | "CASCADE Topology V3, (c) Open Cascade")\<_\\n\>;
+  \<version\> = ("CASCADE Topology V1, (c) Matra-Datavision" | "CASCADE Topology V2, (c) Matra-Datavision" | "CASCADE Topology V3, (c) Open Cascade")\<_\\n\>;
   The difference of the versions is described in the  document.  
  
   Sections \<locations\>, \<geometry\> and \<shapes\> are described below in separate chapters of the document.  
@@ -1193,7 +1193,7 @@ The example record is interpreted as a parabola in plane which passes through a 
  
 \<2D curve record 5\> describes a hyperbola. The  hyperbola data consist of a 2D point *P*, orthogonal 2D directions *D<sub>x</sub>* and *D<sub>y</sub>* and non-negative reals *k<sub>x</sub>* and *k<sub>y</sub>*. The hyperbola coordinate system has origin *P* and axis directions *D<sub>x</sub>* and *D<sub>y</sub>*. The hyperbola is defined by  the following parametric equation:  
  
-@f[ C(u)=P+k_{x} \cdot cosh(u) D_{x}+k_{y} \cdot sinh(u) \cdot D_{y},\; u \in (-\infty,\; \infty). @f]  
+@f[ C(u)=P+k_{x} \cdot cosh(u) \cdot D_{x}+k_{y} \cdot sinh(u) \cdot D_{y},\; u \in (-\infty,\; \infty). @f]  
  
 The example record is interpreted as a hyperbola with  coordinate system which has origin *P*=(1,2) and axis directions *D<sub>x</sub>*=(1,0) and *D<sub>y</sub>*=(0,1). Other data for the hyperbola are *k<sub>x</sub>*=3 and *k<sub>y</sub>*=4. The hyperbola is defined  by the following parametric equation: @f$ C(u)=(1,2)+3 \cdot cosh(u) \cdot (1,0)+4 \cdot sinh(u) \cdot (0,1) @f$.  
  
@@ -1709,7 +1709,7 @@ The terms below are used by \<vertex data\>, \<edge data\> and \<face data\>.
 	<curve parameter minimal and maximal values> = <real> <_> <real>;
 
 	<curve values for parameter minimal and maximal values> =
-	real> <_> <real> <_> <real> <_> <real>;
+	<real> <_> <real> <_> <real> <_> <real>;
 @endverbatim
  
 **Description**  
@@ -1788,7 +1788,7 @@ The usage of \<vertex data representation u  parameter\> *U* is  described belo
 **BNF-like Definition**
 
 ~~~~{.cpp}
-	<edge data> = <_> <edge data tolerance> <_> <edge data same parameter flag> <_> edge data same range flag> <_> <edge data degenerated flag> <_\n> <edge data representations>;
+	<edge data> = <_> <edge data tolerance> <_> <edge data same parameter flag> <_> <edge data same range flag> <_> <edge data degenerated flag> <_\n> <edge data representations>;
 
 	<edge data tolerance> = <real>;
 
@@ -1816,7 +1816,7 @@ The usage of \<vertex data representation u  parameter\> *U* is  described belo
 	<location number> <_> <curve parameter minimal and maximal values>
 	[<_\n> <curve values for parameter minimal and maximal values>];
 
-	<edge data representation data 3> = (<2D curve number> <_>) ^ 2 <continuity order> <_> <surface number> <_> <location number> <_> <curve parameter minimal and maximal values> <\n> <curve values for parameter minimal and maximal values>];
+	<edge data representation data 3> = (<2D curve number> <_>) ^ 2 <continuity order> <_> <surface number> <_> <location number> <_> <curve parameter minimal and maximal values> <\n> <curve values for parameter minimal and maximal values>;
 
 	<continuity order> = "C0" | "C1" | "C2" | "C3" | "CN" | "G1" | "G2".
 
@@ -1883,7 +1883,7 @@ Flag \<face data natural restriction flag\> is  used in a special way [1].
 @verbatim
     DBRep_DrawableShape  
      
-    CASCADE Topology V1, (c)  Matra-Datavision  
+    CASCADE Topology V1, (c) Matra-Datavision  
     Locations 3  
     1  
                   0                0               1               0   

--- a/dox/tutorial/tutorial.md
+++ b/dox/tutorial/tutorial.md
@@ -105,10 +105,10 @@ Both of these classes return a *Geom_TrimmedCurve* manipulated by handle. This e
 All *GC* classes provide a casting method to obtain a result automatically with a function-like call. Note that this method will raise an exception if construction has failed. To handle possible errors more explicitly, you may use the *IsDone* and *Value* methods. For example:
 
 ~~~~{.cpp}
-    GC_MakeSegment mkSeg (aPnt1, aPnt2);
+    GC_MakeSegment aMkSeg (aPnt1, aPnt2);
     occ::handle<Geom_TrimmedCurve> aSegment1;
-    if(mkSeg.IsDone()){
-        aSegment1 = mkSeg.Value();
+    if(aMkSeg.IsDone()){
+        aSegment1 = aMkSeg.Value();
     }
     else {
     // handle error
@@ -240,10 +240,10 @@ The bottle's profile is almost finished. You have created two wires: *aWire* and
   * add all edges of the two wires by using the *Add* method on this object.
 
 ~~~~{.cpp}
-    BRepBuilderAPI_MakeWire mkWire;
-    mkWire.Add(aWire);
-    mkWire.Add(aMirroredWire);
-    TopoDS_Wire aWireProfile = mkWire.Wire();
+    BRepBuilderAPI_MakeWire aMkWire;
+    aMkWire.Add(aWire);
+    aMkWire.Add(aMirroredWire);
+    TopoDS_Wire aWireProfile = aMkWire.Wire();
 ~~~~
 
 
@@ -309,7 +309,7 @@ To apply fillets on the edges of a shape, you use the *BRepFilletAPI_MakeFillet*
   * Ask for the resulting filleted shape with the *Shape* method.
 
 ~~~~{.cpp}
-BRepFilletAPI_MakeFillet mkFillet(aBody);
+BRepFilletAPI_MakeFillet aMkFillet(aBody);
 ~~~~
 
 To add the fillet description, you need to know the edges belonging to your shape. The best solution is to explore your solid to retrieve its edges. This kind of functionality is provided with the *TopExp_Explorer* class, which explores the data structure described in a *TopoDS_Shape* and extracts the sub-shapes you specifically need. 
@@ -341,13 +341,13 @@ An explorer is usually applied in a loop by using its three main methods:
 In the explorer loop, you have found all the edges of the bottle shape. Each one must then be added in the *BRepFilletAPI_MakeFillet* instance with the *Add()* method. Do not forget to specify the radius of the fillet along with it.
 
 ~~~~{.cpp}
-    mkFillet.Add(theThickness / 12., anEdge);
+    aMkFillet.Add(theThickness / 12., anEdge);
 ~~~~
 
 Once this is done, you perform the last step of the procedure by asking for the filleted shape.
 
 ~~~~{.cpp}
-    aBody = mkFillet.Shape();
+    aBody = aMkFillet.Shape();
 ~~~~
 
 
@@ -362,9 +362,9 @@ To position the cylinder, you need to define a coordinate system with the *gp_Ax
 To align the neck with the center of the top face, being in the global coordinate system (0, 0, *theHeight*), with its normal on the global Z axis, your local coordinate system can be defined as follows:
 
 ~~~~{.cpp}
-    gp_Pnt neckLocation(0, 0, theHeight);
-    gp_Dir neckAxis = gp::DZ();
-    gp_Ax2 neckAx2(neckLocation, neckAxis);
+    gp_Pnt aNeckLocation(0, 0, theHeight);
+    gp_Dir aNeckAxis = gp::DZ();
+    gp_Ax2 neckAx2(aNeckLocation, aNeckAxis);
 ~~~~
 
 To create a cylinder, use another class from the primitives construction package: the *BRepPrimAPI_MakeCylinder* class. The information you must provide is:
@@ -375,8 +375,8 @@ To create a cylinder, use another class from the primitives construction package
 ~~~~{.cpp}
     double aNeckRadius = theThickness / 4.;
     double aNeckHeight = theHeight / 10;
-    BRepPrimAPI_MakeCylinder MKCylinder(neckAx2, aNeckRadius, aNeckHeight);
-    TopoDS_Shape aNeck = MKCylinder.Shape();
+    BRepPrimAPI_MakeCylinder aMkCylinder(neckAx2, aNeckRadius, aNeckHeight);
+    TopoDS_Shape aNeck = aMkCylinder.Shape();
 ~~~~
 
 You now have two separate parts: a main body and a neck that you need to fuse together.
@@ -384,7 +384,11 @@ The *BRepAlgoAPI* package provides services to perform Boolean operations betwee
 Use *BRepAlgoAPI_Fuse* to fuse the two shapes:
 
 ~~~~{.cpp}
-    aBody = BRepAlgoAPI_Fuse(aBody, aNeck);
+    BRepAlgoAPI_Fuse aFuser(aBody, aNeck);
+    if (aFuser.IsDone())
+    {
+      aBody = aFuser.Shape();
+    }
 ~~~~
 
 
@@ -453,8 +457,8 @@ If this comparison is true, you know that the *aSurface* real type is *Geom_Plan
 Remember that the goal of all these conversions is to find the highest face of the bottle lying on a plane. Suppose that you have these two global variables:
 
 ~~~~{.cpp}
-    TopoDS_Face faceToRemove;
-    double zMax = -1;
+    TopoDS_Face aFaceToRemove;
+    double aZMax = -1;
 ~~~~
 
 You can easily find the plane whose origin is the biggest in Z knowing that the location of the plane is given with the *Geom_Plane::Location* method. For example:
@@ -464,9 +468,9 @@ You can easily find the plane whose origin is the biggest in Z knowing that the 
     {
       gp_Pnt aPnt = aPlane->Location();
       double aZ = aPnt.Z();
-      if(aZ > zMax){
-          zMax = aZ;
-          faceToRemove = aFace;
+      if(aZ > aZMax){
+          aZMax = aZ;
+          aFaceToRemove = aFace;
       }
     }
 ~~~~
@@ -478,16 +482,19 @@ The collection for shapes can be found in the *TopTools* package. As *BRepOffset
 @note In OCCT 8.0.0 the package-level `TCol*` typedefs are deprecated. Prefer `NCollection_*<T>` directly -- see the @ref upgrade_occt800 "Upgrade to OCCT 8.0.0".
 
 ~~~~{.cpp}
-    NCollection_List<TopoDS_Shape> facesToRemove;
-    facesToRemove.Append(faceToRemove);
+    NCollection_List<TopoDS_Shape> aFacesToRemove;
+    aFacesToRemove.Append(aFaceToRemove);
 ~~~~
 
 All the necessary data are now available so you can create your hollowed solid by calling the *BRepOffsetAPI_MakeThickSolid* MakeThickSolidByJoin method:
 
 ~~~~{.cpp}
     BRepOffsetAPI_MakeThickSolid aSolidMaker;
-    aSolidMaker.MakeThickSolidByJoin(aBody, facesToRemove, -theThickness / 50, 1.e-3);
-    aBody = aSolidMaker.Shape();
+    aSolidMaker.MakeThickSolidByJoin(aBody, aFacesToRemove, -theThickness / 50, 1.e-3);
+    if (aSolidMaker.IsDone())
+    {
+      aBody = aSolidMaker.Shape();
+    }
 ~~~~
 
 
@@ -653,8 +660,8 @@ To compute the edges out of these curves, once again use the *BRepBuilderAPI_Mak
 Now, you can create the two profiles of the threading, lying on each surface.
 
 ~~~~{.cpp}
-    TopoDS_Wire threadingWire1 = BRepBuilderAPI_MakeWire(anEdge1OnSurf1, anEdge2OnSurf1);
-    TopoDS_Wire threadingWire2 = BRepBuilderAPI_MakeWire(anEdge1OnSurf2, anEdge2OnSurf2);
+    TopoDS_Wire aThreadingWire1 = BRepBuilderAPI_MakeWire(anEdge1OnSurf1, anEdge2OnSurf1);
+    TopoDS_Wire aThreadingWire2 = BRepBuilderAPI_MakeWire(anEdge1OnSurf2, anEdge2OnSurf2);
 ~~~~
 
 Remember that these wires were built out of a surface and 2D curves.
@@ -662,8 +669,8 @@ One important data item is missing as far as these wires are concerned: there is
 When a shape contains all the necessary information except 3D curves, Open CASCADE Technology provides a tool to build them automatically. In the BRepLib tool package, you can use the *BuildCurves3d* method to compute 3D curves for all the edges of a shape.
 
 ~~~~{.cpp}
-    BRepLib::BuildCurves3d(threadingWire1);
-    BRepLib::BuildCurves3d(threadingWire2);
+    BRepLib::BuildCurves3d(aThreadingWire1);
+    BRepLib::BuildCurves3d(aThreadingWire2);
 ~~~~
 
 
@@ -683,7 +690,7 @@ The loft function is implemented in the *BRepOffsetAPI_ThruSections* class, whic
 
 ~~~~{.cpp}
     BRepOffsetAPI_ThruSections aTool(true);
-    aTool.AddWire(threadingWire1); aTool.AddWire(threadingWire2);
+    aTool.AddWire(aThreadingWire1); aTool.AddWire(aThreadingWire2);
     aTool.CheckCompatibility(false);
     TopoDS_Shape aThreading = aTool.Shape();
 ~~~~
@@ -716,8 +723,8 @@ If you want to know more and develop major projects using Open CASCADE Technolog
 Complete definition of MakeBottle function:
 
 ~~~~{.cpp}
-    TopoDS_Shape MakeBottle(const double theWidth, const double theHeight,
-                            const double theThickness)
+    TopoDS_Shape MakeBottle(double theWidth, double theHeight,
+                            double theThickness)
     {
         // Profile : Define Support Points
         gp_Pnt aPnt1(-theWidth / 2., 0, 0);        
@@ -746,10 +753,10 @@ Complete definition of MakeBottle function:
         TopoDS_Shape aMirroredShape = aBRepTrsf.Shape();
         TopoDS_Wire aMirroredWire = TopoDS::Wire(aMirroredShape);
 
-        BRepBuilderAPI_MakeWire mkWire;
-        mkWire.Add(aWire);
-        mkWire.Add(aMirroredWire);
-        TopoDS_Wire aWireProfile = mkWire.Wire();
+        BRepBuilderAPI_MakeWire aMkWire;
+        aMkWire.Add(aWire);
+        aMkWire.Add(aMirroredWire);
+        TopoDS_Wire aWireProfile = aMkWire.Wire();
 
         // Body : Prism the Profile
         TopoDS_Face aFaceProfile = BRepBuilderAPI_MakeFace(aWireProfile);
@@ -757,27 +764,27 @@ Complete definition of MakeBottle function:
         TopoDS_Shape aBody = BRepPrimAPI_MakePrism(aFaceProfile, aPrismVec);
 
         // Body : Apply Fillets
-        BRepFilletAPI_MakeFillet mkFillet(aBody);
+        BRepFilletAPI_MakeFillet aMkFillet(aBody);
         TopExp_Explorer anEdgeExplorer(aBody, TopAbs_EDGE);
         while(anEdgeExplorer.More()){
             TopoDS_Edge anEdge = TopoDS::Edge(anEdgeExplorer.Current());
             //Add edge to fillet algorithm
-            mkFillet.Add(theThickness / 12., anEdge);
+            aMkFillet.Add(theThickness / 12., anEdge);
             anEdgeExplorer.Next();
         }
 
-        aBody = mkFillet.Shape();
+        aBody = aMkFillet.Shape();
 
         // Body : Add the Neck
-        gp_Pnt neckLocation(0, 0, theHeight);
-        gp_Dir neckAxis = gp::DZ();
-        gp_Ax2 neckAx2(neckLocation, neckAxis);
+        gp_Pnt aNeckLocation(0, 0, theHeight);
+        gp_Dir aNeckAxis = gp::DZ();
+        gp_Ax2 neckAx2(aNeckLocation, aNeckAxis);
 
         double aNeckRadius = theThickness / 4.;
         double aNeckHeight = theHeight / 10.;
 
-        BRepPrimAPI_MakeCylinder MKCylinder(neckAx2, aNeckRadius, aNeckHeight);
-        TopoDS_Shape aNeck = MKCylinder.Shape();
+        BRepPrimAPI_MakeCylinder aMkCylinder(neckAx2, aNeckRadius, aNeckHeight);
+        TopoDS_Shape aNeck = aMkCylinder.Shape();
 
         BRepAlgoAPI_Fuse aFuser(aBody, aNeck);
         if (aFuser.IsDone())
@@ -791,8 +798,8 @@ Complete definition of MakeBottle function:
         }
 
         // Body : Create a Hollowed Solid
-        TopoDS_Face   faceToRemove;
-        double zMax = -1;
+        TopoDS_Face   aFaceToRemove;
+        double aZMax = -1;
 
         for(TopExp_Explorer aFaceExplorer(aBody, TopAbs_FACE); aFaceExplorer.More(); aFaceExplorer.Next()){
             TopoDS_Face aFace = TopoDS::Face(aFaceExplorer.Current());
@@ -804,18 +811,18 @@ Complete definition of MakeBottle function:
                 {
                   gp_Pnt aPnt = aPlane->Location();
                   double aZ   = aPnt.Z();
-                  if(aZ > zMax){
-                      zMax = aZ;
-                      faceToRemove = aFace;
+                  if(aZ > aZMax){
+                      aZMax = aZ;
+                      aFaceToRemove = aFace;
                   }
                 }
             }
         }
 
-        NCollection_List<TopoDS_Shape> facesToRemove;
-        facesToRemove.Append(faceToRemove);
+        NCollection_List<TopoDS_Shape> aFacesToRemove;
+        aFacesToRemove.Append(aFaceToRemove);
         BRepOffsetAPI_MakeThickSolid aSolidMaker;
-        aSolidMaker.MakeThickSolidByJoin(aBody, facesToRemove, -theThickness / 50, 1.e-3);
+        aSolidMaker.MakeThickSolidByJoin(aBody, aFacesToRemove, -theThickness / 50, 1.e-3);
         aBody = aSolidMaker.Shape();
         // Threading : Create Surfaces
         occ::handle<Geom_CylindricalSurface> aCyl1 = new Geom_CylindricalSurface(neckAx2, aNeckRadius * 0.99);
@@ -842,15 +849,15 @@ Complete definition of MakeBottle function:
         TopoDS_Edge anEdge2OnSurf1 = BRepBuilderAPI_MakeEdge(aSegment, aCyl1);
         TopoDS_Edge anEdge1OnSurf2 = BRepBuilderAPI_MakeEdge(anArc2, aCyl2);
         TopoDS_Edge anEdge2OnSurf2 = BRepBuilderAPI_MakeEdge(aSegment, aCyl2);
-        TopoDS_Wire threadingWire1 = BRepBuilderAPI_MakeWire(anEdge1OnSurf1, anEdge2OnSurf1);
-        TopoDS_Wire threadingWire2 = BRepBuilderAPI_MakeWire(anEdge1OnSurf2, anEdge2OnSurf2);
-        BRepLib::BuildCurves3d(threadingWire1);
-        BRepLib::BuildCurves3d(threadingWire2);
+        TopoDS_Wire aThreadingWire1 = BRepBuilderAPI_MakeWire(anEdge1OnSurf1, anEdge2OnSurf1);
+        TopoDS_Wire aThreadingWire2 = BRepBuilderAPI_MakeWire(anEdge1OnSurf2, anEdge2OnSurf2);
+        BRepLib::BuildCurves3d(aThreadingWire1);
+        BRepLib::BuildCurves3d(aThreadingWire2);
 
         // Create Threading 
         BRepOffsetAPI_ThruSections aTool(true);
-        aTool.AddWire(threadingWire1);
-        aTool.AddWire(threadingWire2);
+        aTool.AddWire(aThreadingWire1);
+        aTool.AddWire(aThreadingWire2);
         aTool.CheckCompatibility(false);
 
         TopoDS_Shape aThreading = aTool.Shape();

--- a/dox/upgrade/upgrade.md
+++ b/dox/upgrade/upgrade.md
@@ -197,9 +197,9 @@ Class *BRepOffsetAPI_MakeOffsetShape*:
 
 The code below shows new calling procedure:
 ~~~~{.cpp}
-    BRepOffsetAPI_MakeOffsetShape OffsetMaker;
-    OffsetMaker.PerformByJoin(Shape, OffsetValue, Tolerance);
-    NewShape = OffsetMaker.Shape();
+    BRepOffsetAPI_MakeOffsetShape anOffsetMaker;
+    anOffsetMaker.PerformByJoin(Shape, OffsetValue, Tolerance);
+    NewShape = anOffsetMaker.Shape();
 ~~~~
 
 Class *BRepOffsetAPI_MakeThickSolid*:
@@ -208,9 +208,9 @@ Class *BRepOffsetAPI_MakeThickSolid*:
 
 The code below shows new calling procedure:
 ~~~~{.cpp}
-    BRepOffsetAPI_MakeThickSolid BodyMaker;
-    BodyMaker.MakeThickSolidByJoin(myBody, facesToRemove, -myThickness / 50, 1.e-3);
-    myBody = BodyMaker.Shape();
+    BRepOffsetAPI_MakeThickSolid aBodyMaker;
+    aBodyMaker.MakeThickSolidByJoin(myBody, facesToRemove, -myThickness / 50, 1.e-3);
+    myBody = aBodyMaker.Shape();
 ~~~~
 
 @subsection upgrade_720_highlight Highlight style
@@ -300,7 +300,7 @@ In most cases this change should be transparent, however applications implementi
   Old definitions are preserved as deprecated aliases to the new ones;
 * Methods *Image_PixMap::PixelColor()* and *Image_PixMap::SetPixelColor()* now take/return Quantity_ColorRGBA instead of Quantity_Color/NCollection_Vec4.
 * The method BOPAlgo_Builder::Origins() returns BOPCol_DataMapOfShapeListOfShape instead of BOPCol_DataMapOfShapeShape.
-* The methods BOPDS_DS::IsToSort(const Handle(BOPDS_CommonBlock)&, Standard_Integer&) and BOPDS_DS::SortPaveBlocks(const Handle(BOPDS_CommonBlock)&) have been removed. The sorting is now performed during the addition of the Pave Blocks into Common Block.
+* The methods BOPDS_DS::IsToSort(const occ::handle<BOPDS_CommonBlock>&, Standard_Integer&) and BOPDS_DS::SortPaveBlocks(const occ::handle<BOPDS_CommonBlock>&) have been removed. The sorting is now performed during the addition of the Pave Blocks into Common Block.
 * The methods BOPAlgo_Tools::MakeBlocks() and BOPAlgo_Tools::MakeBlocksCnx() have been replaced with the single template method BOPAlgo_Tools::MakeBlocks(). The chains of connected elements are now stored into the list of list instead of data map.
 * The methods BOPAlgo_Tools::FillMap() have been replaced with the single template method BOPAlgo_Tools::FillMap().
 * Package BVH now uses opencascade::handle instead of NCollection_Handle (for classes BVH_Properties, BVH_Builder, BVH_Tree, BVH_Object).
@@ -366,7 +366,7 @@ if (!aRoots.IsNull())
     occ::handle<StdObjMgt_Persistent> aPObject = aRoot->Object();
     if (!aPObject.IsNull())
     {
-      Handle(ShapePersistent_TopoDS::HShape) aHShape = Handle(ShapePersistent_TopoDS::HShape)::DownCast(aPObject);
+      occ::handle<ShapePersistent_TopoDS::HShape> aHShape = occ::down_cast<ShapePersistent_TopoDS::HShape>(aPObject);
       if (aHShape) // Downcast to an expected type to import transient data
       {
         TopoDS_Shape aShape = aHShape->Import();
@@ -406,7 +406,7 @@ for (int i = 1; i <= shapes.Length(); ++i)
 {
   TopoDS_Shape aShape = shapes.Value(i);
   // Translate a shape to a persistent object
-  Handle(ShapePersistent_TopoDS::HShape) aPShape =
+  occ::handle<ShapePersistent_TopoDS::HShape> aPShape =
     ShapePersistent_TopoDS::Translate(aShape, aMap, ShapePersistent_WithTriangle);
   if (aPShape.IsNull())
   {
@@ -483,7 +483,7 @@ to the more lower level class BRepLib.
 
 The following obsolete features have been removed:
 * The package BOPCol has been fully removed:
-  - *BOPCol_BaseAllocator* is replaced with *Handle(NCollection_BaseAllocator)*;
+  - *BOPCol_BaseAllocator* is replaced with *occ::handle<NCollection_BaseAllocator>*;
   - *BOPCol_BoxBndTree* is replaced with *BOPTools_BoxBndTree*;
   - *BOPCol_Box2DBndTree* is removed as unused;
   - *BOPCol_DataMapOfIntegerInteger* is replaced with *TColStd_DataMapOfIntegerInteger*;
@@ -954,7 +954,7 @@ The method Select3D_SensitiveEntity::NbSubElements() has been changed to be cons
 ~~~~{.cpp}
 void BOPTools_AlgoTools::TreatCompound (const TopoDS_Shape& theS,
                                         NCollection_List<TopoDS_Shape>& theLS,
-                                        NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>* theMap = NULL);
+                                        NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>* theMap = nullptr);
 ~~~~
 
 @subsection upgrade_750_Adaptor2d_OffsetCurve  Offset direction change
@@ -1001,7 +1001,7 @@ class MyAlgo
 public:
   //! Algorithm entry point taking an optional Progress Indicator.
   bool Perform (const TCollection_AsciiString& theFileName,
-                const Handle(Message_ProgressIndicator)& theProgress = Handle(Message_ProgressIndicator)())
+                const occ::handle<Message_ProgressIndicator>& theProgress = occ::handle<Message_ProgressIndicator>())
   {
     Message_ProgressSentry aPSentry (theProgress, (TCollection_AsciiString("Processing ") + theFileName).ToCString(), 2);
     {
@@ -1023,7 +1023,7 @@ public:
 
 private:
   //! Nested sub-algorithm taking Progress Indicator.
-  bool perform2 (const Handle(Message_ProgressIndicator)& theProgress)
+  bool perform2 (const occ::handle<Message_ProgressIndicator>& theProgress)
   {
     Message_ProgressSentry aPSentry2 (theProgress, "Stage 2", 0, 100, 1);
     for (int anIter = 0; anIter < 100 && aPSentry2.More(); ++anIter, aPSentry2.Next()) {}
@@ -1032,7 +1032,7 @@ private:
 };
 
 // application executing an algorithm
-Handle(Message_ProgressIndicator) aProgress = new MyProgress();
+occ::handle<Message_ProgressIndicator> aProgress = new MyProgress();
 MyAlgo anAlgo;
 anAlgo.Perform ("FileName", aProgress);
 @endcode
@@ -1094,7 +1094,7 @@ public:
 };
 
 // application executing an algorithm
-Handle(Message_ProgressIndicator) aProgress = new MyProgress();
+occ::handle<Message_ProgressIndicator> aProgress = new MyProgress();
 MyAlgo anAlgo;
 anAlgo.Perform ("FileName", aProgress->Start());
 @endcode
@@ -1284,8 +1284,8 @@ Method SetProgressIndicator() has been removed due to Progress indicator mechani
 To enable progress indicator and user break in Boolean operations user has to pass progress range as a parameter to Perform or Build method.
 For example:
 ~~~~
-Handle(Draw_ProgressIndicator) aProgress = new Draw_ProgressIndicator(di, 1);
-BRepAlgoApi_Cut(S1, S2, aProgress->Start()); // method Start() creates range for usage in cut algorithm
+occ::handle<Draw_ProgressIndicator> aProgress = new Draw_ProgressIndicator(di, 1);
+BRepAlgoAPI_Cut(S1, S2, aProgress->Start()); // method Start() creates range for usage in cut algorithm
 ~~~~
 
 @subsection upgrade_occt760_change_check_to_adaptors Changes in BRepLib_CheckCurveOnSurface & GeomLib_CheckCurveOnSurface interfaces
@@ -1347,7 +1347,7 @@ aValidateEdge.Process();
 @subsection upgrade_occt770_drawer_aspects Prs3d_Drawer aspects
 
 `Prs3d_Drawer` getters no more implicitly create "default" aspects.
-If specific property has not been set before to this drawer instance nor to linked drawer instance, then NULL property will be returned.
+If specific property has not been set before to this drawer instance nor to linked drawer instance, then nullptr property will be returned.
 Make sure to set property beforehand or to call `SetOwn*` / `SetupOwn*` methods to derive from defaults.
 
 @subsection upgrade_occt770_opengl OpenGL functions

--- a/dox/user_guides/de_wrapper/de_wrapper.md
+++ b/dox/user_guides/de_wrapper/de_wrapper.md
@@ -381,7 +381,8 @@ Code sample to configure via transfer.
     "global.priority.STEP :   OCC DTK\n"
     "global.general.length.unit : 1\n"
     "provider.STEP.OCC.read.precision.val : 0.\n";
-  if (!aSession->Load(aString, aIsRecursive))
+  bool isRecursive = true;
+  if (!aSession->Load(aString, isRecursive))
   {
     Message::SendFail() << "Error: configuration is incorrect";
   }

--- a/dox/user_guides/draw_test_harness/draw_test_harness.md
+++ b/dox/user_guides/draw_test_harness/draw_test_harness.md
@@ -783,17 +783,17 @@ restore theBox
 #### In DrawTrSurf package:
 
 ~~~~{.cpp}
-void Set(const char*& Name,const gp_Pnt& G) ; 
-void Set(const char*& Name,const gp_Pnt2d& G) ; 
-void Set(const char*& Name, 
+void Set(const char* Name,const gp_Pnt& G) ; 
+void Set(const char* Name,const gp_Pnt2d& G) ; 
+void Set(const char* Name, 
 const occ::handle<Geom_Geometry>& G) ; 
-void Set(const char*& Name, 
+void Set(const char* Name, 
 const occ::handle<Geom2d_Curve>& C) ; 
-void Set(const char*& Name, 
+void Set(const char* Name, 
 const occ::handle<Poly_Triangulation>& T) ; 
-void Set(const char*& Name, 
+void Set(const char* Name, 
 const occ::handle<Poly_Polygon3D>& P) ; 
-void Set(const char*& Name, 
+void Set(const char* Name, 
 const occ::handle<Poly_Polygon2D>& P) ; 
 ~~~~
 
@@ -809,15 +809,15 @@ Example of *DrawTrSurf*
 ~~~~{.cpp}
 occ::handle<Geom2d_Circle> C1 = new Geom2d_Circle 
 (gce_MakeCirc2d (gp_Pnt2d(50,0), 25)); 
-DrawTrSurf::Set(char*, C1); 
+DrawTrSurf::Set("C1", C1); 
 ~~~~
 
 Example of *DBRep* 
 
 ~~~~{.cpp}
-TopoDS_Solid B; 
-B = BRepPrimAPI_MakeBox (10,10,10); 
-DBRep::Set(char*,B); 
+TopoDS_Solid aB; 
+aB = BRepPrimAPI_MakeBox (10,10,10); 
+DBRep::Set("B", aB); 
 ~~~~
 
 @subsubsection occt_draw_3_3_2 get
@@ -825,13 +825,13 @@ DBRep::Set(char*,B);
 #### In DrawTrSurf package:
  
 ~~~~{.cpp}
-occ::handle<Geom_Geometry> Get(const char*& Name) ; 
+occ::handle<Geom_Geometry> Get(const char* Name) ; 
 ~~~~
 
 #### In DBRep package:
 
 ~~~~{.cpp}
-TopoDS_Shape Get(const char*& Name, 
+TopoDS_Shape Get(const char* Name, 
 const TopAbs_ShapeEnum Typ = TopAbs_SHAPE, 
 const bool Complain 
 = true) ; 
@@ -859,7 +859,7 @@ int argc, char** argv)
 {...... 
 // Creation of a TopoDS_Shape from a Draw topological 
 // name 
-TopoDS_Solid B = DBRep::Get(argv[1]); 
+TopoDS_Shape aShape = DBRep::Get(argv[1]); 
 } 
 ~~~~
 
@@ -1055,7 +1055,7 @@ color index name
 
 **color** sets the color to a value. The index of the *color* is a value between 0 and 15. The name is an X window color name. The list of these can be found in the file *rgb.txt* in the X library directory. 
 
-The default values are: 0 White, 1 Red, 2 Green, 3 Blue, 4 Cyan, 5 Gold, 6 Magenta, 7 Marron, 8 Orange, 9 Pink, 10 Salmon, 11 Violet, 12 Yellow, 13 Khaki, 14 Coral. 
+The default values are: 0 White, 1 Red, 2 Green, 3 Blue, 4 Cyan, 5 Gold, 6 Magenta, 7 Maroon, 8 Orange, 9 Pink, 10 Salmon, 11 Violet, 12 Yellow, 13 Khaki, 14 Coral. 
 
 **Example:** 
 ~~~~{.tcl}
@@ -1512,7 +1512,7 @@ vfit
 # erase only first box
 verase b1
 # erase second box and sphere
-verseall
+veraseall
 ~~~~
 
 @subsubsection occt_draw_4_3_6 vsetdispmode
@@ -2601,7 +2601,7 @@ Syntax:
 ~~~~{.tcl}
 Children docname label
 ~~~~
-Returns the list of attributes of label.
+Returns the list of child labels of the label.
 
 Example
 ~~~~{.tcl}
@@ -2962,7 +2962,7 @@ Syntax:
 SetIntArray dfname entry lower upper value1 value2 … 
 ~~~~
 
-Finds or creates an IntegerArray attribute at *entry* label with lower and upper bounds and sets **value1*, *value2*... 
+Finds or creates an IntegerArray attribute at *entry* label with lower and upper bounds and sets *value1*, *value2*... 
 
 **Example:** 
 ~~~~{.tcl}
@@ -2994,7 +2994,7 @@ Finds or creates a RealArray attribute at *entry* label with lower and upper bou
 
 **Example:** 
 ~~~~{.tcl}
-GetRealArray D 0:2 1 4 100. 200. 300. 400. 
+SetRealArray D 0:2 1 4 100. 200. 300. 400. 
 ~~~~
 
 @subsubsection occt_draw_5_5_8  GetRealArray
@@ -3142,7 +3142,7 @@ SetUAttribute D 0:2 ${localGUID}
 
 Syntax:
 ~~~~{.tcl}
-GetUAttribute dfname entry loacalGUID 
+GetUAttribute dfname entry localGUID 
 ~~~~
 
 Finds a *UAttribute* at *entry* label with *localGUID*. 
@@ -3212,7 +3212,7 @@ box b 10 10 10
 SetShape D 0:2 b 
 ~~~~
 
-@subsubsection occt_draw_5_5_23  GetShape
+@subsubsection occt_draw_5_5_23  GetShape2
 
 Syntax:
 ~~~~{.tcl}
@@ -3644,7 +3644,7 @@ Syntax:
 AISDisplay docname entry [not_update] 
 ~~~~
 
-Displays a presantation of *AISobject* from *entry* label in AIS viewer. If *not_update* is not defined then *AISobject* is recomputed and all visualization settings are applied. 
+Displays a presentation of *AISobject* from *entry* label in AIS viewer. If *not_update* is not defined then *AISobject* is recomputed and all visualization settings are applied. 
 
 **Example:** 
 ~~~~{.tcl}
@@ -3771,7 +3771,7 @@ Syntax:
 AISMaterial docname entry [material] 
 ~~~~
 
-Sets (if *material* is defined) or gets the value of transparency for *AISPresentation* attribute of an *entry* label. *material* is integer from 0 to 20 (see @ref occt_draw_4_5_6 "meshmat" command). 
+Sets (if *material* is defined) or gets the value of material for *AISPresentation* attribute of an *entry* label. *material* is integer from 0 to 20 (see @ref occt_draw_4_5_6 "meshmat" command). 
 
 **Example:** 
 ~~~~{.tcl}
@@ -4193,7 +4193,7 @@ Note that this definition will be used for all analytical surfaces.
 # with U direction on Y 
 plane p1 10 0 0 1 0 0 0 1 0 
 
-# an horixontal plane with origin 10, -20, -5 
+# an horizontal plane with origin 10, -20, -5 
 plane p2 10 -20 -5 
 ~~~~
 
@@ -4842,7 +4842,7 @@ pscale s 0 0 0 2
   * **coord** to find the coordinates of a point.
   * **cvalue** and **2dcvalue** to compute points and derivatives on curves.
   * **svalue** to compute points and derivatives on a surface.
-  * **localprop** and **minmaxcurandif** to compute the curvature on a curve.
+  * **localprop** and **minmaxcurandinf** to compute the curvature on a curve.
   * **parameters** to compute (u,v) values for a point on a surface.
   * **proj** and **2dproj** to project a point on a curve or a surface.
   * **surface_radius** to compute the curvature on a surface.
@@ -4982,7 +4982,7 @@ Let us compute curvatures of a cylinder:
 cylinder c 5 
 surface_radius c pi 3 c1 c2 
 == Min Radius of Curvature : -5 
-== Min Radius of Curvature : infinite 
+== Max Radius of Curvature : infinite 
 ~~~~
 
 
@@ -5391,7 +5391,7 @@ range name value value
 * **orientation** -- assigns the orientation of simple and complex shapes to one of the following four values: *FORWARD, REVERSED, INTERNAL, EXTERNAL*. 
 * **complement** -- changes the current orientation of shapes to its complement: *FORWARD* to *REVERSED* and  *INTERNAL* to *EXTERNAL*. 
 * **invert** -- creates a copy of the original shape with a reversed orientation of all subshapes. For example, it may be useful to reverse the normals of a solid. 
-* *normals** -- returns the assignment of colors to orientation values. 
+* **normals** -- returns the assignment of colors to orientation values. 
 * **range** -- defines the length of a selected edge by defining the values of a starting point and an end point.
  
 **Example:** 
@@ -5479,9 +5479,9 @@ compound [name ...] compoundname
 **add** inserts shape *C* into shape *S*. Verify that *C* and *S* reference compatible types of objects: 
   * Any *Shape* can be added to a *Compound*.
   * Only a *Solid* can be added to a *CompSolid*.
-  * Only a *Shell* can *Edge* or a *Vertex* can be added into a *Solid*.
+  * Only a *Shell* can be added to a *Solid*.
   * Only a *Face* can be added to a *Shell*.
-  * Only a *Wire* and *Vertex* can be added in a *Solid*.
+  * Only a *Wire* can be added to a *Face*.
   * Only an *Edge* can be added to a *Wire*.
   * Only a *Vertex* can be added to an *Edge*.
   * Nothing can be added to a *Vertex*.
@@ -5595,7 +5595,7 @@ visoedge edge face v u1 u2
 ~~~~
 
 * **edge** creates a straight line edge between two vertices. 
-* **mkedge** generates edges from curves<.Two parameters can be given for the vertices: the first and last parameters of the curve are given by default. Vertices can also be given with their parameters, this option allows blocking the creation of new vertices. If the parameters of the vertices are not given, they are computed by projection on the curve. Instead of a 3d curve, a 2d curve and a surface can be given. 
+* **mkedge** generates edges from curves. Two parameters can be given for the vertices: the first and last parameters of the curve are given by default. Vertices can also be given with their parameters, this option allows blocking the creation of new vertices. If the parameters of the vertices are not given, they are computed by projection on the curve. Instead of a 3d curve, a 2d curve and a surface can be given. 
 
 **Example:** 
 ~~~~{.tcl}
@@ -5741,7 +5741,7 @@ profile p F 1 0 x 2 y 1 c 1 45 l 1 tt 1.5 1.5 xx 0.2 yy 2 c 1 290
 # wire continues at a tangent to the intersection x = 0 
 profile p F 1 0 x 2 y 1 c 1 45 l 1 tt 1.5 1.5 xx 0.2 yy 2 c 1 290 ix 0 ww 
 
-# continue the wire at an angle of 90 degrees until it intersects the y axis at y= -o.3 
+# continue the wire at an angle of 90 degrees until it intersects the y axis at y= -0.3 
 profile p F 1 0 x 2 y 1 c 1 45 l 1 tt 1.5 1.5 xx 0.2 yy 2 c 1 290 ix 0 r 90 ix -0.3 ww 
 
 #close the wire 
@@ -6004,7 +6004,7 @@ Primitive commands make it possible to create simple shapes. They include:
 Syntax:
 ~~~~{.tcl}
 box name [x y z] dx dy dz 
-wedge name dx dy dz ltx / xmin zmin xmax xmax 
+wedge name dx dy dz ltx / xmin zmin xmax zmax 
 ~~~~
 
 **box** creates a box parallel to the axes with dimensions *dx,dy,dz*. *x,y,z* is the corner of the box. It is the default origin. 
@@ -6036,7 +6036,6 @@ wedge w3 20 20 20 10 10 10 10
 Syntax:
 ~~~~{.tcl}
 pcylinder name [plane] radius height [angle] 
-pcone name [plane] radius1 radius2 height [angle] 
 pcone name [plane] radius1 radius2 height [angle] 
 psphere name [plane] radius1 [angle1 angle2] [angle] 
 ptorus name [plane] radius1 radius2 [angle1 angle2] [angle] 
@@ -6226,7 +6225,7 @@ polyline w3 0 0 5 5 0 5 5 5 5 2 3 5
 # create the shape 
 thrusections th issolid isruled w1 w2 w3 
 ==thrusections th issolid isruled w1 w2 w3 
-Tolerances obtenues   -- 3d : 0 
+Tolerances obtained  -- 3d : 0 
 -- 2d : 0 
 ~~~~
 
@@ -6392,7 +6391,7 @@ Blending is the creation of a new shape by rounding edges to create a fillet.
 
 Syntax:
 ~~~~{.tcl}
-dep result shape dirx diry dirz face angle x y x dx dy dz [face angle...] 
+dep result shape dirx diry dirz face angle x y z dx dy dz [face angle...] 
 ~~~~
 
 Creates a new shape by drafting one or more faces of a shape. 
@@ -7161,7 +7160,7 @@ gplate r2 4 1 p e1 0 e2 0 e3 0 e4 0 pp
 ======== Results =========== 
 DistMax=3.65622157610934e-06 
 * GEOMPLATE END* 
-Calculculation time: 0.27 
+Calculation time: 0.27 
 Loop number: 1 
 Approximation results 
 Approximation error : 0.000422195884750181 
@@ -7581,7 +7580,7 @@ modified m5 fillet_hist b_5
 
 @subsubsection occt_draw_hist_gen generated
 
-*generated* command returns the shapes Generated from the given shape in the given history. All generated shapes are put into a compound. If no shapes have been generated from the shape, the resulting compound will be empty. Note that; if the shape has generated a single shape only, it will be returned without enclosure into the compound.
+*generated* command returns the shapes Generated from the given shape in the given history. All generated shapes are put into a compound. If no shapes have been generated from the shape, the resulting compound will be empty. Note that, if the shape has generated a single shape only, it will be returned without enclosure into the compound.
 
 Syntax:
 ~~~~{.tcl}
@@ -7930,7 +7929,7 @@ The following commands are used to perform the operation using API implementatio
 * **bapibop** -- to perform API Boolean operation.
 * **bapisplit** -- to perform API Split operation.
 
-These commands have the same syntax as the analogical commands described above.
+These commands have the same syntax as the analogous commands described above.
 
 
 @subsection occt_draw_bop_options Setting options for the operation
@@ -8085,7 +8084,7 @@ bopcheck c
 ~~~~
 
 In this example one box is completely included into other box. So the output shows that all sub-shapes of b2 interfering with the solid b1.
-**bopcheck** command does not modifies the input shape, thus can be safely used.
+**bopcheck** command does not modify the input shape, thus can be safely used.
 
 
 @subsubsection occt_draw_bop_check_2 bopargcheck
@@ -8145,7 +8144,7 @@ Made faulty shape: s1si_1
 Made faulty shape: s1se_1
 Faulties for FIRST  shape found : 2
 ---------------------------------
-Shapes are not suppotrted by BOP: NO
+Shapes are not supported by BOP: NO
 Self-Intersections              : YES  Cases(1)  Total shapes(2)
 Check for SI has been aborted   : NO
 Too small edges                 : YES  Cases(1)  Total shapes(1)
@@ -8428,7 +8427,7 @@ This chapter presents some general information about Data Exchange (DE) operatio
 
 DE commands are intended for translation files of various formats (IGES,STEP) into OCCT shapes with their attributes (colors, layers etc.) 
 
-This files include a number of entities. Each entity has its own number in the file which we call label and denote as # for a STEP file and D for an IGES file. Each file has entities called roots (one or more). A full description of such entities is contained in the Users' Guides 
+These files include a number of entities. Each entity has its own number in the file which we call label and denote as # for a STEP file and D for an IGES file. Each file has entities called roots (one or more). A full description of such entities is contained in the Users' Guides 
 * for <a href="user_guides__step.html#occt_step_1">STEP format</a> and
 * for <a href="user_guides__iges.html#occt_iges_1">IGES format</a>. 
 
@@ -8711,7 +8710,7 @@ givecount <selection_name> [<selection_name>]
 
 
 Prints a number of loaded entities defined by the selection argument.
-Possible values of \<selection_name\> you can find in the “IGES FORMAT Users’s Guide”.
+Possible values of \<selection_name\> you can find in the "IGES FORMAT User's Guide".
 
 **Example:**
 ~~~~{.tcl}
@@ -8743,7 +8742,7 @@ givelist xst-model-all
 
 @subsubsection occt_draw_8_3_10  listcount
 
-Syntax:listcount \<counter\> [\<selection\> ...]
+Syntax: listcount \<counter\> [\<selection\> ...]
 
 Prints a list of entities per each type matching the criteria defined by arguments. 
 Optional <i>\<selection\></i> argument, if specified, defines a subset of entities, which are to be taken into account. Argument <i>\<counter\></i>  should be one of the currently defined counters: 
@@ -8920,7 +8919,7 @@ These commands are used for translation of IGES and STEP files into an XCAF docu
   * XDE layer’s commands
   * XDE property’s commands
 
-Reminding: All operations of translation are performed with parameters managed by command @ref occt_draw_8_3_14 "param".
+Reminder: All operations of translation are performed with parameters managed by command @ref occt_draw_8_3_14 "param".
 
 @subsubsection occt_draw_8_4_1  ReadIges
 
@@ -9000,13 +8999,13 @@ Syntax:
 XFileList  
 ~~~~
 
-Returns a list all files that were transferred by the last transfer. This command is  meant (assigned) for the assemble step file. 
+Returns a list all files that were transferred by the last transfer. This command is  meant (assigned) for the assembly STEP file. 
 
 **Example:**
 ~~~~{.tcl}
 XFileList 
 ==> *as1-ct-Bolt.stp* 
-==> *as1-ct-L-Bracktet.stp* 
+==> *as1-ct-L-Bracket.stp* 
 ==> *as1-ct-LBA.stp* 
 ==> *as1-ct-NBA.stp* 
 ==> … 
@@ -9019,7 +9018,7 @@ Syntax:
 XFileSet <filename> 
 ~~~~
 
-Sets the current file taking it from the components list of the assemble file. 
+Sets the current file taking it from the components list of the assembly file. 
 
 **Example:**
 ~~~~{.tcl}
@@ -9338,7 +9337,7 @@ Syntax:
 XRemoveShape <document> <label>
 ~~~~
 
-Removes a shape from a document (by it’s label). 
+Removes a shape from a document (by its label). 
 
 **Example:**
 ~~~~{.tcl}
@@ -9641,7 +9640,7 @@ XRemoveLayer D layer2
 
 Syntax:
 ~~~~{.tcl}
-XSetLayer XSetLayer <document> {<shape>|<label>} <layer> [shape_in_one_layer {0|1}]
+XSetLayer <document> {<shape>|<label>} <layer> [shape_in_one_layer {0|1}]
 
 ~~~~
  
@@ -9895,7 +9894,7 @@ Checks the overlapping of two given edges. If the distance between two edges is 
 checkoverlapedges e1 e2 
 ~~~~
 
-@subsubsection occt_draw_9_1_4 comtol
+@subsubsection occt_draw_9_1_4 comptol
 
 Syntax:
 ~~~~{.tcl}
@@ -9968,7 +9967,7 @@ Syntax:
 fixsmall <result> <shape> [<toler>=1.]
 ~~~~
 
-Fixes small edges in given shape by merging adjacent edges with agiven tolerance. Results are put into the shape, which is given as the result parameter. 
+Fixes small edges in given shape by merging adjacent edges with a given tolerance. Results are put into the shape, which is given as the result parameter. 
 
 **Example:**
 ~~~~{.tcl}
@@ -10221,11 +10220,11 @@ DT_ClosedSplit <result> <shape>
 ~~~~
 
 Divides all closed faces in the shape (for example cone) and returns result of given shape into shape, which is given as parameter result. Number of faces in resulting shapes will be increased. 
-Note: A closed face is a face with one or more seam. 
+Note: A closed face is a face with one or more seams. 
 
 **Example:**
 ~~~~{.tcl}
-DT_ClosetSplit r a 
+DT_ClosedSplit r a 
 ~~~~
 
 @subsubsection occt_draw_9_2_2 DT_ShapeConvert, DT_ShapeConvertRev
@@ -10430,7 +10429,7 @@ Syntax:
 pln <x1> <y1> <z1> <x2> <y2> <z2> <x3> <y3> <z3>
 ~~~~
 
-Returns plane built on three points. A plane is represented by 6 double values: coordinates of the origin point and the normal directoin.
+Returns plane built on three points. A plane is represented by 6 double values: coordinates of the origin point and the normal direction.
 
 Example: 
 ~~~~{.tcl}
@@ -10500,7 +10499,7 @@ Syntax:
 inverse <x> <y> <z>
 ~~~~
 
-Returns inversed 3D vector.
+Returns inverted 3D vector.
 
 Example: 
 ~~~~{.tcl}
@@ -10514,7 +10513,7 @@ Syntax:
 2dinverse <x> <y>
 ~~~~
 
-Returns inversed 2D vector.
+Returns inverted 2D vector.
 
 Example: 
 ~~~~{.tcl}

--- a/dox/user_guides/iges/iges.md
+++ b/dox/user_guides/iges/iges.md
@@ -71,17 +71,10 @@ IFSelect_ReturnStatus stat  = reader.ReadFile("filename.igs");
 The loading operation  only loads the IGES file into computer memory; it does not translate it. 
 
 @subsubsection occt_iges_2_3_2 Checking the IGES file
-This step is not obligatory.  Check the loaded file with:  
+This step is not obligatory.  Check the loaded file with:
 ~~~~{.cpp}
-bool ok =  reader.Check(true); 
-~~~~
-The variable "ok is  True" is returned if no fail message was found; "ok is False" is returned if  there was at least one fail message.  
-~~~~{.cpp}
-reader.PrintCheckLoad  (failsonly, mode); 
-~~~~
-Error messages are  displayed if there are invalid or incomplete IGES entities, giving you  information on the cause of the error.  
-~~~~{.cpp}
-bool failsonly  = true or false; 
+bool failsonly = true; // or false — true shows fail messages only, false shows both fail and warning messages
+reader.PrintCheckLoad (failsonly, mode); 
 ~~~~
 If you give True, you  will see fail messages only. If you give False, you will see both fail and  warning messages.  
 
@@ -349,7 +342,7 @@ faces =  reader.GiveList("xst-type(!=SurfaceOfRevolution)");
 Perform translation  according to what you want to translate:  
 1.  Translate an entity identified  by its rank with:  
 ~~~~{.cpp}
-bool ok =  reader.Transfer (rank); 
+bool ok =  reader.TransferOne (rank); 
 ~~~~
 2.  Translate an entity  identified by its handle with: 
 ~~~~{.cpp}
@@ -377,7 +370,7 @@ reader.TransferRoots();
 
 @subsubsection occt_iges_2_3_6 Getting the  translation results
 Each successful  translation operation outputs one shape. A series of translations gives a  series of shapes.  
-Each time you invoke  *TransferEntity, Transfer* or *Transferlist*, their results are accumulated and  NbShapes increases. You can clear the results (Clear function) between two  translation operations, if you do not do this, the results from the next  translation will be added to the accumulation. *TransferRoots* operations  automatically clear all existing results before they start.  
+Each time you invoke  *TransferEntity*, *TransferOne()*, *TransferRoot()* or *TransferList*, their results are accumulated and  NbShapes increases. You can clear the results (Clear function) between two  translation operations, if you do not do this, the results from the next  translation will be added to the accumulation. *TransferRoots* operations  automatically clear all existing results before they start.  
 ~~~~{.cpp}
 int nbs =  reader.NbShapes(); 
 ~~~~
@@ -1175,7 +1168,7 @@ aWriter.SetNameMode(mode);
 
 You can perform the translation of a document by calling the  function: 
 ~~~~{.cpp}
-IFSelect_ReturnStatus aRetSt = aWriter.Transfer(doc); 
+bool aRetSt = aWriter.Transfer(doc); 
 ~~~~
 where "doc" is a variable which contains a handle to the input document for transferring  and should have a type *occ::handle\<TDocStd_Document\>*.
  
@@ -1183,11 +1176,11 @@ where "doc" is a variable which contains a handle to the input document for tran
 
 Write an IGES file with: 
 ~~~~{.cpp}
-IFSelect_ReturnStatus statw =  aWriter.WriteFile("filename.igs"); 
+bool statw = aWriter.Write("filename.igs"); 
 ~~~~
 or 
 ~~~~{.cpp}
-IFSelect_ReturnStatus statw = writer.WriteFile (S); 
+bool statw = aWriter.Write (S); 
 ~~~~
 where S is OStream.  
 

--- a/dox/user_guides/modeling_algos/modeling_algos.md
+++ b/dox/user_guides/modeling_algos/modeling_algos.md
@@ -642,9 +642,9 @@ GeomPlate_BuildPlateSurface BPSurf(3,15,2);
 for (BRepTools_WireExplorer anExp(W); anExp.More(); anExp.Next()) 
 { 
 TopoDS_Edge E = anExp.Current(); 
-occ::handle<BRepAdaptor_Curve> C = new BRepAdaptor_Curve (E);
+occ::handle<BRepAdaptor_Curve> aCurve = new BRepAdaptor_Curve (E);
 occ::handle<BRepFill_CurveConstraint> Cont = new
-BRepFill_CurveConstraint (C, 0);
+BRepFill_CurveConstraint (aCurve, 0);
 
 BPSurf.Add(Cont); 
 } 
@@ -1213,7 +1213,7 @@ gp_Ax2 Origin = gp::XOY();
 gp_Vec Offset(x, y, 0.); 
 Origin.Translate(Offset); 
 BRepBuilderAPI_MakeEdge 
-ME(gp_Circ(Origin,R),  ang, ang+PI/2); 
+ME(gp_Circ(Origin,R),  ang, ang+M_PI/2); 
 E = ME; 
 V1 = ME.Vertex1(); 
 V2 = ME.Vertex2(); 
@@ -1230,13 +1230,13 @@ NCollection_Array1<TopoDS_Shape> theVertices(1,8);
 // using the MakeArc function described above. 
 
 double x = L/2 - R, y = H/2 - R; 
-MakeArc(x,-y,R,3.*PI/2.,theEdges(2),theVertices(2), 
+MakeArc(x,-y,R,3.*M_PI/2.,theEdges(2),theVertices(2), 
 theVertices(3)); 
 MakeArc(x,y,R,0.,theEdges(4),theVertices(4), 
 theVertices(5)); 
-MakeArc(-x,y,R,PI/2.,theEdges(6),theVertices(6), 
+MakeArc(-x,y,R,M_PI/2.,theEdges(6),theVertices(6), 
 theVertices(7)); 
-MakeArc(-x,-y,R,PI,theEdges(8),theVertices(8), 
+MakeArc(-x,-y,R,M_PI,theEdges(8),theVertices(8), 
 theVertices(1)); 
 // Create the linear edges 
 for (int i = 1; i <= 7; i += 2) 
@@ -1540,7 +1540,7 @@ double X = 20, Y = 10, Z = 15, R = 10, DY = 30;
 gp_Ax2 axes = gp::ZOX(); 
 axes.Translate(gp_Vec(X,Y,Z)); 
 TopoDS_Face F = 
-BRepPrimAPI_MakeCylinder(axes,R,DY,PI/2.); 
+BRepPrimAPI_MakeCylinder(axes,R,DY,M_PI/2.); 
 ~~~~
 @figure{/user_guides/modeling_algos/images/modeling_algos_image029.png,"Cylinder",360}
 
@@ -1564,14 +1564,14 @@ TopoDS_Solid S = BRepPrimAPI_MakeCone(R1,R2,H);
 
   * From a radius -- builds a full  sphere. 
   * From a radius and an angle -- builds  a lune (digon).
-  * From a radius and two angles -- builds a wraparound spherical segment between two latitudes. The angles *a1* and *a2* must follow the relation: <i>PI/2 <= a1 < a2 <= PI/2 </i>. 
+  * From a radius and two angles -- builds a wraparound spherical segment between two latitudes. The angles *a1* and *a2* must follow the relation: <i>-PI/2 <= a1 < a2 <= PI/2 </i>. 
   * From a radius and three angles -- a combination of two previous methods builds a portion of spherical segment. 
 
 The following code  builds four spheres from a radius and three angles. 
 
 ~~~~{.cpp}
 double R = 30, ang = 
-	PI/2, a1 = -PI/2.3,  a2 = PI/4; 
+	M_PI/2, a1 = -M_PI/2.3,  a2 = M_PI/4; 
 TopoDS_Solid S1 = BRepPrimAPI_MakeSphere(R); 
 TopoDS_Solid S2 = BRepPrimAPI_MakeSphere(R,ang); 
 TopoDS_Solid S3 = BRepPrimAPI_MakeSphere(R,a1,a2); 
@@ -1596,8 +1596,8 @@ Note that we could  equally well choose to create Shells instead of Solids.
 The following code  builds four toroidal shells from two radii and three angles. 
 
 ~~~~{.cpp}
-double R1 = 30, R2 = 10, ang = PI, a1 = 0, 
-	a2 = PI/2; 
+double R1 = 30, R2 = 10, ang = M_PI, a1 = 0, 
+	a2 = M_PI/2; 
 TopoDS_Shell S1 = BRepPrimAPI_MakeTorus(R1,R2); 
 TopoDS_Shell S2 = BRepPrimAPI_MakeTorus(R1,R2,ang); 
 TopoDS_Shell S3 = BRepPrimAPI_MakeTorus(R1,R2,a1,a2); 
@@ -1672,7 +1672,7 @@ The following code creates a full and a partial rotation using a face, an axis a
 ~~~~{.cpp}
 TopoDS_Face F = ...; // the profile 
 gp_Ax1 axis(gp_Pnt(0,0,0),gp_Dir(0,0,1)); 
-double ang = PI/3; 
+double ang = M_PI/3; 
 TopoDS_Solid R1 = BRepPrimAPI_MakeRevol(F,axis); 
 // Full revol 
 TopoDS_Solid R2 = BRepPrimAPI_MakeRevol(F,axis,ang); 
@@ -2113,14 +2113,18 @@ void CSampleTopologicalOperationsDoc::OnEvolvedblend1()
 
 	NCollection_Array1<gp_Pnt2d>  ParAndRad(1, 6); 
 	ParAndRad(1).SetCoord(0.,  10.); 
-	ParAndRad(1).SetCoord(50.,  20.); 
-	ParAndRad(1).SetCoord(70.,  20.); 
-	ParAndRad(1).SetCoord(130.,  60.); 
-	ParAndRad(1).SetCoord(160.,  30.); 
-	ParAndRad(1).SetCoord(200.,  20.); 
+	ParAndRad(2).SetCoord(50.,  20.); 
+	ParAndRad(3).SetCoord(70.,  20.); 
+	ParAndRad(4).SetCoord(130.,  60.); 
+	ParAndRad(5).SetCoord(160.,  30.); 
+	ParAndRad(6).SetCoord(200.,  20.); 
 
 	TopExp_Explorer  ex(aBox,TopAbs_EDGE); 
-	Rake.Add(ParAndRad, TopoDS::Edge(ex.Current())); 
+	while (ex.More())
+	{
+	  Rake.Add(ParAndRad, TopoDS::Edge(ex.Current()));
+	  ex.Next();
+	}
 	TopoDS_Shape  evolvedBox = Rake.Shape(); 
 } 
 ~~~~
@@ -2294,7 +2298,7 @@ NCollection_List<TopoDS_Shape> ListOfFace;
 
 gp_Dir Direc(0.,0.,1.); 
 // Z direction 
-double Angle = 5.*PI/180.; 
+double Angle = 5.*M_PI/180.; 
 // 5 degree angle 
 gp_Pln Neutral(gp_Pnt(0.,0.,5.), Direc); 
 // Neutral plane Z=5 
@@ -2377,7 +2381,7 @@ TopoDS_Shape aShape2 = ...;
 // The original shape2 
 gp_Trsf T; 
 T.SetRotation(gp_Ax1(gp_Pnt(0.,0.,0.),gp_Vec(0.,0.,1.)), 
-2.*PI/5.); 
+2.*M_PI/5.); 
 BRepBuilderAPI_Transform theTrsf(T); 
 theTrsf.Perform(aShape1); 
 TopoDS_Shape aNewShape1 = theTrsf.Shape();
@@ -2419,7 +2423,7 @@ try {
 TopoDS_Edge E = BRepBuilderAPI_MakeEdge(P1,P2); 
 // go on with the edge 
 } 
-catch { 
+catch (...) { 
 // process the error. 
 } 
 ~~~~
@@ -2539,12 +2543,14 @@ See the example:
 //initial sewn shapes
 TopoDS_Shape aS1, aS2;  // these shapes are expected to be well sewn shells
 TopoDS_Shape aComp;
+TopoDS_Shape aF1, aF2;
 BRep_Builder aB;
 aB.MakeCompound(aComp);
 aB.Add(aComp, aS1);
 aB.Add(aComp, aS2);
-................................
+BRepBuilderAPI_Sewing aSewing;
 aSewing.Load(aComp);
+aF1 = aSewing.SewedShape();
 
 //sub shapes which should be locally sewed
 aSewing.Add(aF1);
@@ -2619,11 +2625,11 @@ In the following  sequence, a protrusion is performed, i.e. a face of the shape 
 TopoDS_Shape Sbase = ...;  // an initial shape 
 TopoDS_Face Fbase = ....; // a base of prism 
 
-gp_Dir Extrusion (.,.,.); 
+gp_Dir anExtrusion (0., 0., 1.); 
 
 // An empty face is given as the sketch face 
 
-BRepFeat_MakePrism thePrism(Sbase, Fbase, TopoDS_Face(),  Extrusion, true, true); 
+BRepFeat_MakePrism thePrism(Sbase, Fbase, TopoDS_Face(),  anExtrusion, 1, true); 
 
 thePrism.Perform (100.); 
 if (thePrism.IsDone()) { 
@@ -2672,8 +2678,8 @@ occ::handle<Geom_Surface> surf = BRep_Tool::Surface(F);
 gp_Circ2d c(gp_Ax2d(gp_Pnt2d(200.,130.),gp_Dir2d(1.,0.)),50.);
 BRepBuilderAPI_MakeWire MW;
 occ::handle<Geom2d_Curve> aline = new Geom2d_Circle(c);
-MW.Add(BRepBuilderAPI_MakeEdge(aline,surf,0.,PI));
-MW.Add(BRepBuilderAPI_MakeEdge(aline,surf,PI,2.*PI));
+MW.Add(BRepBuilderAPI_MakeEdge(aline,surf,0.,M_PI));
+MW.Add(BRepBuilderAPI_MakeEdge(aline,surf,M_PI,2.*M_PI));
 BRepBuilderAPI_MakeFace MKF(surf, false);
 MKF.Add(MW.Wire());
 TopoDS_Face FP = MKF.Face();
@@ -2713,12 +2719,12 @@ TopoDS_Shape Sbase = ...;  // an initial shape
 TopoDS_Face Frevol = ....; // a base of prism 
 TopoDS_Face FUntil = ....; // face limiting the revol 
 
-gp_Dir RevolDir (.,.,.); 
-gp_Ax1 RevolAx(gp_Pnt(.,.,.), RevolDir); 
+gp_Dir aRevolDir (0., 1., 0.); 
+gp_Ax1 aRevolAx(gp_Pnt(0., 0., 0.), aRevolDir); 
 
 // An empty face is given as the sketch face 
 
-BRepFeat_MakeRevol theRevol(Sbase, Frevol, TopoDS_Face(), RevolAx,  true, true); 
+BRepFeat_MakeRevol theRevol(Sbase, Frevol, TopoDS_Face(), aRevolAx,  1, true); 
 
 theRevol.Perform(FUntil); 
 if (theRevol.IsDone()) { 
@@ -2837,7 +2843,7 @@ p2 = gp_Pnt(0.,0.,200.);
 mkw.Add(BRepBuilderAPI_MakeEdge(p1,p2)); 
 p1 = p2; 
 mkw.Add(BRepBuilderAPI_MakeEdge(p2,gp_Pnt(0.,0.,0.))); 
-TopoDS_Shape S = BRepBuilderAPI_MakePrism(BRepBuilderAPI_MakeFace 
+TopoDS_Shape S = BRepPrimAPI_MakePrism(BRepBuilderAPI_MakeFace 
 	(mkw.Wire()),gp_Vec(gp_Pnt(0.,0.,0.),gp_Pnt(0.,100.,0.))); 
 TopoDS_Wire W = BRepBuilderAPI_MakeWire(BRepBuilderAPI_MakeEdge(gp_Pnt 
 	(50.,45.,100.), 
@@ -3027,7 +3033,7 @@ For more details on commands above, refer to the @ref occt_draw_defeaturing "Def
 
 Here are the examples of defeaturing of the ANC101 model:
 
-@figure{/user_guides/modeling_algos/images/modeling_algos_rf_im004.png,"ANC101 model",220}</td>
+@figure{/user_guides/modeling_algos/images/modeling_algos_rf_im004.png,"ANC101 model",220}
 
 
 @figure{/user_guides/modeling_algos/images/modeling_algos_rf_im005.png,"Removing the cylindrical protrusion",220}
@@ -3301,7 +3307,7 @@ For an *HLRBRep_HLRToShape* object built from an *HLRBRep_Algo* object you can a
 
 ~~~~{.cpp}
 // Build The algorithm object 
-anAlgo = new HLRBRep_Algo(); 
+occ::handle<HLRBRep_Algo> anAlgo = new HLRBRep_Algo(); 
 
 // Add Shapes into the algorithm 
 NCollection_List<TopoDS_Shape>::Iterator anIterator(myListOfShape); 
@@ -3348,7 +3354,7 @@ aHLRToShape.IsoLineHCompound();
 ~~~~{.cpp}
 
 // Build The algorithm object 
-aPolyAlgo = new HLRBRep_PolyAlgo(); 
+occ::handle<HLRBRep_PolyAlgo> aPolyAlgo = new HLRBRep_PolyAlgo(); 
 
 // Add Shapes into the algorithm 
 NCollection_List<TopoDS_Shape>::Iterator 
@@ -3453,7 +3459,7 @@ For more information on the error/warning reporting system please see the chapte
 
 @subsection occt_modalg_makeconnected_usage Usage
 
-Here is the example of usage of the *BOPAlgo_MakePeriodic* algorithm on the API level:
+Here is the example of usage of the *BOPAlgo_MakeConnected* algorithm on the API level:
 ~~~~{.cpp}
 NCollection_List<TopoDS_Shape> anArguments = ...;  // Shapes to make connected
 bool bRunParallel = ...;     // Parallel processing mode

--- a/dox/user_guides/modeling_data/modeling_data.md
+++ b/dox/user_guides/modeling_data/modeling_data.md
@@ -1032,13 +1032,13 @@ The following steps are performed:
       switch (faceCount[i])
       {
         case 0:
-          DrawEdge (TopoDS::Edge (edgemap (i)), FreeEdgeColor);
+          DrawEdge (TopoDS::Edge (edgeMap (i)), FreeEdgeColor);
           break; 
         case 1:
-          DrawEdge (TopoDS::Edge (edgemap (i)), BorderEdgeColor);
+          DrawEdge (TopoDS::Edge (edgeMap (i)), BorderEdgeColor);
           break; 
         default:
-          DrawEdge (TopoDS::Edge (edgemap (i)), SharedEdgeColor);
+          DrawEdge (TopoDS::Edge (edgeMap (i)), SharedEdgeColor);
           break;
       }
     }

--- a/dox/user_guides/ocaf/ocaf.md
+++ b/dox/user_guides/ocaf/ocaf.md
@@ -1006,7 +1006,7 @@ The class *TNaming_Tool* provides a toolkit to read current data contained in th
 If you need to create a topological attribute for existing data, use the method *NamedShape*. 
 
 ~~~~{.cpp}
-class MyPkg_MyClass 
+class CafTest_MyClass 
 { 
 public: bool SameEdge (const occ::handle<CafTest_Line>& L1, const occ::handle<CafTest_Line>& L2); 
 }; 
@@ -1015,7 +1015,7 @@ bool CafTest_MyClass::SameEdge (const occ::handle<CafTest_Line>& L1, const occ::
 { 
   occ::handle<TNaming_NamedShape> NS1 = L1->NamedShape(); 
   occ::handle<TNaming_NamedShape> NS2 = L2->NamedShape(); 
-  return BRepTools::Compare(NS1->Shape(), NS2->Shape()); 
+  return BRepTools::Compare(TopoDS::Edge(NS1->Get()), TopoDS::Edge(NS2->Get())); 
 } 
 ~~~~
 
@@ -1167,7 +1167,7 @@ To find an attribute attached to a specific label, you use the GUID of the attri
 
 ~~~~{.cpp}
     Standard_GUID anID = MyAttributeClass::GetID();
-    bool HasAttribute = aLabel.Find(anID,anAttribute);
+    bool HasAttribute = aLabel.FindAttribute(anID,anAttribute);
 ~~~~
 
 @subsubsection occt_ocaf_6_2_2 Conventional Interface of Standard Attributes
@@ -1641,7 +1641,7 @@ for (; anIterator.More(); anIterator.Next())
 ~~~~{.cpp}
 
     // A virtual method ::Arguments() returns a list of arguments of the function.
-    void CylinderDriver::Arguments( NCollection_List<TDF_Label>& args )
+    void CylinderDriver::Arguments( NCollection_List<TDF_Label>& args ) const
     {
       // The direct arguments, located at sub-leaves of the function, are collected (see picture 2)
       TDF_ChildIterator  cIterator( Label(), false );
@@ -1660,14 +1660,14 @@ for (; anIterator.More(); anIterator.Next())
     }
 
     // A virtual method ::Results() returns a list of result leaves.
-    void CylinderDriver::Results( NCollection_List<TDF_Label>& res )
+    void CylinderDriver::Results( NCollection_List<TDF_Label>& res ) const
     {
       // The result is kept at the function  label.
       res.Append(  Label() );
     }
      
     // Execution of the function  driver.  
-    int CylinderDriver::Execute (occ::handle<TFunction_Logbook>& log)
+    int CylinderDriver::Execute (occ::handle<TFunction_Logbook>& log) const
 
     {  
       // Position of the cylinder - position of the first  function (cone)   

--- a/dox/user_guides/shape_healing/shape_healing.md
+++ b/dox/user_guides/shape_healing/shape_healing.md
@@ -962,7 +962,7 @@ ShapeAnalysis_FreeBounds aCheckFreeBnd (aShape, toSplitClosed, toSplitOpen);
 // getting the results
 TopoDS_Compound aClosedWires = aCheckFreeBnd.GetClosedWires();
 // return a compound of closed free bounds
-TopoDS_Compound anOpenWires  = aCheckFreeBnd.GetClosedWires();
+TopoDS_Compound anOpenWires  = aCheckFreeBnd.GetOpenWires();
 // return a compound of open free bounds
 ~~~~
 
@@ -1115,9 +1115,9 @@ Let us split a shape according to a specified criterion.
 
 ~~~~{.cpp}
 // creation of new tools for geometry splitting by a specified criterion
-occ::handle<MyTools_SplitSurfaceTool> MySplitSurfaceTool = new MyTools_SplitSurfaceTool();
-occ::handle<MyTools_SplitCurve3DTool> MySplitCurve3Dtool = new MyTools_SplitCurve3DTool();
-occ::handle<MyTools_SplitCurve2DTool> MySplitCurve2Dtool = new MyTools_SplitCurve2DTool();
+occ::handle<MyTools_SplitSurfaceTool> aSplitSurfaceTool = new MyTools_SplitSurfaceTool();
+occ::handle<MyTools_SplitCurve3DTool> aSplitCurve3DTool = new MyTools_SplitCurve3DTool();
+occ::handle<MyTools_SplitCurve2DTool> aSplitCurve2DTool = new MyTools_SplitCurve2DTool();
 
 // creation of a tool for splitting the shape and initialization of that tool by shape
 TopoDS_Shape anInitShape = ...;
@@ -1128,14 +1128,14 @@ aShapeDivide.SetPrecision (prec);
 aShapeDivide.SetMaxTolerance (MaxTol);
 
 // setting of new splitting geometry tools in the shape splitting tools
-occ::handle<ShapeUpgrade_FaceDivide> aFaceDivide = aShapeDivide->GetSplitFaceTool();
+occ::handle<ShapeUpgrade_FaceDivide> aFaceDivide = aShapeDivide.GetSplitFaceTool();
 occ::handle<ShapeUpgrade_WireDivide> aWireDivide = aFaceDivide->GetWireDivideTool();
-aFaceDivide->SetSplitSurfaceTool (MySplitSurfaceTool);
-aWireDivide->SetSplitCurve3dTool (MySplitCurve3DTool);
-aWireDivide->SetSplitCurve2dTool (MySplitCurve2DTool);
+aFaceDivide->SetSplitSurfaceTool (aSplitSurfaceTool);
+aWireDivide->SetSplitCurve3dTool (aSplitCurve3DTool);
+aWireDivide->SetSplitCurve2dTool (aSplitCurve2DTool);
 
 // setting of the value criterion
-aShapeDivide.SetValCriterion (val);
+aShapeDivide.SetValCriterion (aVal);
             
 // shape splitting
 aShapeDivide.Perform();
@@ -1413,7 +1413,7 @@ TopoDS_Shape aResultShape = ShapeCustom::DirectFaces (anInitialShape);
 
 ~~~~{.cpp}
 ShapeCustom::DirectFaces()
-  static TopoDS_Shape DirectFaces (const TopoDS_Shape& aShape);
+  static TopoDS_Shape DirectFaces (const TopoDS_Shape& theShape);
 ~~~~
 
 This method provides conversion of indirect elementary surfaces (elementary surfaces with left-handed coordinate systems) in the shape into direct ones.
@@ -1423,7 +1423,7 @@ New 2d curves (recomputed for converted surfaces) are added to the same edges be
 
 ~~~~{.cpp}
 ShapeCustom::ScaleShape()
-  TopoDS_Shape ShapeCustom::ScaleShape (const TopoDS_Shape& aShape, const double theScale);
+  TopoDS_Shape ShapeCustom::ScaleShape (const TopoDS_Shape& theShape, const double theScale);
 ~~~~
 
 This method returns a new shape, which is a scaled original shape with a coefficient equal to the specified value of scale.
@@ -1437,7 +1437,7 @@ If the approximation result cannot be achieved with the specified continuity, th
 The method with all parameters looks as follows:
 ~~~~{.cpp}
 ShapeCustom::BsplineRestriction()
-  TopoDS_Shape ShapeCustom::BSplineRestriction (const TopoDS_Shape& aShape,
+  TopoDS_Shape ShapeCustom::BSplineRestriction (const TopoDS_Shape& theShape,
                                                 const double theTol3d, const double theTol2d,
                                                 const int theMaxDegree,
                                                 const int theMaxNbSegment,
@@ -1478,7 +1478,7 @@ The following flags define whether a specified-type geometry has been converted 
 
 ~~~~{.cpp}
 ShapeCustom::ConvertToRevolution()
-  TopoDS_Shape ShapeCustom::ConvertToRevolution (const TopoDS_Shape& aShape);
+  TopoDS_Shape ShapeCustom::ConvertToRevolution (const TopoDS_Shape& theShape);
 ~~~~
 
 This method returns a new shape with all elementary periodic surfaces converted to *Geom_SurfaceOfRevolution*. It uses the tool *ShapeCustom_ConvertToRevolution*.
@@ -1487,7 +1487,7 @@ This method returns a new shape with all elementary periodic surfaces converted 
 
 ~~~~{.cpp}
 ShapeCustom::ConvertToBSpline()
-  TopoDS_Shape ShapeCustom::ConvertToBSpline (const TopoDS_Shape& aShape,
+  TopoDS_Shape ShapeCustom::ConvertToBSpline (const TopoDS_Shape& theShape,
                                               const bool theExtrMode,
                                               const bool theRevolMode,
                                               const bool theOffsetMode);
@@ -1740,7 +1740,7 @@ TopoDS_Shape aResultSubshape1 = aContext->Apply (theSubshape1);
 
 @subsection occt_shg_5_2 Status definition
 
-*ShapExtend_Status* is used to report the status after executing some methods that can either fail, do something, or do nothing.
+*ShapeExtend_Status* is used to report the status after executing some methods that can either fail, do something, or do nothing.
 The status is a set of flags *DONEi* and *FAILi*.
 Any combination of them can be set at the same time. For exploring the status, enumeration is used.
 
@@ -1902,7 +1902,7 @@ Let us create a custom sequence of operations:
   where *Tolerance* is the name of the parameter and 0.01 is its value.
 3. Add the following string into *void ShapeProcess_OperLibrary::Init()*:
 ~~~~{.cpp}
-  ShapeProcess::RegisterOperator (MyOper, new ShapeProcess_UOperator (myFunction));
+  ShapeProcess::RegisterOperator ("MyOper", new ShapeProcess_UOperator (myFunction));
 ~~~~
   where *myFunction* is a function which implements the operation.
 4. Create this function in *ShapeProcess_OperLibrary* as follows:
@@ -1914,7 +1914,7 @@ static bool myFunction (const occ::handle<ShapeProcess_Context>& theContext)
   TopoDS_Shape aShape = aCtx->Result();
   // receive our parameter:
   double aToler = 0.0;
-  aCtx->GetReal (Tolerance, aToler);
+  aCtx->GetReal ("Tolerance", aToler);
 ~~~~
 5. Make the necessary operations with *aShape* using the received value of parameter *Tolerance* from the resource file.
 ~~~~{.cpp}

--- a/dox/user_guides/step/step.md
+++ b/dox/user_guides/step/step.md
@@ -473,7 +473,8 @@ of for each of the two "AXIS2_PLACEMENT_3D" entities referenced by it. as follow
   occ::handle<StepGeom_Axis2Placement3d> aSTEPAxis = ...;
   occ::handle<Transfer_Binder> aBinder = aReader->WS()->TransferReader()->TransientProcess()->Find(aSTEPAxis);
   occ::handle<TransferBRep_ShapeBinder> aShBinder = occ::down_cast<TransferBRep_ShapeBinder>(aBinder);
-  if (! aShBinder.IsNull())
+  if (! aShBinder.IsNull()
+   && aShBinder->Result().ShapeType() == TopAbs_FACE)
   {
     TopoDS_Face aFace = TopoDS::Face (aShBinder->Result());
     if (! aFace.IsNull())
@@ -569,12 +570,12 @@ between two translation operations, if you do not, the results from the next tra
 If several individual translations follow each other, the results give a list that can be purged with *reader.ClearShapes()*, which erases the existing results. 
 
 <h5>Checking that translation was correctly performed</h5>
-Each time you invoke *Transfer* or *TransferRoots()*,  you can display the related messages with the help of: 
+Each time you invoke *TransferOne(), TransferRoot()* or *TransferList()*, you can display the related messages with the help of: 
 ~~~~{.cpp}
 reader.PrintCheckTransfer(failsonly,mode); 
 ~~~~
 
-This check concerns the last invocation of *Transfer* or *TransferRoots()* only. 
+This check concerns the last invocation of *TransferOne(), TransferRoot()* or *TransferList()* only. 
 
 @subsubsection occt_step_2_3_6 Selecting STEP entities for translation
 
@@ -1199,9 +1200,9 @@ The table below describes STEP entities, which are created when the assembly str
 | | Geom_SphericalSurface |  spherical_surface | | 
 | | Geom_SurfaceOfLinear Extrusion | surface_of_linear_extrusion | | 
 | | Geom_SurfaceOf Revolution | surface_of_revolution | |
-| | Geom_ToroidalSurface | toroidal_surface or degenerate_toroidal_surface |   *degenerate_toroidal_surface* is produced if the minor radius is greater then the major one |
+| | Geom_ToroidalSurface | toroidal_surface or degenerate_toroidal_surface |   *degenerate_toroidal_surface* is produced if the minor radius is greater than the major one |
 | | Geom_BezierSurface | b_spline_surface_with_knots | | 
-| | Geom_BsplineSurface | b_spline_surface_with_knots or rational_b_spline_surface |  *rational_b_spline_surface* is produced if *Geom_BSplineSurface* is a rational Bspline |
+| | Geom_BSplineSurface | b_spline_surface_with_knots or rational_b_spline_surface |  *rational_b_spline_surface* is produced if *Geom_BSplineSurface* is a rational BSpline |
 | Triangulations | Poly_Triangulation | *triangulated_face* is produced for face active triangulation | |
 
 
@@ -1267,7 +1268,7 @@ Physical file reading consists of the following steps:
    2.Mapping STEP entities to the array of strings 
    3.Creating empty OCCT objects representing STEP entities 
    4.Initializing OCCT objects 
-   5.Building a references graph 
+   5. Building a references graph 
    
 @subsubsection occt_step_4_2_1 Loading a STEP file and syntactic analysis of its contents
 In the first phase, a STEP file is syntactically checked and loaded in memory as a sequence of strings. 
@@ -1303,7 +1304,7 @@ Each field of a STEP entity should be represented by a corresponding field of th
 * Update file *RWStepAP214_ReadWriteModule.cxx*. The changes should be the following: 
  * For simple types: 
     * Add a static object of class *TCollection_AsciiString* with name *Reco_NewEntity* and initialize it with a string containing the STEP type. 
-    * In constructor *WStepAP214_ReadWriteModule::RWStepAP214_ReadWriteModule()* add this object onto the list with the unique integer identifier of the new entity type. 
+    * In constructor *RWStepAP214_ReadWriteModule::RWStepAP214_ReadWriteModule()* add this object onto the list with the unique integer identifier of the new entity type. 
     * In function *RWStepAP214_ReadWriteModule::StepType()* add a new C++ case operator for this identifier. 
  * For complex types: 
     * In the method *RWStepAP214_ReadWriteModule::CaseStep()* add a code for recognition the new entity type returning its unique integer identifier. 
@@ -1769,7 +1770,7 @@ Interface_Static::SetCVal("write.step.schema", "AP242DIS");
 ~~~~
 or
 ~~~~{.cpp}
-Interface_Static::SetIVal("write.step.schema", 5));  
+Interface_Static::SetIVal("write.step.schema", 5);  
 ~~~~
 ### Saved views
 Saved Views are not exported by OCCT.

--- a/dox/user_guides/vis/vis.md
+++ b/dox/user_guides/vis/vis.md
@@ -324,13 +324,13 @@ Picking algorithm  uses an instance of viewer selector (OCCT term), which manage
 The typical usage of *IVtk_IShapePickerAlgo* consists in the following sequence of actions:
 1. Create an instance of the picker class:
 ~~~~{.cpp}
-IVtkOCC_ShapePickerAlgo::Handle Picker = new IVtkOCC_ShapePickerAlgo();
+IVtkOCC_ShapePickerAlgo::Handle myOccPickerAlgo = new IVtkOCC_ShapePickerAlgo();
 ~~~~
 
 2. Set an instance of *IVtk_IView* class to the algorithm in order to define the viewer parameters:
 ~~~~{.cpp}
-IVtkVTK_View::Handle View = new IVtkVTK_View(Renderer);
-Picker->SetView(View);
+IVtkVTK_View::Handle aView = new IVtkVTK_View(Renderer);
+myOccPickerAlgo->SetView(aView);
 ~~~~
 3. Activate the desired selection modes using values from *IVtk_SelectionMode* enumeration. For example, the following call allows selection of edges:
 ~~~~{.cpp}
@@ -339,12 +339,12 @@ TopoDS_Shape aShape;
 ...
 IVtk_IShape::Handle shapeImpl = new IVtkOCC_Shape(aShape);
 ...
-myOccPickerAlgo->SetSelectionMode(occShape, SM_Edge);
+myOccPickerAlgo->SetSelectionMode(shapeImpl, SM_Edge);
 ~~~~
 Different selection modes can be turned on/off for a picker at the same time independently from each other.
 To turn off a selection mode the additional optional Boolean parameter is used with *false* value, for example:
 ~~~~{.cpp}
-myOccPickerAlgo->SetSelectionMode(occShape, SM_Edge, false);
+myOccPickerAlgo->SetSelectionMode(shapeImpl, SM_Edge, false);
 ~~~~
 4. Call *Pick* method passing the mouse coordinates:
 ~~~~{.cpp}

--- a/dox/user_guides/visualization/visualization.md
+++ b/dox/user_guides/visualization/visualization.md
@@ -493,7 +493,7 @@ To change this, use the following code:
 // Assume there is a created interactive context
 const occ::handle<AIS_InteractiveContext> aContext;
 // Retrieve the current viewer selector
-const occ::handle<StdSelect_ViewerSelector3d>& aMainSelector = aContext->MainSelector();
+const occ::handle<SelectMgr_ViewerSelector>& aMainSelector = aContext->MainSelector();
 // Set the flag to allow overlap detection
 aMainSelector->AllowOverlapDetection (true);
 ~~~~
@@ -635,8 +635,8 @@ you can cancel its "infinite" status using *AIS_InteractiveObject::SetInfiniteSt
 Let us take for example the class called *IShape* representing an interactive object:
 
 ~~~~{.cpp}
-myPk_IShape::myPk_IShape (const TopoDS_Shape& aShape, PrsMgr_TypeOfPresentation theType)
-: AIS_InteractiveObject (theType), myShape (aShape) { SetHilightMode (0); }
+myPk_IShape::myPk_IShape (const TopoDS_Shape& theShape, PrsMgr_TypeOfPresentation3d theType)
+: AIS_InteractiveObject (theType), myShape (theShape) { SetHilightMode (0); }
 
 bool myPk_IShape::AcceptDisplayMode (const int theMode) const
 {
@@ -1260,7 +1260,7 @@ aScaleMap.Bind (anId, aValue);
 aBuilder->SetColorMap (aColorMap);
 aBuilder->SetInvalidColor (Quantity_NOC_BLACK);
 aBuilder->SetTextureCoords (aScaleMap);
-aMesh->AddBuilder (aBuilder, true);
+theMeshPrs->AddBuilder (aBuilder, true);
 ~~~~
 
 @subsection occt_visu_3_6 Dynamic Selection
@@ -1684,9 +1684,9 @@ aView->Update();
 Other 3D displays are also supported, including row-interlaced with passive glasses and anaglyph glasses - see *Graphic3d_StereoMode* enumeration.
 Example to activate another stereoscopic display:
 ~~~~{.cpp}
-occ::handle<V3d_View> aView;
+occ::handle<V3d_View> aView = myViewer->CreateView(); // create a view first
 aView->Camera()->SetProjectionType (Graphic3d_Camera::Projection_Stereo);
-aView->ChangeRenderingParams().StereoParams = Graphic3d_StereoMode_RowInterlaced;
+aView->ChangeRenderingParams().StereoMode = Graphic3d_StereoMode_RowInterlaced;
 ~~~~
 
 Supporting of VR/AR headsets in application is more involving.
@@ -2010,7 +2010,7 @@ aFirebrickMarker->SetColor (aFirebrick);
 aFirebrickMarker->SetScale (1.0f);
 aFirebrickMarker->SetType (Aspect_TOM_BALL);
 // or custom image
-aFirebrickMarker->SetMarkerImage (theImage)
+aFirebrickMarker->SetMarkerImage (theImage);
 ~~~~
 
 Create facet attributes.
@@ -2034,7 +2034,7 @@ occ::handle<Graphic3d_AspectText3d> aTextAspect = new Graphic3d_AspectText3d (aF
 
 ~~~~{.cpp}
 // create a graphic driver
-occ::handle<OpenGl_GraphicDriver> aGraphicDriver = new OpenGl_GraphicDriver (occ::handle<Aspect_DisplayConnection>());
+occ::handle<OpenGl_GraphicDriver> aGraphicDriver = new OpenGl_GraphicDriver (new Aspect_DisplayConnection());
 // create a viewer
 myViewer = new V3d_Viewer (aGraphicDriver);
 // set parameters for V3d_Viewer
@@ -2155,17 +2155,17 @@ aGroup->SetGroupPrimitivesAspect (new Graphic3d_AspectLine3d());
 Create text and markers in group *aGroup*.
 
 ~~~~{.cpp}
-static char* THE_TEXT[3] =
+static const char* THE_TEXT[3] =
 {
   "Application title",
   "My company",
   "My company address."
 };
-occ::handle<Graphic3d_ArrayOfPoints> aPtsArr = new Graphic3d_ArrayOfPoints (2, 1);
+occ::handle<Graphic3d_ArrayOfPoints> aPtsArr = new Graphic3d_ArrayOfPoints (2);
 aPtsArr->AddVertex (-40.0, -40.0, -40.0);
 aPtsArr->AddVertex (40.0, 40.0, 40.0);
 aGroup->AddPrimitiveArray (aPtsArr);
-aGroup->SetGroupPrimitivesAspect (new Graphic3d_AspectText3d());
+aGroup->SetGroupPrimitivesAspect (new Graphic3d_AspectMarker3d());
 
 for (int i = 0; i <= 2; ++i)
 {

--- a/dox/user_guides/xde/xde.md
+++ b/dox/user_guides/xde/xde.md
@@ -734,7 +734,7 @@ if (!aColorTool->GetColor (aLabel, aCol))
 }
 ~~~~
 
-Color name can also be queried from `aCol.StringName` or `aCol.Name`.
+Color name can also be queried from `aCol.StringName()` or `aCol.Name()`.
 In this example, `aLabel` can be replaced by `aShape` directly.
 
 To get the Color attached to a Shape, with a specific color type, use:
@@ -832,7 +832,7 @@ All methods create a sub-label for the corresponding GD\&T entity of the tool ma
 Here is an example of adding a new dimension:
 ~~~~{.cpp}
 TDF_Label aDimLabel = aDimTolTool->AddDimension();
-if (!aDimLabel.IsNull())
+if (aDimLabel.IsNull())
 {
   // error processing
 }


### PR DESCRIPTION
- Align example variable names with OCCT conventions; modernize macros and types (Handle -> occ::handle, NULL -> nullptr, PI -> M_PI, Standard_EXPORT casing).
- Correct API and enum names across user guides (BOPTools_Tools -> BOPTools_AlgoTools, BOPAlgo_Glue -> BOPAlgo_GlueEnum, Geom_BSplineSurface, BRepPrimAPI_MakePrism, TransferOne, FindAttribute, BRepFeat_MakePrism int-Fuse signature).
- Fix long-standing snippet bugs: GetClosedWires/GetOpenWires mix-up, inverted IsNull in xde, vertex dimension, missing IsDone() guards in tutorial, missing loop around Rake.Add, JSON syntax in debug, BNF brackets in brep_format, sphere latitude range, plus assorted typos.