### PR TITLE
Visualization - Fix V3d shader grid issues

### DIFF
--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -5045,7 +5045,7 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
   double                   aNewArcStart = 0.0, aNewArcEnd = 0.0;
   Quantity_Color           aNewColor, aNewTenthColor;
   bool hasOrigin = false, hasStep = false, hasRotAngle = false, hasSize = false, hasRadius = false,
-       hasZOffset = false;
+       hasZOffset   = false;
   bool isShaderGrid = false, hasGridOff = false, hasScale = false, hasArc = false;
   bool hasGridType = false, hasGridMode = false;
   bool hasColor = false, hasTenthColor = false;
@@ -5185,7 +5185,7 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
     else if (anArgIter + 1 < theArgNb && anArg == "-scale")
     {
-      hasScale      = true;
+      hasScale         = true;
       hasShaderOnlyOpt = true;
       aGridParams.SetScale(Draw::Atof(theArgVec[++anArgIter]));
     }
@@ -5196,20 +5196,20 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
     else if (anArgIter + 1 < theArgNb && anArg == "-background")
     {
-      hasShaderOnlyOpt  = true;
-      const int aVal = Draw::Atoi(theArgVec[++anArgIter]);
+      hasShaderOnlyOpt = true;
+      const int aVal   = Draw::Atoi(theArgVec[++anArgIter]);
       aGridParams.SetIsBackground(aVal != 0);
     }
     else if (anArgIter + 1 < theArgNb && anArg == "-drawaxis")
     {
-      hasShaderOnlyOpt  = true;
-      const int aVal = Draw::Atoi(theArgVec[++anArgIter]);
+      hasShaderOnlyOpt = true;
+      const int aVal   = Draw::Atoi(theArgVec[++anArgIter]);
       aGridParams.SetIsDrawAxis(aVal != 0);
     }
     else if (anArgIter + 1 < theArgNb && (anArg == "-viewadaptive" || anArg == "-adaptive"))
     {
-      hasShaderOnlyOpt  = true;
-      const int aVal = Draw::Atoi(theArgVec[++anArgIter]);
+      hasShaderOnlyOpt = true;
+      const int aVal   = Draw::Atoi(theArgVec[++anArgIter]);
       aGridParams.SetIsViewAdaptive(aVal != 0);
     }
     else if (anArg == "-gpu" || anArg == "-shader")

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -5300,7 +5300,11 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
       {
         double aRadiusStep    = 0.0;
         int    aDivisionCount = 0;
-        aViewer->CircularGridValues(anOrigXY.x(), anOrigXY.y(), aRadiusStep, aDivisionCount, aRotAngle);
+        aViewer->CircularGridValues(anOrigXY.x(),
+                                    anOrigXY.y(),
+                                    aRadiusStep,
+                                    aDivisionCount,
+                                    aRotAngle);
         if (hasOrigin)
         {
           anOrigXY = aNewOriginXY;
@@ -5333,7 +5337,11 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
       else
       {
         NCollection_Vec2<double> aStepXY(1.0, 1.0);
-        aViewer->RectangularGridValues(anOrigXY.x(), anOrigXY.y(), aStepXY.x(), aStepXY.y(), aRotAngle);
+        aViewer->RectangularGridValues(anOrigXY.x(),
+                                       anOrigXY.y(),
+                                       aStepXY.x(),
+                                       aStepXY.y(),
+                                       aRotAngle);
         if (hasOrigin)
         {
           anOrigXY = aNewOriginXY;

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -5038,19 +5038,20 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     return 1;
   }
 
-  Aspect_GridType          aType = aViewer->GridType();
-  Aspect_GridDrawMode      aMode = aViewer->GridDrawMode();
+  Aspect_GridType          aType = Aspect_GT_Rectangular;
+  Aspect_GridDrawMode      aMode = Aspect_GDM_Lines;
   NCollection_Vec2<double> aNewOriginXY, aNewStepXY, aNewSizeXY;
   double                   aNewRadius = 0.0, aNewRotAngle = 0.0, aNewZOffset = 0.0;
   double                   aNewArcStart = 0.0, aNewArcEnd = 0.0;
   Quantity_Color           aNewColor, aNewTenthColor;
   bool hasOrigin = false, hasStep = false, hasRotAngle = false, hasSize = false, hasRadius = false,
        hasZOffset = false;
-  bool isGpuGrid = false, hasGridOff = false, hasScale = false, hasArc = false;
+  bool isShaderGrid = false, hasGridOff = false, hasScale = false, hasArc = false;
+  bool hasGridType = false, hasGridMode = false;
   bool hasColor = false, hasTenthColor = false;
-  // Tracks whether any GPU-grid-only option was passed; used to warn when
-  // such options are silently ignored on the CPU path.
-  bool                   hasGpuOnlyOpt = false;
+  // Tracks whether any shader-grid-only option was passed; used to warn when
+  // such options are ignored by the non-shader grid path.
+  bool                   hasShaderOnlyOpt = false;
   Aspect_GridParams      aGridParams;
   ViewerTest_AutoUpdater anUpdateTool(ViewerTest::GetAISContext(), aView);
   for (int anArgIter = 1; anArgIter < theArgNb; ++anArgIter)
@@ -5067,15 +5068,17 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
       anArgNext.LowerCase();
       if (anArgNext == "r" || anArgNext == "rect" || anArgNext == "rectangular")
       {
-        aType = Aspect_GT_Rectangular;
+        aType       = Aspect_GT_Rectangular;
+        hasGridType = true;
       }
       else if (anArgNext == "c" || anArgNext == "circ" || anArgNext == "circular")
       {
-        aType = Aspect_GT_Circular;
+        aType       = Aspect_GT_Circular;
+        hasGridType = true;
       }
       else if (anArgNext == "gpu" || anArgNext == "shader")
       {
-        isGpuGrid = true;
+        isShaderGrid = true;
       }
       else
       {
@@ -5089,11 +5092,13 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
       anArgNext.LowerCase();
       if (anArgNext == "l" || anArgNext == "line" || anArgNext == "lines")
       {
-        aMode = Aspect_GDM_Lines;
+        aMode       = Aspect_GDM_Lines;
+        hasGridMode = true;
       }
       else if (anArgNext == "p" || anArgNext == "point" || anArgNext == "points")
       {
-        aMode = Aspect_GDM_Points;
+        aMode       = Aspect_GDM_Points;
+        hasGridMode = true;
       }
       else
       {
@@ -5158,9 +5163,8 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
     else if (anArgIter + 3 < theArgNb && (anArg == "-color"))
     {
-      // Colors feed both backends through different sinks: aGridParams here
-      // for the GPU path, and Aspect_Grid::SetColors at the end of this
-      // function for the CPU path (so V3d_Viewer::syncViews picks them up).
+      // Colors feed both implementations through different sinks: aGridParams here
+      // for the shader path, and Aspect_Grid::SetColors at the end of this function.
       hasColor  = true;
       aNewColor = Quantity_Color(Draw::Atof(theArgVec[anArgIter + 1]),
                                  Draw::Atof(theArgVec[anArgIter + 2]),
@@ -5182,35 +5186,35 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     else if (anArgIter + 1 < theArgNb && anArg == "-scale")
     {
       hasScale      = true;
-      hasGpuOnlyOpt = true;
+      hasShaderOnlyOpt = true;
       aGridParams.SetScale(Draw::Atof(theArgVec[++anArgIter]));
     }
     else if (anArgIter + 1 < theArgNb && (anArg == "-linethickness" || anArg == "-thickness"))
     {
-      hasGpuOnlyOpt = true;
+      hasShaderOnlyOpt = true;
       aGridParams.SetLineThickness(Draw::Atof(theArgVec[++anArgIter]));
     }
     else if (anArgIter + 1 < theArgNb && anArg == "-background")
     {
-      hasGpuOnlyOpt  = true;
+      hasShaderOnlyOpt  = true;
       const int aVal = Draw::Atoi(theArgVec[++anArgIter]);
       aGridParams.SetIsBackground(aVal != 0);
     }
     else if (anArgIter + 1 < theArgNb && anArg == "-drawaxis")
     {
-      hasGpuOnlyOpt  = true;
+      hasShaderOnlyOpt  = true;
       const int aVal = Draw::Atoi(theArgVec[++anArgIter]);
       aGridParams.SetIsDrawAxis(aVal != 0);
     }
     else if (anArgIter + 1 < theArgNb && (anArg == "-viewadaptive" || anArg == "-adaptive"))
     {
-      hasGpuOnlyOpt  = true;
+      hasShaderOnlyOpt  = true;
       const int aVal = Draw::Atoi(theArgVec[++anArgIter]);
       aGridParams.SetIsViewAdaptive(aVal != 0);
     }
     else if (anArg == "-gpu" || anArg == "-shader")
     {
-      isGpuGrid = true;
+      isShaderGrid = true;
     }
     else if (anArgIter + 2 < theArgNb && anArg == "-arc")
     {
@@ -5223,19 +5227,23 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
     else if (anArg == "r" || anArg == "rect" || anArg == "rectangular")
     {
-      aType = Aspect_GT_Rectangular;
+      aType       = Aspect_GT_Rectangular;
+      hasGridType = true;
     }
     else if (anArg == "c" || anArg == "circ" || anArg == "circular")
     {
-      aType = Aspect_GT_Circular;
+      aType       = Aspect_GT_Circular;
+      hasGridType = true;
     }
     else if (anArg == "l" || anArg == "line" || anArg == "lines")
     {
-      aMode = Aspect_GDM_Lines;
+      aMode       = Aspect_GDM_Lines;
+      hasGridMode = true;
     }
     else if (anArg == "p" || anArg == "point" || anArg == "points")
     {
-      aMode = Aspect_GDM_Points;
+      aMode       = Aspect_GDM_Points;
+      hasGridMode = true;
     }
     else if (anArg == "off")
     {
@@ -5248,43 +5256,49 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
   }
 
-  if (isGpuGrid && hasGridOff)
+  if (isShaderGrid && hasGridOff)
   {
-    Message::SendFail("Syntax error: 'off' cannot be combined with GPU grid display");
+    Message::SendFail("Syntax error: 'off' cannot be combined with shader grid display");
     return 1;
   }
 
-  // GPU-only options (-scale, -lineThickness, -background, -drawAxis,
+  // Shader-only options (-scale, -lineThickness, -background, -drawAxis,
   // -viewAdaptive) are stored on Aspect_GridParams and consumed only by the
-  // shader path. Silently ignoring them on the CPU path leaves the user
+  // shader path. Silently ignoring them on the non-shader path leaves the user
   // wondering why nothing changed; warn explicitly.
-  if (hasGpuOnlyOpt && !isGpuGrid && !hasGridOff)
+  if (hasShaderOnlyOpt && !isShaderGrid && !hasGridOff)
   {
     Message::SendWarning("vgrid: -scale / -lineThickness / -background / -drawAxis / "
-                         "-viewAdaptive are GPU-grid only; pass -gpu (or -type gpu) to apply.");
+                         "-viewAdaptive are shader-grid only; pass -gpu (or -type gpu) to apply.");
   }
 
-  if (isGpuGrid || hasGridOff)
+  if (!isShaderGrid)
+  {
+    if (!hasGridType)
+    {
+      aType = aViewer->GridType();
+    }
+    if (!hasGridMode)
+    {
+      aMode = aViewer->GridDrawMode();
+    }
+  }
+
+  if (isShaderGrid || hasGridOff)
   {
     if (hasGridOff)
     {
       aView->GridErase();
     }
-    if (isGpuGrid)
+    if (isShaderGrid)
     {
-      // The shader grid keeps a real Aspect_Grid to back snap selection, so we
-      // route through ActivateGrid(rect|circ) first and override the display
-      // with shader-specific params afterwards. Decide the shape from aType
-      // or from the presence of circular-only options.
-      const bool   isGpuCircular = aType == Aspect_GT_Circular || hasRadius || hasArc;
-      const double anOrigX       = hasOrigin ? aNewOriginXY.x() : 0.0;
-      const double anOrigY       = hasOrigin ? aNewOriginXY.y() : 0.0;
-      const double aRotAngle     = hasRotAngle ? aNewRotAngle : 0.0;
+      const bool   isShaderCircular = aType == Aspect_GT_Circular || hasRadius || hasArc;
+      const double anOrigX          = hasOrigin ? aNewOriginXY.x() : 0.0;
+      const double anOrigY          = hasOrigin ? aNewOriginXY.y() : 0.0;
+      const double aRotAngle        = hasRotAngle ? aNewRotAngle : 0.0;
 
-      if (isGpuCircular)
+      if (isShaderCircular)
       {
-        // Radial step + angular divisions. `-step R N` supplies both; otherwise
-        // use sensible defaults that keep snap consistent with the visible grid.
         double aRadiusStep    = 1.0;
         int    aDivisionCount = 16;
         if (hasStep)
@@ -5296,29 +5310,12 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
         {
           aRadiusStep = 1.0 / aGridParams.Scale();
         }
-        aViewer->SetCircularGridValues(anOrigX, anOrigY, aRadiusStep, aDivisionCount, aRotAngle);
-        // Arc range reaches the circular grid base before ActivateGrid's first
-        // syncViews fires (otherwise syncViews would overwrite our override).
-        if (hasArc)
-        {
-          if (occ::handle<Aspect_CircularGrid> aCircGrid =
-                occ::down_cast<Aspect_CircularGrid>(aViewer->Grid(true)))
-          {
-            aCircGrid->SetArcRange(aNewArcStart, aNewArcEnd);
-          }
-        }
-        aViewer->ActivateGrid(Aspect_GT_Circular, aMode);
-
         aGridParams.SetScale(1.0 / aRadiusStep);
-        aGridParams.SetScaleY(0.0); // unused in circular mode
+        aGridParams.SetScaleY(0.0);
         aGridParams.SetAngularDivisions(aDivisionCount);
       }
       else
       {
-        // Rectangular shader grid. Derive step from explicit -step or from the
-        // Aspect_GridParams scale; fall back to 1 world unit so the default is
-        // immediately useful (Aspect_GridParams::Scale defaults to 0.01 which
-        // would give step 100 - too coarse for typical scenes).
         if (!hasScale)
         {
           if (hasStep)
@@ -5332,23 +5329,13 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
             aGridParams.SetScaleY(1.0);
           }
         }
-        const double aInfStepX = 1.0 / aGridParams.Scale();
-        const double aInfStepY = 1.0 / aGridParams.EffectiveScaleY();
-        aViewer->SetRectangularGridValues(anOrigX, anOrigY, aInfStepX, aInfStepY, aRotAngle);
-        aViewer->ActivateGrid(Aspect_GT_Rectangular, aMode);
-
         aGridParams.SetAngularDivisions(0);
       }
 
-      // Convert origin to the same world-offset convention used by V3d
-      // syncViews so the shader's aPlaneOrigin matches snap's aPnt0.
-      const gp_Ax3 aPlane = aViewer->PrivilegedPlane();
-      const gp_XYZ aOriginOffset =
-        aPlane.XDirection().XYZ() * -anOrigX + aPlane.YDirection().XYZ() * -anOrigY;
-      aGridParams.SetOrigin(gp_Pnt(aOriginOffset));
+      aGridParams.SetOrigin(gp_Pnt(-anOrigX, -anOrigY, 0.0));
       aGridParams.SetDrawMode(aMode);
       aGridParams.SetRotationAngle(aRotAngle);
-      if (hasSize && !isGpuCircular)
+      if (hasSize && !isShaderCircular)
       {
         aGridParams.SetSizeX(aNewSizeXY.x());
         aGridParams.SetSizeY(aNewSizeXY.y());
@@ -5363,9 +5350,9 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
       }
       aView->GridDisplay(aGridParams);
     }
-    if (hasGridOff && !isGpuGrid)
+    if (hasGridOff && !isShaderGrid)
     {
-      // plain 'vgrid off' still deactivates the classical grid
+      // Plain 'vgrid off' still deactivates the viewer-managed grid.
       aViewer->DeactivateGrid();
     }
     return 0;
@@ -5476,7 +5463,7 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
   }
   // Apply -color / -tenthColor to the active grid so V3d syncViews picks
-  // them up on the next display. GPU-grid display drives these through
+  // them up on the next display. Shader-grid display drives these through
   // aGridParams directly (set earlier in the parser loop).
   if (hasColor || hasTenthColor)
   {
@@ -6581,8 +6568,7 @@ static int VMoveTo(Draw_Interpretor& theDI, int theNbArgs, const char** theArgVe
         return 1;
       }
 
-      const bool toEchoGrid =
-        aContext->CurrentViewer()->IsGridActive() && aContext->CurrentViewer()->GridEcho();
+      const bool toEchoGrid = aView->IsGridActive() && aContext->CurrentViewer()->GridEcho();
       if (toEchoGrid)
       {
         aContext->CurrentViewer()->HideGridEcho(aView);
@@ -14284,17 +14270,14 @@ vgrid [off] [-type {rect|circ|gpu|shader}] [-gpu] [-mode {line|point}] [-origin 
       [-step StepRadius NbDivisions] [-radius Radius] [-arc AngleStart AngleEnd]
       [-color R G B] [-tenthColor R G B] [-scale N] [-lineThickness T]
       [-background {0|1}] [-drawAxis {0|1}] [-viewAdaptive {0|1}]
-Two render backends are available:
-  - '-type rect' / '-type circ' (default) draws the legacy CPU grid into a
-    bounded Graphic3d_Structure shared by every active view.
-  - '-type gpu' / '-gpu' activates the shader-rendered grid on the active view.
+Two grid implementations are available:
+  - '-type rect' / '-type circ' draws the viewer grid shared by every active view.
+  - '-type gpu' / '-gpu' activates the shader grid on the active view.
     Without '-size' or '-radius' it is unbounded; combine with '-size DX DY'
     for a rectangle, '-radius R' for a disc, '-arc S E' for a wedge.
-'-color', '-tenthColor' apply to both backends. '-scale', '-lineThickness',
-'-background', '-drawAxis', '-viewAdaptive {0|1}' are GPU-grid only. Switching
-to GPU-grid display hides the CPU grid in the viewer; switching back to a CPU
-grid type erases the shader grid in the active view. 'off' deactivates whichever
-grid is currently visible.
+'-color', '-tenthColor' apply to both implementations. '-scale',
+'-lineThickness', '-background', '-drawAxis', '-viewAdaptive {0|1}' are
+shader-grid only. 'off' deactivates the active grid in the current view/viewer.
 )" /* [vgrid] */);
 
   addCmd("vpriviledgedplane", VPriviledgedPlane, /* [vpriviledgedplane] */ R"(

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest_ViewerCommands.cxx
@@ -5292,23 +5292,39 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
     }
     if (isShaderGrid)
     {
-      const bool   isShaderCircular = aType == Aspect_GT_Circular || hasRadius || hasArc;
-      const double anOrigX          = hasOrigin ? aNewOriginXY.x() : 0.0;
-      const double anOrigY          = hasOrigin ? aNewOriginXY.y() : 0.0;
-      const double aRotAngle        = hasRotAngle ? aNewRotAngle : 0.0;
+      const bool isShaderCircular = aType == Aspect_GT_Circular || hasRadius || hasArc;
+      NCollection_Vec2<double> anOrigXY(0.0, 0.0);
+      double                   aRotAngle = 0.0;
 
       if (isShaderCircular)
       {
-        double aRadiusStep    = 1.0;
-        int    aDivisionCount = 16;
+        double aRadiusStep    = 0.0;
+        int    aDivisionCount = 0;
+        aViewer->CircularGridValues(anOrigXY.x(), anOrigXY.y(), aRadiusStep, aDivisionCount, aRotAngle);
+        if (hasOrigin)
+        {
+          anOrigXY = aNewOriginXY;
+        }
+        if (hasRotAngle)
+        {
+          aRotAngle = aNewRotAngle;
+        }
         if (hasStep)
         {
           aRadiusStep    = aNewStepXY.x();
-          aDivisionCount = int(aNewStepXY.y() > 0 ? aNewStepXY.y() : aDivisionCount);
+          aDivisionCount = int(aNewStepXY.y());
         }
         else if (hasScale && aGridParams.Scale() > 0.0)
         {
           aRadiusStep = 1.0 / aGridParams.Scale();
+        }
+        if (aRadiusStep <= 0.0)
+        {
+          aRadiusStep = 1.0;
+        }
+        if (aDivisionCount <= 0)
+        {
+          aDivisionCount = 16;
         }
         aGridParams.SetScale(1.0 / aRadiusStep);
         aGridParams.SetScaleY(0.0);
@@ -5316,6 +5332,16 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
       }
       else
       {
+        NCollection_Vec2<double> aStepXY(1.0, 1.0);
+        aViewer->RectangularGridValues(anOrigXY.x(), anOrigXY.y(), aStepXY.x(), aStepXY.y(), aRotAngle);
+        if (hasOrigin)
+        {
+          anOrigXY = aNewOriginXY;
+        }
+        if (hasRotAngle)
+        {
+          aRotAngle = aNewRotAngle;
+        }
         if (!hasScale)
         {
           if (hasStep)
@@ -5325,14 +5351,14 @@ static int VGrid(Draw_Interpretor& /*theDI*/, int theArgNb, const char** theArgV
           }
           else
           {
-            aGridParams.SetScale(1.0);
-            aGridParams.SetScaleY(1.0);
+            aGridParams.SetScale(aStepXY.x() > 0.0 ? 1.0 / aStepXY.x() : 1.0);
+            aGridParams.SetScaleY(aStepXY.y() > 0.0 ? 1.0 / aStepXY.y() : 1.0);
           }
         }
         aGridParams.SetAngularDivisions(0);
       }
 
-      aGridParams.SetOrigin(gp_Pnt(-anOrigX, -anOrigY, 0.0));
+      aGridParams.SetOrigin(gp_Pnt(-anOrigXY.x(), -anOrigXY.y(), 0.0));
       aGridParams.SetDrawMode(aMode);
       aGridParams.SetRotationAngle(aRotAngle);
       if (hasSize && !isShaderCircular)

--- a/src/Visualization/TKOpenGl/OpenGl/FILES.cmake
+++ b/src/Visualization/TKOpenGl/OpenGl/FILES.cmake
@@ -27,6 +27,8 @@ set(OCCT_OpenGl_FILES
   OpenGl_FrameStatsPrs.hxx
   OpenGl_Group.hxx
   OpenGl_Group.cxx
+  OpenGl_ShaderGrid.hxx
+  OpenGl_ShaderGrid.cxx
   OpenGl_Structure.hxx
   OpenGl_Structure.cxx
   OpenGl_StructureShadow.hxx

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
@@ -84,7 +84,7 @@ static bool isSameAngle(const double theFirst, const double theSecond)
   aDelta        = std::min(aDelta, THE_TWO_PI - aDelta);
   return aDelta <= Precision::Angular();
 }
-}
+} // namespace
 
 //=================================================================================================
 
@@ -571,8 +571,8 @@ bool OpenGl_ShaderGrid::echoDisplayPoint(const occ::handle<Graphic3d_Camera>& th
   {
     return false;
   }
-  const double aDisplayZ    = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
-  theDisplayPoint           = theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
+  const double aDisplayZ = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
+  theDisplayPoint = theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
   return isFinitePoint(theDisplayPoint);
 }
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
@@ -78,8 +78,7 @@ void OpenGl_ShaderGrid::frame(gp_Pnt& theOrigin, gp_XYZ& theX, gp_XYZ& theY, gp_
   theN               = myPlane.Direction().XYZ();
 
   const gp_Pnt& anOriginLocal = myParams.Origin();
-  theOrigin.SetXYZ(myPlane.Location().XYZ() + aRawX * anOriginLocal.X()
-                   + aRawY * anOriginLocal.Y()
+  theOrigin.SetXYZ(myPlane.Location().XYZ() + aRawX * anOriginLocal.X() + aRawY * anOriginLocal.Y()
                    + theN * (anOriginLocal.Z() + myParams.ZOffset()));
 }
 
@@ -96,9 +95,9 @@ void OpenGl_ShaderGrid::effectiveScale(const occ::handle<Graphic3d_Camera>& theC
     return;
   }
 
-  const double aCurrentScale =
-    !theCamera.IsNull() && theCamera->Scale() > Precision::Confusion() ? theCamera->Scale()
-                                                                        : Precision::Confusion();
+  const double aCurrentScale = !theCamera.IsNull() && theCamera->Scale() > Precision::Confusion()
+                                 ? theCamera->Scale()
+                                 : Precision::Confusion();
   theScaleX /= aCurrentScale;
   theScaleY /= aCurrentScale;
 }
@@ -280,10 +279,10 @@ bool OpenGl_ShaderGrid::planeLocalHit(const occ::handle<Graphic3d_Camera>& theCa
     return false;
   }
 
-  const gp_XYZ aHit = aRayOriginP.XYZ() + aRay * aT;
+  const gp_XYZ aHit    = aRayOriginP.XYZ() + aRay * aT;
   const gp_XYZ aLocal3 = aHit - aPlaneOrigin.XYZ();
-  theLocalX = aLocal3.Dot(aPlaneX);
-  theLocalY = aLocal3.Dot(aPlaneY);
+  theLocalX            = aLocal3.Dot(aPlaneX);
+  theLocalY            = aLocal3.Dot(aPlaneY);
   if (theHit != nullptr)
   {
     *theHit = aHit;
@@ -293,9 +292,8 @@ bool OpenGl_ShaderGrid::planeLocalHit(const occ::handle<Graphic3d_Camera>& theCa
 
 //=================================================================================================
 
-void OpenGl_ShaderGrid::addViewFootprintBounds(
-  Bnd_Box&                             theBox,
-  const occ::handle<Graphic3d_Camera>& theCamera) const
+void OpenGl_ShaderGrid::addViewFootprintBounds(Bnd_Box&                             theBox,
+                                               const occ::handle<Graphic3d_Camera>& theCamera) const
 {
   const double aSamples[][2] = {{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {0.0, 0.0}};
   for (const double* aSample : aSamples)
@@ -438,8 +436,8 @@ bool OpenGl_ShaderGrid::Echo(const occ::handle<Graphic3d_Camera>& theCamera,
     return false;
   }
 
-  const double aNdcX = 2.0 * double(theX) / double(theWidth) - 1.0;
-  const double aNdcY = 2.0 * double(theHeight - 1 - theY) / double(theHeight) - 1.0;
+  const double aNdcX   = 2.0 * double(theX) / double(theWidth) - 1.0;
+  const double aNdcY   = 2.0 * double(theHeight - 1 - theY) / double(theHeight) - 1.0;
   double       aLocalX = 0.0;
   double       aLocalY = 0.0;
   if (!planeLocalHit(theCamera, aNdcX, aNdcY, aLocalX, aLocalY))
@@ -523,8 +521,7 @@ bool OpenGl_ShaderGrid::Echo(const occ::handle<Graphic3d_Camera>& theCamera,
     {
       const double aSnapRadius = std::round(aRadius / aRadiusStep) * aRadiusStep;
       const double aSnapAngle  = std::round(anAngle / anAngleStep) * anAngleStep;
-      if (!isPointInBounds(aSnapRadius * std::cos(aSnapAngle),
-                           aSnapRadius * std::sin(aSnapAngle)))
+      if (!isPointInBounds(aSnapRadius * std::cos(aSnapAngle), aSnapRadius * std::sin(aSnapAngle)))
       {
         return false;
       }
@@ -688,8 +685,8 @@ void OpenGl_ShaderGrid::SetUniforms(const occ::handle<OpenGl_Context>&       the
   theProgram->SetUniform(theContext, "uGridType", myParams.IsCircular() ? 1 : 0);
   theProgram->SetUniform(theContext, "uIsBackground", myParams.IsBackground() ? 1 : 0);
 
-  const double aAngularScale = myParams.IsCircular() ? double(myParams.AngularDivisions()) / M_PI
-                                                      : 0.0;
+  const double aAngularScale =
+    myParams.IsCircular() ? double(myParams.AngularDivisions()) / M_PI : 0.0;
   theProgram->SetUniform(theContext, "uAngularScale", GLfloat(aAngularScale));
   theProgram->SetUniform(theContext, "uDrawMode", myParams.DrawMode() == Aspect_GDM_Points ? 1 : 0);
   theProgram->SetUniform(theContext, "uIsPerspective", theCamera->IsOrthographic() ? 0 : 1);
@@ -700,18 +697,17 @@ void OpenGl_ShaderGrid::SetUniforms(const occ::handle<OpenGl_Context>&       the
   NCollection_Vec2<float> anAccentLocalOriginShift(0.0f, 0.0f);
   float                   aRadialOriginShift        = 0.0f;
   float                   anAccentRadialOriginShift = 0.0f;
-  double                  aLocalRefX = 0.0;
-  double                  aLocalRefY = 0.0;
+  double                  aLocalRefX                = 0.0;
+  double                  aLocalRefY                = 0.0;
   if (referenceLocal(theCamera, aLocalRefX, aLocalRefY))
   {
     if (myParams.IsCircular())
     {
-      const double aRadiusRef = std::sqrt(aLocalRefX * aLocalRefX + aLocalRefY * aLocalRefY);
-      aRadialOriginShift      = float(snappedLocalShift(aRadiusRef, aScaleX));
-      anAccentRadialOriginShift =
-        myParams.AccentScaleX() > Precision::Confusion()
-          ? float(snappedLocalShift(aRadiusRef, myParams.AccentScaleX()))
-          : aRadialOriginShift;
+      const double aRadiusRef   = std::sqrt(aLocalRefX * aLocalRefX + aLocalRefY * aLocalRefY);
+      aRadialOriginShift        = float(snappedLocalShift(aRadiusRef, aScaleX));
+      anAccentRadialOriginShift = myParams.AccentScaleX() > Precision::Confusion()
+                                    ? float(snappedLocalShift(aRadiusRef, myParams.AccentScaleX()))
+                                    : aRadialOriginShift;
     }
     else
     {
@@ -737,7 +733,9 @@ void OpenGl_ShaderGrid::SetUniforms(const occ::handle<OpenGl_Context>&       the
   theProgram->SetUniform(theContext, "uLocalOriginShift", aLocalOriginShift);
   theProgram->SetUniform(theContext, "uAccentLocalOriginShift", anAccentLocalOriginShift);
   theProgram->SetUniform(theContext, "uRadialOriginShift", GLfloat(aRadialOriginShift));
-  theProgram->SetUniform(theContext, "uAccentRadialOriginShift", GLfloat(anAccentRadialOriginShift));
+  theProgram->SetUniform(theContext,
+                         "uAccentRadialOriginShift",
+                         GLfloat(anAccentRadialOriginShift));
 
   const float aHalfX  = myParams.SizeX() > 0.0 ? float(myParams.SizeX() * 0.5) : 0.0f;
   const float aHalfY  = myParams.SizeY() > 0.0 ? float(myParams.SizeY() * 0.5) : 0.0f;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
@@ -21,6 +21,69 @@
 namespace
 {
 static constexpr double THE_TWO_PI = 2.0 * M_PI;
+
+static bool isFiniteCoord(const double theValue)
+{
+  return std::isfinite(theValue) && !Precision::IsInfinite(theValue);
+}
+
+static bool isFinitePoint(const gp_Pnt& thePoint)
+{
+  return isFiniteCoord(thePoint.X()) && isFiniteCoord(thePoint.Y()) && isFiniteCoord(thePoint.Z());
+}
+
+static bool isFinitePoint(const gp_XYZ& thePoint)
+{
+  return isFiniteCoord(thePoint.X()) && isFiniteCoord(thePoint.Y()) && isFiniteCoord(thePoint.Z());
+}
+
+static double normalizedAngle(const double theAngle)
+{
+  double anAngle = std::fmod(theAngle, THE_TWO_PI);
+  if (anAngle < 0.0)
+  {
+    anAngle += THE_TWO_PI;
+  }
+  return anAngle;
+}
+
+static double positiveAngleSpan(const double theStart, const double theEnd)
+{
+  double aSpan = std::fmod(theEnd - theStart, THE_TWO_PI);
+  if (aSpan < 0.0)
+  {
+    aSpan += THE_TWO_PI;
+  }
+
+  if (std::abs(aSpan) <= Precision::Angular()
+      && std::abs(theEnd - theStart) >= THE_TWO_PI - Precision::Angular())
+  {
+    return THE_TWO_PI;
+  }
+  return aSpan;
+}
+
+static bool isSamePoint(const gp_Pnt& theFirst, const gp_Pnt& theSecond)
+{
+  return theFirst.SquareDistance(theSecond) <= Precision::SquareConfusion();
+}
+
+static bool isSameDirection(const gp_Dir& theFirst, const gp_Dir& theSecond)
+{
+  return theFirst.Angle(theSecond) <= Precision::Angular();
+}
+
+static bool isSameScalar(const double theFirst, const double theSecond)
+{
+  return std::abs(theFirst - theSecond) <= Precision::Confusion();
+}
+
+static bool isSameAngle(const double theFirst, const double theSecond)
+{
+  double aDelta = std::abs(normalizedAngle(theFirst) - normalizedAngle(theSecond));
+  aDelta        = std::min(aDelta, THE_TWO_PI - aDelta);
+  return aDelta <= Precision::Angular();
+}
 }
 
 //=================================================================================================
@@ -35,6 +98,12 @@ bool OpenGl_ShaderGrid::Display(const Aspect_GridParams&             theParams,
     Erase();
     return true;
   }
+
+  const bool wasShown       = myIsShown;
+  const bool wasBackground  = wasShown && myParams.IsBackground();
+  const bool hasSameAnchor  = wasShown && hasSameAnchorFrame(theParams, thePlane);
+  const bool toCaptureFrame = theParams.IsBackground() && !theContext.IsNull()
+                              && (!wasShown || !wasBackground || !hasSameAnchor);
 
   myParams  = theParams;
   myPlane   = thePlane;
@@ -51,7 +120,7 @@ bool OpenGl_ShaderGrid::Display(const Aspect_GridParams&             theParams,
     }
   }
 
-  if (theParams.IsBackground() && !theContext.IsNull())
+  if (toCaptureFrame)
   {
     myRefViewMatrix = theContext->WorldViewState.Current();
   }
@@ -108,18 +177,18 @@ bool OpenGl_ShaderGrid::angleInArc(const double theStart,
                                    const double theEnd,
                                    const double theAngle)
 {
-  double aSpan = theEnd - theStart;
-  if (aSpan < 0.0)
+  const double aSpan = positiveAngleSpan(theStart, theEnd);
+  if (aSpan >= THE_TWO_PI - Precision::Angular())
   {
-    aSpan += THE_TWO_PI;
+    return true;
   }
 
-  double aDelta = theAngle - theStart;
+  double aDelta = normalizedAngle(theAngle) - normalizedAngle(theStart);
   if (aDelta < 0.0)
   {
     aDelta += THE_TWO_PI;
   }
-  return aDelta <= aSpan;
+  return aDelta <= aSpan + Precision::Angular();
 }
 
 //=================================================================================================
@@ -156,7 +225,11 @@ void OpenGl_ShaderGrid::addLocalPoint(Bnd_Box&      theBox,
                                       const double  theLocalX,
                                       const double  theLocalY)
 {
-  theBox.Add(gp_Pnt(theOrigin.XYZ() + theX * theLocalX + theY * theLocalY));
+  const gp_Pnt aPoint(theOrigin.XYZ() + theX * theLocalX + theY * theLocalY);
+  if (isFinitePoint(aPoint))
+  {
+    theBox.Add(aPoint);
+  }
 }
 
 //=================================================================================================
@@ -309,14 +382,16 @@ void OpenGl_ShaderGrid::addViewFootprintBounds(Bnd_Box&                         
     {
       continue;
     }
-    theBox.Add(gp_Pnt(aHit));
+    if (isFinitePoint(aHit))
+    {
+      theBox.Add(gp_Pnt(aHit));
+    }
   }
 }
 
 //=================================================================================================
 
-void OpenGl_ShaderGrid::AddZFitBounds(Bnd_Box&                             thePrimaryBox,
-                                      Bnd_Box&                             theGraphicBox,
+void OpenGl_ShaderGrid::AddZFitBounds(Bnd_Box&                             theGraphicBox,
                                       const occ::handle<Graphic3d_Camera>& theCamera) const
 {
   if (!myIsShown || myParams.DrawMode() == Aspect_GDM_None || myParams.IsBackground())
@@ -340,9 +415,22 @@ void OpenGl_ShaderGrid::AddZFitBounds(Bnd_Box&                             thePr
   }
   if (!aGridBox.IsVoid())
   {
-    thePrimaryBox.Add(aGridBox);
     theGraphicBox.Add(aGridBox);
   }
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::hasSameAnchorFrame(const Aspect_GridParams& theParams,
+                                           const gp_Ax3&            thePlane) const
+{
+  return isSamePoint(myPlane.Location(), thePlane.Location())
+         && isSameDirection(myPlane.Direction(), thePlane.Direction())
+         && isSameDirection(myPlane.XDirection(), thePlane.XDirection())
+         && isSameDirection(myPlane.YDirection(), thePlane.YDirection())
+         && isSamePoint(myParams.Origin(), theParams.Origin())
+         && isSameAngle(myParams.RotationAngle(), theParams.RotationAngle())
+         && isSameScalar(myParams.ZOffset(), theParams.ZOffset());
 }
 
 //=================================================================================================
@@ -412,12 +500,80 @@ NCollection_Vec3<float> OpenGl_ShaderGrid::viewDirection(
 
 //=================================================================================================
 
-gp_Pnt OpenGl_ShaderGrid::echoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
-                                           const gp_XYZ&                        theSnapped)
+bool OpenGl_ShaderGrid::acceptEchoCandidate(const occ::handle<Graphic3d_Camera>& theCamera,
+                                            const int                            theWidth,
+                                            const int                            theHeight,
+                                            const int                            theX,
+                                            const int                            theY,
+                                            const gp_Pnt&                        theGridOrigin,
+                                            const gp_XYZ&                        theGridX,
+                                            const gp_XYZ&                        theGridY,
+                                            const double                         theLocalX,
+                                            const double                         theLocalY,
+                                            gp_XYZ&                              theBestSnapped,
+                                            double&                              theBestDist2,
+                                            bool& theHasBestPoint) const
+{
+  if (!isPointInBounds(theLocalX, theLocalY))
+  {
+    return false;
+  }
+
+  const gp_XYZ aCandidate = theGridOrigin.XYZ() + theGridX * theLocalX + theGridY * theLocalY;
+  if (!isFinitePoint(aCandidate))
+  {
+    return false;
+  }
+  if (!theCamera->IsOrthographic()
+      && theCamera->Direction().XYZ().Dot(aCandidate - theCamera->Eye().XYZ())
+           <= Precision::Confusion())
+  {
+    return false;
+  }
+
+  const gp_Pnt aProj = theCamera->Project(gp_Pnt(aCandidate));
+  if (!isFinitePoint(aProj))
+  {
+    return false;
+  }
+
+  const double aPx    = (aProj.X() + 1.0) * 0.5 * double(theWidth);
+  const double aPy    = double(theHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(theHeight);
+  const double aDistX = aPx - double(theX);
+  const double aDistY = aPy - double(theY);
+  if (!isFiniteCoord(aDistX) || !isFiniteCoord(aDistY))
+  {
+    return false;
+  }
+
+  const double aDist2 = aDistX * aDistX + aDistY * aDistY;
+  if (!isFiniteCoord(aDist2))
+  {
+    return false;
+  }
+  if (!theHasBestPoint || aDist2 < theBestDist2)
+  {
+    theHasBestPoint = true;
+    theBestDist2    = aDist2;
+    theBestSnapped  = aCandidate;
+  }
+  return true;
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::echoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                                         const gp_XYZ&                        theSnapped,
+                                         gp_Pnt&                              theDisplayPoint)
 {
   const gp_Pnt aProjSnapped = theCamera->Project(gp_Pnt(theSnapped));
+  if (!isFinitePoint(aProjSnapped))
+  {
+    return false;
+  }
   const double aDisplayZ    = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
-  return theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
+  theDisplayPoint           = theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
+  return isFinitePoint(theDisplayPoint);
 }
 
 //=================================================================================================
@@ -466,28 +622,19 @@ bool OpenGl_ShaderGrid::Echo(const occ::handle<Graphic3d_Camera>& theCamera,
   double     aBestDist2     = RealLast();
   bool       hasBestPoint   = false;
   auto       addCandidate   = [&](const double theLocalX, const double theLocalY) {
-    if (!isPointInBounds(theLocalX, theLocalY))
-    {
-      return;
-    }
-    const gp_XYZ aCandidate = aGridOrigin.XYZ() + aGridX * theLocalX + aGridY * theLocalY;
-    if (!theCamera->IsOrthographic()
-        && theCamera->Direction().XYZ().Dot(aCandidate - theCamera->Eye().XYZ()) <= 0.0)
-    {
-      return;
-    }
-    const gp_Pnt aProj  = theCamera->Project(gp_Pnt(aCandidate));
-    const double aPx    = (aProj.X() + 1.0) * 0.5 * double(theWidth);
-    const double aPy    = double(theHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(theHeight);
-    const double aDistX = aPx - double(theX);
-    const double aDistY = aPy - double(theY);
-    const double aDist2 = aDistX * aDistX + aDistY * aDistY;
-    if (!hasBestPoint || aDist2 < aBestDist2)
-    {
-      hasBestPoint = true;
-      aBestDist2   = aDist2;
-      aSnapped     = aCandidate;
-    }
+    acceptEchoCandidate(theCamera,
+                        theWidth,
+                        theHeight,
+                        theX,
+                        theY,
+                        aGridOrigin,
+                        aGridX,
+                        aGridY,
+                        theLocalX,
+                        theLocalY,
+                        aSnapped,
+                        aBestDist2,
+                        hasBestPoint);
   };
 
   if (myParams.IsCircular())
@@ -521,12 +668,22 @@ bool OpenGl_ShaderGrid::Echo(const occ::handle<Graphic3d_Camera>& theCamera,
     {
       const double aSnapRadius = std::round(aRadius / aRadiusStep) * aRadiusStep;
       const double aSnapAngle  = std::round(anAngle / anAngleStep) * anAngleStep;
-      if (!isPointInBounds(aSnapRadius * std::cos(aSnapAngle), aSnapRadius * std::sin(aSnapAngle)))
+      if (!acceptEchoCandidate(theCamera,
+                               theWidth,
+                               theHeight,
+                               theX,
+                               theY,
+                               aGridOrigin,
+                               aGridX,
+                               aGridY,
+                               aSnapRadius * std::cos(aSnapAngle),
+                               aSnapRadius * std::sin(aSnapAngle),
+                               aSnapped,
+                               aBestDist2,
+                               hasBestPoint))
       {
         return false;
       }
-      aSnapped += aGridX * (aSnapRadius * std::cos(aSnapAngle))
-                  + aGridY * (aSnapRadius * std::sin(aSnapAngle));
     }
   }
   else
@@ -555,16 +712,36 @@ bool OpenGl_ShaderGrid::Echo(const occ::handle<Graphic3d_Camera>& theCamera,
     {
       aLocalX = std::round(aLocalX / aStepX) * aStepX;
       aLocalY = std::round(aLocalY / aStepY) * aStepY;
-      if (!isPointInBounds(aLocalX, aLocalY))
+      if (!acceptEchoCandidate(theCamera,
+                               theWidth,
+                               theHeight,
+                               theX,
+                               theY,
+                               aGridOrigin,
+                               aGridX,
+                               aGridY,
+                               aLocalX,
+                               aLocalY,
+                               aSnapped,
+                               aBestDist2,
+                               hasBestPoint))
       {
         return false;
       }
-      aSnapped += aGridX * aLocalX + aGridY * aLocalY;
     }
   }
 
+  if (!hasBestPoint)
+  {
+    return false;
+  }
+
   thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
-  const gp_Pnt aDisplayP = echoDisplayPoint(theCamera, aSnapped);
+  gp_Pnt aDisplayP;
+  if (!echoDisplayPoint(theCamera, aSnapped, aDisplayP))
+  {
+    return false;
+  }
   theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
   return true;
 }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.cxx
@@ -1,0 +1,754 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <OpenGl_ShaderGrid.hxx>
+
+#include <Precision.hxx>
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+static constexpr double THE_TWO_PI = 2.0 * M_PI;
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::Display(const Aspect_GridParams&             theParams,
+                                const gp_Ax3&                        thePlane,
+                                const occ::handle<Graphic3d_Camera>& theCamera,
+                                const occ::handle<OpenGl_Context>&   theContext)
+{
+  if (theParams.DrawMode() == Aspect_GDM_None)
+  {
+    Erase();
+    return true;
+  }
+
+  myParams  = theParams;
+  myPlane   = thePlane;
+  myIsShown = true;
+
+  if (theParams.IsViewAdaptive())
+  {
+    const double aReferenceScale =
+      !theCamera.IsNull() && theCamera->Scale() > Precision::Confusion() ? theCamera->Scale() : 1.0;
+    myParams.SetScale(theParams.Scale() * aReferenceScale);
+    if (theParams.ScaleY() > 0.0)
+    {
+      myParams.SetScaleY(theParams.ScaleY() * aReferenceScale);
+    }
+  }
+
+  if (theParams.IsBackground() && !theContext.IsNull())
+  {
+    myRefViewMatrix = theContext->WorldViewState.Current();
+  }
+  return true;
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::Erase()
+{
+  myIsShown = false;
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::frame(gp_Pnt& theOrigin, gp_XYZ& theX, gp_XYZ& theY, gp_XYZ& theN) const
+{
+  const double aCosA = std::cos(myParams.RotationAngle());
+  const double aSinA = std::sin(myParams.RotationAngle());
+  const gp_XYZ aRawX = myPlane.XDirection().XYZ();
+  const gp_XYZ aRawY = myPlane.YDirection().XYZ();
+  theX               = aRawX * aCosA - aRawY * aSinA;
+  theY               = aRawX * aSinA + aRawY * aCosA;
+  theN               = myPlane.Direction().XYZ();
+
+  const gp_Pnt& anOriginLocal = myParams.Origin();
+  theOrigin.SetXYZ(myPlane.Location().XYZ() + aRawX * anOriginLocal.X()
+                   + aRawY * anOriginLocal.Y()
+                   + theN * (anOriginLocal.Z() + myParams.ZOffset()));
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::effectiveScale(const occ::handle<Graphic3d_Camera>& theCamera,
+                                       double&                              theScaleX,
+                                       double&                              theScaleY) const
+{
+  theScaleX = myParams.Scale();
+  theScaleY = myParams.EffectiveScaleY();
+  if (!myParams.IsViewAdaptive())
+  {
+    return;
+  }
+
+  const double aCurrentScale =
+    !theCamera.IsNull() && theCamera->Scale() > Precision::Confusion() ? theCamera->Scale()
+                                                                        : Precision::Confusion();
+  theScaleX /= aCurrentScale;
+  theScaleY /= aCurrentScale;
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::angleInArc(const double theStart,
+                                   const double theEnd,
+                                   const double theAngle)
+{
+  double aSpan = theEnd - theStart;
+  if (aSpan < 0.0)
+  {
+    aSpan += THE_TWO_PI;
+  }
+
+  double aDelta = theAngle - theStart;
+  if (aDelta < 0.0)
+  {
+    aDelta += THE_TWO_PI;
+  }
+  return aDelta <= aSpan;
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::isPointInBounds(const double theLocalX, const double theLocalY) const
+{
+  if (myParams.IsCircular())
+  {
+    const double aRadius = std::sqrt(theLocalX * theLocalX + theLocalY * theLocalY);
+    if (myParams.Radius() > 0.0 && aRadius > myParams.Radius())
+    {
+      return false;
+    }
+    if (myParams.IsArc())
+    {
+      if (!angleInArc(myParams.AngleStart(), myParams.AngleEnd(), std::atan2(theLocalY, theLocalX)))
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return (myParams.SizeX() <= 0.0 || std::abs(theLocalX) <= myParams.SizeX() * 0.5)
+         && (myParams.SizeY() <= 0.0 || std::abs(theLocalY) <= myParams.SizeY() * 0.5);
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::addLocalPoint(Bnd_Box&      theBox,
+                                      const gp_Pnt& theOrigin,
+                                      const gp_XYZ& theX,
+                                      const gp_XYZ& theY,
+                                      const double  theLocalX,
+                                      const double  theLocalY)
+{
+  theBox.Add(gp_Pnt(theOrigin.XYZ() + theX * theLocalX + theY * theLocalY));
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::addFiniteBounds(Bnd_Box& theBox) const
+{
+  gp_Pnt anOrigin;
+  gp_XYZ aGridX, aGridY, aGridN;
+  frame(anOrigin, aGridX, aGridY, aGridN);
+
+  addLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, 0.0);
+  if (myParams.IsCircular())
+  {
+    const double aRadius = myParams.Radius();
+    if (aRadius <= 0.0)
+    {
+      return;
+    }
+
+    if (!myParams.IsArc())
+    {
+      addLocalPoint(theBox, anOrigin, aGridX, aGridY, aRadius, 0.0);
+      addLocalPoint(theBox, anOrigin, aGridX, aGridY, -aRadius, 0.0);
+      addLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, aRadius);
+      addLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, -aRadius);
+      return;
+    }
+
+    auto addArcPoint = [&](const double theAngle) {
+      addLocalPoint(theBox,
+                    anOrigin,
+                    aGridX,
+                    aGridY,
+                    aRadius * std::cos(theAngle),
+                    aRadius * std::sin(theAngle));
+    };
+
+    addArcPoint(myParams.AngleStart());
+    addArcPoint(myParams.AngleEnd());
+
+    const double aCardinalAngles[] = {0.0, M_PI * 0.5, M_PI, -M_PI * 0.5};
+    for (const double anAngle : aCardinalAngles)
+    {
+      if (angleInArc(myParams.AngleStart(), myParams.AngleEnd(), anAngle))
+      {
+        addArcPoint(anAngle);
+      }
+    }
+    return;
+  }
+
+  const double aHalfX = myParams.SizeX() > 0.0 ? myParams.SizeX() * 0.5 : 0.0;
+  const double aHalfY = myParams.SizeY() > 0.0 ? myParams.SizeY() * 0.5 : 0.0;
+  if (aHalfX <= 0.0 && aHalfY <= 0.0)
+  {
+    return;
+  }
+
+  if (aHalfX > 0.0 && aHalfY > 0.0)
+  {
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, -aHalfY);
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, -aHalfY);
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, aHalfY);
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, aHalfY);
+    return;
+  }
+
+  if (aHalfX > 0.0)
+  {
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, 0.0);
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, 0.0);
+  }
+  if (aHalfY > 0.0)
+  {
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, -aHalfY);
+    addLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, aHalfY);
+  }
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::planeLocalHit(const occ::handle<Graphic3d_Camera>& theCamera,
+                                      const double                         theNdcX,
+                                      const double                         theNdcY,
+                                      double&                              theLocalX,
+                                      double&                              theLocalY,
+                                      gp_XYZ*                              theHit,
+                                      const bool                           theToRejectBehind) const
+{
+  if (theCamera.IsNull())
+  {
+    return false;
+  }
+
+  gp_Pnt aPlaneOrigin;
+  gp_XYZ aPlaneX, aPlaneY, aPlaneN;
+  frame(aPlaneOrigin, aPlaneX, aPlaneY, aPlaneN);
+
+  const double aNearZ        = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
+  const gp_Pnt aNearP        = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, aNearZ));
+  const gp_Pnt aFarP         = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, 1.0));
+  const bool   isPerspective = !theCamera->IsOrthographic();
+  const gp_Pnt aRayOriginP   = isPerspective ? theCamera->Eye() : aNearP;
+  const gp_XYZ aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
+  const double aRayMod       = aRay.Modulus();
+  if (aRayMod <= Precision::Confusion())
+  {
+    return false;
+  }
+
+  const double aDenom = aPlaneN.Dot(aRay);
+  if (std::abs(aDenom / aRayMod) <= Precision::Angular())
+  {
+    return false;
+  }
+
+  const double aT = aPlaneN.Dot(aPlaneOrigin.XYZ() - aRayOriginP.XYZ()) / aDenom;
+  if (theToRejectBehind && isPerspective && aT < 0.0)
+  {
+    return false;
+  }
+
+  const gp_XYZ aHit = aRayOriginP.XYZ() + aRay * aT;
+  const gp_XYZ aLocal3 = aHit - aPlaneOrigin.XYZ();
+  theLocalX = aLocal3.Dot(aPlaneX);
+  theLocalY = aLocal3.Dot(aPlaneY);
+  if (theHit != nullptr)
+  {
+    *theHit = aHit;
+  }
+  return true;
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::addViewFootprintBounds(
+  Bnd_Box&                             theBox,
+  const occ::handle<Graphic3d_Camera>& theCamera) const
+{
+  const double aSamples[][2] = {{-1.0, -1.0}, {1.0, -1.0}, {1.0, 1.0}, {-1.0, 1.0}, {0.0, 0.0}};
+  for (const double* aSample : aSamples)
+  {
+    double aLocalX = 0.0;
+    double aLocalY = 0.0;
+    gp_XYZ aHit;
+    if (!planeLocalHit(theCamera, aSample[0], aSample[1], aLocalX, aLocalY, &aHit))
+    {
+      continue;
+    }
+    if (!isPointInBounds(aLocalX, aLocalY))
+    {
+      continue;
+    }
+    theBox.Add(gp_Pnt(aHit));
+  }
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::AddZFitBounds(Bnd_Box&                             thePrimaryBox,
+                                      Bnd_Box&                             theGraphicBox,
+                                      const occ::handle<Graphic3d_Camera>& theCamera) const
+{
+  if (!myIsShown || myParams.DrawMode() == Aspect_GDM_None || myParams.IsBackground())
+  {
+    return;
+  }
+
+  Bnd_Box aGridBox;
+  if (myParams.IsBounded())
+  {
+    addFiniteBounds(aGridBox);
+  }
+  else
+  {
+    addViewFootprintBounds(aGridBox, theCamera);
+  }
+
+  if (aGridBox.IsVoid())
+  {
+    addFiniteBounds(aGridBox);
+  }
+  if (!aGridBox.IsVoid())
+  {
+    thePrimaryBox.Add(aGridBox);
+    theGraphicBox.Add(aGridBox);
+  }
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::referenceLocal(const occ::handle<Graphic3d_Camera>& theCamera,
+                                       double&                              theLocalX,
+                                       double&                              theLocalY) const
+{
+  const double aSamples[][2] = {{0.0, 0.0},
+                                {-1.0, -1.0},
+                                {1.0, -1.0},
+                                {1.0, 1.0},
+                                {-1.0, 1.0},
+                                {0.0, -1.0},
+                                {1.0, 0.0},
+                                {0.0, 1.0},
+                                {-1.0, 0.0}};
+  for (const double* aSample : aSamples)
+  {
+    if (planeLocalHit(theCamera, aSample[0], aSample[1], theLocalX, theLocalY))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+//=================================================================================================
+
+double OpenGl_ShaderGrid::snappedLocalShift(const double theLocal, const double theScale)
+{
+  if (theScale <= Precision::Confusion())
+  {
+    return 0.0;
+  }
+
+  const double aStep = 1.0 / theScale;
+  return std::round(theLocal / aStep) * aStep;
+}
+
+//=================================================================================================
+
+NCollection_Vec3<float> OpenGl_ShaderGrid::viewPoint(const NCollection_Mat4<float>& theWorldView,
+                                                     const gp_Pnt&                  thePoint)
+{
+  const NCollection_Vec4<float> aPoint(float(thePoint.X()),
+                                       float(thePoint.Y()),
+                                       float(thePoint.Z()),
+                                       1.0f);
+  const NCollection_Vec4<float> aView = theWorldView * aPoint;
+  return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
+}
+
+//=================================================================================================
+
+NCollection_Vec3<float> OpenGl_ShaderGrid::viewDirection(
+  const NCollection_Mat4<float>& theWorldView,
+  const gp_XYZ&                  theDirection)
+{
+  const NCollection_Vec4<float> aDir(float(theDirection.X()),
+                                     float(theDirection.Y()),
+                                     float(theDirection.Z()),
+                                     0.0f);
+  const NCollection_Vec4<float> aView = theWorldView * aDir;
+  return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
+}
+
+//=================================================================================================
+
+gp_Pnt OpenGl_ShaderGrid::echoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                                           const gp_XYZ&                        theSnapped)
+{
+  const gp_Pnt aProjSnapped = theCamera->Project(gp_Pnt(theSnapped));
+  const double aDisplayZ    = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
+  return theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::Echo(const occ::handle<Graphic3d_Camera>& theCamera,
+                             const int                            theWidth,
+                             const int                            theHeight,
+                             const int                            theX,
+                             const int                            theY,
+                             Graphic3d_Vertex&                    thePoint,
+                             Graphic3d_Vertex&                    theDisplayPoint) const
+{
+  if (!myIsShown || myParams.DrawMode() == Aspect_GDM_None || myParams.IsBackground()
+      || theCamera.IsNull() || theWidth <= 0 || theHeight <= 0)
+  {
+    return false;
+  }
+
+  const double aNdcX = 2.0 * double(theX) / double(theWidth) - 1.0;
+  const double aNdcY = 2.0 * double(theHeight - 1 - theY) / double(theHeight) - 1.0;
+  double       aLocalX = 0.0;
+  double       aLocalY = 0.0;
+  if (!planeLocalHit(theCamera, aNdcX, aNdcY, aLocalX, aLocalY))
+  {
+    return false;
+  }
+  if (!isPointInBounds(aLocalX, aLocalY))
+  {
+    return false;
+  }
+
+  double aScaleX = 0.0;
+  double aScaleY = 0.0;
+  effectiveScale(theCamera, aScaleX, aScaleY);
+  if (aScaleX <= Precision::Confusion() || aScaleY <= Precision::Confusion())
+  {
+    return false;
+  }
+
+  gp_Pnt aGridOrigin;
+  gp_XYZ aGridX, aGridY, aGridN;
+  frame(aGridOrigin, aGridX, aGridY, aGridN);
+
+  gp_XYZ     aSnapped       = aGridOrigin.XYZ();
+  const bool toSnapByScreen = myParams.DrawMode() == Aspect_GDM_Points;
+  double     aBestDist2     = RealLast();
+  bool       hasBestPoint   = false;
+  auto       addCandidate   = [&](const double theLocalX, const double theLocalY) {
+    if (!isPointInBounds(theLocalX, theLocalY))
+    {
+      return;
+    }
+    const gp_XYZ aCandidate = aGridOrigin.XYZ() + aGridX * theLocalX + aGridY * theLocalY;
+    if (!theCamera->IsOrthographic()
+        && theCamera->Direction().XYZ().Dot(aCandidate - theCamera->Eye().XYZ()) <= 0.0)
+    {
+      return;
+    }
+    const gp_Pnt aProj  = theCamera->Project(gp_Pnt(aCandidate));
+    const double aPx    = (aProj.X() + 1.0) * 0.5 * double(theWidth);
+    const double aPy    = double(theHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(theHeight);
+    const double aDistX = aPx - double(theX);
+    const double aDistY = aPy - double(theY);
+    const double aDist2 = aDistX * aDistX + aDistY * aDistY;
+    if (!hasBestPoint || aDist2 < aBestDist2)
+    {
+      hasBestPoint = true;
+      aBestDist2   = aDist2;
+      aSnapped     = aCandidate;
+    }
+  };
+
+  if (myParams.IsCircular())
+  {
+    const double aRadius      = std::sqrt(aLocalX * aLocalX + aLocalY * aLocalY);
+    const double anAngle      = std::atan2(aLocalY, aLocalX);
+    const double aRadiusStep  = 1.0 / aScaleX;
+    const int    aNbDivisions = myParams.AngularDivisions();
+    const double anAngleStep  = aNbDivisions > 0 ? M_PI / double(aNbDivisions) : M_PI;
+    if (toSnapByScreen)
+    {
+      const double aRadiusIndex = std::floor(aRadius / aRadiusStep);
+      const double anAngleIndex = std::floor(anAngle / anAngleStep);
+      const double aRadii[2]    = {std::max(0.0, aRadiusIndex * aRadiusStep),
+                                   std::max(0.0, (aRadiusIndex + 1.0) * aRadiusStep)};
+      const double anAngles[2]  = {anAngleIndex * anAngleStep, (anAngleIndex + 1.0) * anAngleStep};
+      for (double aCandidateRadius : aRadii)
+      {
+        for (double aCandidateAngle : anAngles)
+        {
+          addCandidate(aCandidateRadius * std::cos(aCandidateAngle),
+                       aCandidateRadius * std::sin(aCandidateAngle));
+        }
+      }
+      if (!hasBestPoint)
+      {
+        return false;
+      }
+    }
+    else
+    {
+      const double aSnapRadius = std::round(aRadius / aRadiusStep) * aRadiusStep;
+      const double aSnapAngle  = std::round(anAngle / anAngleStep) * anAngleStep;
+      if (!isPointInBounds(aSnapRadius * std::cos(aSnapAngle),
+                           aSnapRadius * std::sin(aSnapAngle)))
+      {
+        return false;
+      }
+      aSnapped += aGridX * (aSnapRadius * std::cos(aSnapAngle))
+                  + aGridY * (aSnapRadius * std::sin(aSnapAngle));
+    }
+  }
+  else
+  {
+    const double aStepX = 1.0 / aScaleX;
+    const double aStepY = 1.0 / aScaleY;
+    if (toSnapByScreen)
+    {
+      const double anIndexX    = std::floor(aLocalX / aStepX);
+      const double anIndexY    = std::floor(aLocalY / aStepY);
+      const double aLocalXs[2] = {anIndexX * aStepX, (anIndexX + 1.0) * aStepX};
+      const double aLocalYs[2] = {anIndexY * aStepY, (anIndexY + 1.0) * aStepY};
+      for (double aCandidateX : aLocalXs)
+      {
+        for (double aCandidateY : aLocalYs)
+        {
+          addCandidate(aCandidateX, aCandidateY);
+        }
+      }
+      if (!hasBestPoint)
+      {
+        return false;
+      }
+    }
+    else
+    {
+      aLocalX = std::round(aLocalX / aStepX) * aStepX;
+      aLocalY = std::round(aLocalY / aStepY) * aStepY;
+      if (!isPointInBounds(aLocalX, aLocalY))
+      {
+        return false;
+      }
+      aSnapped += aGridX * aLocalX + aGridY * aLocalY;
+    }
+  }
+
+  thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
+  const gp_Pnt aDisplayP = echoDisplayPoint(theCamera, aSnapped);
+  theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
+  return true;
+}
+
+//=================================================================================================
+
+bool OpenGl_ShaderGrid::SnapPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                                  const Graphic3d_Vertex&              thePoint,
+                                  Graphic3d_Vertex&                    theGridPoint) const
+{
+  if (!myIsShown || myParams.DrawMode() == Aspect_GDM_None || myParams.IsBackground())
+  {
+    return false;
+  }
+
+  double aScaleX = 0.0;
+  double aScaleY = 0.0;
+  effectiveScale(theCamera, aScaleX, aScaleY);
+  if (aScaleX <= Precision::Confusion() || aScaleY <= Precision::Confusion())
+  {
+    return false;
+  }
+
+  gp_Pnt aGridOrigin;
+  gp_XYZ aGridX, aGridY, aGridN;
+  frame(aGridOrigin, aGridX, aGridY, aGridN);
+
+  const gp_XYZ aPoint(thePoint.X(), thePoint.Y(), thePoint.Z());
+  const gp_XYZ aLocal3 = aPoint - aGridOrigin.XYZ();
+  double       aLocalX = aLocal3.Dot(aGridX);
+  double       aLocalY = aLocal3.Dot(aGridY);
+
+  gp_XYZ aSnapped = aGridOrigin.XYZ();
+  if (myParams.IsCircular())
+  {
+    const double aRadius      = std::sqrt(aLocalX * aLocalX + aLocalY * aLocalY);
+    const double anAngle      = std::atan2(aLocalY, aLocalX);
+    const double aRadiusStep  = 1.0 / aScaleX;
+    const int    aNbDivisions = myParams.AngularDivisions();
+    const double anAngleStep  = aNbDivisions > 0 ? M_PI / double(aNbDivisions) : M_PI;
+    const double aSnapRadius  = std::round(aRadius / aRadiusStep) * aRadiusStep;
+    const double aSnapAngle   = std::round(anAngle / anAngleStep) * anAngleStep;
+    aLocalX                   = aSnapRadius * std::cos(aSnapAngle);
+    aLocalY                   = aSnapRadius * std::sin(aSnapAngle);
+    if (!isPointInBounds(aLocalX, aLocalY))
+    {
+      return false;
+    }
+    aSnapped += aGridX * aLocalX + aGridY * aLocalY;
+  }
+  else
+  {
+    const double aStepX = 1.0 / aScaleX;
+    const double aStepY = 1.0 / aScaleY;
+    aLocalX             = std::round(aLocalX / aStepX) * aStepX;
+    aLocalY             = std::round(aLocalY / aStepY) * aStepY;
+    if (!isPointInBounds(aLocalX, aLocalY))
+    {
+      return false;
+    }
+    aSnapped += aGridX * aLocalX + aGridY * aLocalY;
+  }
+
+  theGridPoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
+  return true;
+}
+
+//=================================================================================================
+
+NCollection_Mat4<float> OpenGl_ShaderGrid::DrawWorldView(
+  const NCollection_Mat4<float>& theCurrentWorldView) const
+{
+  if (!myParams.IsBackground())
+  {
+    return theCurrentWorldView;
+  }
+
+  NCollection_Mat4<float> aRefInv;
+  if (!myRefViewMatrix.Inverted(aRefInv))
+  {
+    aRefInv.InitIdentity();
+  }
+  return theCurrentWorldView * aRefInv;
+}
+
+//=================================================================================================
+
+void OpenGl_ShaderGrid::SetUniforms(const occ::handle<OpenGl_Context>&       theContext,
+                                    const occ::handle<OpenGl_ShaderProgram>& theProgram,
+                                    const occ::handle<Graphic3d_Camera>&     theCamera,
+                                    const NCollection_Mat4<float>&           theWorldView) const
+{
+  double aScaleX = 0.0;
+  double aScaleY = 0.0;
+  effectiveScale(theCamera, aScaleX, aScaleY);
+
+  gp_Pnt aPlaneOrigin;
+  gp_XYZ aXRotated, aYRotated, aNDir;
+  frame(aPlaneOrigin, aXRotated, aYRotated, aNDir);
+
+  theProgram->SetUniform(theContext, "uScaleX", GLfloat(aScaleX));
+  theProgram->SetUniform(theContext, "uScaleY", GLfloat(aScaleY));
+  theProgram->SetUniform(theContext, "uThickness", GLfloat(myParams.LineThickness()));
+  theProgram->SetUniform(theContext,
+                         "uColor",
+                         NCollection_Vec3<float>((float)myParams.Color().Red(),
+                                                 (float)myParams.Color().Green(),
+                                                 (float)myParams.Color().Blue()));
+  theProgram->SetUniform(theContext,
+                         "uAccentColor",
+                         NCollection_Vec3<float>((float)myParams.AccentColor().Red(),
+                                                 (float)myParams.AccentColor().Green(),
+                                                 (float)myParams.AccentColor().Blue()));
+  theProgram->SetUniform(theContext, "uAccentScaleX", GLfloat(myParams.AccentScaleX()));
+  theProgram->SetUniform(theContext, "uAccentScaleY", GLfloat(myParams.AccentScaleY()));
+  theProgram->SetUniform(theContext, "uAccentAngularScale", GLfloat(myParams.AccentAngularScale()));
+  theProgram->SetUniform(theContext, "uIsDrawAxis", myParams.IsDrawAxis() ? 1 : 0);
+  theProgram->SetUniform(theContext, "uGridType", myParams.IsCircular() ? 1 : 0);
+  theProgram->SetUniform(theContext, "uIsBackground", myParams.IsBackground() ? 1 : 0);
+
+  const double aAngularScale = myParams.IsCircular() ? double(myParams.AngularDivisions()) / M_PI
+                                                      : 0.0;
+  theProgram->SetUniform(theContext, "uAngularScale", GLfloat(aAngularScale));
+  theProgram->SetUniform(theContext, "uDrawMode", myParams.DrawMode() == Aspect_GDM_Points ? 1 : 0);
+  theProgram->SetUniform(theContext, "uIsPerspective", theCamera->IsOrthographic() ? 0 : 1);
+  theProgram->SetUniform(theContext, "uIsZeroToOneDepth", theCamera->IsZeroToOneDepth() ? 1 : 0);
+  theProgram->SetUniform(theContext, "uParallelTolerance", GLfloat(Precision::Angular()));
+
+  NCollection_Vec2<float> aLocalOriginShift(0.0f, 0.0f);
+  NCollection_Vec2<float> anAccentLocalOriginShift(0.0f, 0.0f);
+  float                   aRadialOriginShift        = 0.0f;
+  float                   anAccentRadialOriginShift = 0.0f;
+  double                  aLocalRefX = 0.0;
+  double                  aLocalRefY = 0.0;
+  if (referenceLocal(theCamera, aLocalRefX, aLocalRefY))
+  {
+    if (myParams.IsCircular())
+    {
+      const double aRadiusRef = std::sqrt(aLocalRefX * aLocalRefX + aLocalRefY * aLocalRefY);
+      aRadialOriginShift      = float(snappedLocalShift(aRadiusRef, aScaleX));
+      anAccentRadialOriginShift =
+        myParams.AccentScaleX() > Precision::Confusion()
+          ? float(snappedLocalShift(aRadiusRef, myParams.AccentScaleX()))
+          : aRadialOriginShift;
+    }
+    else
+    {
+      aLocalOriginShift.SetValues(float(snappedLocalShift(aLocalRefX, aScaleX)),
+                                  float(snappedLocalShift(aLocalRefY, aScaleY)));
+      anAccentLocalOriginShift.SetValues(
+        myParams.AccentScaleX() > Precision::Confusion()
+          ? float(snappedLocalShift(aLocalRefX, myParams.AccentScaleX()))
+          : aLocalOriginShift.x(),
+        myParams.AccentScaleY() > Precision::Confusion()
+          ? float(snappedLocalShift(aLocalRefY, myParams.AccentScaleY()))
+          : aLocalOriginShift.y());
+    }
+  }
+
+  const gp_Pnt aPlaneRef(aPlaneOrigin.XYZ() + aXRotated * double(aLocalOriginShift.x())
+                         + aYRotated * double(aLocalOriginShift.y()));
+  theProgram->SetUniform(theContext, "uPlaneOriginView", viewPoint(theWorldView, aPlaneOrigin));
+  theProgram->SetUniform(theContext, "uPlaneRefView", viewPoint(theWorldView, aPlaneRef));
+  theProgram->SetUniform(theContext, "uPlaneXView", viewDirection(theWorldView, aXRotated));
+  theProgram->SetUniform(theContext, "uPlaneYView", viewDirection(theWorldView, aYRotated));
+  theProgram->SetUniform(theContext, "uPlaneNView", viewDirection(theWorldView, aNDir));
+  theProgram->SetUniform(theContext, "uLocalOriginShift", aLocalOriginShift);
+  theProgram->SetUniform(theContext, "uAccentLocalOriginShift", anAccentLocalOriginShift);
+  theProgram->SetUniform(theContext, "uRadialOriginShift", GLfloat(aRadialOriginShift));
+  theProgram->SetUniform(theContext, "uAccentRadialOriginShift", GLfloat(anAccentRadialOriginShift));
+
+  const float aHalfX  = myParams.SizeX() > 0.0 ? float(myParams.SizeX() * 0.5) : 0.0f;
+  const float aHalfY  = myParams.SizeY() > 0.0 ? float(myParams.SizeY() * 0.5) : 0.0f;
+  const float aRadius = myParams.Radius() > 0.0 ? float(myParams.Radius()) : 0.0f;
+  theProgram->SetUniform(theContext, "uBounds", NCollection_Vec3<float>(aHalfX, aHalfY, aRadius));
+  theProgram->SetUniform(theContext,
+                         "uIsBoundFade",
+                         myParams.IsBounded() && !myParams.IsViewAdaptive() ? 1 : 0);
+  theProgram->SetUniform(
+    theContext,
+    "uArcRange",
+    NCollection_Vec2<float>(float(myParams.AngleStart()), float(myParams.AngleEnd())));
+  theProgram->SetUniform(theContext, "uArcBounded", myParams.IsArc() ? 1 : 0);
+}

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
@@ -38,17 +38,17 @@ public:
   const Aspect_GridParams& Params() const { return myParams; }
 
   //! Store grid state. Returns FALSE when parameters cannot produce a shader grid.
-  bool Display(const Aspect_GridParams&               theParams,
-               const gp_Ax3&                          thePlane,
-               const occ::handle<Graphic3d_Camera>&   theCamera,
-               const occ::handle<OpenGl_Context>&     theContext);
+  bool Display(const Aspect_GridParams&             theParams,
+               const gp_Ax3&                        thePlane,
+               const occ::handle<Graphic3d_Camera>& theCamera,
+               const occ::handle<OpenGl_Context>&   theContext);
 
   //! Clear grid state.
   void Erase();
 
   //! Add bounds required by camera Z fitting.
-  void AddZFitBounds(Bnd_Box&                           thePrimaryBox,
-                     Bnd_Box&                           theGraphicBox,
+  void AddZFitBounds(Bnd_Box&                             thePrimaryBox,
+                     Bnd_Box&                             theGraphicBox,
                      const occ::handle<Graphic3d_Camera>& theCamera) const;
 
   //! Return snapped point for the grid under the window pixel.
@@ -66,10 +66,10 @@ public:
                  Graphic3d_Vertex&                    theGridPoint) const;
 
   //! Upload shader uniforms for current grid state.
-  void SetUniforms(const occ::handle<OpenGl_Context>&        theContext,
-                   const occ::handle<OpenGl_ShaderProgram>&  theProgram,
-                   const occ::handle<Graphic3d_Camera>&      theCamera,
-                   const NCollection_Mat4<float>&            theWorldView) const;
+  void SetUniforms(const occ::handle<OpenGl_Context>&       theContext,
+                   const occ::handle<OpenGl_ShaderProgram>& theProgram,
+                   const occ::handle<Graphic3d_Camera>&     theCamera,
+                   const NCollection_Mat4<float>&           theWorldView) const;
 
   //! Return worldview matrix to use for drawing.
   NCollection_Mat4<float> DrawWorldView(const NCollection_Mat4<float>& theCurrentWorldView) const;
@@ -98,7 +98,7 @@ private:
   void addFiniteBounds(Bnd_Box& theBox) const;
 
   //! Add view footprint bounds to the box.
-  void addViewFootprintBounds(Bnd_Box&                           theBox,
+  void addViewFootprintBounds(Bnd_Box&                             theBox,
                               const occ::handle<Graphic3d_Camera>& theCamera) const;
 
   //! Intersect camera ray at NDC point with the grid plane.
@@ -107,7 +107,7 @@ private:
                      const double                         theNdcY,
                      double&                              theLocalX,
                      double&                              theLocalY,
-                     gp_XYZ*                              theHit = nullptr,
+                     gp_XYZ*                              theHit            = nullptr,
                      const bool                           theToRejectBehind = true) const;
 
   //! Return stable visible reference point in local coordinates.

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
@@ -1,0 +1,143 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _OpenGl_ShaderGrid_HeaderFile
+#define _OpenGl_ShaderGrid_HeaderFile
+
+#include <Aspect_GridParams.hxx>
+#include <Bnd_Box.hxx>
+#include <Graphic3d_Camera.hxx>
+#include <Graphic3d_Vertex.hxx>
+#include <NCollection_Mat4.hxx>
+#include <NCollection_Vec2.hxx>
+#include <OpenGl_Context.hxx>
+#include <OpenGl_ShaderProgram.hxx>
+#include <gp_Ax3.hxx>
+
+//! State and geometry model of the OpenGl shader-rendered grid.
+class OpenGl_ShaderGrid
+{
+public:
+  //! Return TRUE if the grid is currently shown.
+  bool IsShown() const { return myIsShown; }
+
+  //! Return TRUE if the grid is rendered as a background.
+  bool IsBackground() const { return myParams.IsBackground(); }
+
+  //! Return current parameters.
+  const Aspect_GridParams& Params() const { return myParams; }
+
+  //! Store grid state. Returns FALSE when parameters cannot produce a shader grid.
+  bool Display(const Aspect_GridParams&               theParams,
+               const gp_Ax3&                          thePlane,
+               const occ::handle<Graphic3d_Camera>&   theCamera,
+               const occ::handle<OpenGl_Context>&     theContext);
+
+  //! Clear grid state.
+  void Erase();
+
+  //! Add bounds required by camera Z fitting.
+  void AddZFitBounds(Bnd_Box&                           thePrimaryBox,
+                     Bnd_Box&                           theGraphicBox,
+                     const occ::handle<Graphic3d_Camera>& theCamera) const;
+
+  //! Return snapped point for the grid under the window pixel.
+  bool Echo(const occ::handle<Graphic3d_Camera>& theCamera,
+            const int                            theWidth,
+            const int                            theHeight,
+            const int                            theX,
+            const int                            theY,
+            Graphic3d_Vertex&                    thePoint,
+            Graphic3d_Vertex&                    theDisplayPoint) const;
+
+  //! Return snapped point for an arbitrary world point.
+  bool SnapPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                 const Graphic3d_Vertex&              thePoint,
+                 Graphic3d_Vertex&                    theGridPoint) const;
+
+  //! Upload shader uniforms for current grid state.
+  void SetUniforms(const occ::handle<OpenGl_Context>&        theContext,
+                   const occ::handle<OpenGl_ShaderProgram>&  theProgram,
+                   const occ::handle<Graphic3d_Camera>&      theCamera,
+                   const NCollection_Mat4<float>&            theWorldView) const;
+
+  //! Return worldview matrix to use for drawing.
+  NCollection_Mat4<float> DrawWorldView(const NCollection_Mat4<float>& theCurrentWorldView) const;
+
+private:
+  //! Compute grid plane frame.
+  void frame(gp_Pnt& theOrigin, gp_XYZ& theX, gp_XYZ& theY, gp_XYZ& theN) const;
+
+  //! Compute effective scales for the current camera.
+  void effectiveScale(const occ::handle<Graphic3d_Camera>& theCamera,
+                      double&                              theScaleX,
+                      double&                              theScaleY) const;
+
+  //! Return TRUE if local coordinates are inside configured grid domain.
+  bool isPointInBounds(const double theLocalX, const double theLocalY) const;
+
+  //! Add local point to box.
+  static void addLocalPoint(Bnd_Box&      theBox,
+                            const gp_Pnt& theOrigin,
+                            const gp_XYZ& theX,
+                            const gp_XYZ& theY,
+                            const double  theLocalX,
+                            const double  theLocalY);
+
+  //! Add configured finite bounds to the box.
+  void addFiniteBounds(Bnd_Box& theBox) const;
+
+  //! Add view footprint bounds to the box.
+  void addViewFootprintBounds(Bnd_Box&                           theBox,
+                              const occ::handle<Graphic3d_Camera>& theCamera) const;
+
+  //! Intersect camera ray at NDC point with the grid plane.
+  bool planeLocalHit(const occ::handle<Graphic3d_Camera>& theCamera,
+                     const double                         theNdcX,
+                     const double                         theNdcY,
+                     double&                              theLocalX,
+                     double&                              theLocalY,
+                     gp_XYZ*                              theHit = nullptr,
+                     const bool                           theToRejectBehind = true) const;
+
+  //! Return stable visible reference point in local coordinates.
+  bool referenceLocal(const occ::handle<Graphic3d_Camera>& theCamera,
+                      double&                              theLocalX,
+                      double&                              theLocalY) const;
+
+  //! Return local shift snapped to a grid phase.
+  static double snappedLocalShift(const double theLocal, const double theScale);
+
+  //! Convert point to current draw view coordinates.
+  static NCollection_Vec3<float> viewPoint(const NCollection_Mat4<float>& theWorldView,
+                                           const gp_Pnt&                  thePoint);
+
+  //! Convert direction to current draw view coordinates.
+  static NCollection_Vec3<float> viewDirection(const NCollection_Mat4<float>& theWorldView,
+                                               const gp_XYZ&                  theDirection);
+
+  //! Return display-safe echo marker point.
+  static gp_Pnt echoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                                 const gp_XYZ&                        theSnapped);
+
+  //! Return TRUE if angle belongs to arc.
+  static bool angleInArc(const double theStart, const double theEnd, const double theAngle);
+
+private:
+  Aspect_GridParams       myParams;
+  gp_Ax3                  myPlane;
+  NCollection_Mat4<float> myRefViewMatrix;
+  bool                    myIsShown = false;
+};
+
+#endif // _OpenGl_ShaderGrid_HeaderFile

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
@@ -46,9 +46,8 @@ public:
   //! Clear grid state.
   void Erase();
 
-  //! Add bounds required by camera Z fitting.
-  void AddZFitBounds(Bnd_Box&                             thePrimaryBox,
-                     Bnd_Box&                             theGraphicBox,
+  //! Add helper bounds required by camera Z fitting.
+  void AddZFitBounds(Bnd_Box&                             theGraphicBox,
                      const occ::handle<Graphic3d_Camera>& theCamera) const;
 
   //! Return snapped point for the grid under the window pixel.
@@ -118,6 +117,24 @@ private:
   //! Return local shift snapped to a grid phase.
   static double snappedLocalShift(const double theLocal, const double theScale);
 
+  //! Return TRUE if previous and new grid definitions share the same background anchor frame.
+  bool hasSameAnchorFrame(const Aspect_GridParams& theParams, const gp_Ax3& thePlane) const;
+
+  //! Accept echo candidate if it is visible and closer to the requested pixel.
+  bool acceptEchoCandidate(const occ::handle<Graphic3d_Camera>& theCamera,
+                           const int                            theWidth,
+                           const int                            theHeight,
+                           const int                            theX,
+                           const int                            theY,
+                           const gp_Pnt&                        theGridOrigin,
+                           const gp_XYZ&                        theGridX,
+                           const gp_XYZ&                        theGridY,
+                           const double                         theLocalX,
+                           const double                         theLocalY,
+                           gp_XYZ&                              theBestSnapped,
+                           double&                              theBestDist2,
+                           bool&                                theHasBestPoint) const;
+
   //! Convert point to current draw view coordinates.
   static NCollection_Vec3<float> viewPoint(const NCollection_Mat4<float>& theWorldView,
                                            const gp_Pnt&                  thePoint);
@@ -127,8 +144,9 @@ private:
                                                const gp_XYZ&                  theDirection);
 
   //! Return display-safe echo marker point.
-  static gp_Pnt echoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
-                                 const gp_XYZ&                        theSnapped);
+  static bool echoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                               const gp_XYZ&                        theSnapped,
+                               gp_Pnt&                              theDisplayPoint);
 
   //! Return TRUE if angle belongs to arc.
   static bool angleInArc(const double theStart, const double theEnd, const double theAngle);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderGrid.hxx
@@ -47,8 +47,7 @@ public:
   void Erase();
 
   //! Add helper bounds required by camera Z fitting.
-  void AddZFitBounds(Bnd_Box&                             theGraphicBox,
-                     const occ::handle<Graphic3d_Camera>& theCamera) const;
+  void AddZFitBounds(Bnd_Box& theGraphicBox, const occ::handle<Graphic3d_Camera>& theCamera) const;
 
   //! Return snapped point for the grid under the window pixel.
   bool Echo(const occ::handle<Graphic3d_Camera>& theCamera,

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -294,6 +294,117 @@ static bool isShaderGridPointInBounds(const Aspect_GridParams& theParams,
          && (theParams.SizeY() <= 0.0 || std::abs(theLocalY) <= theParams.SizeY() * 0.5);
 }
 
+//! Return TRUE if the angle belongs to the grid arc.
+static bool shaderGridArcContains(const double theStart, const double theEnd, const double theAngle)
+{
+  const double aTwoPi = 2.0 * M_PI;
+  double       aSpan = theEnd - theStart;
+  if (aSpan < 0.0)
+  {
+    aSpan += aTwoPi;
+  }
+
+  double aDelta = theAngle - theStart;
+  if (aDelta < 0.0)
+  {
+    aDelta += aTwoPi;
+  }
+  return aDelta <= aSpan;
+}
+
+//! Add local shader-grid point into world-space bounding box.
+static void addShaderGridLocalPoint(Bnd_Box&       theBox,
+                                    const gp_Pnt&  theOrigin,
+                                    const gp_XYZ&  theX,
+                                    const gp_XYZ&  theY,
+                                    const double   theLocalX,
+                                    const double   theLocalY)
+{
+  theBox.Add(gp_Pnt(theOrigin.XYZ() + theX * theLocalX + theY * theLocalY));
+}
+
+//! Add exactly known finite shader-grid extents to a bounding box.
+//!
+//! Unbounded shader grids have no finite world-space box; in that case only the
+//! plane origin is added so the grid plane can still participate in Z fitting
+//! without inventing artificial viewport-dependent extents.
+static void addShaderGridFiniteBounds(Bnd_Box&                 theBox,
+                                      const Aspect_GridParams& theParams,
+                                      const gp_Ax3&            thePlane)
+{
+  gp_Pnt anOrigin;
+  gp_XYZ aGridX, aGridY, aGridN;
+  shaderGridFrame(theParams, thePlane, anOrigin, aGridX, aGridY, aGridN);
+
+  addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, 0.0);
+  if (theParams.IsCircular())
+  {
+    const double aRadius = theParams.Radius();
+    if (aRadius <= 0.0)
+    {
+      return;
+    }
+
+    if (!theParams.IsArc())
+    {
+      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aRadius, 0.0);
+      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aRadius, 0.0);
+      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, aRadius);
+      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, -aRadius);
+      return;
+    }
+
+    auto addArcPoint = [&](const double theAngle) {
+      addShaderGridLocalPoint(theBox,
+                              anOrigin,
+                              aGridX,
+                              aGridY,
+                              aRadius * std::cos(theAngle),
+                              aRadius * std::sin(theAngle));
+    };
+
+    addArcPoint(theParams.AngleStart());
+    addArcPoint(theParams.AngleEnd());
+
+    const double aCardinalAngles[] = {0.0, M_PI * 0.5, M_PI, -M_PI * 0.5};
+    for (const double anAngle : aCardinalAngles)
+    {
+      if (shaderGridArcContains(theParams.AngleStart(), theParams.AngleEnd(), anAngle))
+      {
+        addArcPoint(anAngle);
+      }
+    }
+    return;
+  }
+
+  const double aHalfX = theParams.SizeX() > 0.0 ? theParams.SizeX() * 0.5 : 0.0;
+  const double aHalfY = theParams.SizeY() > 0.0 ? theParams.SizeY() * 0.5 : 0.0;
+  if (aHalfX <= 0.0 && aHalfY <= 0.0)
+  {
+    return;
+  }
+
+  if (aHalfX > 0.0 && aHalfY > 0.0)
+  {
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, -aHalfY);
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, -aHalfY);
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, aHalfY);
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, aHalfY);
+    return;
+  }
+
+  if (aHalfX > 0.0)
+  {
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, 0.0);
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, 0.0);
+  }
+  if (aHalfY > 0.0)
+  {
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, -aHalfY);
+    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, aHalfY);
+  }
+}
+
 //! Chooses compatible internal color format for OIT frame buffer.
 static bool chooseOitColorConfiguration(const occ::handle<OpenGl_Context>& theGlContext,
                                         const int                          theConfigIndex,
@@ -1102,6 +1213,12 @@ Bnd_Box OpenGl_View::MinMaxValues(const bool theToIncludeAuxiliary) const
   }
 
   Bnd_Box aBox = base_type::MinMaxValues(theToIncludeAuxiliary);
+
+  if (theToIncludeAuxiliary && myToShowGrid && myGridParams.DrawMode() != Aspect_GDM_None
+      && !myGridParams.IsBackground())
+  {
+    addShaderGridFiniteBounds(aBox, myGridParams, myGridPlane);
+  }
 
   // make sure that stats overlay isn't clamped on hardware with unavailable depth clamping
   if (theToIncludeAuxiliary && myRenderParams.ToShowStats
@@ -4095,21 +4212,12 @@ void OpenGl_View::renderGrid()
   aContext->core11fwd->glGetIntegerv(GL_BLEND_DST_ALPHA, &aPrevBlendDstA);
   const occ::handle<OpenGl_ShaderProgram> aPrevProgram = aContext->ActiveProgram();
 
-  const double                       aZNearKeep = aCamera->ZNear();
-  const double                       aZFarKeep  = aCamera->ZFar();
-  const Graphic3d_Camera::Projection aProjKeep  = aCamera->ProjectionType();
+  const Graphic3d_Camera::Projection aProjKeep = aCamera->ProjectionType();
 
   gp_Pnt aPlaneOrigin;
   gp_XYZ aXRotated, aYRotated, aNDir;
   shaderGridFrame(myGridParams, myGridPlane, aPlaneOrigin, aXRotated, aYRotated, aNDir);
 
-  Bnd_Box      aBnd      = MinMaxValues(true);
-  const gp_Pnt aPlaneLoc = myGridPlane.Location();
-  if (myGridParams.IsBackground() || aBnd.IsVoid() || aBnd.IsOut(aPlaneLoc))
-  {
-    aBnd.Add(aPlaneLoc);
-    aCamera->ZFitAll(1.0, aBnd, aBnd);
-  }
   if (myGridParams.IsBackground())
   {
     aCamera->SetProjectionType(Graphic3d_Camera::Projection_Orthographic);
@@ -4180,7 +4288,7 @@ void OpenGl_View::renderGrid()
     aProg->SetUniform(aContext, "uAngularScale", GLfloat(aAngularScale));
     aProg->SetUniform(aContext, "uDrawMode", myGridParams.DrawMode() == Aspect_GDM_Points ? 1 : 0);
     aProg->SetUniform(aContext, "uIsPerspective", aCamera->IsOrthographic() ? 0 : 1);
-    aProg->SetUniform(aContext, "uNdcNear", GLfloat(aCamera->IsZeroToOneDepth() ? 0.0f : -1.0f));
+    aProg->SetUniform(aContext, "uIsZeroToOneDepth", aCamera->IsZeroToOneDepth() ? 1 : 0);
 
     NCollection_Vec2<float> aLocalOriginShift(0.0f, 0.0f);
     NCollection_Vec2<float> anAccentLocalOriginShift(0.0f, 0.0f);
@@ -4256,7 +4364,6 @@ void OpenGl_View::renderGrid()
   aContext->BindProgram(aPrevProgram);
   aContext->core30->glBindVertexArray((GLuint)aPrevVao);
 
-  aCamera->SetZRange(aZNearKeep, aZFarKeep);
   aCamera->SetProjectionType(aProjKeep);
 
   aContext->WorldViewState.Pop();

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -4235,6 +4235,7 @@ void OpenGl_View::renderGrid()
   aContext->ApplyWorldViewMatrix();
 
   aContext->core11fwd->glEnable(GL_DEPTH_TEST);
+  aContext->core11fwd->glDepthFunc(GL_LEQUAL);
   aContext->core11fwd->glDepthMask(GL_FALSE);
   aContext->core11fwd->glEnable(GL_BLEND);
   aContext->core11fwd->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -3582,21 +3582,18 @@ void OpenGl_View::updatePBREnvironment(const occ::handle<OpenGl_Context>& theCtx
 
 //=================================================================================================
 
-bool OpenGl_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
+void OpenGl_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
 {
   const occ::handle<OpenGl_Context>& aCtx = myWorkspace->GetGlContext();
   if (!aCtx.IsNull() && aCtx->core30 == nullptr)
   {
-    return false;
+    myShaderGrid.Erase();
+    Invalidate();
+    return;
   }
 
-  if (!myShaderGrid.Display(theParams, thePlane, Camera(), aCtx))
-  {
-    return false;
-  }
-
+  myShaderGrid.Display(theParams, thePlane, Camera(), aCtx);
   Invalidate();
-  return true;
 }
 
 //=================================================================================================

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -3624,7 +3624,7 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
     return false;
   }
 
-  int aWidth = 0;
+  int aWidth  = 0;
   int aHeight = 0;
   Window()->Size(aWidth, aHeight);
   return myShaderGrid.Echo(Camera(), aWidth, aHeight, theX, theY, thePoint, theDisplayPoint);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -909,7 +909,7 @@ void OpenGl_View::ZFitAllBounds(Bnd_Box& thePrimaryBox, Bnd_Box& theGraphicBox) 
 {
   thePrimaryBox = base_type::MinMaxValues(false);
   theGraphicBox = MinMaxValues(true);
-  myShaderGrid.AddZFitBounds(thePrimaryBox, theGraphicBox, Camera());
+  myShaderGrid.AddZFitBounds(theGraphicBox, Camera());
 }
 
 //=================================================================================================

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -136,13 +136,13 @@ static bool shaderGridPlaneLocalHit(const occ::handle<Graphic3d_Camera>& theCame
     return false;
   }
 
-  const double aNearZ = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
-  const gp_Pnt aNearP = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, aNearZ));
-  const gp_Pnt aFarP  = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, 1.0));
+  const double aNearZ        = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
+  const gp_Pnt aNearP        = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, aNearZ));
+  const gp_Pnt aFarP         = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, 1.0));
   const bool   isPerspective = !theCamera->IsOrthographic();
   const gp_Pnt aRayOriginP   = isPerspective ? theCamera->Eye() : aNearP;
   const gp_XYZ aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
-  const double aDenom = thePlaneN.Dot(aRay);
+  const double aDenom        = thePlaneN.Dot(aRay);
   if (std::abs(aDenom) <= Precision::Angular())
   {
     return false;
@@ -233,7 +233,8 @@ static NCollection_Vec3<float> shaderGridViewDirection(const NCollection_Mat4<fl
   return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
 }
 
-//! Return a world-space point suitable for drawing a 3D echo marker at the snapped point projection.
+//! Return a world-space point suitable for drawing a 3D echo marker at the snapped point
+//! projection.
 static gp_Pnt shaderGridEchoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
                                          const gp_XYZ&                        theSnapped)
 {
@@ -241,7 +242,6 @@ static gp_Pnt shaderGridEchoDisplayPoint(const occ::handle<Graphic3d_Camera>& th
   const double aDisplayZ    = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
   return theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
 }
-
 
 static bool isShaderGridPointInBounds(const Aspect_GridParams& theParams,
                                       const double             theLocalX,
@@ -3961,15 +3961,15 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
     return false;
   }
 
-  const double aNdcX   = 2.0 * double(theX) / double(aWidth) - 1.0;
-  const double aNdcY   = 2.0 * double(aHeight - 1 - theY) / double(aHeight) - 1.0;
-  const double aNearZ  = aCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
-  const gp_Pnt aNearP  = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, aNearZ));
-  const gp_Pnt aFarP   = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, 1.0));
+  const double aNdcX         = 2.0 * double(theX) / double(aWidth) - 1.0;
+  const double aNdcY         = 2.0 * double(aHeight - 1 - theY) / double(aHeight) - 1.0;
+  const double aNearZ        = aCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
+  const gp_Pnt aNearP        = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, aNearZ));
+  const gp_Pnt aFarP         = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, 1.0));
   const bool   isPerspective = !aCamera->IsOrthographic();
   const gp_Pnt aRayOriginP   = isPerspective ? aCamera->Eye() : aNearP;
   gp_XYZ       aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
-  const double aRayMod = aRay.Modulus();
+  const double aRayMod       = aRay.Modulus();
   if (aRayMod <= Precision::Confusion())
   {
     return false;
@@ -4004,12 +4004,11 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
     return false;
   }
 
-  gp_XYZ aSnapped = aGridOrigin.XYZ();
+  gp_XYZ     aSnapped       = aGridOrigin.XYZ();
   const bool toSnapByScreen = myGridParams.DrawMode() == Aspect_GDM_Points;
   double     aBestDist2     = RealLast();
   bool       hasBestPoint   = false;
-  auto addCandidate = [&](const double theLocalX, const double theLocalY)
-  {
+  auto       addCandidate   = [&](const double theLocalX, const double theLocalY) {
     if (!isShaderGridPointInBounds(myGridParams, theLocalX, theLocalY))
     {
       return;
@@ -4019,12 +4018,12 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
     {
       return;
     }
-    const gp_Pnt aProj      = aCamera->Project(gp_Pnt(aCandidate));
-    const double aPx        = (aProj.X() + 1.0) * 0.5 * double(aWidth);
-    const double aPy        = double(aHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(aHeight);
-    const double aDistX     = aPx - double(theX);
-    const double aDistY     = aPy - double(theY);
-    const double aDist2     = aDistX * aDistX + aDistY * aDistY;
+    const gp_Pnt aProj  = aCamera->Project(gp_Pnt(aCandidate));
+    const double aPx    = (aProj.X() + 1.0) * 0.5 * double(aWidth);
+    const double aPy    = double(aHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(aHeight);
+    const double aDistX = aPx - double(theX);
+    const double aDistY = aPy - double(theY);
+    const double aDist2 = aDistX * aDistX + aDistY * aDistY;
     if (!hasBestPoint || aDist2 < aBestDist2)
     {
       hasBestPoint = true;
@@ -4065,8 +4064,8 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
       return true;
     }
 
-    const double aSnapRadius  = std::round(aRadius / aRadiusStep) * aRadiusStep;
-    const double aSnapAngle   = std::round(anAngle / anAngleStep) * anAngleStep;
+    const double aSnapRadius = std::round(aRadius / aRadiusStep) * aRadiusStep;
+    const double aSnapAngle  = std::round(anAngle / anAngleStep) * anAngleStep;
     aSnapped +=
       aGridX * (aSnapRadius * std::cos(aSnapAngle)) + aGridY * (aSnapRadius * std::sin(aSnapAngle));
     if (!isShaderGridPointInBounds(myGridParams,
@@ -4082,8 +4081,8 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
     const double aStepY = 1.0 / aScaleY;
     if (toSnapByScreen)
     {
-      const double anIndexX = std::floor(aLocalX / aStepX);
-      const double anIndexY = std::floor(aLocalY / aStepY);
+      const double anIndexX    = std::floor(aLocalX / aStepX);
+      const double anIndexY    = std::floor(aLocalY / aStepY);
       const double aLocalXs[2] = {anIndexX * aStepX, (anIndexX + 1.0) * aStepX};
       const double aLocalYs[2] = {anIndexY * aStepY, (anIndexY + 1.0) * aStepY};
       for (double aCandidateX : aLocalXs)
@@ -4103,8 +4102,8 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
       return true;
     }
 
-    aLocalX             = std::round(aLocalX / aStepX) * aStepX;
-    aLocalY             = std::round(aLocalY / aStepY) * aStepY;
+    aLocalX = std::round(aLocalX / aStepX) * aStepX;
+    aLocalY = std::round(aLocalY / aStepY) * aStepY;
     if (!isShaderGridPointInBounds(myGridParams, aLocalX, aLocalY))
     {
       return false;
@@ -4277,13 +4276,11 @@ void OpenGl_View::renderGrid()
     aProg->SetUniform(aContext, "uAngularScale", GLfloat(aAngularScale));
     aProg->SetUniform(aContext, "uDrawMode", myGridParams.DrawMode() == Aspect_GDM_Points ? 1 : 0);
     aProg->SetUniform(aContext, "uIsPerspective", aCamera->IsOrthographic() ? 0 : 1);
-    aProg->SetUniform(aContext,
-                      "uNdcNear",
-                      GLfloat(aCamera->IsZeroToOneDepth() ? 0.0f : -1.0f));
+    aProg->SetUniform(aContext, "uNdcNear", GLfloat(aCamera->IsZeroToOneDepth() ? 0.0f : -1.0f));
 
     NCollection_Vec2<float> aLocalOriginShift(0.0f, 0.0f);
     NCollection_Vec2<float> anAccentLocalOriginShift(0.0f, 0.0f);
-    float                   aRadialOriginShift = 0.0f;
+    float                   aRadialOriginShift        = 0.0f;
     float                   anAccentRadialOriginShift = 0.0f;
     double                  aLocalRefX = 0.0, aLocalRefY = 0.0;
     if (shaderGridReferenceLocal(aCamera,
@@ -4297,7 +4294,7 @@ void OpenGl_View::renderGrid()
       if (myGridParams.IsCircular())
       {
         const double aRadiusRef = std::sqrt(aLocalRefX * aLocalRefX + aLocalRefY * aLocalRefY);
-        aRadialOriginShift = float(shaderGridSnappedLocalShift(aRadiusRef, aScaleX));
+        aRadialOriginShift      = float(shaderGridSnappedLocalShift(aRadiusRef, aScaleX));
         anAccentRadialOriginShift =
           myGridParams.AccentScaleX() > Precision::Confusion()
             ? float(shaderGridSnappedLocalShift(aRadiusRef, myGridParams.AccentScaleX()))
@@ -4320,7 +4317,9 @@ void OpenGl_View::renderGrid()
     const gp_Pnt aPlaneRef(aPlaneOrigin.XYZ() + aXRotated * double(aLocalOriginShift.x())
                            + aYRotated * double(aLocalOriginShift.y()));
     const NCollection_Mat4<float>& aGridWorldView = aContext->WorldViewState.Current();
-    aProg->SetUniform(aContext, "uPlaneOriginView", shaderGridViewPoint(aGridWorldView, aPlaneOrigin));
+    aProg->SetUniform(aContext,
+                      "uPlaneOriginView",
+                      shaderGridViewPoint(aGridWorldView, aPlaneOrigin));
     aProg->SetUniform(aContext, "uPlaneRefView", shaderGridViewPoint(aGridWorldView, aPlaneRef));
     aProg->SetUniform(aContext, "uPlaneXView", shaderGridViewDirection(aGridWorldView, aXRotated));
     aProg->SetUniform(aContext, "uPlaneYView", shaderGridViewDirection(aGridWorldView, aYRotated));

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -294,97 +294,6 @@ static bool isShaderGridPointInBounds(const Aspect_GridParams& theParams,
          && (theParams.SizeY() <= 0.0 || std::abs(theLocalY) <= theParams.SizeY() * 0.5);
 }
 
-//! Add visible view-ray hits on the shader grid plane to the Z-fit box.
-static void addShaderGridViewRayBounds(Bnd_Box&                             theBox,
-                                       const occ::handle<Graphic3d_Camera>& theCamera,
-                                       const gp_Pnt&                        thePlaneOrigin,
-                                       const gp_XYZ&                        thePlaneNormal)
-{
-  if (theCamera.IsNull())
-  {
-    return;
-  }
-
-  const double aNearZ        = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
-  const gp_Pnt aNdcSamples[] = {gp_Pnt(-1.0, -1.0, 0.0),
-                                gp_Pnt(1.0, -1.0, 0.0),
-                                gp_Pnt(-1.0, 1.0, 0.0),
-                                gp_Pnt(1.0, 1.0, 0.0),
-                                gp_Pnt(0.0, 0.0, 0.0)};
-  for (const gp_Pnt& aNdcSample : aNdcSamples)
-  {
-    const gp_Pnt aNearP = theCamera->UnProject(gp_Pnt(aNdcSample.X(), aNdcSample.Y(), aNearZ));
-    const gp_Pnt aFarP  = theCamera->UnProject(gp_Pnt(aNdcSample.X(), aNdcSample.Y(), 1.0));
-    const gp_XYZ aRay   = aFarP.XYZ() - aNearP.XYZ();
-    const double aDenom = thePlaneNormal.Dot(aRay);
-    if (std::abs(aDenom) <= Precision::Angular())
-    {
-      continue;
-    }
-
-    const double aT = thePlaneNormal.Dot(thePlaneOrigin.XYZ() - aNearP.XYZ()) / aDenom;
-    if (aT < 0.0)
-    {
-      continue;
-    }
-    theBox.Add(gp_Pnt(aNearP.XYZ() + aRay * aT));
-  }
-}
-
-//! Add a finite patch of the shader grid plane to the Z-fit box.
-//! The shader grid is rendered by ray/plane intersection, not by a structure with
-//! own bounds, so empty scenes still need an explicit depth range covering the
-//! plane patch that can become visible.
-static void addShaderGridZFitBounds(Bnd_Box&                             theBox,
-                                    const Aspect_GridParams&             theParams,
-                                    const gp_Pnt&                        thePlaneOrigin,
-                                    const gp_XYZ&                        theGridX,
-                                    const gp_XYZ&                        theGridY,
-                                    const gp_XYZ&                        theGridN,
-                                    const occ::handle<Graphic3d_Camera>& theCamera,
-                                    const double                         theViewHeight)
-{
-  if (theParams.IsViewAdaptive())
-  {
-    addShaderGridViewRayBounds(theBox, theCamera, thePlaneOrigin, theGridN);
-  }
-
-  double aHalfX  = theParams.SizeX() > 0.0 ? theParams.SizeX() * 0.5 : 0.0;
-  double aHalfY  = theParams.SizeY() > 0.0 ? theParams.SizeY() * 0.5 : 0.0;
-  double aRadius = theParams.Radius();
-  if (aHalfX <= 0.0 && aHalfY <= 0.0 && aRadius <= 0.0)
-  {
-    aHalfX  = theViewHeight;
-    aHalfY  = theViewHeight;
-    aRadius = theParams.IsCircular() ? theViewHeight : 0.0;
-  }
-
-  if (theParams.IsCircular())
-  {
-    const double anExtent = aRadius > 0.0 ? aRadius : std::max(aHalfX, aHalfY);
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridX * anExtent));
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridX * anExtent));
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridY * anExtent));
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridY * anExtent));
-  }
-  else
-  {
-    if (aHalfX <= 0.0)
-    {
-      aHalfX = theViewHeight;
-    }
-    if (aHalfY <= 0.0)
-    {
-      aHalfY = theViewHeight;
-    }
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridX * aHalfX + theGridY * aHalfY));
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridX * aHalfX - theGridY * aHalfY));
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridX * aHalfX + theGridY * aHalfY));
-    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridX * aHalfX - theGridY * aHalfY));
-  }
-  theBox.Add(thePlaneOrigin);
-}
-
 //! Chooses compatible internal color format for OIT frame buffer.
 static bool chooseOitColorConfiguration(const occ::handle<OpenGl_Context>& theGlContext,
                                         const int                          theConfigIndex,
@@ -4194,17 +4103,11 @@ void OpenGl_View::renderGrid()
   gp_XYZ aXRotated, aYRotated, aNDir;
   shaderGridFrame(myGridParams, myGridPlane, aPlaneOrigin, aXRotated, aYRotated, aNDir);
 
-  if (myGridParams.IsBackground())
+  Bnd_Box      aBnd      = MinMaxValues(true);
+  const gp_Pnt aPlaneLoc = myGridPlane.Location();
+  if (myGridParams.IsBackground() || aBnd.IsVoid() || aBnd.IsOut(aPlaneLoc))
   {
-    Bnd_Box aBnd = MinMaxValues(true);
-    addShaderGridZFitBounds(aBnd,
-                            myGridParams,
-                            aPlaneOrigin,
-                            aXRotated,
-                            aYRotated,
-                            aNDir,
-                            aCamera,
-                            aCamera->Scale());
+    aBnd.Add(aPlaneLoc);
     aCamera->ZFitAll(1.0, aBnd, aBnd);
   }
   if (myGridParams.IsBackground())

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -43,6 +43,7 @@
 #include <OpenGl_Window.hxx>
 #include <OpenGl_Workspace.hxx>
 #include <OSD_Parallel.hxx>
+#include <Precision.hxx>
 #include <Standard_CLocaleSentry.hxx>
 
 #include "../Textures/Textures_EnvLUT.pxx"
@@ -77,64 +78,311 @@ static bool checkWasFailedFbo(const occ::handle<OpenGl_FrameBuffer>& theFboToChe
                            theFboRef->NbSamples());
 }
 
-//! Unproject window-space (theWinX, theWinY) to a near/far ray, intersect the
-//! grid plane, express the hit in plane-local (X, Y). Returns FALSE if the
-//! unprojection fails or the ray is near-parallel to the plane.
-static bool unprojectGridPointToPlaneLocal(const occ::handle<OpenGl_Context>& theCtx,
-                                           const int*                         theViewport,
-                                           const float                        theWinX,
-                                           const float                        theWinY,
-                                           const NCollection_Vec3<float>&     thePlaneN,
-                                           const NCollection_Vec3<float>&     thePlaneOriginV,
-                                           const NCollection_Vec3<float>&     thePlaneX,
-                                           const NCollection_Vec3<float>&     thePlaneY,
-                                           double&                            theOutLocalX,
-                                           double&                            theOutLocalY)
+//! Return grid plane frame used by the shader path.
+static void shaderGridFrame(const Aspect_GridParams& theParams,
+                            const gp_Ax3&            thePlane,
+                            gp_Pnt&                  theOrigin,
+                            gp_XYZ&                  theX,
+                            gp_XYZ&                  theY,
+                            gp_XYZ&                  theN)
 {
-  if (theViewport == nullptr)
+  const double aCosA = std::cos(theParams.RotationAngle());
+  const double aSinA = std::sin(theParams.RotationAngle());
+  const gp_XYZ aRawX = thePlane.XDirection().XYZ();
+  const gp_XYZ aRawY = thePlane.YDirection().XYZ();
+  theX               = aRawX * aCosA - aRawY * aSinA;
+  theY               = aRawX * aSinA + aRawY * aCosA;
+  theN               = thePlane.Direction().XYZ();
+
+  const gp_Pnt& anOriginLocal = theParams.Origin();
+  const gp_Pnt& aPlaneLoc     = thePlane.Location();
+  theOrigin.SetXYZ(aPlaneLoc.XYZ() + aRawX * anOriginLocal.X() + aRawY * anOriginLocal.Y()
+                   + theN * (anOriginLocal.Z() + theParams.ZOffset()));
+}
+
+//! Return shader grid scales for current camera.
+static void shaderGridEffectiveScale(const Aspect_GridParams& theParams,
+                                     const double             theCurrentCameraScale,
+                                     double&                  theScaleX,
+                                     double&                  theScaleY)
+{
+  theScaleX = theParams.Scale();
+  theScaleY = theParams.EffectiveScaleY();
+  if (!theParams.IsViewAdaptive())
+  {
+    return;
+  }
+
+  const double aCurrentScale =
+    theCurrentCameraScale > Precision::Confusion() ? theCurrentCameraScale : Precision::Confusion();
+  theScaleX /= aCurrentScale;
+  theScaleY /= aCurrentScale;
+}
+
+//! Intersect camera ray at NDC point with the shader grid plane and return plane-local coordinates.
+static bool shaderGridPlaneLocalHit(const occ::handle<Graphic3d_Camera>& theCamera,
+                                    const double                         theNdcX,
+                                    const double                         theNdcY,
+                                    const gp_Pnt&                        thePlaneOrigin,
+                                    const gp_XYZ&                        thePlaneX,
+                                    const gp_XYZ&                        thePlaneY,
+                                    const gp_XYZ&                        thePlaneN,
+                                    double&                              theLocalX,
+                                    double&                              theLocalY,
+                                    const bool                           theToRejectBehind = true)
+{
+  if (theCamera.IsNull())
   {
     return false;
   }
-  float aNearX = 0.0f, aNearY = 0.0f, aNearZ = 0.0f;
-  float aFarX = 0.0f, aFarY = 0.0f, aFarZ = 0.0f;
-  if (!Graphic3d_TransformUtils::UnProject<float>(theWinX,
-                                                  theWinY,
-                                                  0.0f,
-                                                  theCtx->WorldViewState.Current(),
-                                                  theCtx->ProjectionState.Current(),
-                                                  theViewport,
-                                                  aNearX,
-                                                  aNearY,
-                                                  aNearZ))
+
+  const double aNearZ = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
+  const gp_Pnt aNearP = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, aNearZ));
+  const gp_Pnt aFarP  = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, 1.0));
+  const bool   isPerspective = !theCamera->IsOrthographic();
+  const gp_Pnt aRayOriginP   = isPerspective ? theCamera->Eye() : aNearP;
+  const gp_XYZ aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
+  const double aDenom = thePlaneN.Dot(aRay);
+  if (std::abs(aDenom) <= Precision::Angular())
   {
     return false;
   }
-  if (!Graphic3d_TransformUtils::UnProject<float>(theWinX,
-                                                  theWinY,
-                                                  1.0f,
-                                                  theCtx->WorldViewState.Current(),
-                                                  theCtx->ProjectionState.Current(),
-                                                  theViewport,
-                                                  aFarX,
-                                                  aFarY,
-                                                  aFarZ))
+
+  const double aT = thePlaneN.Dot(thePlaneOrigin.XYZ() - aRayOriginP.XYZ()) / aDenom;
+  if (theToRejectBehind && isPerspective && aT < 0.0)
   {
     return false;
   }
-  const NCollection_Vec3<float> aNearP(aNearX, aNearY, aNearZ);
-  const NCollection_Vec3<float> aFarP(aFarX, aFarY, aFarZ);
-  const NCollection_Vec3<float> aDir   = aFarP - aNearP;
-  const float                   aDenom = thePlaneN.Dot(aDir);
-  if (std::abs(aDenom) <= 1.0e-6f)
-  {
-    return false;
-  }
-  const float                   aT      = thePlaneN.Dot(thePlaneOriginV - aNearP) / aDenom;
-  const NCollection_Vec3<float> aHit    = aNearP + aDir * aT;
-  const NCollection_Vec3<float> aLocal3 = aHit - thePlaneOriginV;
-  theOutLocalX                          = double(aLocal3.Dot(thePlaneX));
-  theOutLocalY                          = double(aLocal3.Dot(thePlaneY));
+
+  const gp_XYZ aHit    = aRayOriginP.XYZ() + aRay * aT;
+  const gp_XYZ aLocal3 = aHit - thePlaneOrigin.XYZ();
+  theLocalX            = aLocal3.Dot(thePlaneX);
+  theLocalY            = aLocal3.Dot(thePlaneY);
   return true;
+}
+
+//! Snap local shift to grid-cell multiples so subtracting it preserves grid phase.
+static double shaderGridSnappedLocalShift(const double theLocal, const double theScale)
+{
+  if (theScale <= Precision::Confusion())
+  {
+    return 0.0;
+  }
+
+  const double aStep = 1.0 / theScale;
+  return std::round(theLocal / aStep) * aStep;
+}
+
+//! Pick a visible viewport sample on the shader-grid plane for stable phase rebasing.
+static bool shaderGridReferenceLocal(const occ::handle<Graphic3d_Camera>& theCamera,
+                                     const gp_Pnt&                        thePlaneOrigin,
+                                     const gp_XYZ&                        thePlaneX,
+                                     const gp_XYZ&                        thePlaneY,
+                                     const gp_XYZ&                        thePlaneN,
+                                     double&                              theLocalX,
+                                     double&                              theLocalY)
+{
+  const double aSamples[][2] = {{0.0, 0.0},
+                                {-1.0, -1.0},
+                                {1.0, -1.0},
+                                {1.0, 1.0},
+                                {-1.0, 1.0},
+                                {0.0, -1.0},
+                                {1.0, 0.0},
+                                {0.0, 1.0},
+                                {-1.0, 0.0}};
+  for (const double* aSample : aSamples)
+  {
+    if (shaderGridPlaneLocalHit(theCamera,
+                                aSample[0],
+                                aSample[1],
+                                thePlaneOrigin,
+                                thePlaneX,
+                                thePlaneY,
+                                thePlaneN,
+                                theLocalX,
+                                theLocalY))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+//! Transform world-space point by the active world-view matrix.
+static NCollection_Vec3<float> shaderGridViewPoint(const NCollection_Mat4<float>& theWorldView,
+                                                   const gp_Pnt&                  thePoint)
+{
+  const NCollection_Vec4<float> aPoint(float(thePoint.X()),
+                                       float(thePoint.Y()),
+                                       float(thePoint.Z()),
+                                       1.0f);
+  const NCollection_Vec4<float> aView = theWorldView * aPoint;
+  return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
+}
+
+//! Transform world-space direction by the active world-view matrix.
+static NCollection_Vec3<float> shaderGridViewDirection(const NCollection_Mat4<float>& theWorldView,
+                                                       const gp_XYZ&                  theDirection)
+{
+  const NCollection_Vec4<float> aDir(float(theDirection.X()),
+                                     float(theDirection.Y()),
+                                     float(theDirection.Z()),
+                                     0.0f);
+  const NCollection_Vec4<float> aView = theWorldView * aDir;
+  return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
+}
+
+//! Return a world-space point suitable for drawing a 3D echo marker at the snapped point projection.
+static gp_Pnt shaderGridEchoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
+                                         const gp_XYZ&                        theSnapped)
+{
+  const gp_Pnt aProjSnapped = theCamera->Project(gp_Pnt(theSnapped));
+  const double aDisplayZ    = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
+  return theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
+}
+
+
+static bool isShaderGridPointInBounds(const Aspect_GridParams& theParams,
+                                      const double             theLocalX,
+                                      const double             theLocalY)
+{
+  if (theParams.IsCircular())
+  {
+    const double aRadius = std::sqrt(theLocalX * theLocalX + theLocalY * theLocalY);
+    if (theParams.Radius() > 0.0 && aRadius > theParams.Radius())
+    {
+      return false;
+    }
+    if (theParams.IsArc())
+    {
+      const double aTwoPi = 2.0 * M_PI;
+      double       aStart = std::fmod(theParams.AngleStart(), aTwoPi);
+      double       anEnd  = std::fmod(theParams.AngleEnd(), aTwoPi);
+      double       anAng  = std::fmod(std::atan2(theLocalY, theLocalX), aTwoPi);
+      if (aStart < 0.0)
+      {
+        aStart += aTwoPi;
+      }
+      if (anEnd < 0.0)
+      {
+        anEnd += aTwoPi;
+      }
+      if (anAng < 0.0)
+      {
+        anAng += aTwoPi;
+      }
+      double aSpan = anEnd - aStart;
+      if (aSpan < 0.0)
+      {
+        aSpan += aTwoPi;
+      }
+      double aDelta = anAng - aStart;
+      if (aDelta < 0.0)
+      {
+        aDelta += aTwoPi;
+      }
+      if (aDelta > aSpan)
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  return (theParams.SizeX() <= 0.0 || std::abs(theLocalX) <= theParams.SizeX() * 0.5)
+         && (theParams.SizeY() <= 0.0 || std::abs(theLocalY) <= theParams.SizeY() * 0.5);
+}
+
+//! Add visible view-ray hits on the shader grid plane to the Z-fit box.
+static void addShaderGridViewRayBounds(Bnd_Box&                             theBox,
+                                       const occ::handle<Graphic3d_Camera>& theCamera,
+                                       const gp_Pnt&                        thePlaneOrigin,
+                                       const gp_XYZ&                        thePlaneNormal)
+{
+  if (theCamera.IsNull())
+  {
+    return;
+  }
+
+  const double aNearZ        = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
+  const gp_Pnt aNdcSamples[] = {gp_Pnt(-1.0, -1.0, 0.0),
+                                gp_Pnt(1.0, -1.0, 0.0),
+                                gp_Pnt(-1.0, 1.0, 0.0),
+                                gp_Pnt(1.0, 1.0, 0.0),
+                                gp_Pnt(0.0, 0.0, 0.0)};
+  for (const gp_Pnt& aNdcSample : aNdcSamples)
+  {
+    const gp_Pnt aNearP = theCamera->UnProject(gp_Pnt(aNdcSample.X(), aNdcSample.Y(), aNearZ));
+    const gp_Pnt aFarP  = theCamera->UnProject(gp_Pnt(aNdcSample.X(), aNdcSample.Y(), 1.0));
+    const gp_XYZ aRay   = aFarP.XYZ() - aNearP.XYZ();
+    const double aDenom = thePlaneNormal.Dot(aRay);
+    if (std::abs(aDenom) <= Precision::Angular())
+    {
+      continue;
+    }
+
+    const double aT = thePlaneNormal.Dot(thePlaneOrigin.XYZ() - aNearP.XYZ()) / aDenom;
+    if (aT < 0.0)
+    {
+      continue;
+    }
+    theBox.Add(gp_Pnt(aNearP.XYZ() + aRay * aT));
+  }
+}
+
+//! Add a finite patch of the shader grid plane to the Z-fit box.
+//! The shader grid is rendered by ray/plane intersection, not by a structure with
+//! own bounds, so empty scenes still need an explicit depth range covering the
+//! plane patch that can become visible.
+static void addShaderGridZFitBounds(Bnd_Box&                             theBox,
+                                    const Aspect_GridParams&             theParams,
+                                    const gp_Pnt&                        thePlaneOrigin,
+                                    const gp_XYZ&                        theGridX,
+                                    const gp_XYZ&                        theGridY,
+                                    const gp_XYZ&                        theGridN,
+                                    const occ::handle<Graphic3d_Camera>& theCamera,
+                                    const double                         theViewHeight)
+{
+  if (theParams.IsViewAdaptive())
+  {
+    addShaderGridViewRayBounds(theBox, theCamera, thePlaneOrigin, theGridN);
+  }
+
+  double aHalfX  = theParams.SizeX() > 0.0 ? theParams.SizeX() * 0.5 : 0.0;
+  double aHalfY  = theParams.SizeY() > 0.0 ? theParams.SizeY() * 0.5 : 0.0;
+  double aRadius = theParams.Radius();
+  if (aHalfX <= 0.0 && aHalfY <= 0.0 && aRadius <= 0.0)
+  {
+    aHalfX  = theViewHeight;
+    aHalfY  = theViewHeight;
+    aRadius = theParams.IsCircular() ? theViewHeight : 0.0;
+  }
+
+  if (theParams.IsCircular())
+  {
+    const double anExtent = aRadius > 0.0 ? aRadius : std::max(aHalfX, aHalfY);
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridX * anExtent));
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridX * anExtent));
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridY * anExtent));
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridY * anExtent));
+  }
+  else
+  {
+    if (aHalfX <= 0.0)
+    {
+      aHalfX = theViewHeight;
+    }
+    if (aHalfY <= 0.0)
+    {
+      aHalfY = theViewHeight;
+    }
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridX * aHalfX + theGridY * aHalfY));
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() + theGridX * aHalfX - theGridY * aHalfY));
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridX * aHalfX + theGridY * aHalfY));
+    theBox.Add(gp_Pnt(thePlaneOrigin.XYZ() - theGridX * aHalfX - theGridY * aHalfY));
+  }
+  theBox.Add(thePlaneOrigin);
 }
 
 //! Chooses compatible internal color format for OIT frame buffer.
@@ -3646,6 +3894,17 @@ void OpenGl_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& 
   myGridParams = theParams;
   myGridPlane  = thePlane;
   myToShowGrid = true;
+  if (theParams.IsViewAdaptive())
+  {
+    const occ::handle<Graphic3d_Camera>& aCamera = Camera();
+    const double                         aReferenceScale =
+      !aCamera.IsNull() && aCamera->Scale() > Precision::Confusion() ? aCamera->Scale() : 1.0;
+    myGridParams.SetScale(theParams.Scale() * aReferenceScale);
+    if (theParams.ScaleY() > 0.0)
+    {
+      myGridParams.SetScaleY(theParams.ScaleY() * aReferenceScale);
+    }
+  }
 
   if (toCapture)
   {
@@ -3666,6 +3925,201 @@ void OpenGl_View::GridErase()
 
 //=================================================================================================
 
+bool OpenGl_View::ShaderGridEcho(const int theX, const int theY, Graphic3d_Vertex& thePoint) const
+{
+  Graphic3d_Vertex aDisplayPoint;
+  return ShaderGridEcho(theX, theY, thePoint, aDisplayPoint);
+}
+
+//=================================================================================================
+
+bool OpenGl_View::ShaderGridEcho(const int         theX,
+                                 const int         theY,
+                                 Graphic3d_Vertex& thePoint,
+                                 Graphic3d_Vertex& theDisplayPoint) const
+{
+  if (!myToShowGrid || myGridParams.DrawMode() == Aspect_GDM_None || myGridParams.IsBackground()
+      || Window().IsNull())
+  {
+    return false;
+  }
+
+  const occ::handle<Graphic3d_Camera>& aCamera = Camera();
+  if (aCamera.IsNull())
+  {
+    return false;
+  }
+
+  gp_Pnt aGridOrigin;
+  gp_XYZ aGridX, aGridY, aGridN;
+  shaderGridFrame(myGridParams, myGridPlane, aGridOrigin, aGridX, aGridY, aGridN);
+
+  int aWidth = 0, aHeight = 0;
+  Window()->Size(aWidth, aHeight);
+  if (aWidth <= 0 || aHeight <= 0)
+  {
+    return false;
+  }
+
+  const double aNdcX   = 2.0 * double(theX) / double(aWidth) - 1.0;
+  const double aNdcY   = 2.0 * double(aHeight - 1 - theY) / double(aHeight) - 1.0;
+  const double aNearZ  = aCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
+  const gp_Pnt aNearP  = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, aNearZ));
+  const gp_Pnt aFarP   = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, 1.0));
+  const bool   isPerspective = !aCamera->IsOrthographic();
+  const gp_Pnt aRayOriginP   = isPerspective ? aCamera->Eye() : aNearP;
+  gp_XYZ       aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
+  const double aRayMod = aRay.Modulus();
+  if (aRayMod <= Precision::Confusion())
+  {
+    return false;
+  }
+  aRay /= aRayMod;
+
+  const double aDenom = aGridN.Dot(aRay);
+  if (std::abs(aDenom) <= Precision::Angular())
+  {
+    return false;
+  }
+
+  const double aT = aGridN.Dot(aGridOrigin.XYZ() - aRayOriginP.XYZ()) / aDenom;
+  if (isPerspective && aT < 0.0)
+  {
+    return false;
+  }
+
+  const gp_XYZ aHit    = aRayOriginP.XYZ() + aRay * aT;
+  const gp_XYZ aLocal3 = aHit - aGridOrigin.XYZ();
+  double       aLocalX = aLocal3.Dot(aGridX);
+  double       aLocalY = aLocal3.Dot(aGridY);
+  if (!isShaderGridPointInBounds(myGridParams, aLocalX, aLocalY))
+  {
+    return false;
+  }
+
+  double aScaleX = 0.0, aScaleY = 0.0;
+  shaderGridEffectiveScale(myGridParams, aCamera->Scale(), aScaleX, aScaleY);
+  if (aScaleX <= 0.0 || aScaleY <= 0.0)
+  {
+    return false;
+  }
+
+  gp_XYZ aSnapped = aGridOrigin.XYZ();
+  const bool toSnapByScreen = myGridParams.DrawMode() == Aspect_GDM_Points;
+  double     aBestDist2     = RealLast();
+  bool       hasBestPoint   = false;
+  auto addCandidate = [&](const double theLocalX, const double theLocalY)
+  {
+    if (!isShaderGridPointInBounds(myGridParams, theLocalX, theLocalY))
+    {
+      return;
+    }
+    const gp_XYZ aCandidate = aGridOrigin.XYZ() + aGridX * theLocalX + aGridY * theLocalY;
+    if (isPerspective && aCamera->Direction().XYZ().Dot(aCandidate - aCamera->Eye().XYZ()) <= 0.0)
+    {
+      return;
+    }
+    const gp_Pnt aProj      = aCamera->Project(gp_Pnt(aCandidate));
+    const double aPx        = (aProj.X() + 1.0) * 0.5 * double(aWidth);
+    const double aPy        = double(aHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(aHeight);
+    const double aDistX     = aPx - double(theX);
+    const double aDistY     = aPy - double(theY);
+    const double aDist2     = aDistX * aDistX + aDistY * aDistY;
+    if (!hasBestPoint || aDist2 < aBestDist2)
+    {
+      hasBestPoint = true;
+      aBestDist2   = aDist2;
+      aSnapped     = aCandidate;
+    }
+  };
+
+  if (myGridParams.IsCircular())
+  {
+    const double aRadius      = std::sqrt(aLocalX * aLocalX + aLocalY * aLocalY);
+    const double anAngle      = std::atan2(aLocalY, aLocalX);
+    const double aRadiusStep  = 1.0 / aScaleX;
+    const int    aNbDivisions = myGridParams.AngularDivisions();
+    const double anAngleStep  = aNbDivisions > 0 ? M_PI / double(aNbDivisions) : M_PI;
+    if (toSnapByScreen)
+    {
+      const double aRadiusIndex = std::floor(aRadius / aRadiusStep);
+      const double anAngleIndex = std::floor(anAngle / anAngleStep);
+      const double aRadii[2]    = {std::max(0.0, aRadiusIndex * aRadiusStep),
+                                   std::max(0.0, (aRadiusIndex + 1.0) * aRadiusStep)};
+      const double anAngles[2]  = {anAngleIndex * anAngleStep, (anAngleIndex + 1.0) * anAngleStep};
+      for (double aCandidateRadius : aRadii)
+      {
+        for (double aCandidateAngle : anAngles)
+        {
+          addCandidate(aCandidateRadius * std::cos(aCandidateAngle),
+                       aCandidateRadius * std::sin(aCandidateAngle));
+        }
+      }
+      if (!hasBestPoint)
+      {
+        return false;
+      }
+      thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
+      const gp_Pnt aDisplayP = shaderGridEchoDisplayPoint(aCamera, aSnapped);
+      theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
+      return true;
+    }
+
+    const double aSnapRadius  = std::round(aRadius / aRadiusStep) * aRadiusStep;
+    const double aSnapAngle   = std::round(anAngle / anAngleStep) * anAngleStep;
+    aSnapped +=
+      aGridX * (aSnapRadius * std::cos(aSnapAngle)) + aGridY * (aSnapRadius * std::sin(aSnapAngle));
+    if (!isShaderGridPointInBounds(myGridParams,
+                                   aSnapRadius * std::cos(aSnapAngle),
+                                   aSnapRadius * std::sin(aSnapAngle)))
+    {
+      return false;
+    }
+  }
+  else
+  {
+    const double aStepX = 1.0 / aScaleX;
+    const double aStepY = 1.0 / aScaleY;
+    if (toSnapByScreen)
+    {
+      const double anIndexX = std::floor(aLocalX / aStepX);
+      const double anIndexY = std::floor(aLocalY / aStepY);
+      const double aLocalXs[2] = {anIndexX * aStepX, (anIndexX + 1.0) * aStepX};
+      const double aLocalYs[2] = {anIndexY * aStepY, (anIndexY + 1.0) * aStepY};
+      for (double aCandidateX : aLocalXs)
+      {
+        for (double aCandidateY : aLocalYs)
+        {
+          addCandidate(aCandidateX, aCandidateY);
+        }
+      }
+      if (!hasBestPoint)
+      {
+        return false;
+      }
+      thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
+      const gp_Pnt aDisplayP = shaderGridEchoDisplayPoint(aCamera, aSnapped);
+      theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
+      return true;
+    }
+
+    aLocalX             = std::round(aLocalX / aStepX) * aStepX;
+    aLocalY             = std::round(aLocalY / aStepY) * aStepY;
+    if (!isShaderGridPointInBounds(myGridParams, aLocalX, aLocalY))
+    {
+      return false;
+    }
+    aSnapped += aGridX * aLocalX + aGridY * aLocalY;
+  }
+
+  thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
+  const gp_Pnt aDisplayP = shaderGridEchoDisplayPoint(aCamera, aSnapped);
+  theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
+  return true;
+}
+
+//=================================================================================================
+
 void OpenGl_View::renderGrid()
 {
   if (!myToShowGrid || myGridParams.DrawMode() == Aspect_GDM_None)
@@ -3680,7 +4134,7 @@ void OpenGl_View::renderGrid()
   }
   if (aContext->core30 == nullptr)
   {
-    // The shader grid requires GL 3.0+ / GLES 3.0+ (VAO + gl_VertexID + gl_FragDepth).
+    // The shader grid requires GL 3.0+ / GLES 3.0+ (VAO + gl_VertexID).
     // Warn once per process so the caller knows why the grid isn't drawn; snap
     // math still works. The process scope avoids per-view state bloat - a stray
     // missed warning on a second view is less costly than a data member.
@@ -3731,26 +4185,27 @@ void OpenGl_View::renderGrid()
   aContext->core11fwd->glGetIntegerv(GL_BLEND_DST_RGB, &aPrevBlendDstRgb);
   aContext->core11fwd->glGetIntegerv(GL_BLEND_SRC_ALPHA, &aPrevBlendSrcA);
   aContext->core11fwd->glGetIntegerv(GL_BLEND_DST_ALPHA, &aPrevBlendDstA);
-  const bool hasDepthClamp = aContext->arbDepthClamp;
-  const bool wasDepthClamp =
-    hasDepthClamp && aContext->core11fwd->glIsEnabled(GL_DEPTH_CLAMP) == GL_TRUE;
   const occ::handle<OpenGl_ShaderProgram> aPrevProgram = aContext->ActiveProgram();
 
-  // Capture the user-set camera ZRange BEFORE any grid-specific adjustment.
-  // ZFitAll below mutates the camera; the restore block at the end of this
-  // method targets these original values, otherwise vconvert and other APIs
-  // observing ZRange between frames see values inflated by the grid bounds.
   const double                       aZNearKeep = aCamera->ZNear();
   const double                       aZFarKeep  = aCamera->ZFar();
   const Graphic3d_Camera::Projection aProjKeep  = aCamera->ProjectionType();
 
-  Bnd_Box      aBnd      = MinMaxValues(true);
-  const gp_Pnt aPlaneLoc = myGridPlane.Location();
-  if (myGridParams.IsBackground() || aBnd.IsVoid() || aBnd.IsOut(aPlaneLoc))
+  gp_Pnt aPlaneOrigin;
+  gp_XYZ aXRotated, aYRotated, aNDir;
+  shaderGridFrame(myGridParams, myGridPlane, aPlaneOrigin, aXRotated, aYRotated, aNDir);
+
+  if (myGridParams.IsBackground())
   {
-    aBnd.Add(aPlaneLoc);
-    // ZFitAll asserts ZFar > ZNear on return (Graphic3d_Camera.cxx:1636),
-    // so no post-hoc SetZRange nudge is needed.
+    Bnd_Box aBnd = MinMaxValues(true);
+    addShaderGridZFitBounds(aBnd,
+                            myGridParams,
+                            aPlaneOrigin,
+                            aXRotated,
+                            aYRotated,
+                            aNDir,
+                            aCamera,
+                            aCamera->Scale());
     aCamera->ZFitAll(1.0, aBnd, aBnd);
   }
   if (myGridParams.IsBackground())
@@ -3780,9 +4235,8 @@ void OpenGl_View::renderGrid()
   }
   aContext->ApplyWorldViewMatrix();
 
-  aContext->core11fwd->glEnable(GL_DEPTH_TEST);
-  aContext->core11fwd->glDepthFunc(GL_LESS);
-  aContext->core11fwd->glDepthMask(GL_TRUE);
+  aContext->core11fwd->glDisable(GL_DEPTH_TEST);
+  aContext->core11fwd->glDepthMask(GL_FALSE);
   aContext->core11fwd->glEnable(GL_BLEND);
   aContext->core11fwd->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
   // The clip-space full-screen quad winds CW; if back-face culling is on
@@ -3790,24 +4244,10 @@ void OpenGl_View::renderGrid()
   // is culled and the grid silently vanishes. Disable culling for the draw
   // call and restore at the end.
   aContext->core11fwd->glDisable(GL_CULL_FACE);
-  if (hasDepthClamp && !wasDepthClamp)
-  {
-    aContext->core11fwd->glEnable(GL_DEPTH_CLAMP);
-  }
-
   aContext->core30->glBindVertexArray(myGridVao);
 
-  double aScaleX = myGridParams.Scale();
-  double aScaleY = myGridParams.EffectiveScaleY();
-  if (myGridParams.IsViewAdaptive())
-  {
-    const double aTargetCellsY =
-      std::max(1.0, std::min(200.0, aScaleY > 0.0 ? 1.0 / aScaleY : 10.0));
-    const double aViewHeight = std::max(aCamera->Scale(), 1.0e-9);
-    const double aCellSize   = aViewHeight / aTargetCellsY;
-    aScaleX                  = 1.0 / aCellSize;
-    aScaleY                  = aScaleX;
-  }
+  double aScaleX = 0.0, aScaleY = 0.0;
+  shaderGridEffectiveScale(myGridParams, aCamera->Scale(), aScaleX, aScaleY);
 
   if (aContext->ShaderManager()->BindGridProgram())
   {
@@ -3830,184 +4270,84 @@ void OpenGl_View::renderGrid()
     aProg->SetUniform(aContext, "uAccentScaleY", GLfloat(myGridParams.AccentScaleY()));
     aProg->SetUniform(aContext, "uAccentAngularScale", GLfloat(myGridParams.AccentAngularScale()));
     aProg->SetUniform(aContext, "uIsDrawAxis", myGridParams.IsDrawAxis() ? 1 : 0);
-    aProg->SetUniform(aContext, "uIsBackground", myGridParams.IsBackground() ? 1 : 0);
     aProg->SetUniform(aContext, "uGridType", myGridParams.IsCircular() ? 1 : 0);
     // Angular spokes per radian: N spokes in 180 deg = N / pi spokes per radian.
     const double aAngularScale =
       myGridParams.IsCircular() ? double(myGridParams.AngularDivisions()) / M_PI : 0.0;
     aProg->SetUniform(aContext, "uAngularScale", GLfloat(aAngularScale));
     aProg->SetUniform(aContext, "uDrawMode", myGridParams.DrawMode() == Aspect_GDM_Points ? 1 : 0);
+    aProg->SetUniform(aContext, "uIsPerspective", aCamera->IsOrthographic() ? 0 : 1);
+    aProg->SetUniform(aContext,
+                      "uNdcNear",
+                      GLfloat(aCamera->IsZeroToOneDepth() ? 0.0f : -1.0f));
 
-    // Plane basis used for both the view-adaptive bounds search and the final
-    // shader uniforms.
-    //  - In-plane rotation rotates X/Y around the plane normal. Sign matches
-    //    V3d_View::SetGrid's Trsf2 so snap (V3d_View::Compute) and the drawn
-    //    grid use the same basis: gridX = cos*planeX - sin*planeY,
-    //                              gridY = sin*planeX + cos*planeY.
-    //  - ZOffset pushes the displayed plane along its normal to avoid
-    //    z-fighting with coplanar geometry. Snap math uses the unshifted
-    //    plane, so selection still lands on the true plane.
-    const double aCosA        = std::cos(myGridParams.RotationAngle());
-    const double aSinA        = std::sin(myGridParams.RotationAngle());
-    const gp_Dir aRawX        = myGridPlane.XDirection();
-    const gp_Dir aRawY        = myGridPlane.YDirection();
-    const gp_Dir aNDir        = myGridPlane.Direction();
-    const gp_XYZ aXRotated    = aRawX.XYZ() * aCosA - aRawY.XYZ() * aSinA;
-    const gp_XYZ aYRotated    = aRawX.XYZ() * aSinA + aRawY.XYZ() * aCosA;
-    const double aZOffset     = myGridParams.ZOffset();
-    const gp_Pnt aOriginLocal = myGridParams.Origin();
-    const gp_Pnt aPlaneOrigin(aPlaneLoc.X() + aOriginLocal.X() + aNDir.X() * aZOffset,
-                              aPlaneLoc.Y() + aOriginLocal.Y() + aNDir.Y() * aZOffset,
-                              aPlaneLoc.Z() + aOriginLocal.Z() + aNDir.Z() * aZOffset);
-    const NCollection_Vec3<float> aPlaneNV((float)aNDir.X(), (float)aNDir.Y(), (float)aNDir.Z());
-    const NCollection_Vec3<float> aPlaneOriginV((float)aPlaneOrigin.X(),
-                                                (float)aPlaneOrigin.Y(),
-                                                (float)aPlaneOrigin.Z());
-    const NCollection_Vec3<float> aPlaneXV((float)aXRotated.X(),
-                                           (float)aXRotated.Y(),
-                                           (float)aXRotated.Z());
-    const NCollection_Vec3<float> aPlaneYV((float)aYRotated.X(),
-                                           (float)aYRotated.Y(),
-                                           (float)aYRotated.Z());
+    NCollection_Vec2<float> aLocalOriginShift(0.0f, 0.0f);
+    NCollection_Vec2<float> anAccentLocalOriginShift(0.0f, 0.0f);
+    float                   aRadialOriginShift = 0.0f;
+    float                   anAccentRadialOriginShift = 0.0f;
+    double                  aLocalRefX = 0.0, aLocalRefY = 0.0;
+    if (shaderGridReferenceLocal(aCamera,
+                                 aPlaneOrigin,
+                                 aXRotated,
+                                 aYRotated,
+                                 aNDir,
+                                 aLocalRefX,
+                                 aLocalRefY))
+    {
+      if (myGridParams.IsCircular())
+      {
+        const double aRadiusRef = std::sqrt(aLocalRefX * aLocalRefX + aLocalRefY * aLocalRefY);
+        aRadialOriginShift = float(shaderGridSnappedLocalShift(aRadiusRef, aScaleX));
+        anAccentRadialOriginShift =
+          myGridParams.AccentScaleX() > Precision::Confusion()
+            ? float(shaderGridSnappedLocalShift(aRadiusRef, myGridParams.AccentScaleX()))
+            : aRadialOriginShift;
+      }
+      else
+      {
+        aLocalOriginShift.SetValues(float(shaderGridSnappedLocalShift(aLocalRefX, aScaleX)),
+                                    float(shaderGridSnappedLocalShift(aLocalRefY, aScaleY)));
+        anAccentLocalOriginShift.SetValues(
+          myGridParams.AccentScaleX() > Precision::Confusion()
+            ? float(shaderGridSnappedLocalShift(aLocalRefX, myGridParams.AccentScaleX()))
+            : aLocalOriginShift.x(),
+          myGridParams.AccentScaleY() > Precision::Confusion()
+            ? float(shaderGridSnappedLocalShift(aLocalRefY, myGridParams.AccentScaleY()))
+            : aLocalOriginShift.y());
+      }
+    }
 
-    const int* aViewport = aContext->Viewport();
+    const gp_Pnt aPlaneRef(aPlaneOrigin.XYZ() + aXRotated * double(aLocalOriginShift.x())
+                           + aYRotated * double(aLocalOriginShift.y()));
+    const NCollection_Mat4<float>& aGridWorldView = aContext->WorldViewState.Current();
+    aProg->SetUniform(aContext, "uPlaneOriginView", shaderGridViewPoint(aGridWorldView, aPlaneOrigin));
+    aProg->SetUniform(aContext, "uPlaneRefView", shaderGridViewPoint(aGridWorldView, aPlaneRef));
+    aProg->SetUniform(aContext, "uPlaneXView", shaderGridViewDirection(aGridWorldView, aXRotated));
+    aProg->SetUniform(aContext, "uPlaneYView", shaderGridViewDirection(aGridWorldView, aYRotated));
+    aProg->SetUniform(aContext, "uPlaneNView", shaderGridViewDirection(aGridWorldView, aNDir));
+    aProg->SetUniform(aContext, "uLocalOriginShift", aLocalOriginShift);
+    aProg->SetUniform(aContext, "uAccentLocalOriginShift", anAccentLocalOriginShift);
+    aProg->SetUniform(aContext, "uRadialOriginShift", GLfloat(aRadialOriginShift));
+    aProg->SetUniform(aContext, "uAccentRadialOriginShift", GLfloat(anAccentRadialOriginShift));
 
     // Bounded work area (HalfSizeX, HalfSizeY, Radius). 0 = unbounded along that axis.
     float aHalfX  = myGridParams.SizeX() > 0.0 ? float(myGridParams.SizeX() * 0.5) : 0.0f;
     float aHalfY  = myGridParams.SizeY() > 0.0 ? float(myGridParams.SizeY() * 0.5) : 0.0f;
     float aRadius = myGridParams.Radius() > 0.0 ? float(myGridParams.Radius()) : 0.0f;
-    if (myGridParams.IsViewAdaptive())
-    {
-      // Derive a tight world-space bound from the visible region: unproject
-      // the four viewport corners + center to the grid plane and enclose
-      // their plane-local extents. The center sample is a safety net when
-      // a corner ray is near-parallel to the plane and gets rejected.
-      double aMinLocalX      = 0.0;
-      double aMaxLocalX      = 0.0;
-      double aMinLocalY      = 0.0;
-      double aMaxLocalY      = 0.0;
-      double aMaxLocalRadius = 0.0;
-      bool   aHasBounds      = false;
-      if (aViewport != nullptr)
-      {
-        const float                   aWinMinX   = float(aViewport[0]);
-        const float                   aWinMinY   = float(aViewport[1]);
-        const float                   aWinMaxX   = float(aViewport[0] + aViewport[2]);
-        const float                   aWinMaxY   = float(aViewport[1] + aViewport[3]);
-        const float                   aWinMidX   = (aWinMinX + aWinMaxX) * 0.5f;
-        const float                   aWinMidY   = (aWinMinY + aWinMaxY) * 0.5f;
-        const NCollection_Vec2<float> aSamples[] = {NCollection_Vec2<float>(aWinMinX, aWinMinY),
-                                                    NCollection_Vec2<float>(aWinMaxX, aWinMinY),
-                                                    NCollection_Vec2<float>(aWinMinX, aWinMaxY),
-                                                    NCollection_Vec2<float>(aWinMaxX, aWinMaxY),
-                                                    NCollection_Vec2<float>(aWinMidX, aWinMidY)};
-        for (const NCollection_Vec2<float>& aSample : aSamples)
-        {
-          double aLocalX = 0.0, aLocalY = 0.0;
-          if (!unprojectGridPointToPlaneLocal(aContext,
-                                              aViewport,
-                                              aSample.x(),
-                                              aSample.y(),
-                                              aPlaneNV,
-                                              aPlaneOriginV,
-                                              aPlaneXV,
-                                              aPlaneYV,
-                                              aLocalX,
-                                              aLocalY))
-          {
-            continue;
-          }
-          const double aHitR = std::sqrt(aLocalX * aLocalX + aLocalY * aLocalY);
-          if (!aHasBounds)
-          {
-            aMinLocalX      = aLocalX;
-            aMaxLocalX      = aLocalX;
-            aMinLocalY      = aLocalY;
-            aMaxLocalY      = aLocalY;
-            aMaxLocalRadius = aHitR;
-            aHasBounds      = true;
-          }
-          else
-          {
-            aMinLocalX      = std::min(aMinLocalX, aLocalX);
-            aMaxLocalX      = std::max(aMaxLocalX, aLocalX);
-            aMinLocalY      = std::min(aMinLocalY, aLocalY);
-            aMaxLocalY      = std::max(aMaxLocalY, aLocalY);
-            aMaxLocalRadius = std::max(aMaxLocalRadius, aHitR);
-          }
-        }
-      }
-
-      const double aStepX = aScaleX > 0.0 ? 1.0 / aScaleX : 1.0;
-      const double aStepY = aScaleY > 0.0 ? 1.0 / aScaleY : aStepX;
-      if (myGridParams.IsCircular())
-      {
-        const double aPad = std::max(aStepX, aStepY) * 4.0;
-        if (aHasBounds)
-        {
-          aRadius = std::max(aRadius, float(aMaxLocalRadius + aPad));
-        }
-        else
-        {
-          aRadius = std::max(aRadius, float(std::max(aCamera->Scale(), aPad) * 2.0));
-        }
-      }
-      else if (aHasBounds)
-      {
-        const double aPadX = std::max((aMaxLocalX - aMinLocalX) * 0.10, aStepX * 4.0);
-        const double aPadY = std::max((aMaxLocalY - aMinLocalY) * 0.10, aStepY * 4.0);
-        aHalfX =
-          std::max(aHalfX, float(std::max(std::abs(aMinLocalX), std::abs(aMaxLocalX)) + aPadX));
-        aHalfY =
-          std::max(aHalfY, float(std::max(std::abs(aMinLocalY), std::abs(aMaxLocalY)) + aPadY));
-      }
-      else
-      {
-        aHalfX = std::max(aHalfX, float(std::max(aCamera->Scale(), aStepX * 8.0)));
-        aHalfY = std::max(aHalfY, float(std::max(aCamera->Scale(), aStepY * 8.0)));
-      }
-    }
     aProg->SetUniform(aContext, "uBounds", NCollection_Vec3<float>(aHalfX, aHalfY, aRadius));
+    aProg->SetUniform(aContext,
+                      "uIsBoundFade",
+                      myGridParams.IsBounded() && !myGridParams.IsViewAdaptive() ? 1 : 0);
     aProg->SetUniform(
       aContext,
       "uArcRange",
       NCollection_Vec2<float>(float(myGridParams.AngleStart()), float(myGridParams.AngleEnd())));
     aProg->SetUniform(aContext, "uArcBounded", myGridParams.IsArc() ? 1 : 0);
 
-    aProg->SetUniform(aContext, "uPlaneOrigin", aPlaneOriginV);
-    aProg->SetUniform(aContext, "uPlaneX", aPlaneXV);
-    aProg->SetUniform(aContext, "uPlaneY", aPlaneYV);
-
-    // Stable per-frame rectangular-grid reference point in plane-local
-    // coordinates. Keeps shader fract() arguments bounded at shallow angles
-    // without re-running extra unproject/intersection work for every fragment.
-    int                     aHasStableRef = 0;
-    NCollection_Vec2<float> aStableRefLocal(0.0f, 0.0f);
-    if (!myGridParams.IsCircular() && aViewport != nullptr)
+    if (aScaleX > Precision::Confusion() && aScaleY > Precision::Confusion())
     {
-      const float aWinX   = float(aViewport[0]) + float(aViewport[2]) * 0.5f;
-      const float aWinY   = float(aViewport[1]) + float(aViewport[3]) * 0.5f;
-      double      aLocalX = 0.0, aLocalY = 0.0;
-      if (unprojectGridPointToPlaneLocal(aContext,
-                                         aViewport,
-                                         aWinX,
-                                         aWinY,
-                                         aPlaneNV,
-                                         aPlaneOriginV,
-                                         aPlaneXV,
-                                         aPlaneYV,
-                                         aLocalX,
-                                         aLocalY))
-      {
-        aStableRefLocal.SetValues(float(aLocalX), float(aLocalY));
-        aHasStableRef = 1;
-      }
+      aContext->core11fwd->glDrawArrays(GL_TRIANGLES, 0, 3);
     }
-    aProg->SetUniform(aContext, "uStableRefLocal", aStableRefLocal);
-    aProg->SetUniform(aContext, "uHasStableRef", aHasStableRef);
-    aProg->SetUniform(aContext, "uPlaneN", aPlaneNV);
-
-    aContext->core11fwd->glDrawArrays(GL_TRIANGLES, 0, 6);
   }
 
   aContext->BindProgram(aPrevProgram);
@@ -4021,7 +4361,11 @@ void OpenGl_View::renderGrid()
   aContext->ApplyWorldViewMatrix();
   aContext->ApplyProjectionMatrix();
 
-  if (wasDepthTest == GL_FALSE)
+  if (wasDepthTest == GL_TRUE)
+  {
+    aContext->core11fwd->glEnable(GL_DEPTH_TEST);
+  }
+  else
   {
     aContext->core11fwd->glDisable(GL_DEPTH_TEST);
   }
@@ -4038,9 +4382,5 @@ void OpenGl_View::renderGrid()
   if (wasCullFace == GL_TRUE)
   {
     aContext->core11fwd->glEnable(GL_CULL_FACE);
-  }
-  if (hasDepthClamp && !wasDepthClamp)
-  {
-    aContext->core11fwd->glDisable(GL_DEPTH_CLAMP);
   }
 }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -78,333 +78,6 @@ static bool checkWasFailedFbo(const occ::handle<OpenGl_FrameBuffer>& theFboToChe
                            theFboRef->NbSamples());
 }
 
-//! Return grid plane frame used by the shader path.
-static void shaderGridFrame(const Aspect_GridParams& theParams,
-                            const gp_Ax3&            thePlane,
-                            gp_Pnt&                  theOrigin,
-                            gp_XYZ&                  theX,
-                            gp_XYZ&                  theY,
-                            gp_XYZ&                  theN)
-{
-  const double aCosA = std::cos(theParams.RotationAngle());
-  const double aSinA = std::sin(theParams.RotationAngle());
-  const gp_XYZ aRawX = thePlane.XDirection().XYZ();
-  const gp_XYZ aRawY = thePlane.YDirection().XYZ();
-  theX               = aRawX * aCosA - aRawY * aSinA;
-  theY               = aRawX * aSinA + aRawY * aCosA;
-  theN               = thePlane.Direction().XYZ();
-
-  const gp_Pnt& anOriginLocal = theParams.Origin();
-  const gp_Pnt& aPlaneLoc     = thePlane.Location();
-  theOrigin.SetXYZ(aPlaneLoc.XYZ() + aRawX * anOriginLocal.X() + aRawY * anOriginLocal.Y()
-                   + theN * (anOriginLocal.Z() + theParams.ZOffset()));
-}
-
-//! Return shader grid scales for current camera.
-static void shaderGridEffectiveScale(const Aspect_GridParams& theParams,
-                                     const double             theCurrentCameraScale,
-                                     double&                  theScaleX,
-                                     double&                  theScaleY)
-{
-  theScaleX = theParams.Scale();
-  theScaleY = theParams.EffectiveScaleY();
-  if (!theParams.IsViewAdaptive())
-  {
-    return;
-  }
-
-  const double aCurrentScale =
-    theCurrentCameraScale > Precision::Confusion() ? theCurrentCameraScale : Precision::Confusion();
-  theScaleX /= aCurrentScale;
-  theScaleY /= aCurrentScale;
-}
-
-//! Intersect camera ray at NDC point with the shader grid plane and return plane-local coordinates.
-static bool shaderGridPlaneLocalHit(const occ::handle<Graphic3d_Camera>& theCamera,
-                                    const double                         theNdcX,
-                                    const double                         theNdcY,
-                                    const gp_Pnt&                        thePlaneOrigin,
-                                    const gp_XYZ&                        thePlaneX,
-                                    const gp_XYZ&                        thePlaneY,
-                                    const gp_XYZ&                        thePlaneN,
-                                    double&                              theLocalX,
-                                    double&                              theLocalY,
-                                    const bool                           theToRejectBehind = true)
-{
-  if (theCamera.IsNull())
-  {
-    return false;
-  }
-
-  const double aNearZ        = theCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
-  const gp_Pnt aNearP        = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, aNearZ));
-  const gp_Pnt aFarP         = theCamera->UnProject(gp_Pnt(theNdcX, theNdcY, 1.0));
-  const bool   isPerspective = !theCamera->IsOrthographic();
-  const gp_Pnt aRayOriginP   = isPerspective ? theCamera->Eye() : aNearP;
-  const gp_XYZ aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
-  const double aDenom        = thePlaneN.Dot(aRay);
-  if (std::abs(aDenom) <= Precision::Angular())
-  {
-    return false;
-  }
-
-  const double aT = thePlaneN.Dot(thePlaneOrigin.XYZ() - aRayOriginP.XYZ()) / aDenom;
-  if (theToRejectBehind && isPerspective && aT < 0.0)
-  {
-    return false;
-  }
-
-  const gp_XYZ aHit    = aRayOriginP.XYZ() + aRay * aT;
-  const gp_XYZ aLocal3 = aHit - thePlaneOrigin.XYZ();
-  theLocalX            = aLocal3.Dot(thePlaneX);
-  theLocalY            = aLocal3.Dot(thePlaneY);
-  return true;
-}
-
-//! Snap local shift to grid-cell multiples so subtracting it preserves grid phase.
-static double shaderGridSnappedLocalShift(const double theLocal, const double theScale)
-{
-  if (theScale <= Precision::Confusion())
-  {
-    return 0.0;
-  }
-
-  const double aStep = 1.0 / theScale;
-  return std::round(theLocal / aStep) * aStep;
-}
-
-//! Pick a visible viewport sample on the shader-grid plane for stable phase rebasing.
-static bool shaderGridReferenceLocal(const occ::handle<Graphic3d_Camera>& theCamera,
-                                     const gp_Pnt&                        thePlaneOrigin,
-                                     const gp_XYZ&                        thePlaneX,
-                                     const gp_XYZ&                        thePlaneY,
-                                     const gp_XYZ&                        thePlaneN,
-                                     double&                              theLocalX,
-                                     double&                              theLocalY)
-{
-  const double aSamples[][2] = {{0.0, 0.0},
-                                {-1.0, -1.0},
-                                {1.0, -1.0},
-                                {1.0, 1.0},
-                                {-1.0, 1.0},
-                                {0.0, -1.0},
-                                {1.0, 0.0},
-                                {0.0, 1.0},
-                                {-1.0, 0.0}};
-  for (const double* aSample : aSamples)
-  {
-    if (shaderGridPlaneLocalHit(theCamera,
-                                aSample[0],
-                                aSample[1],
-                                thePlaneOrigin,
-                                thePlaneX,
-                                thePlaneY,
-                                thePlaneN,
-                                theLocalX,
-                                theLocalY))
-    {
-      return true;
-    }
-  }
-  return false;
-}
-
-//! Transform world-space point by the active world-view matrix.
-static NCollection_Vec3<float> shaderGridViewPoint(const NCollection_Mat4<float>& theWorldView,
-                                                   const gp_Pnt&                  thePoint)
-{
-  const NCollection_Vec4<float> aPoint(float(thePoint.X()),
-                                       float(thePoint.Y()),
-                                       float(thePoint.Z()),
-                                       1.0f);
-  const NCollection_Vec4<float> aView = theWorldView * aPoint;
-  return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
-}
-
-//! Transform world-space direction by the active world-view matrix.
-static NCollection_Vec3<float> shaderGridViewDirection(const NCollection_Mat4<float>& theWorldView,
-                                                       const gp_XYZ&                  theDirection)
-{
-  const NCollection_Vec4<float> aDir(float(theDirection.X()),
-                                     float(theDirection.Y()),
-                                     float(theDirection.Z()),
-                                     0.0f);
-  const NCollection_Vec4<float> aView = theWorldView * aDir;
-  return NCollection_Vec3<float>(aView.x(), aView.y(), aView.z());
-}
-
-//! Return a world-space point suitable for drawing a 3D echo marker at the snapped point
-//! projection.
-static gp_Pnt shaderGridEchoDisplayPoint(const occ::handle<Graphic3d_Camera>& theCamera,
-                                         const gp_XYZ&                        theSnapped)
-{
-  const gp_Pnt aProjSnapped = theCamera->Project(gp_Pnt(theSnapped));
-  const double aDisplayZ    = theCamera->IsZeroToOneDepth() ? 0.5 : 0.0;
-  return theCamera->UnProject(gp_Pnt(aProjSnapped.X(), aProjSnapped.Y(), aDisplayZ));
-}
-
-static bool isShaderGridPointInBounds(const Aspect_GridParams& theParams,
-                                      const double             theLocalX,
-                                      const double             theLocalY)
-{
-  if (theParams.IsCircular())
-  {
-    const double aRadius = std::sqrt(theLocalX * theLocalX + theLocalY * theLocalY);
-    if (theParams.Radius() > 0.0 && aRadius > theParams.Radius())
-    {
-      return false;
-    }
-    if (theParams.IsArc())
-    {
-      const double aTwoPi = 2.0 * M_PI;
-      double       aStart = std::fmod(theParams.AngleStart(), aTwoPi);
-      double       anEnd  = std::fmod(theParams.AngleEnd(), aTwoPi);
-      double       anAng  = std::fmod(std::atan2(theLocalY, theLocalX), aTwoPi);
-      if (aStart < 0.0)
-      {
-        aStart += aTwoPi;
-      }
-      if (anEnd < 0.0)
-      {
-        anEnd += aTwoPi;
-      }
-      if (anAng < 0.0)
-      {
-        anAng += aTwoPi;
-      }
-      double aSpan = anEnd - aStart;
-      if (aSpan < 0.0)
-      {
-        aSpan += aTwoPi;
-      }
-      double aDelta = anAng - aStart;
-      if (aDelta < 0.0)
-      {
-        aDelta += aTwoPi;
-      }
-      if (aDelta > aSpan)
-      {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  return (theParams.SizeX() <= 0.0 || std::abs(theLocalX) <= theParams.SizeX() * 0.5)
-         && (theParams.SizeY() <= 0.0 || std::abs(theLocalY) <= theParams.SizeY() * 0.5);
-}
-
-//! Return TRUE if the angle belongs to the grid arc.
-static bool shaderGridArcContains(const double theStart, const double theEnd, const double theAngle)
-{
-  const double aTwoPi = 2.0 * M_PI;
-  double       aSpan = theEnd - theStart;
-  if (aSpan < 0.0)
-  {
-    aSpan += aTwoPi;
-  }
-
-  double aDelta = theAngle - theStart;
-  if (aDelta < 0.0)
-  {
-    aDelta += aTwoPi;
-  }
-  return aDelta <= aSpan;
-}
-
-//! Add local shader-grid point into world-space bounding box.
-static void addShaderGridLocalPoint(Bnd_Box&       theBox,
-                                    const gp_Pnt&  theOrigin,
-                                    const gp_XYZ&  theX,
-                                    const gp_XYZ&  theY,
-                                    const double   theLocalX,
-                                    const double   theLocalY)
-{
-  theBox.Add(gp_Pnt(theOrigin.XYZ() + theX * theLocalX + theY * theLocalY));
-}
-
-//! Add exactly known finite shader-grid extents to a bounding box.
-//!
-//! Unbounded shader grids have no finite world-space box; in that case only the
-//! plane origin is added so the grid plane can still participate in Z fitting
-//! without inventing artificial viewport-dependent extents.
-static void addShaderGridFiniteBounds(Bnd_Box&                 theBox,
-                                      const Aspect_GridParams& theParams,
-                                      const gp_Ax3&            thePlane)
-{
-  gp_Pnt anOrigin;
-  gp_XYZ aGridX, aGridY, aGridN;
-  shaderGridFrame(theParams, thePlane, anOrigin, aGridX, aGridY, aGridN);
-
-  addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, 0.0);
-  if (theParams.IsCircular())
-  {
-    const double aRadius = theParams.Radius();
-    if (aRadius <= 0.0)
-    {
-      return;
-    }
-
-    if (!theParams.IsArc())
-    {
-      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aRadius, 0.0);
-      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aRadius, 0.0);
-      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, aRadius);
-      addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, -aRadius);
-      return;
-    }
-
-    auto addArcPoint = [&](const double theAngle) {
-      addShaderGridLocalPoint(theBox,
-                              anOrigin,
-                              aGridX,
-                              aGridY,
-                              aRadius * std::cos(theAngle),
-                              aRadius * std::sin(theAngle));
-    };
-
-    addArcPoint(theParams.AngleStart());
-    addArcPoint(theParams.AngleEnd());
-
-    const double aCardinalAngles[] = {0.0, M_PI * 0.5, M_PI, -M_PI * 0.5};
-    for (const double anAngle : aCardinalAngles)
-    {
-      if (shaderGridArcContains(theParams.AngleStart(), theParams.AngleEnd(), anAngle))
-      {
-        addArcPoint(anAngle);
-      }
-    }
-    return;
-  }
-
-  const double aHalfX = theParams.SizeX() > 0.0 ? theParams.SizeX() * 0.5 : 0.0;
-  const double aHalfY = theParams.SizeY() > 0.0 ? theParams.SizeY() * 0.5 : 0.0;
-  if (aHalfX <= 0.0 && aHalfY <= 0.0)
-  {
-    return;
-  }
-
-  if (aHalfX > 0.0 && aHalfY > 0.0)
-  {
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, -aHalfY);
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, -aHalfY);
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, aHalfY);
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, aHalfY);
-    return;
-  }
-
-  if (aHalfX > 0.0)
-  {
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, -aHalfX, 0.0);
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, aHalfX, 0.0);
-  }
-  if (aHalfY > 0.0)
-  {
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, -aHalfY);
-    addShaderGridLocalPoint(theBox, anOrigin, aGridX, aGridY, 0.0, aHalfY);
-  }
-}
-
 //! Chooses compatible internal color format for OIT frame buffer.
 static bool chooseOitColorConfiguration(const occ::handle<OpenGl_Context>& theGlContext,
                                         const int                          theConfigIndex,
@@ -469,7 +142,6 @@ OpenGl_View::OpenGl_View(const occ::handle<Graphic3d_StructureManager>& theMgr,
       myCubeMapParams(new OpenGl_Aspects()),
       myColoredQuadParams(new OpenGl_Aspects()),
       myGridVao(0),
-      myToShowGrid(false),
       myPBREnvState(OpenGl_PBREnvState_NONEXISTENT),
       myPBREnvRequest(false),
       // ray-tracing fields initialization
@@ -1214,12 +886,6 @@ Bnd_Box OpenGl_View::MinMaxValues(const bool theToIncludeAuxiliary) const
 
   Bnd_Box aBox = base_type::MinMaxValues(theToIncludeAuxiliary);
 
-  if (theToIncludeAuxiliary && myToShowGrid && myGridParams.DrawMode() != Aspect_GDM_None
-      && !myGridParams.IsBackground())
-  {
-    addShaderGridFiniteBounds(aBox, myGridParams, myGridPlane);
-  }
-
   // make sure that stats overlay isn't clamped on hardware with unavailable depth clamping
   if (theToIncludeAuxiliary && myRenderParams.ToShowStats
       && !myWorkspace->GetGlContext()->arbDepthClamp)
@@ -1235,6 +901,15 @@ Bnd_Box OpenGl_View::MinMaxValues(const bool theToIncludeAuxiliary) const
     aBox.Add(aStatsBox);
   }
   return aBox;
+}
+
+//=================================================================================================
+
+void OpenGl_View::ZFitAllBounds(Bnd_Box& thePrimaryBox, Bnd_Box& theGraphicBox) const
+{
+  thePrimaryBox = base_type::MinMaxValues(false);
+  theGraphicBox = MinMaxValues(true);
+  myShaderGrid.AddZFitBounds(thePrimaryBox, theGraphicBox, Camera());
 }
 
 //=================================================================================================
@@ -3907,46 +3582,29 @@ void OpenGl_View::updatePBREnvironment(const occ::handle<OpenGl_Context>& theCtx
 
 //=================================================================================================
 
-void OpenGl_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
+bool OpenGl_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
 {
-  // Reference view matrix (for background-mode anchoring) is captured only on
-  // transitions into background mode or into the showing state. Otherwise live
-  // param edits (SetArcRange, SetSize, etc.) while the camera is mid-orbit would
-  // re-snapshot the current view and visually snap the anchored grid.
-  const bool wasShowing    = myToShowGrid;
-  const bool wasBackground = wasShowing && myGridParams.IsBackground();
-  const bool toCapture     = theParams.IsBackground() && (!wasShowing || !wasBackground);
-
-  myGridParams = theParams;
-  myGridPlane  = thePlane;
-  myToShowGrid = true;
-  if (theParams.IsViewAdaptive())
+  const occ::handle<OpenGl_Context>& aCtx = myWorkspace->GetGlContext();
+  if (!aCtx.IsNull() && aCtx->core30 == nullptr)
   {
-    const occ::handle<Graphic3d_Camera>& aCamera = Camera();
-    const double                         aReferenceScale =
-      !aCamera.IsNull() && aCamera->Scale() > Precision::Confusion() ? aCamera->Scale() : 1.0;
-    myGridParams.SetScale(theParams.Scale() * aReferenceScale);
-    if (theParams.ScaleY() > 0.0)
-    {
-      myGridParams.SetScaleY(theParams.ScaleY() * aReferenceScale);
-    }
+    return false;
   }
 
-  if (toCapture)
+  if (!myShaderGrid.Display(theParams, thePlane, Camera(), aCtx))
   {
-    const occ::handle<OpenGl_Context>& aCtx = myWorkspace->GetGlContext();
-    if (!aCtx.IsNull())
-    {
-      myGridRefViewMatrix = aCtx->WorldViewState.Current();
-    }
+    return false;
   }
+
+  Invalidate();
+  return true;
 }
 
 //=================================================================================================
 
 void OpenGl_View::GridErase()
 {
-  myToShowGrid = false;
+  myShaderGrid.Erase();
+  Invalidate();
 }
 
 //=================================================================================================
@@ -3964,190 +3622,30 @@ bool OpenGl_View::ShaderGridEcho(const int         theX,
                                  Graphic3d_Vertex& thePoint,
                                  Graphic3d_Vertex& theDisplayPoint) const
 {
-  if (!myToShowGrid || myGridParams.DrawMode() == Aspect_GDM_None || myGridParams.IsBackground()
-      || Window().IsNull())
+  if (Window().IsNull())
   {
     return false;
   }
 
-  const occ::handle<Graphic3d_Camera>& aCamera = Camera();
-  if (aCamera.IsNull())
-  {
-    return false;
-  }
-
-  gp_Pnt aGridOrigin;
-  gp_XYZ aGridX, aGridY, aGridN;
-  shaderGridFrame(myGridParams, myGridPlane, aGridOrigin, aGridX, aGridY, aGridN);
-
-  int aWidth = 0, aHeight = 0;
+  int aWidth = 0;
+  int aHeight = 0;
   Window()->Size(aWidth, aHeight);
-  if (aWidth <= 0 || aHeight <= 0)
-  {
-    return false;
-  }
+  return myShaderGrid.Echo(Camera(), aWidth, aHeight, theX, theY, thePoint, theDisplayPoint);
+}
 
-  const double aNdcX         = 2.0 * double(theX) / double(aWidth) - 1.0;
-  const double aNdcY         = 2.0 * double(aHeight - 1 - theY) / double(aHeight) - 1.0;
-  const double aNearZ        = aCamera->IsZeroToOneDepth() ? 0.0 : -1.0;
-  const gp_Pnt aNearP        = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, aNearZ));
-  const gp_Pnt aFarP         = aCamera->UnProject(gp_Pnt(aNdcX, aNdcY, 1.0));
-  const bool   isPerspective = !aCamera->IsOrthographic();
-  const gp_Pnt aRayOriginP   = isPerspective ? aCamera->Eye() : aNearP;
-  gp_XYZ       aRay          = aFarP.XYZ() - aRayOriginP.XYZ();
-  const double aRayMod       = aRay.Modulus();
-  if (aRayMod <= Precision::Confusion())
-  {
-    return false;
-  }
-  aRay /= aRayMod;
+//=================================================================================================
 
-  const double aDenom = aGridN.Dot(aRay);
-  if (std::abs(aDenom) <= Precision::Angular())
-  {
-    return false;
-  }
-
-  const double aT = aGridN.Dot(aGridOrigin.XYZ() - aRayOriginP.XYZ()) / aDenom;
-  if (isPerspective && aT < 0.0)
-  {
-    return false;
-  }
-
-  const gp_XYZ aHit    = aRayOriginP.XYZ() + aRay * aT;
-  const gp_XYZ aLocal3 = aHit - aGridOrigin.XYZ();
-  double       aLocalX = aLocal3.Dot(aGridX);
-  double       aLocalY = aLocal3.Dot(aGridY);
-  if (!isShaderGridPointInBounds(myGridParams, aLocalX, aLocalY))
-  {
-    return false;
-  }
-
-  double aScaleX = 0.0, aScaleY = 0.0;
-  shaderGridEffectiveScale(myGridParams, aCamera->Scale(), aScaleX, aScaleY);
-  if (aScaleX <= 0.0 || aScaleY <= 0.0)
-  {
-    return false;
-  }
-
-  gp_XYZ     aSnapped       = aGridOrigin.XYZ();
-  const bool toSnapByScreen = myGridParams.DrawMode() == Aspect_GDM_Points;
-  double     aBestDist2     = RealLast();
-  bool       hasBestPoint   = false;
-  auto       addCandidate   = [&](const double theLocalX, const double theLocalY) {
-    if (!isShaderGridPointInBounds(myGridParams, theLocalX, theLocalY))
-    {
-      return;
-    }
-    const gp_XYZ aCandidate = aGridOrigin.XYZ() + aGridX * theLocalX + aGridY * theLocalY;
-    if (isPerspective && aCamera->Direction().XYZ().Dot(aCandidate - aCamera->Eye().XYZ()) <= 0.0)
-    {
-      return;
-    }
-    const gp_Pnt aProj  = aCamera->Project(gp_Pnt(aCandidate));
-    const double aPx    = (aProj.X() + 1.0) * 0.5 * double(aWidth);
-    const double aPy    = double(aHeight - 1) - (aProj.Y() + 1.0) * 0.5 * double(aHeight);
-    const double aDistX = aPx - double(theX);
-    const double aDistY = aPy - double(theY);
-    const double aDist2 = aDistX * aDistX + aDistY * aDistY;
-    if (!hasBestPoint || aDist2 < aBestDist2)
-    {
-      hasBestPoint = true;
-      aBestDist2   = aDist2;
-      aSnapped     = aCandidate;
-    }
-  };
-
-  if (myGridParams.IsCircular())
-  {
-    const double aRadius      = std::sqrt(aLocalX * aLocalX + aLocalY * aLocalY);
-    const double anAngle      = std::atan2(aLocalY, aLocalX);
-    const double aRadiusStep  = 1.0 / aScaleX;
-    const int    aNbDivisions = myGridParams.AngularDivisions();
-    const double anAngleStep  = aNbDivisions > 0 ? M_PI / double(aNbDivisions) : M_PI;
-    if (toSnapByScreen)
-    {
-      const double aRadiusIndex = std::floor(aRadius / aRadiusStep);
-      const double anAngleIndex = std::floor(anAngle / anAngleStep);
-      const double aRadii[2]    = {std::max(0.0, aRadiusIndex * aRadiusStep),
-                                   std::max(0.0, (aRadiusIndex + 1.0) * aRadiusStep)};
-      const double anAngles[2]  = {anAngleIndex * anAngleStep, (anAngleIndex + 1.0) * anAngleStep};
-      for (double aCandidateRadius : aRadii)
-      {
-        for (double aCandidateAngle : anAngles)
-        {
-          addCandidate(aCandidateRadius * std::cos(aCandidateAngle),
-                       aCandidateRadius * std::sin(aCandidateAngle));
-        }
-      }
-      if (!hasBestPoint)
-      {
-        return false;
-      }
-      thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
-      const gp_Pnt aDisplayP = shaderGridEchoDisplayPoint(aCamera, aSnapped);
-      theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
-      return true;
-    }
-
-    const double aSnapRadius = std::round(aRadius / aRadiusStep) * aRadiusStep;
-    const double aSnapAngle  = std::round(anAngle / anAngleStep) * anAngleStep;
-    aSnapped +=
-      aGridX * (aSnapRadius * std::cos(aSnapAngle)) + aGridY * (aSnapRadius * std::sin(aSnapAngle));
-    if (!isShaderGridPointInBounds(myGridParams,
-                                   aSnapRadius * std::cos(aSnapAngle),
-                                   aSnapRadius * std::sin(aSnapAngle)))
-    {
-      return false;
-    }
-  }
-  else
-  {
-    const double aStepX = 1.0 / aScaleX;
-    const double aStepY = 1.0 / aScaleY;
-    if (toSnapByScreen)
-    {
-      const double anIndexX    = std::floor(aLocalX / aStepX);
-      const double anIndexY    = std::floor(aLocalY / aStepY);
-      const double aLocalXs[2] = {anIndexX * aStepX, (anIndexX + 1.0) * aStepX};
-      const double aLocalYs[2] = {anIndexY * aStepY, (anIndexY + 1.0) * aStepY};
-      for (double aCandidateX : aLocalXs)
-      {
-        for (double aCandidateY : aLocalYs)
-        {
-          addCandidate(aCandidateX, aCandidateY);
-        }
-      }
-      if (!hasBestPoint)
-      {
-        return false;
-      }
-      thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
-      const gp_Pnt aDisplayP = shaderGridEchoDisplayPoint(aCamera, aSnapped);
-      theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
-      return true;
-    }
-
-    aLocalX = std::round(aLocalX / aStepX) * aStepX;
-    aLocalY = std::round(aLocalY / aStepY) * aStepY;
-    if (!isShaderGridPointInBounds(myGridParams, aLocalX, aLocalY))
-    {
-      return false;
-    }
-    aSnapped += aGridX * aLocalX + aGridY * aLocalY;
-  }
-
-  thePoint.SetCoord(aSnapped.X(), aSnapped.Y(), aSnapped.Z());
-  const gp_Pnt aDisplayP = shaderGridEchoDisplayPoint(aCamera, aSnapped);
-  theDisplayPoint.SetCoord(aDisplayP.X(), aDisplayP.Y(), aDisplayP.Z());
-  return true;
+bool OpenGl_View::ShaderGridSnapPoint(const Graphic3d_Vertex& thePoint,
+                                      Graphic3d_Vertex&       theGridPoint) const
+{
+  return myShaderGrid.SnapPoint(Camera(), thePoint, theGridPoint);
 }
 
 //=================================================================================================
 
 void OpenGl_View::renderGrid()
 {
-  if (!myToShowGrid || myGridParams.DrawMode() == Aspect_GDM_None)
+  if (!myShaderGrid.IsShown() || myShaderGrid.Params().DrawMode() == Aspect_GDM_None)
   {
     return;
   }
@@ -4189,7 +3687,7 @@ void OpenGl_View::renderGrid()
     aContext->core30->glGenVertexArrays(1, &myGridVao);
     if (myGridVao == 0)
     {
-      myToShowGrid = false;
+      myShaderGrid.Erase();
       return;
     }
   }
@@ -4212,37 +3710,13 @@ void OpenGl_View::renderGrid()
   aContext->core11fwd->glGetIntegerv(GL_BLEND_DST_ALPHA, &aPrevBlendDstA);
   const occ::handle<OpenGl_ShaderProgram> aPrevProgram = aContext->ActiveProgram();
 
-  const Graphic3d_Camera::Projection aProjKeep = aCamera->ProjectionType();
-
-  gp_Pnt aPlaneOrigin;
-  gp_XYZ aXRotated, aYRotated, aNDir;
-  shaderGridFrame(myGridParams, myGridPlane, aPlaneOrigin, aXRotated, aYRotated, aNDir);
-
-  if (myGridParams.IsBackground())
-  {
-    aCamera->SetProjectionType(Graphic3d_Camera::Projection_Orthographic);
-  }
-
   aContext->ProjectionState.Push();
   aContext->ProjectionState.SetCurrent(aCamera->ProjectionMatrixF());
   aContext->ApplyProjectionMatrix();
 
   const NCollection_Mat4<float> aWorldViewCurrent = aContext->WorldViewState.Current();
   aContext->WorldViewState.Push();
-  if (myGridParams.IsBackground())
-  {
-    // In background mode the grid lives in an unchanging reference frame.
-    // Derive the camera-motion delta from the captured reference view matrix so the
-    // grid stays fixed in world coords during pan/rotate, without exposing
-    // PanningVector / RotationPoint on Graphic3d_Camera.
-    NCollection_Mat4<float> aRefInv;
-    if (!myGridRefViewMatrix.Inverted(aRefInv))
-    {
-      aRefInv.InitIdentity();
-    }
-    NCollection_Mat4<float> aDelta = aWorldViewCurrent * aRefInv;
-    aContext->WorldViewState.SetCurrent(aDelta);
-  }
+  aContext->WorldViewState.SetCurrent(myShaderGrid.DrawWorldView(aWorldViewCurrent));
   aContext->ApplyWorldViewMatrix();
 
   aContext->core11fwd->glEnable(GL_DEPTH_TEST);
@@ -4257,114 +3731,15 @@ void OpenGl_View::renderGrid()
   aContext->core11fwd->glDisable(GL_CULL_FACE);
   aContext->core30->glBindVertexArray(myGridVao);
 
-  double aScaleX = 0.0, aScaleY = 0.0;
-  shaderGridEffectiveScale(myGridParams, aCamera->Scale(), aScaleX, aScaleY);
-
   if (aContext->ShaderManager()->BindGridProgram())
   {
     const occ::handle<OpenGl_ShaderProgram>& aProg = aContext->ActiveProgram();
-
-    aProg->SetUniform(aContext, "uScaleX", GLfloat(aScaleX));
-    aProg->SetUniform(aContext, "uScaleY", GLfloat(aScaleY));
-    aProg->SetUniform(aContext, "uThickness", GLfloat(myGridParams.LineThickness()));
-    aProg->SetUniform(aContext,
-                      "uColor",
-                      NCollection_Vec3<float>((float)myGridParams.Color().Red(),
-                                              (float)myGridParams.Color().Green(),
-                                              (float)myGridParams.Color().Blue()));
-    aProg->SetUniform(aContext,
-                      "uAccentColor",
-                      NCollection_Vec3<float>((float)myGridParams.AccentColor().Red(),
-                                              (float)myGridParams.AccentColor().Green(),
-                                              (float)myGridParams.AccentColor().Blue()));
-    aProg->SetUniform(aContext, "uAccentScaleX", GLfloat(myGridParams.AccentScaleX()));
-    aProg->SetUniform(aContext, "uAccentScaleY", GLfloat(myGridParams.AccentScaleY()));
-    aProg->SetUniform(aContext, "uAccentAngularScale", GLfloat(myGridParams.AccentAngularScale()));
-    aProg->SetUniform(aContext, "uIsDrawAxis", myGridParams.IsDrawAxis() ? 1 : 0);
-    aProg->SetUniform(aContext, "uGridType", myGridParams.IsCircular() ? 1 : 0);
-    // Angular spokes per radian: N spokes in 180 deg = N / pi spokes per radian.
-    const double aAngularScale =
-      myGridParams.IsCircular() ? double(myGridParams.AngularDivisions()) / M_PI : 0.0;
-    aProg->SetUniform(aContext, "uAngularScale", GLfloat(aAngularScale));
-    aProg->SetUniform(aContext, "uDrawMode", myGridParams.DrawMode() == Aspect_GDM_Points ? 1 : 0);
-    aProg->SetUniform(aContext, "uIsPerspective", aCamera->IsOrthographic() ? 0 : 1);
-    aProg->SetUniform(aContext, "uIsZeroToOneDepth", aCamera->IsZeroToOneDepth() ? 1 : 0);
-
-    NCollection_Vec2<float> aLocalOriginShift(0.0f, 0.0f);
-    NCollection_Vec2<float> anAccentLocalOriginShift(0.0f, 0.0f);
-    float                   aRadialOriginShift        = 0.0f;
-    float                   anAccentRadialOriginShift = 0.0f;
-    double                  aLocalRefX = 0.0, aLocalRefY = 0.0;
-    if (shaderGridReferenceLocal(aCamera,
-                                 aPlaneOrigin,
-                                 aXRotated,
-                                 aYRotated,
-                                 aNDir,
-                                 aLocalRefX,
-                                 aLocalRefY))
-    {
-      if (myGridParams.IsCircular())
-      {
-        const double aRadiusRef = std::sqrt(aLocalRefX * aLocalRefX + aLocalRefY * aLocalRefY);
-        aRadialOriginShift      = float(shaderGridSnappedLocalShift(aRadiusRef, aScaleX));
-        anAccentRadialOriginShift =
-          myGridParams.AccentScaleX() > Precision::Confusion()
-            ? float(shaderGridSnappedLocalShift(aRadiusRef, myGridParams.AccentScaleX()))
-            : aRadialOriginShift;
-      }
-      else
-      {
-        aLocalOriginShift.SetValues(float(shaderGridSnappedLocalShift(aLocalRefX, aScaleX)),
-                                    float(shaderGridSnappedLocalShift(aLocalRefY, aScaleY)));
-        anAccentLocalOriginShift.SetValues(
-          myGridParams.AccentScaleX() > Precision::Confusion()
-            ? float(shaderGridSnappedLocalShift(aLocalRefX, myGridParams.AccentScaleX()))
-            : aLocalOriginShift.x(),
-          myGridParams.AccentScaleY() > Precision::Confusion()
-            ? float(shaderGridSnappedLocalShift(aLocalRefY, myGridParams.AccentScaleY()))
-            : aLocalOriginShift.y());
-      }
-    }
-
-    const gp_Pnt aPlaneRef(aPlaneOrigin.XYZ() + aXRotated * double(aLocalOriginShift.x())
-                           + aYRotated * double(aLocalOriginShift.y()));
-    const NCollection_Mat4<float>& aGridWorldView = aContext->WorldViewState.Current();
-    aProg->SetUniform(aContext,
-                      "uPlaneOriginView",
-                      shaderGridViewPoint(aGridWorldView, aPlaneOrigin));
-    aProg->SetUniform(aContext, "uPlaneRefView", shaderGridViewPoint(aGridWorldView, aPlaneRef));
-    aProg->SetUniform(aContext, "uPlaneXView", shaderGridViewDirection(aGridWorldView, aXRotated));
-    aProg->SetUniform(aContext, "uPlaneYView", shaderGridViewDirection(aGridWorldView, aYRotated));
-    aProg->SetUniform(aContext, "uPlaneNView", shaderGridViewDirection(aGridWorldView, aNDir));
-    aProg->SetUniform(aContext, "uLocalOriginShift", aLocalOriginShift);
-    aProg->SetUniform(aContext, "uAccentLocalOriginShift", anAccentLocalOriginShift);
-    aProg->SetUniform(aContext, "uRadialOriginShift", GLfloat(aRadialOriginShift));
-    aProg->SetUniform(aContext, "uAccentRadialOriginShift", GLfloat(anAccentRadialOriginShift));
-
-    // Bounded work area (HalfSizeX, HalfSizeY, Radius). 0 = unbounded along that axis.
-    float aHalfX  = myGridParams.SizeX() > 0.0 ? float(myGridParams.SizeX() * 0.5) : 0.0f;
-    float aHalfY  = myGridParams.SizeY() > 0.0 ? float(myGridParams.SizeY() * 0.5) : 0.0f;
-    float aRadius = myGridParams.Radius() > 0.0 ? float(myGridParams.Radius()) : 0.0f;
-    aProg->SetUniform(aContext, "uBounds", NCollection_Vec3<float>(aHalfX, aHalfY, aRadius));
-    aProg->SetUniform(aContext,
-                      "uIsBoundFade",
-                      myGridParams.IsBounded() && !myGridParams.IsViewAdaptive() ? 1 : 0);
-    aProg->SetUniform(
-      aContext,
-      "uArcRange",
-      NCollection_Vec2<float>(float(myGridParams.AngleStart()), float(myGridParams.AngleEnd())));
-    aProg->SetUniform(aContext, "uArcBounded", myGridParams.IsArc() ? 1 : 0);
-
-    if (aScaleX > Precision::Confusion() && aScaleY > Precision::Confusion())
-    {
-      aContext->core11fwd->glDrawArrays(GL_TRIANGLES, 0, 3);
-    }
+    myShaderGrid.SetUniforms(aContext, aProg, aCamera, aContext->WorldViewState.Current());
+    aContext->core11fwd->glDrawArrays(GL_TRIANGLES, 0, 3);
   }
 
   aContext->BindProgram(aPrevProgram);
   aContext->core30->glBindVertexArray((GLuint)aPrevVao);
-
-  aCamera->SetProjectionType(aProjKeep);
 
   aContext->WorldViewState.Pop();
   aContext->ProjectionState.Pop();

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -4234,7 +4234,7 @@ void OpenGl_View::renderGrid()
   }
   aContext->ApplyWorldViewMatrix();
 
-  aContext->core11fwd->glDisable(GL_DEPTH_TEST);
+  aContext->core11fwd->glEnable(GL_DEPTH_TEST);
   aContext->core11fwd->glDepthMask(GL_FALSE);
   aContext->core11fwd->glEnable(GL_BLEND);
   aContext->core11fwd->glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -25,6 +25,7 @@
 #include <OpenGl_GraduatedTrihedron.hxx>
 #include <OpenGl_LayerList.hxx>
 #include <OpenGl_SceneGeometry.hxx>
+#include <OpenGl_ShaderGrid.hxx>
 #include <OpenGl_Structure.hxx>
 #include <OpenGl_TileSampler.hxx>
 #include <TCollection_AsciiString.hxx>
@@ -162,6 +163,10 @@ public:
   //! @return computed bounding box
   Standard_EXPORT Bnd_Box MinMaxValues(const bool theToIncludeAuxiliary) const override;
 
+  //! Return primary and graphical bounding boxes used by camera Z fitting.
+  Standard_EXPORT void ZFitAllBounds(Bnd_Box& thePrimaryBox,
+                                     Bnd_Box& theGraphicBox) const override;
+
   //! Returns pointer to an assigned framebuffer object.
   Standard_EXPORT occ::handle<Standard_Transient> FBO() const override;
 
@@ -223,7 +228,7 @@ public:
   Standard_EXPORT void SetImageBasedLighting(bool theToEnableIBL) override;
 
   //! Display a shader-rendered grid on the given plane.
-  Standard_EXPORT void GridDisplay(const Aspect_GridParams& theParams,
+  Standard_EXPORT bool GridDisplay(const Aspect_GridParams& theParams,
                                    const gp_Ax3&            thePlane) override;
 
   //! Erase the shader-rendered grid.
@@ -239,6 +244,10 @@ public:
                                       const int         theY,
                                       Graphic3d_Vertex& thePoint,
                                       Graphic3d_Vertex& theDisplayPoint) const override;
+
+  //! Return snapped point for the shader-rendered grid from an arbitrary world point.
+  Standard_EXPORT bool ShaderGridSnapPoint(const Graphic3d_Vertex& thePoint,
+                                           Graphic3d_Vertex&       theGridPoint) const override;
 
   //! Returns number of mipmap levels used in specular IBL map.
   //! 0 if PBR environment is not created.
@@ -550,11 +559,8 @@ protected: //! @name Background parameters
   OpenGl_Aspects*            myTextureParams;                     //!< Stores texture and its parameters for textured background
   OpenGl_Aspects*            myCubeMapParams;                     //!< Stores cubemap and its parameters for cubemap background
   OpenGl_Aspects*            myColoredQuadParams;                 //!< Stores parameters for gradient (corner mode) background
-  Aspect_GridParams          myGridParams;                        //!< parameters of shader grid
-  gp_Ax3                     myGridPlane;                         //!< grid plane in world coordinates
-  NCollection_Mat4<float>    myGridRefViewMatrix;                 //!< worldview captured at GridDisplay() for pan/rotate compensation
+  OpenGl_ShaderGrid          myShaderGrid;                        //!< shader grid state and geometry model
   unsigned int               myGridVao;                           //!< dedicated VAO for textureless grid draw
-  bool                       myToShowGrid;                        //!< flag indicating the grid is active
   OpenGl_BackgroundArray*    myBackgrounds[Graphic3d_TypeOfBackground_NB]; //!< Array of primitive arrays of different background types
                                                   // clang-format on
   occ::handle<OpenGl_TextureSet> myTextureEnv;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -164,8 +164,7 @@ public:
   Standard_EXPORT Bnd_Box MinMaxValues(const bool theToIncludeAuxiliary) const override;
 
   //! Return primary and graphical bounding boxes used by camera Z fitting.
-  Standard_EXPORT void ZFitAllBounds(Bnd_Box& thePrimaryBox,
-                                     Bnd_Box& theGraphicBox) const override;
+  Standard_EXPORT void ZFitAllBounds(Bnd_Box& thePrimaryBox, Bnd_Box& theGraphicBox) const override;
 
   //! Returns pointer to an assigned framebuffer object.
   Standard_EXPORT occ::handle<Standard_Transient> FBO() const override;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -228,7 +228,7 @@ public:
   Standard_EXPORT void SetImageBasedLighting(bool theToEnableIBL) override;
 
   //! Display a shader-rendered grid on the given plane.
-  Standard_EXPORT bool GridDisplay(const Aspect_GridParams& theParams,
+  Standard_EXPORT void GridDisplay(const Aspect_GridParams& theParams,
                                    const gp_Ax3&            thePlane) override;
 
   //! Erase the shader-rendered grid.

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.hxx
@@ -229,6 +229,17 @@ public:
   //! Erase the shader-rendered grid.
   Standard_EXPORT void GridErase() override;
 
+  //! Return snapped point for the shader-rendered grid under the window pixel.
+  Standard_EXPORT bool ShaderGridEcho(const int         theX,
+                                      const int         theY,
+                                      Graphic3d_Vertex& thePoint) const override;
+
+  //! Return snapped point and clip-safe display point for the shader-rendered grid echo marker.
+  Standard_EXPORT bool ShaderGridEcho(const int         theX,
+                                      const int         theY,
+                                      Graphic3d_Vertex& thePoint,
+                                      Graphic3d_Vertex& theDisplayPoint) const override;
+
   //! Returns number of mipmap levels used in specular IBL map.
   //! 0 if PBR environment is not created.
   Standard_EXPORT unsigned int SpecIBLMapLevels() const;

--- a/src/Visualization/TKService/Aspect/Aspect_GridParams.hxx
+++ b/src/Visualization/TKService/Aspect/Aspect_GridParams.hxx
@@ -22,10 +22,8 @@
 #include <Quantity_Color.hxx>
 #include <gp_Pnt.hxx>
 
-//! Shader grid appearance (color, scale, bounds, arc, draw mode, background / adaptive flags).
-//! Consumed only by the GPU path: V3d_View::GridDisplay -> OpenGl_View::renderGrid.
-//! No effect on the CPU path (V3d_Viewer::ActivateGrid). Snap math is independent and
-//! lives on Aspect_RectangularGrid / Aspect_CircularGrid.
+//! Grid appearance for V3d_View::GridDisplay: color, scale, bounds, arc, draw mode,
+//! background and adaptive flags.
 class Aspect_GridParams
 {
 public:
@@ -183,8 +181,7 @@ public:
   //! Return signed plane-normal offset applied at render time.
   double ZOffset() const { return myZOffset; }
 
-  //! Set signed plane-normal offset applied at render time (display only;
-  //! snap math stays on the unshifted plane).
+  //! Set signed plane-normal offset applied at render and echo time.
   void SetZOffset(const double theOffset) { myZOffset = theOffset; }
 
   //! Return arc start angle (radians). Meaningful only when IsArc() is true.
@@ -229,10 +226,8 @@ public:
   //! Return TRUE if grid spacing and visible extents adapt to the camera view.
   bool IsViewAdaptive() const { return myIsViewAdaptive; }
 
-  //! Set view-adaptive grid on/off. When enabled, renderer derives temporary
-  //! cell spacing and bounds from the current camera. The inverse of ScaleY()
-  //! (or Scale() when ScaleY() is zero) is used as the target number of cells
-  //! across the view height.
+  //! Set view-adaptive grid on/off. When enabled, shader renderer keeps the
+  //! screen-space grid step stable by scaling the cell spacing with camera zoom.
   void SetIsViewAdaptive(const bool theIsViewAdaptive) { myIsViewAdaptive = theIsViewAdaptive; }
 
 private:

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_CView.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_CView.hxx
@@ -175,6 +175,13 @@ public:
   //! @return computed bounding box
   Standard_EXPORT virtual Bnd_Box MinMaxValues(const bool theToIncludeAuxiliary = false) const;
 
+  //! Return primary and graphical bounding boxes used by camera Z fitting.
+  virtual void ZFitAllBounds(Bnd_Box& thePrimaryBox, Bnd_Box& theGraphicBox) const
+  {
+    thePrimaryBox = MinMaxValues(false);
+    theGraphicBox = MinMaxValues(true);
+  }
+
   //! Returns the coordinates of the boundary box of all structures in the set <theSet>.
   //! If <theToIgnoreInfiniteFlag> is TRUE, then the boundary box
   //! also includes minimum and maximum limits of graphical elements
@@ -442,13 +449,14 @@ public:
   virtual void SetImageBasedLighting(bool theToEnableIBL) = 0;
 
   //! Display a shader-rendered grid on the given plane.
-  //! The default implementation is a no-op; drivers with shader support override it.
+  //! The default implementation returns FALSE; drivers with shader support override it.
   //! @param[in] theParams appearance parameters
   //! @param[in] thePlane  grid plane in world coordinates (origin + X/Y directions)
-  virtual void GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
+  virtual bool GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
   {
     (void)theParams;
     (void)thePlane;
+    return false;
   }
 
   //! Erase the shader-rendered grid.
@@ -480,6 +488,16 @@ public:
     }
     theDisplayPoint = thePoint;
     return true;
+  }
+
+  //! Return snapped point for the shader-rendered grid from an arbitrary world point.
+  //! The default implementation is a no-op; drivers with shader grid support override it.
+  virtual bool ShaderGridSnapPoint(const Graphic3d_Vertex& thePoint,
+                                   Graphic3d_Vertex&       theGridPoint) const
+  {
+    (void)thePoint;
+    (void)theGridPoint;
+    return false;
   }
 
   //! Returns environment texture set for the view.

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_CView.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_CView.hxx
@@ -24,6 +24,7 @@
 #include <Graphic3d_DataStructureManager.hxx>
 #include <Graphic3d_DiagnosticInfo.hxx>
 #include <Graphic3d_GraduatedTrihedron.hxx>
+#include <Graphic3d_Vertex.hxx>
 #include <Standard_Transient.hxx>
 #include <NCollection_Map.hxx>
 #include <NCollection_Shared.hxx>
@@ -453,6 +454,33 @@ public:
   //! Erase the shader-rendered grid.
   //! The default implementation is a no-op; drivers with shader support override it.
   virtual void GridErase() {}
+
+  //! Return snapped point for the shader-rendered grid under the window pixel.
+  //! The default implementation is a no-op; drivers with shader grid support override it.
+  virtual bool ShaderGridEcho(const int theX, const int theY, Graphic3d_Vertex& thePoint) const
+  {
+    (void)theX;
+    (void)theY;
+    (void)thePoint;
+    return false;
+  }
+
+  //! Return snapped point and display point for the shader-rendered grid under the window pixel.
+  //! The snapped point is the geometric grid point in world coordinates.
+  //! The display point is a clip-safe proxy projected to the same window position for echo marker
+  //! presentation; it should not be used as the geometric snap result.
+  virtual bool ShaderGridEcho(const int         theX,
+                              const int         theY,
+                              Graphic3d_Vertex& thePoint,
+                              Graphic3d_Vertex& theDisplayPoint) const
+  {
+    if (!ShaderGridEcho(theX, theY, thePoint))
+    {
+      return false;
+    }
+    theDisplayPoint = thePoint;
+    return true;
+  }
 
   //! Returns environment texture set for the view.
   const occ::handle<Graphic3d_TextureEnv>& TextureEnv() const { return myTextureEnvData; }

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_CView.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_CView.hxx
@@ -449,14 +449,13 @@ public:
   virtual void SetImageBasedLighting(bool theToEnableIBL) = 0;
 
   //! Display a shader-rendered grid on the given plane.
-  //! The default implementation returns FALSE; drivers with shader support override it.
+  //! The default implementation is a no-op; drivers with shader support override it.
   //! @param[in] theParams appearance parameters
   //! @param[in] thePlane  grid plane in world coordinates (origin + X/Y directions)
-  virtual bool GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
+  virtual void GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
   {
     (void)theParams;
     (void)thePlane;
-    return false;
   }
 
   //! Erase the shader-rendered grid.

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2229,6 +2229,11 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  float aWidth = max (aPixelWidth, theThickness);" EOL
     "  if (aWidth == 0.0) { return 0.0; }" EOL "  return 1.0 - min (aDist / aWidth, 1.0);" EOL "}"
 
+    EOL "float axisLine1d (float theCoord, float theThickness)" EOL "{" EOL
+    "  float aWidth = max (fwidth (theCoord), theThickness);" EOL
+    "  if (aWidth == 0.0) { return 0.0; }" EOL
+    "  return 1.0 - min (abs (theCoord) / aWidth, 1.0);" EOL "}"
+
     EOL "vec4 gridLines2d (vec2 theUV, vec2 theAxisUV, vec3 theColor, vec2 theScale," EOL
     "                  vec2 theShift, bool theIsDrawAxis, float theThickness)" EOL "{" EOL
     "  float aAlphaX = gridLine1d (theUV.x, theShift.x, theScale.x, theThickness);" EOL
@@ -2236,11 +2241,14 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  float aAlpha  = uDrawMode == 1 ? aAlphaX * aAlphaY : max (aAlphaX, aAlphaY);" EOL
     "  vec4  aColor  = vec4 (theColor, aAlpha);" EOL
     "  if (uIsDrawAxis != 0 && theIsDrawAxis && uDrawMode != 1)" EOL "  {" EOL
-    "    float anAxisX = gridLine1d (theAxisUV.y, 0.0, 1.0, theThickness);" EOL
-    "    float anAxisY = gridLine1d (theAxisUV.x, 0.0, 1.0, theThickness);" EOL
-    "    if      (anAxisX > 0.0 && anAxisY > 0.0) { aColor.xyz = vec3 (0.0, 0.0, 1.0); }" EOL
-    "    else if (anAxisX > 0.0)                  { aColor.xyz = vec3 (1.0, 0.0, 0.0); }" EOL
-    "    else if (anAxisY > 0.0)                  { aColor.xyz = vec3 (0.0, 1.0, 0.0); }" EOL
+    "    float anAxisX = axisLine1d (theAxisUV.y, theThickness);" EOL
+    "    float anAxisY = axisLine1d (theAxisUV.x, theThickness);" EOL
+    "    if      (anAxisX > 0.0 && anAxisY > 0.0) { aColor = vec4 (0.0, 0.0, 1.0, max "
+    "(aColor.a, max (anAxisX, anAxisY))); }" EOL
+    "    else if (anAxisX > 0.0)                  { aColor = vec4 (1.0, 0.0, 0.0, max "
+    "(aColor.a, anAxisX)); }" EOL
+    "    else if (anAxisY > 0.0)                  { aColor = vec4 (0.0, 1.0, 0.0, max "
+    "(aColor.a, anAxisY)); }" EOL
     "  }" EOL "  return aColor;" EOL "}"
 
     EOL "vec4 gridLines1d (float theCoord, float theShift, float theScale, vec3 theColor, float "
@@ -2322,13 +2330,15 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "uAccentColor, uThickness));" EOL "      }" EOL "    }" EOL
     // For circular grid, paint X/Y axis lines explicitly using plane-local coords.
     "    if (uIsDrawAxis != 0 && uGridType == 1)" EOL "    {" EOL
-    "      vec2 aDerivAxis = max (fwidth (aAxisUv), vec2 (uThickness));" EOL
-    "      if (abs (aAxisUv.x) < aDerivAxis.x && abs (aAxisUv.y) < aDerivAxis.y)" EOL "      {" EOL
+    "      float anAxisX = axisLine1d (aAxisUv.y, uThickness);" EOL
+    "      float anAxisY = axisLine1d (aAxisUv.x, uThickness);" EOL
+    "      if (anAxisX > 0.0 && anAxisY > 0.0)" EOL "      {" EOL
     "        aColor = vec4 (0.0, 0.0, 1.0, 1.0);" EOL "      }" EOL
-    "      else if (abs (aAxisUv.y) < aDerivAxis.y)" EOL "      {" EOL
-    "        aColor = vec4 (1.0, 0.0, 0.0, 1.0);" EOL "      }" EOL
-    "      else if (abs (aAxisUv.x) < aDerivAxis.x)" EOL "      {" EOL
-    "        aColor = vec4 (0.0, 1.0, 0.0, 1.0);" EOL "      }" EOL "    }" EOL "  }"
+    "      else if (anAxisX > 0.0)" EOL "      {" EOL
+    "        aColor = vec4 (1.0, 0.0, 0.0, max (aColor.a, anAxisX));" EOL "      }" EOL
+    "      else if (anAxisY > 0.0)" EOL "      {" EOL
+    "        aColor = vec4 (0.0, 1.0, 0.0, max (aColor.a, anAxisY));" EOL "      }" EOL
+    "    }" EOL "  }"
 
     EOL "  if (aColor.a == 0.0) { discard; }" EOL "  aColor.a *= aBoundFade;" EOL
     "  occFragColor = aColor;" EOL "}";

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2194,7 +2194,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("int uIsPerspective", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
-    Graphic3d_ShaderObject::ShaderVariable("float uNdcNear", Graphic3d_TOS_FRAGMENT));
+    Graphic3d_ShaderObject::ShaderVariable("int uIsZeroToOneDepth", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 uLocalOriginShift", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
@@ -2262,16 +2262,22 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  vec4 aView = occProjectionMatrixInverse * vec4 (theX, theY, theZ, 1.0);" EOL
     "  return aView.xyz / aView.w;" EOL "}"
 
+    EOL "float gridNdcNear()" EOL "{" EOL
+    "  return uIsZeroToOneDepth != 0 ? 0.0 : -1.0;" EOL "}"
+
+    EOL "float gridDepthFromNdc (float theNdcZ)" EOL "{" EOL
+    "  return uIsZeroToOneDepth != 0 ? theNdcZ : (theNdcZ * 0.5 + 0.5);" EOL "}"
+
     EOL "float fragmentDepthFromView (vec3 theViewPnt)" EOL "{" EOL
     "  vec4 aClip = occProjectionMatrix * vec4 (theViewPnt, 1.0);" EOL
     "  float aNdcZ = aClip.z / aClip.w;" EOL
-    "  return uNdcNear == 0.0 ? aNdcZ : (aNdcZ * 0.5 + 0.5);" EOL "}"
+    "  return gridDepthFromNdc (aNdcZ);" EOL "}"
 
     EOL "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL "{" EOL
     "  vec3 aRayOrigin = uIsPerspective != 0 ? vec3 (0.0) : theNearPoint;" EOL
     "  vec3 aRayTarget = theFarPoint;" EOL "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
     "  float aDenom = dot (uPlaneNView, aDir);" EOL "  if (aDenom == 0.0)" EOL "  {" EOL
-    "    theHit = theNearPoint;" EOL "    return false;" EOL "  }" EOL
+    "    return false;" EOL "  }" EOL
     "  float aT = dot (uPlaneNView, uPlaneOriginView - aRayOrigin) / aDenom;" EOL
     "  if (uIsPerspective != 0 && aT < 0.0)" EOL "  {" EOL "    theHit = theNearPoint;" EOL
     "    return false;" EOL "  }" EOL "  theHit = aRayOrigin + aT * aDir;" EOL "  return true;" EOL
@@ -2279,10 +2285,17 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
 
     EOL "const float GRID_TWO_PI = 6.28318530718;"
 
+    EOL "bool gridAngleInArc (float theAngle)" EOL "{" EOL
+    "  float aSpan = uArcRange.y - uArcRange.x;" EOL
+    "  if (aSpan < 0.0) { aSpan += GRID_TWO_PI; }" EOL
+    "  float aDelta = theAngle - uArcRange.x;" EOL
+    "  if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL
+    "  return aDelta <= aSpan;" EOL "}"
+
     EOL "void main()" EOL "{"
     // Intersect in view space: the camera is the numerical origin, so zoom and
     // world-coordinate magnitude do not destabilize the line phase.
-    EOL "  vec3 aNearPoint = unprojectView (vNdc.x, vNdc.y, uNdcNear);" EOL
+    EOL "  vec3 aNearPoint = unprojectView (vNdc.x, vNdc.y, gridNdcNear());" EOL
     "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL "  vec3 aHit;" EOL
     "  if (!intersectPlaneView (aNearPoint, aFarPoint, aHit)) { discard; }" EOL
     "  float aFragDepth = fragmentDepthFromView (aHit);" EOL
@@ -2300,11 +2313,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "    float aFwBR = fwidth (aR);" EOL "    if (aR > uBounds.z) { discard; }" EOL
     "    if (uIsBoundFade != 0)" EOL "    {" EOL
     "      aBoundFade *= 1.0 - smoothstep (uBounds.z - aFwBR, uBounds.z, aR);" EOL "    }" EOL
-    "  }" EOL "  if (uArcBounded != 0)" EOL "  {" EOL
-    "    float aSpan = uArcRange.y - uArcRange.x;" EOL
-    "    if (aSpan < 0.0) { aSpan += GRID_TWO_PI; }" EOL "    float aDelta = aA - uArcRange.x;" EOL
-    "    if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL
-    "    if (aDelta > aSpan) { discard; }" EOL "  }" EOL "  if (uBounds.x > 0.0)" EOL "  {" EOL
+    "  }" EOL "  if (uArcBounded != 0 && !gridAngleInArc (aA)) { discard; }" EOL
+    "  if (uBounds.x > 0.0)" EOL "  {" EOL
     // Keep the bounded area geometrically strict; fwidth is used only for the
     // optional fade inside the boundary, never to expand the valid area.
     "    float aFwBX = fwidth (abs (aLocal.x));" EOL

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2252,8 +2252,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "    else if (anAxisX > 0.0)                  { aColor = vec4 (1.0, 0.0, 0.0, max "
     "(aColor.a, anAxisX)); }" EOL
     "    else if (anAxisY > 0.0)                  { aColor = vec4 (0.0, 1.0, 0.0, max "
-    "(aColor.a, anAxisY)); }" EOL
-    "  }" EOL "  return aColor;" EOL "}"
+    "(aColor.a, anAxisY)); }" EOL "  }" EOL "  return aColor;" EOL "}"
 
     EOL "vec4 gridLines1d (float theCoord, float theShift, float theScale, vec3 theColor, float "
     "theThickness)" EOL "{" EOL
@@ -2266,29 +2265,26 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  vec4 aView = occProjectionMatrixInverse * vec4 (theX, theY, theZ, 1.0);" EOL
     "  return aView.xyz / aView.w;" EOL "}"
 
-    EOL "float gridNdcNear()" EOL "{" EOL
-    "  return uIsZeroToOneDepth != 0 ? 0.0 : -1.0;" EOL "}"
+    EOL "float gridNdcNear()" EOL "{" EOL "  return uIsZeroToOneDepth != 0 ? 0.0 : -1.0;" EOL "}"
 
     EOL "float gridDepthFromNdc (float theNdcZ)" EOL "{" EOL
     "  return uIsZeroToOneDepth != 0 ? theNdcZ : (theNdcZ * 0.5 + 0.5);" EOL "}"
 
     EOL "float fragmentDepthFromView (vec3 theViewPnt)" EOL "{" EOL
     "  vec4 aClip = occProjectionMatrix * vec4 (theViewPnt, 1.0);" EOL
-    "  float aNdcZ = aClip.z / aClip.w;" EOL
-    "  return gridDepthFromNdc (aNdcZ);" EOL "}"
+    "  float aNdcZ = aClip.z / aClip.w;" EOL "  return gridDepthFromNdc (aNdcZ);" EOL "}"
 
     EOL "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL "{" EOL
     "  vec3 aRayOrigin = uIsPerspective != 0 ? vec3 (0.0) : theNearPoint;" EOL
     "  vec3 aRayTarget = theFarPoint;" EOL "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
-    "  float aDirLen = length (aDir);" EOL
-    "  if (aDirLen == 0.0) { return false; }" EOL
+    "  float aDirLen = length (aDir);" EOL "  if (aDirLen == 0.0) { return false; }" EOL
     "  float aDenomN = dot (uPlaneNView, aDir / aDirLen);" EOL
     "  if (abs (aDenomN) <= uParallelTolerance) { return false; }" EOL
     "  float aDenom = dot (uPlaneNView, aDir);" EOL
     "  float aT = dot (uPlaneNView, uPlaneOriginView - aRayOrigin) / aDenom;" EOL
-    "  if (uIsBackground == 0 && uIsPerspective != 0 && aT < 0.0)" EOL "  {" EOL "    theHit = theNearPoint;" EOL
-    "    return false;" EOL "  }" EOL "  theHit = aRayOrigin + aT * aDir;" EOL "  return true;" EOL
-    "}" EOL
+    "  if (uIsBackground == 0 && uIsPerspective != 0 && aT < 0.0)" EOL "  {" EOL
+    "    theHit = theNearPoint;" EOL "    return false;" EOL "  }" EOL
+    "  theHit = aRayOrigin + aT * aDir;" EOL "  return true;" EOL "}" EOL
 
     EOL "const float GRID_TWO_PI = 6.28318530718;"
 
@@ -2296,8 +2292,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  float aSpan = uArcRange.y - uArcRange.x;" EOL
     "  if (aSpan < 0.0) { aSpan += GRID_TWO_PI; }" EOL
     "  float aDelta = theAngle - uArcRange.x;" EOL
-    "  if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL
-    "  return aDelta <= aSpan;" EOL "}"
+    "  if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL "  return aDelta <= aSpan;" EOL "}"
 
     EOL "void main()" EOL "{"
     // Intersect in view space: the camera is the numerical origin, so zoom and
@@ -2305,14 +2300,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     EOL "  vec3 aNearPoint = unprojectView (vNdc.x, vNdc.y, gridNdcNear());" EOL
     "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL "  vec3 aHit;" EOL
     "  if (!intersectPlaneView (aNearPoint, aFarPoint, aHit)) { discard; }" EOL
-    "  float aFragDepth = fragmentDepthFromView (aHit);" EOL
-    "  if (uIsBackground == 0)" EOL "  {" EOL
-    "    if (aFragDepth < 0.0) { discard; }" EOL
-    "    gl_FragDepth = min (aFragDepth, 1.0);" EOL
-    "  }" EOL "  else" EOL "  {" EOL
-    "    gl_FragDepth = 1.0;" EOL
-    "  }" EOL
-    "  vec3 aLocalAbs3  = aHit - uPlaneOriginView;" EOL
+    "  float aFragDepth = fragmentDepthFromView (aHit);" EOL "  if (uIsBackground == 0)" EOL
+    "  {" EOL "    if (aFragDepth < 0.0) { discard; }" EOL
+    "    gl_FragDepth = min (aFragDepth, 1.0);" EOL "  }" EOL "  else" EOL "  {" EOL
+    "    gl_FragDepth = 1.0;" EOL "  }" EOL "  vec3 aLocalAbs3  = aHit - uPlaneOriginView;" EOL
     "  vec2 aLocal      = vec2 (dot (aLocalAbs3, uPlaneXView), dot (aLocalAbs3, uPlaneYView));" EOL
     "  vec3 aLocalGrid3 = aHit - uPlaneRefView;" EOL
     "  vec2 aLocalGrid  = vec2 (dot (aLocalGrid3, uPlaneXView), dot (aLocalGrid3, "
@@ -2366,8 +2357,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "      else if (anAxisX > 0.0)" EOL "      {" EOL
     "        aColor = vec4 (1.0, 0.0, 0.0, max (aColor.a, anAxisX));" EOL "      }" EOL
     "      else if (anAxisY > 0.0)" EOL "      {" EOL
-    "        aColor = vec4 (0.0, 1.0, 0.0, max (aColor.a, anAxisY));" EOL "      }" EOL
-    "    }" EOL "  }"
+    "        aColor = vec4 (0.0, 1.0, 0.0, max (aColor.a, anAxisY));" EOL "      }" EOL "    }" EOL
+    "  }"
 
     EOL "  if (aColor.a == 0.0) { discard; }" EOL "  aColor.a *= aBoundFade;" EOL
     "  occFragColor = aColor;" EOL "}";

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2196,6 +2196,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("int uIsZeroToOneDepth", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("int uIsBackground", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("float uParallelTolerance", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 uLocalOriginShift", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 uAccentLocalOriginShift", Graphic3d_TOS_FRAGMENT));
@@ -2276,10 +2280,13 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     EOL "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL "{" EOL
     "  vec3 aRayOrigin = uIsPerspective != 0 ? vec3 (0.0) : theNearPoint;" EOL
     "  vec3 aRayTarget = theFarPoint;" EOL "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
-    "  float aDenom = dot (uPlaneNView, aDir);" EOL "  if (aDenom == 0.0)" EOL "  {" EOL
-    "    return false;" EOL "  }" EOL
+    "  float aDirLen = length (aDir);" EOL
+    "  if (aDirLen == 0.0) { return false; }" EOL
+    "  float aDenomN = dot (uPlaneNView, aDir / aDirLen);" EOL
+    "  if (abs (aDenomN) <= uParallelTolerance) { return false; }" EOL
+    "  float aDenom = dot (uPlaneNView, aDir);" EOL
     "  float aT = dot (uPlaneNView, uPlaneOriginView - aRayOrigin) / aDenom;" EOL
-    "  if (uIsPerspective != 0 && aT < 0.0)" EOL "  {" EOL "    theHit = theNearPoint;" EOL
+    "  if (uIsBackground == 0 && uIsPerspective != 0 && aT < 0.0)" EOL "  {" EOL "    theHit = theNearPoint;" EOL
     "    return false;" EOL "  }" EOL "  theHit = aRayOrigin + aT * aDir;" EOL "  return true;" EOL
     "}" EOL
 
@@ -2299,8 +2306,12 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL "  vec3 aHit;" EOL
     "  if (!intersectPlaneView (aNearPoint, aFarPoint, aHit)) { discard; }" EOL
     "  float aFragDepth = fragmentDepthFromView (aHit);" EOL
-    "  if (aFragDepth < 0.0 || aFragDepth > 1.0) { discard; }" EOL
-    "  gl_FragDepth = aFragDepth;" EOL
+    "  if (uIsBackground == 0)" EOL "  {" EOL
+    "    if (aFragDepth < 0.0) { discard; }" EOL
+    "    gl_FragDepth = min (aFragDepth, 1.0);" EOL
+    "  }" EOL "  else" EOL "  {" EOL
+    "    gl_FragDepth = 1.0;" EOL
+    "  }" EOL
     "  vec3 aLocalAbs3  = aHit - uPlaneOriginView;" EOL
     "  vec2 aLocal      = vec2 (dot (aLocalAbs3, uPlaneXView), dot (aLocalAbs3, uPlaneYView));" EOL
     "  vec3 aLocalGrid3 = aHit - uPlaneRefView;" EOL

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2156,8 +2156,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
   occ::handle<Graphic3d_ShaderProgram> aProgSrc = new Graphic3d_ShaderProgram();
 
   Graphic3d_ShaderObject::ShaderVariableList aUniforms, aStageInOuts;
-  // Pass only NDC.xy to the fragment; the fragment shader maps it to grid-local
-  // coordinates through a CPU-built projective transform.
+  // Pass only NDC.xy to the fragment; each fragment reconstructs its view-space
+  // ray and intersects it with the grid plane.
   aStageInOuts.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 vNdc",
                                            Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
@@ -2288,11 +2288,23 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
 
     EOL "const float GRID_TWO_PI = 6.28318530718;"
 
-    EOL "bool gridAngleInArc (float theAngle)" EOL "{" EOL
-    "  float aSpan = uArcRange.y - uArcRange.x;" EOL
+    EOL "float gridNormalizeAngle (float theAngle)" EOL "{" EOL
+    "  float anAngle = mod (theAngle, GRID_TWO_PI);" EOL
+    "  if (anAngle < 0.0) { anAngle += GRID_TWO_PI; }" EOL "  return anAngle;" EOL "}"
+
+    EOL "float gridPositiveAngleSpan (float theStart, float theEnd)" EOL "{" EOL
+    "  float aSpan = mod (theEnd - theStart, GRID_TWO_PI);" EOL
     "  if (aSpan < 0.0) { aSpan += GRID_TWO_PI; }" EOL
-    "  float aDelta = theAngle - uArcRange.x;" EOL
-    "  if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL "  return aDelta <= aSpan;" EOL "}"
+    "  if (abs (aSpan) <= uParallelTolerance && abs (theEnd - theStart) >= GRID_TWO_PI - "
+    "uParallelTolerance)" EOL "  {" EOL "    return GRID_TWO_PI;" EOL "  }" EOL
+    "  return aSpan;" EOL "}"
+
+    EOL "bool gridAngleInArc (float theAngle)" EOL "{" EOL
+    "  float aSpan = gridPositiveAngleSpan (uArcRange.x, uArcRange.y);" EOL
+    "  if (aSpan >= GRID_TWO_PI - uParallelTolerance) { return true; }" EOL
+    "  float aDelta = gridNormalizeAngle (theAngle) - gridNormalizeAngle (uArcRange.x);" EOL
+    "  if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL
+    "  return aDelta <= aSpan + uParallelTolerance;" EOL "}"
 
     EOL "void main()" EOL "{"
     // Intersect in view space: the camera is the numerical origin, so zoom and

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2156,12 +2156,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
   occ::handle<Graphic3d_ShaderProgram> aProgSrc = new Graphic3d_ShaderProgram();
 
   Graphic3d_ShaderObject::ShaderVariableList aUniforms, aStageInOuts;
-  // Pass only NDC.xy to the fragment. Near/Far world points are computed
-  // per-pixel because the perspective-divide that unproject() performs is
-  // nonlinear in NDC, and linearly interpolating the resulting world-space
-  // points across the full-screen quad produces wrong rays along the
-  // diagonal seam between the two triangles (visible as empty triangular
-  // dead zones at oblique camera angles).
+  // Pass only NDC.xy to the fragment; the fragment shader maps it to grid-local
+  // coordinates through a CPU-built projective transform.
   aStageInOuts.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 vNdc",
                                            Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
@@ -2182,21 +2178,35 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("int uIsDrawAxis", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
-    Graphic3d_ShaderObject::ShaderVariable("int uIsBackground", Graphic3d_TOS_FRAGMENT));
+    Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneOriginView", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
-    Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneOrigin", Graphic3d_TOS_FRAGMENT));
-  aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneX", Graphic3d_TOS_FRAGMENT));
-  aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneY", Graphic3d_TOS_FRAGMENT));
-  aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneN", Graphic3d_TOS_FRAGMENT));
+    Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneRefView", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneXView", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneYView", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("vec3 uPlaneNView", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("int uGridType", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("float uAngularScale", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("int uDrawMode", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
-    Graphic3d_ShaderObject::ShaderVariable("vec2 uStableRefLocal", Graphic3d_TOS_FRAGMENT));
+    Graphic3d_ShaderObject::ShaderVariable("int uIsPerspective", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
-    Graphic3d_ShaderObject::ShaderVariable("int uHasStableRef", Graphic3d_TOS_FRAGMENT));
+    Graphic3d_ShaderObject::ShaderVariable("float uNdcNear", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("vec2 uLocalOriginShift", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("vec2 uAccentLocalOriginShift",
+                                           Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("float uRadialOriginShift", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("float uAccentRadialOriginShift",
+                                                          Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("vec3 uBounds", Graphic3d_TOS_FRAGMENT));
+  aUniforms.Append(
+    Graphic3d_ShaderObject::ShaderVariable("int uIsBoundFade", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 uArcRange", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
@@ -2204,145 +2214,137 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
 
   TCollection_AsciiString aSrcVert =
     TCollection_AsciiString()
-    + EOL "const vec3 gridPlane[6] = vec3[] (" EOL
-          "  vec3( 1.0,  1.0, 0.0), vec3(-1.0, -1.0, 0.0), vec3(-1.0,  1.0, 0.0)," EOL
-          "  vec3(-1.0, -1.0, 0.0), vec3( 1.0,  1.0, 0.0), vec3( 1.0, -1.0, 0.0));"
+    + EOL "const vec2 gridPlane[3] = vec2[] (" EOL
+          "  vec2(-1.0, -1.0), vec2(3.0, -1.0), vec2(-1.0, 3.0));"
 
-    EOL "void main()" EOL "{" EOL "  vec3 aVertex = gridPlane[gl_VertexID];" EOL
-          "  vNdc        = aVertex.xy;" EOL "  gl_Position = vec4 (aVertex, 1.0);" EOL "}";
+    EOL "void main()" EOL "{" EOL "  vec2 aVertex = gridPlane[gl_VertexID];" EOL
+          "  vNdc        = aVertex;" EOL "  gl_Position = vec4 (aVertex, 0.0, 1.0);" EOL "}";
 
   TCollection_AsciiString aSrcFrag =
     TCollection_AsciiString()
     + EOL
-    "vec4 gridLines2d (vec2 theUV, vec2 theAxisUV, vec3 theColor, vec2 theScale," EOL
-    "                  bool theIsDrawAxis, float theThickness)" EOL "{" EOL
-    "  vec2 aCoord      = theUV * theScale;" EOL "  vec2 aFwidth     = fwidth (aCoord);" EOL
-    "  vec2 aDerivative = max (aFwidth, vec2 (theThickness));" EOL
-    "  vec2 aGrid       = abs (fract (aCoord - 0.5) - 0.5) / aDerivative;" EOL
-    // Per-axis Nyquist fade: when more than ~1.5 grid cells map to a pixel in a given
-    // direction, that set of lines fades to zero instead of smearing into a bright band.
-    // Lines mode (uDrawMode!=1): bright when either axis shows a line -> max of per-axis alphas.
-    // Points mode (uDrawMode==1): bright only at intersections -> product of per-axis alphas.
-    EOL "  vec2  aNyq    = vec2 (1.0) - smoothstep (vec2 (1.0), vec2 (2.0), aFwidth);" EOL
-    "  float aAlphaX = (1.0 - min (aGrid.x, 1.0)) * aNyq.x;" EOL
-    "  float aAlphaY = (1.0 - min (aGrid.y, 1.0)) * aNyq.y;" EOL
-    "  float aAlpha  = uDrawMode == 1 ? aAlphaX * aAlphaY : max (aAlphaX, aAlphaY);" EOL
-    "  float aMinY   = min (aDerivative.y, 1.0);" EOL
-    "  float aMinX   = min (aDerivative.x, 1.0);" EOL
-    "  vec4  aColor  = vec4 (theColor, aAlpha);" EOL
-    // Axis colouring in lines mode only; a "point" has no axis direction.
-    EOL "  if (uIsDrawAxis != 0 && theIsDrawAxis && uDrawMode != 1)" EOL "  {" EOL
-    "    vec2 aAxisCoord = theAxisUV * theScale;" EOL
-    "    bool isYAxis = abs (aAxisCoord.x) < aMinX;" EOL
-    "    bool isXAxis = abs (aAxisCoord.y) < aMinY;" EOL
-    "    if      (isXAxis && isYAxis) { aColor.xyz = vec3 (0.0, 0.0, 1.0); }" EOL
-    "    else if (isXAxis)            { aColor.xyz = vec3 (1.0, 0.0, 0.0); }" EOL
-    "    else if (isYAxis)            { aColor.xyz = vec3 (0.0, 1.0, 0.0); }" EOL "  }" EOL
-    "  return aColor;" EOL "}"
+    "float gridLine1d (float theCoord, float theShift, float theScale, float theThickness)" EOL
+    "{" EOL
+    "  float aCoord = (theCoord - theShift) * theScale;" EOL
+    "  float aPixelWidth = fwidth (aCoord);" EOL
+    "  if (!(aPixelWidth >= 0.0)) { return 0.0; }" EOL
+    "  float aDist  = abs (fract (aCoord + 0.5) - 0.5);" EOL
+    "  float aWidth = max (aPixelWidth, theThickness);" EOL
+    "  if (aWidth == 0.0) { return 0.0; }" EOL
+    "  return 1.0 - min (aDist / aWidth, 1.0);" EOL "}"
 
-    EOL "vec4 gridLines1d (float theCoord, float theScale, vec3 theColor, float theThickness)" EOL
-    "{" EOL "  float aCoord      = theCoord * theScale;" EOL
-    "  float aFwidth     = fwidth (aCoord);" EOL
-    "  float aDerivative = max (aFwidth, theThickness);" EOL
-    "  float aGrid       = abs (fract (aCoord - 0.5) - 0.5) / aDerivative;" EOL
-    "  float aNyq        = 1.0 - smoothstep (1.0, 2.0, aFwidth);" EOL
-    "  return vec4 (theColor, (1.0 - min (aGrid, 1.0)) * aNyq);" EOL "}"
+    EOL "vec4 gridLines2d (vec2 theUV, vec2 theAxisUV, vec3 theColor, vec2 theScale," EOL
+    "                  vec2 theShift, bool theIsDrawAxis, float theThickness)" EOL "{" EOL
+    "  float aAlphaX = gridLine1d (theUV.x, theShift.x, theScale.x, theThickness);" EOL
+    "  float aAlphaY = gridLine1d (theUV.y, theShift.y, theScale.y, theThickness);" EOL
+    "  float aAlpha  = uDrawMode == 1 ? aAlphaX * aAlphaY : max (aAlphaX, aAlphaY);" EOL
+    "  vec4  aColor  = vec4 (theColor, aAlpha);" EOL
+    "  if (uIsDrawAxis != 0 && theIsDrawAxis && uDrawMode != 1)" EOL "  {" EOL
+    "    float anAxisX = gridLine1d (theAxisUV.y, 0.0, 1.0, theThickness);" EOL
+    "    float anAxisY = gridLine1d (theAxisUV.x, 0.0, 1.0, theThickness);" EOL
+    "    if      (anAxisX > 0.0 && anAxisY > 0.0) { aColor.xyz = vec3 (0.0, 0.0, 1.0); }" EOL
+    "    else if (anAxisX > 0.0)                  { aColor.xyz = vec3 (1.0, 0.0, 0.0); }" EOL
+    "    else if (anAxisY > 0.0)                  { aColor.xyz = vec3 (0.0, 1.0, 0.0); }" EOL
+    "  }" EOL "  return aColor;" EOL "}"
+
+    EOL
+    "vec4 gridLines1d (float theCoord, float theShift, float theScale, vec3 theColor, float "
+    "theThickness)" EOL
+    "{" EOL "  return vec4 (theColor, gridLine1d (theCoord, theShift, theScale, theThickness));"
+    EOL "}"
 
     EOL "vec4 overlayGrid (vec4 theBase, vec4 theAccent)" EOL "{" EOL
     "  return theAccent.a >= theBase.a ? theAccent : theBase;" EOL "}"
 
-    EOL "vec3 unproject (float theX, float theY, float theZ)" EOL "{" EOL
-    "  vec4 aUnproj = occModelWorldMatrixInverse * occWorldViewMatrixInverse" EOL
-    "               * occProjectionMatrixInverse * vec4 (theX, theY, theZ, 1.0);" EOL
-    "  return aUnproj.xyz / aUnproj.w;" EOL "}"
+    EOL "vec3 unprojectView (float theX, float theY, float theZ)" EOL "{" EOL
+    "  vec4 aView = occProjectionMatrixInverse * vec4 (theX, theY, theZ, 1.0);" EOL
+    "  return aView.xyz / aView.w;" EOL "}"
 
-    // sin(angle) threshold for "ray parallel to plane" - ~5.7e-5 deg.
-    EOL "const float GRID_PARALLEL_EPS = 1e-6;"
+    EOL
+    "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL
+    "{" EOL
+    "  vec3 aRayOrigin = uIsPerspective != 0 ? vec3 (0.0) : theNearPoint;" EOL
+    "  vec3 aRayTarget = theFarPoint;" EOL
+    "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
+    "  float aDenom = dot (uPlaneNView, aDir);" EOL
+    "  if (aDenom == 0.0)" EOL
+    "  {" EOL
+    "    theHit = theNearPoint;" EOL
+    "    return false;" EOL
+    "  }" EOL
+    "  float aT = dot (uPlaneNView, uPlaneOriginView - aRayOrigin) / aDenom;" EOL
+    "  if (uIsPerspective != 0 && aT < 0.0)" EOL
+    "  {" EOL
+    "    theHit = theNearPoint;" EOL
+    "    return false;" EOL
+    "  }" EOL
+    "  theHit = aRayOrigin + aT * aDir;" EOL
+    "  return true;" EOL
+    "}" EOL
 
-    EOL "bool intersectPlane (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL "{" EOL
-    "  vec3  aDir    = theFarPoint - theNearPoint;" EOL
-    "  float aDenomN = dot (uPlaneN, normalize (aDir));" EOL
-    "  if (abs (aDenomN) < GRID_PARALLEL_EPS)" EOL "  {" EOL "    theHit = theNearPoint;" EOL
-    "    return false;" EOL "  }" EOL "  float aDenom = dot (uPlaneN, aDir);" EOL
-    "  float aT = dot (uPlaneN, uPlaneOrigin - theNearPoint) / aDenom;" EOL
-    "  theHit = theNearPoint + aT * aDir;" EOL "  return true;" EOL "}" EOL
-
-    EOL "float computeDepth (vec3 thePos)" EOL "{" EOL
-    "  mat4 aMVP  = occProjectionMatrix * occWorldViewMatrix * occModelWorldMatrix;" EOL
-    "  vec4 aClip = aMVP * vec4 (thePos, 1.0);" EOL "  return aClip.z / aClip.w;" EOL "}"
-
-    // Fade-band width (as a fraction of bound) applied inside the bound edge.
-    // Narrow smoothstep softens rectangular/disc cuts; angular cut stays hard.
-    EOL "const float GRID_FADE_BAND = 0.95;"
-    // Keep gl_FragDepth strictly less than 1.0 so the grid never lands exactly
-    // on the far plane (some drivers cull there).
-    EOL "const float GRID_DEPTH_EPS = 1e-5;" EOL "const float GRID_TWO_PI = 6.28318530718;"
+    EOL "const float GRID_TWO_PI = 6.28318530718;"
 
     EOL "void main()" EOL "{"
-    // Unproject per-pixel from vNdc (linearly interpolated NDC.xy) to avoid the
-    // nonlinearity of the perspective divide when ray endpoints are passed as
-    // varyings. Each fragment reconstructs its own Near/Far world points.
-    EOL "  vec3 aNearPoint = unproject (vNdc.x, vNdc.y, -1.0);" EOL
-    "  vec3 aFarPoint  = unproject (vNdc.x, vNdc.y,  1.0);" EOL "  vec3 aHit;" EOL
-    "  if (!intersectPlane (aNearPoint, aFarPoint, aHit)) { discard; }"
-    // Plane-local 2D coords, origin-centered to tame fp precision at large world offsets.
-    EOL "  vec3  aLocal3  = aHit - uPlaneOrigin;" EOL
-    "  vec2  aLocal   = vec2 (dot (aLocal3, uPlaneX), dot (aLocal3, uPlaneY));"
+    // Intersect in view space: the camera is the numerical origin, so zoom and
+    // world-coordinate magnitude do not destabilize the line phase.
+    EOL "  vec3 aNearPoint = unprojectView (vNdc.x, vNdc.y, uNdcNear);" EOL
+    "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL
+    "  vec3 aHit;" EOL
+    "  if (!intersectPlaneView (aNearPoint, aFarPoint, aHit)) { discard; }" EOL
+    "  vec3 aLocalAbs3  = aHit - uPlaneOriginView;" EOL
+    "  vec2 aLocal      = vec2 (dot (aLocalAbs3, uPlaneXView), dot (aLocalAbs3, uPlaneYView));"
+    EOL
+    "  vec3 aLocalGrid3 = aHit - uPlaneRefView;" EOL
+    "  vec2 aLocalGrid  = vec2 (dot (aLocalGrid3, uPlaneXView), dot (aLocalGrid3, "
+    "uPlaneYView));"
 
     // Bounded work area. Rectangular, radial and angular clipping can be mixed.
     EOL "  float aR = length (aLocal);" EOL "  float aA = atan (aLocal.y, aLocal.x);" EOL
     "  float aBoundFade = 1.0;" EOL "  if (uBounds.z > 0.0)" EOL "  {" EOL
-    "    float aFwBR = fwidth (aR);" EOL "    if (aR > uBounds.z + aFwBR) { discard; }" EOL
-    "    aBoundFade *= 1.0 - smoothstep (GRID_FADE_BAND * uBounds.z, uBounds.z + aFwBR, aR);" EOL
-    "  }" EOL "  if (uArcBounded != 0)" EOL "  {" EOL
+    "    float aFwBR = fwidth (aR);" EOL "    if (aR > uBounds.z) { discard; }" EOL
+    "    if (uIsBoundFade != 0)" EOL "    {" EOL
+    "      aBoundFade *= 1.0 - smoothstep (uBounds.z - aFwBR, uBounds.z, aR);" EOL
+    "    }" EOL "  }" EOL "  if (uArcBounded != 0)" EOL "  {" EOL
     "    float aSpan = uArcRange.y - uArcRange.x;" EOL
     "    if (aSpan < 0.0) { aSpan += GRID_TWO_PI; }" EOL "    float aDelta = aA - uArcRange.x;" EOL
     "    if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL
     "    if (aDelta > aSpan) { discard; }" EOL "  }" EOL "  if (uBounds.x > 0.0)" EOL "  {" EOL
-    // Extend the hard discard and smoothstep range by fwidth so the rectangular
-    // boundary gets sub-pixel AA (one screen-pixel transition) instead of a
-    // hard binary staircase at the clipping edge.
+    // Keep the bounded area geometrically strict; fwidth is used only for the
+    // optional fade inside the boundary, never to expand the valid area.
     "    float aFwBX = fwidth (abs (aLocal.x));" EOL
-    "    if (abs (aLocal.x) > uBounds.x + aFwBX) { discard; }" EOL
-    "    aBoundFade *= 1.0 - smoothstep (GRID_FADE_BAND * uBounds.x, uBounds.x + aFwBX, abs "
-    "(aLocal.x));" EOL "  }" EOL "  if (uBounds.y > 0.0)" EOL "  {" EOL
+    "    if (abs (aLocal.x) > uBounds.x) { discard; }" EOL "    if (uIsBoundFade != 0)" EOL
+    "    {" EOL
+    "      aBoundFade *= 1.0 - smoothstep (uBounds.x - aFwBX, uBounds.x, abs "
+    "(aLocal.x));" EOL "    }" EOL "  }" EOL "  if (uBounds.y > 0.0)" EOL "  {" EOL
     "    float aFwBY = fwidth (abs (aLocal.y));" EOL
-    "    if (abs (aLocal.y) > uBounds.y + aFwBY) { discard; }" EOL
-    "    aBoundFade *= 1.0 - smoothstep (GRID_FADE_BAND * uBounds.y, uBounds.y + aFwBY, abs "
-    "(aLocal.y));" EOL "  }"
+    "    if (abs (aLocal.y) > uBounds.y) { discard; }" EOL "    if (uIsBoundFade != 0)" EOL
+    "    {" EOL
+    "      aBoundFade *= 1.0 - smoothstep (uBounds.y - aFwBY, uBounds.y, abs "
+    "(aLocal.y));" EOL "    }" EOL "  }"
 
     // Grid coordinates depend on uGridType: 0=rectangular (X/Y), 1=circular (radius/angle).
-    // For rectangular grid, rebase UVs around a CPU-provided stable reference
-    // (same for all fragments in the frame) to keep fract() arguments small.
-    EOL "  vec2 aStableLocal = aLocal;" EOL "  if (uGridType == 0)" EOL "  {" EOL
-    "    if (uHasStableRef != 0)" EOL "    {" EOL
-    "      vec2 aScaleSafe = max (abs (vec2 (uScaleX, uScaleY)), vec2 (1e-9));" EOL
-    "      vec2 aShift = floor (uStableRefLocal * aScaleSafe) / aScaleSafe;" EOL
-    "      aStableLocal = aLocal - aShift;" EOL "    }" EOL "  }" EOL "  vec2 aGridUv;" EOL
-    "  vec2 aScale;" EOL "  vec2 aAxisUv;" EOL "  if (uGridType == 1)" EOL "  {" EOL
+    EOL "  vec2 aGridUv;" EOL "  vec2 aScale;" EOL "  vec2 aAxisUv;" EOL
+    "  if (uGridType == 1)" EOL "  {" EOL
     "    aGridUv = vec2 (aR, aA);" EOL "    aScale  = vec2 (uScaleX, uAngularScale);" EOL
-    "    aAxisUv = aLocal;" EOL "  }" EOL "  else" EOL "  {" EOL "    aGridUv = aStableLocal;" EOL
+    "    aAxisUv = aLocal;" EOL "  }" EOL "  else" EOL "  {" EOL "    aGridUv = aLocalGrid;" EOL
     "    aScale  = vec2 (uScaleX, uScaleY);" EOL "    aAxisUv = aLocal;" EOL "  }" EOL
-    "  vec4 aColor = gridLines2d (aGridUv, aAxisUv, uColor, aScale, uGridType == 0, "
-    "uThickness);" EOL "  if (uDrawMode != 1)" EOL "  {" EOL "    if (uGridType == 0)" EOL
+    "  vec2 aGridShift = uGridType == 1 ? vec2 (uRadialOriginShift, 0.0) : vec2 (0.0);" EOL
+    "  vec4 aColor = gridLines2d (aGridUv, aAxisUv, uColor, aScale, aGridShift, "
+    "uGridType == 0, uThickness);" EOL "  if (uDrawMode != 1)" EOL "  {" EOL
+    "    if (uGridType == 0)" EOL
     "    {" EOL "      if (uAccentScaleX > 0.0)" EOL "      {" EOL
-    "        float aAccX = aLocal.x;" EOL "        if (uHasStableRef != 0)" EOL "        {" EOL
-    "          float aScaleAccX = max (abs (uAccentScaleX), 1e-9);" EOL
-    "          float aShiftAccX = floor (uStableRefLocal.x * aScaleAccX) / aScaleAccX;" EOL
-    "          aAccX -= aShiftAccX;" EOL "        }" EOL
-    "        aColor = overlayGrid (aColor, gridLines1d (aAccX, uAccentScaleX, uAccentColor, "
-    "uThickness));" EOL "      }" EOL "      if (uAccentScaleY > 0.0)" EOL "      {" EOL
-    "        float aAccY = aLocal.y;" EOL "        if (uHasStableRef != 0)" EOL "        {" EOL
-    "          float aScaleAccY = max (abs (uAccentScaleY), 1e-9);" EOL
-    "          float aShiftAccY = floor (uStableRefLocal.y * aScaleAccY) / aScaleAccY;" EOL
-    "          aAccY -= aShiftAccY;" EOL "        }" EOL
-    "        aColor = overlayGrid (aColor, gridLines1d (aAccY, uAccentScaleY, uAccentColor, "
-    "uThickness));" EOL "      }" EOL "    }" EOL "    else" EOL "    {" EOL
+    "        aColor = overlayGrid (aColor, gridLines1d (aLocal.x, uAccentLocalOriginShift.x, "
+    "uAccentScaleX, uAccentColor, uThickness));" EOL "      }" EOL
+    "      if (uAccentScaleY > 0.0)" EOL "      {" EOL
+    "        aColor = overlayGrid (aColor, gridLines1d (aLocal.y, uAccentLocalOriginShift.y, "
+    "uAccentScaleY, uAccentColor, uThickness));" EOL "      }" EOL "    }" EOL "    else" EOL
+    "    {" EOL
     "      if (uAccentScaleX > 0.0)" EOL "      {" EOL
-    "        aColor = overlayGrid (aColor, gridLines1d (aR, uAccentScaleX, uAccentColor, "
-    "uThickness));" EOL "      }" EOL "      if (uAccentAngularScale > 0.0)" EOL "      {" EOL
-    "        aColor = overlayGrid (aColor, gridLines1d (aA, uAccentAngularScale, uAccentColor, "
-    "uThickness));" EOL "      }" EOL "    }" EOL
+    "        aColor = overlayGrid (aColor, gridLines1d (aR, uAccentRadialOriginShift, "
+    "uAccentScaleX, uAccentColor, uThickness));" EOL "      }" EOL
+    "      if (uAccentAngularScale > 0.0)" EOL "      {" EOL
+    "        aColor = overlayGrid (aColor, gridLines1d (aA, 0.0, uAccentAngularScale, "
+    "uAccentColor, uThickness));" EOL "      }" EOL "    }" EOL
     // For circular grid, paint X/Y axis lines explicitly using plane-local coords.
     "    if (uIsDrawAxis != 0 && uGridType == 1)" EOL "    {" EOL
     "      vec2 aDerivAxis = max (fwidth (aAxisUv), vec2 (uThickness));" EOL
@@ -2353,22 +2355,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "      else if (abs (aAxisUv.x) < aDerivAxis.x)" EOL "      {" EOL
     "        aColor = vec4 (0.0, 1.0, 0.0, 1.0);" EOL "      }" EOL "    }" EOL "  }"
 
-    EOL "  float aDepth = computeDepth (aHit);" EOL "  float aFar   = gl_DepthRange.far;" EOL
-    "  float aNear  = gl_DepthRange.near;" EOL
-    "  aDepth       = ((aFar - aNear) * aDepth + aNear + aFar) * 0.5;"
-    // No aT-sign discard: when the grid plane passes through / close to the
-    // near clip (the "grid going into camera view" case), aT can be <= 0 for
-    // fragments whose Near point is on the opposite side of the plane. The ray
-    // still intersects the plane; we just clamp depth via gl_FragDepth's [0,1]
-    // range so those fragments read as "in front of everything", which reads
-    // naturally as the ground/plane reaching under the camera.
-    EOL "  if (aColor.a == 0.0) { discard; }"
-
-    EOL "  float aMaxDepth = 1.0 - GRID_DEPTH_EPS;" EOL
-    "  gl_FragDepth = uIsBackground != 0 ? aMaxDepth : min (aDepth, aMaxDepth);" EOL
+    EOL "  if (aColor.a == 0.0) { discard; }" EOL
     "  aColor.a *= aBoundFade;" EOL "  occFragColor = aColor;" EOL "}";
 
-  // Requires gl_VertexID (GL 3.0/ES 3.0+), fwidth, gl_FragDepth.
+  // Requires gl_VertexID (GL 3.0/ES 3.0+) and fwidth.
   if (myGapi == Aspect_GraphicsLibrary_OpenGL)
   {
     aProgSrc->SetHeader(IsGapiGreaterEqual(3, 2) ? "#version 150" : "#version 130");

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2198,8 +2198,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("vec2 uLocalOriginShift", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
-    Graphic3d_ShaderObject::ShaderVariable("vec2 uAccentLocalOriginShift",
-                                           Graphic3d_TOS_FRAGMENT));
+    Graphic3d_ShaderObject::ShaderVariable("vec2 uAccentLocalOriginShift", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(
     Graphic3d_ShaderObject::ShaderVariable("float uRadialOriginShift", Graphic3d_TOS_FRAGMENT));
   aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("float uAccentRadialOriginShift",
@@ -2224,14 +2223,11 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     TCollection_AsciiString()
     + EOL
     "float gridLine1d (float theCoord, float theShift, float theScale, float theThickness)" EOL
-    "{" EOL
-    "  float aCoord = (theCoord - theShift) * theScale;" EOL
-    "  float aPixelWidth = fwidth (aCoord);" EOL
-    "  if (!(aPixelWidth >= 0.0)) { return 0.0; }" EOL
+    "{" EOL "  float aCoord = (theCoord - theShift) * theScale;" EOL
+    "  float aPixelWidth = fwidth (aCoord);" EOL "  if (!(aPixelWidth >= 0.0)) { return 0.0; }" EOL
     "  float aDist  = abs (fract (aCoord + 0.5) - 0.5);" EOL
     "  float aWidth = max (aPixelWidth, theThickness);" EOL
-    "  if (aWidth == 0.0) { return 0.0; }" EOL
-    "  return 1.0 - min (aDist / aWidth, 1.0);" EOL "}"
+    "  if (aWidth == 0.0) { return 0.0; }" EOL "  return 1.0 - min (aDist / aWidth, 1.0);" EOL "}"
 
     EOL "vec4 gridLines2d (vec2 theUV, vec2 theAxisUV, vec3 theColor, vec2 theScale," EOL
     "                  vec2 theShift, bool theIsDrawAxis, float theThickness)" EOL "{" EOL
@@ -2247,11 +2243,9 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "    else if (anAxisY > 0.0)                  { aColor.xyz = vec3 (0.0, 1.0, 0.0); }" EOL
     "  }" EOL "  return aColor;" EOL "}"
 
-    EOL
-    "vec4 gridLines1d (float theCoord, float theShift, float theScale, vec3 theColor, float "
-    "theThickness)" EOL
-    "{" EOL "  return vec4 (theColor, gridLine1d (theCoord, theShift, theScale, theThickness));"
-    EOL "}"
+    EOL "vec4 gridLines1d (float theCoord, float theShift, float theScale, vec3 theColor, float "
+    "theThickness)" EOL "{" EOL
+    "  return vec4 (theColor, gridLine1d (theCoord, theShift, theScale, theThickness));" EOL "}"
 
     EOL "vec4 overlayGrid (vec4 theBase, vec4 theAccent)" EOL "{" EOL
     "  return theAccent.a >= theBase.a ? theAccent : theBase;" EOL "}"
@@ -2260,26 +2254,14 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  vec4 aView = occProjectionMatrixInverse * vec4 (theX, theY, theZ, 1.0);" EOL
     "  return aView.xyz / aView.w;" EOL "}"
 
-    EOL
-    "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL
-    "{" EOL
+    EOL "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL "{" EOL
     "  vec3 aRayOrigin = uIsPerspective != 0 ? vec3 (0.0) : theNearPoint;" EOL
-    "  vec3 aRayTarget = theFarPoint;" EOL
-    "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
-    "  float aDenom = dot (uPlaneNView, aDir);" EOL
-    "  if (aDenom == 0.0)" EOL
-    "  {" EOL
-    "    theHit = theNearPoint;" EOL
-    "    return false;" EOL
-    "  }" EOL
+    "  vec3 aRayTarget = theFarPoint;" EOL "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
+    "  float aDenom = dot (uPlaneNView, aDir);" EOL "  if (aDenom == 0.0)" EOL "  {" EOL
+    "    theHit = theNearPoint;" EOL "    return false;" EOL "  }" EOL
     "  float aT = dot (uPlaneNView, uPlaneOriginView - aRayOrigin) / aDenom;" EOL
-    "  if (uIsPerspective != 0 && aT < 0.0)" EOL
-    "  {" EOL
-    "    theHit = theNearPoint;" EOL
-    "    return false;" EOL
-    "  }" EOL
-    "  theHit = aRayOrigin + aT * aDir;" EOL
-    "  return true;" EOL
+    "  if (uIsPerspective != 0 && aT < 0.0)" EOL "  {" EOL "    theHit = theNearPoint;" EOL
+    "    return false;" EOL "  }" EOL "  theHit = aRayOrigin + aT * aDir;" EOL "  return true;" EOL
     "}" EOL
 
     EOL "const float GRID_TWO_PI = 6.28318530718;"
@@ -2288,12 +2270,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     // Intersect in view space: the camera is the numerical origin, so zoom and
     // world-coordinate magnitude do not destabilize the line phase.
     EOL "  vec3 aNearPoint = unprojectView (vNdc.x, vNdc.y, uNdcNear);" EOL
-    "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL
-    "  vec3 aHit;" EOL
+    "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL "  vec3 aHit;" EOL
     "  if (!intersectPlaneView (aNearPoint, aFarPoint, aHit)) { discard; }" EOL
     "  vec3 aLocalAbs3  = aHit - uPlaneOriginView;" EOL
-    "  vec2 aLocal      = vec2 (dot (aLocalAbs3, uPlaneXView), dot (aLocalAbs3, uPlaneYView));"
-    EOL
+    "  vec2 aLocal      = vec2 (dot (aLocalAbs3, uPlaneXView), dot (aLocalAbs3, uPlaneYView));" EOL
     "  vec3 aLocalGrid3 = aHit - uPlaneRefView;" EOL
     "  vec2 aLocalGrid  = vec2 (dot (aLocalGrid3, uPlaneXView), dot (aLocalGrid3, "
     "uPlaneYView));"
@@ -2303,8 +2283,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  float aBoundFade = 1.0;" EOL "  if (uBounds.z > 0.0)" EOL "  {" EOL
     "    float aFwBR = fwidth (aR);" EOL "    if (aR > uBounds.z) { discard; }" EOL
     "    if (uIsBoundFade != 0)" EOL "    {" EOL
-    "      aBoundFade *= 1.0 - smoothstep (uBounds.z - aFwBR, uBounds.z, aR);" EOL
-    "    }" EOL "  }" EOL "  if (uArcBounded != 0)" EOL "  {" EOL
+    "      aBoundFade *= 1.0 - smoothstep (uBounds.z - aFwBR, uBounds.z, aR);" EOL "    }" EOL
+    "  }" EOL "  if (uArcBounded != 0)" EOL "  {" EOL
     "    float aSpan = uArcRange.y - uArcRange.x;" EOL
     "    if (aSpan < 0.0) { aSpan += GRID_TWO_PI; }" EOL "    float aDelta = aA - uArcRange.x;" EOL
     "    if (aDelta < 0.0) { aDelta += GRID_TWO_PI; }" EOL
@@ -2313,33 +2293,28 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     // optional fade inside the boundary, never to expand the valid area.
     "    float aFwBX = fwidth (abs (aLocal.x));" EOL
     "    if (abs (aLocal.x) > uBounds.x) { discard; }" EOL "    if (uIsBoundFade != 0)" EOL
-    "    {" EOL
-    "      aBoundFade *= 1.0 - smoothstep (uBounds.x - aFwBX, uBounds.x, abs "
+    "    {" EOL "      aBoundFade *= 1.0 - smoothstep (uBounds.x - aFwBX, uBounds.x, abs "
     "(aLocal.x));" EOL "    }" EOL "  }" EOL "  if (uBounds.y > 0.0)" EOL "  {" EOL
     "    float aFwBY = fwidth (abs (aLocal.y));" EOL
     "    if (abs (aLocal.y) > uBounds.y) { discard; }" EOL "    if (uIsBoundFade != 0)" EOL
-    "    {" EOL
-    "      aBoundFade *= 1.0 - smoothstep (uBounds.y - aFwBY, uBounds.y, abs "
+    "    {" EOL "      aBoundFade *= 1.0 - smoothstep (uBounds.y - aFwBY, uBounds.y, abs "
     "(aLocal.y));" EOL "    }" EOL "  }"
 
     // Grid coordinates depend on uGridType: 0=rectangular (X/Y), 1=circular (radius/angle).
-    EOL "  vec2 aGridUv;" EOL "  vec2 aScale;" EOL "  vec2 aAxisUv;" EOL
-    "  if (uGridType == 1)" EOL "  {" EOL
-    "    aGridUv = vec2 (aR, aA);" EOL "    aScale  = vec2 (uScaleX, uAngularScale);" EOL
+    EOL "  vec2 aGridUv;" EOL "  vec2 aScale;" EOL "  vec2 aAxisUv;" EOL "  if (uGridType == 1)" EOL
+    "  {" EOL "    aGridUv = vec2 (aR, aA);" EOL "    aScale  = vec2 (uScaleX, uAngularScale);" EOL
     "    aAxisUv = aLocal;" EOL "  }" EOL "  else" EOL "  {" EOL "    aGridUv = aLocalGrid;" EOL
     "    aScale  = vec2 (uScaleX, uScaleY);" EOL "    aAxisUv = aLocal;" EOL "  }" EOL
     "  vec2 aGridShift = uGridType == 1 ? vec2 (uRadialOriginShift, 0.0) : vec2 (0.0);" EOL
     "  vec4 aColor = gridLines2d (aGridUv, aAxisUv, uColor, aScale, aGridShift, "
     "uGridType == 0, uThickness);" EOL "  if (uDrawMode != 1)" EOL "  {" EOL
-    "    if (uGridType == 0)" EOL
-    "    {" EOL "      if (uAccentScaleX > 0.0)" EOL "      {" EOL
+    "    if (uGridType == 0)" EOL "    {" EOL "      if (uAccentScaleX > 0.0)" EOL "      {" EOL
     "        aColor = overlayGrid (aColor, gridLines1d (aLocal.x, uAccentLocalOriginShift.x, "
     "uAccentScaleX, uAccentColor, uThickness));" EOL "      }" EOL
     "      if (uAccentScaleY > 0.0)" EOL "      {" EOL
     "        aColor = overlayGrid (aColor, gridLines1d (aLocal.y, uAccentLocalOriginShift.y, "
     "uAccentScaleY, uAccentColor, uThickness));" EOL "      }" EOL "    }" EOL "    else" EOL
-    "    {" EOL
-    "      if (uAccentScaleX > 0.0)" EOL "      {" EOL
+    "    {" EOL "      if (uAccentScaleX > 0.0)" EOL "      {" EOL
     "        aColor = overlayGrid (aColor, gridLines1d (aR, uAccentRadialOriginShift, "
     "uAccentScaleX, uAccentColor, uThickness));" EOL "      }" EOL
     "      if (uAccentAngularScale > 0.0)" EOL "      {" EOL
@@ -2355,8 +2330,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "      else if (abs (aAxisUv.x) < aDerivAxis.x)" EOL "      {" EOL
     "        aColor = vec4 (0.0, 1.0, 0.0, 1.0);" EOL "      }" EOL "    }" EOL "  }"
 
-    EOL "  if (aColor.a == 0.0) { discard; }" EOL
-    "  aColor.a *= aBoundFade;" EOL "  occFragColor = aColor;" EOL "}";
+    EOL "  if (aColor.a == 0.0) { discard; }" EOL "  aColor.a *= aBoundFade;" EOL
+    "  occFragColor = aColor;" EOL "}";
 
   // Requires gl_VertexID (GL 3.0/ES 3.0+) and fwidth.
   if (myGapi == Aspect_GraphicsLibrary_OpenGL)

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -2262,6 +2262,11 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     "  vec4 aView = occProjectionMatrixInverse * vec4 (theX, theY, theZ, 1.0);" EOL
     "  return aView.xyz / aView.w;" EOL "}"
 
+    EOL "float fragmentDepthFromView (vec3 theViewPnt)" EOL "{" EOL
+    "  vec4 aClip = occProjectionMatrix * vec4 (theViewPnt, 1.0);" EOL
+    "  float aNdcZ = aClip.z / aClip.w;" EOL
+    "  return uNdcNear == 0.0 ? aNdcZ : (aNdcZ * 0.5 + 0.5);" EOL "}"
+
     EOL "bool intersectPlaneView (vec3 theNearPoint, vec3 theFarPoint, out vec3 theHit)" EOL "{" EOL
     "  vec3 aRayOrigin = uIsPerspective != 0 ? vec3 (0.0) : theNearPoint;" EOL
     "  vec3 aRayTarget = theFarPoint;" EOL "  vec3 aDir = aRayTarget - aRayOrigin;" EOL
@@ -2280,6 +2285,9 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getGridProgram() c
     EOL "  vec3 aNearPoint = unprojectView (vNdc.x, vNdc.y, uNdcNear);" EOL
     "  vec3 aFarPoint  = unprojectView (vNdc.x, vNdc.y, 1.0);" EOL "  vec3 aHit;" EOL
     "  if (!intersectPlaneView (aNearPoint, aFarPoint, aHit)) { discard; }" EOL
+    "  float aFragDepth = fragmentDepthFromView (aHit);" EOL
+    "  if (aFragDepth < 0.0 || aFragDepth > 1.0) { discard; }" EOL
+    "  gl_FragDepth = aFragDepth;" EOL
     "  vec3 aLocalAbs3  = aHit - uPlaneOriginView;" EOL
     "  vec2 aLocal      = vec2 (dot (aLocalAbs3, uPlaneXView), dot (aLocalAbs3, uPlaneYView));" EOL
     "  vec3 aLocalGrid3 = aHit - uPlaneRefView;" EOL

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -2264,12 +2264,12 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
                                              const occ::handle<V3d_View>&               theView,
                                              const AIS_WalkDelta&                       theWalk)
 {
-  const bool hasGridEcho = theView->IsGridActive() && theView->Viewer()->GridEcho();
-  const bool hasShaderGridEcho = hasGridEcho && theView->IsShaderGridActive();
+  const bool            hasGridEcho = theView->IsGridActive() && theView->Viewer()->GridEcho();
+  const bool            hasShaderGridEcho = hasGridEcho && theView->IsShaderGridActive();
   NCollection_Vec2<int> aMoveToAfterCamera =
     HasPreviousMoveTo() ? PreviousMoveTo() : LastMousePosition();
-  bool toUpdateMoveToAfterCamera = hasShaderGridEcho && !theWalk.IsEmpty();
-  bool toHideGridEchoAfterCamera = false;
+  bool       toUpdateMoveToAfterCamera = hasShaderGridEcho && !theWalk.IsEmpty();
+  bool       toHideGridEchoAfterCamera = false;
   const bool isMouseRotation =
     (myGL.OrbitRotation.ToRotate || myGL.ViewRotation.ToRotate || myGL.ZRotate.ToRotate)
     && myToAllowRotation;

--- a/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_ViewController.cxx
@@ -2264,11 +2264,22 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
                                              const occ::handle<V3d_View>&               theView,
                                              const AIS_WalkDelta&                       theWalk)
 {
+  const bool hasGridEcho = theView->IsGridActive() && theView->Viewer()->GridEcho();
+  const bool hasShaderGridEcho = hasGridEcho && theView->IsShaderGridActive();
+  NCollection_Vec2<int> aMoveToAfterCamera =
+    HasPreviousMoveTo() ? PreviousMoveTo() : LastMousePosition();
+  bool toUpdateMoveToAfterCamera = hasShaderGridEcho && !theWalk.IsEmpty();
+  bool toHideGridEchoAfterCamera = false;
+  const bool isMouseRotation =
+    (myGL.OrbitRotation.ToRotate || myGL.ViewRotation.ToRotate || myGL.ZRotate.ToRotate)
+    && myToAllowRotation;
+
   // apply view actions
   if (myGL.Orientation.ToSetViewOrient)
   {
     theView->SetProj(myGL.Orientation.ViewOrient);
     myGL.Orientation.ToFitAll = true;
+    toUpdateMoveToAfterCamera = hasShaderGridEcho;
   }
 
   // apply fit all
@@ -2278,6 +2289,7 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
     theView->FitAll(aFitMargin, false);
     theView->Invalidate();
     myGL.Orientation.ToFitAll = false;
+    toUpdateMoveToAfterCamera = hasShaderGridEcho;
   }
 
   NCollection_List<occ::handle<AIS_InteractiveObject>> anObjects;
@@ -2360,6 +2372,14 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
 
     handlePanning(theView);
     handleZRotate(theView);
+    if (hasShaderGridEcho && myGL.Panning.ToPan && myToAllowPanning)
+    {
+      toUpdateMoveToAfterCamera = true;
+    }
+    if (hasShaderGridEcho && myGL.ZRotate.ToRotate && myToAllowRotation)
+    {
+      toHideGridEchoAfterCamera = true;
+    }
   }
 
   if ((myNavigationMode == AIS_NavigationMode_Orbit || myGL.OrbitRotation.ToStart
@@ -2397,6 +2417,10 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
     handleOrbitRotation(theView,
                         aGravPnt,
                         myToLockOrbitZUp || myNavigationMode != AIS_NavigationMode_Orbit);
+    if (hasShaderGridEcho && myGL.OrbitRotation.ToRotate && myToAllowRotation)
+    {
+      toHideGridEchoAfterCamera = isMouseRotation;
+    }
   }
 
   if ((myNavigationMode != AIS_NavigationMode_Orbit || myGL.ViewRotation.ToStart
@@ -2428,6 +2452,10 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
                        theWalk[AIS_WalkRotation_Pitch].Value,
                        aRoll,
                        myNavigationMode == AIS_NavigationMode_FirstPersonFlight);
+    if (hasShaderGridEcho && myGL.ViewRotation.ToRotate && myToAllowRotation)
+    {
+      toHideGridEchoAfterCamera = isMouseRotation;
+    }
   }
 
   if (!myGL.ZoomActions.IsEmpty())
@@ -2448,6 +2476,10 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
       {
         continue;
       }
+      if (aZoomParams.HasPoint())
+      {
+        aMoveToAfterCamera = aZoomParams.Point;
+      }
 
       if (!theView->Camera()->IsOrthographic())
       {
@@ -2456,6 +2488,7 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
             && PickPoint(aPnt, theCtx, theView, aZoomParams.Point, myToStickToRayOnZoom))
         {
           handleZoom(theView, aZoomParams, &aPnt);
+          toUpdateMoveToAfterCamera = hasGridEcho;
           continue;
         }
 
@@ -2465,12 +2498,32 @@ void AIS_ViewController::handleCameraActions(const occ::handle<AIS_InteractiveCo
         {
           aZoomParams.ResetPoint(); // do not pretend to zoom at 'nothing'
           handleZoom(theView, aZoomParams, &aPnt);
+          toUpdateMoveToAfterCamera = hasGridEcho;
           continue;
         }
       }
       handleZoom(theView, aZoomParams, nullptr);
+      toUpdateMoveToAfterCamera = hasGridEcho;
     }
     myGL.ZoomActions.Clear();
+  }
+
+  if (toHideGridEchoAfterCamera)
+  {
+    theView->Viewer()->HideGridEcho(theView);
+    theView->InvalidateImmediate();
+    ResetPreviousMoveTo();
+  }
+  else if (toUpdateMoveToAfterCamera)
+  {
+    int aWidth = 0, aHeight = 0;
+    theView->Window()->Size(aWidth, aHeight);
+    if (aMoveToAfterCamera.x() >= 0 && aMoveToAfterCamera.x() < aWidth
+        && aMoveToAfterCamera.y() >= 0 && aMoveToAfterCamera.y() < aHeight)
+    {
+      ResetPreviousMoveTo();
+      contextLazyMoveTo(theCtx, theView, aMoveToAfterCamera);
+    }
   }
 }
 
@@ -2865,14 +2918,19 @@ void AIS_ViewController::contextLazyMoveTo(const occ::handle<AIS_InteractiveCont
   theView->Camera()->SetZRange(aZNear, aZFar);
 
   occ::handle<SelectMgr_EntityOwner> aNewPicked = theCtx->DetectedOwner();
-
-  if (theView->Viewer()->IsGridActive() && theView->Viewer()->GridEcho())
+  if (theView->IsGridActive() && theView->Viewer()->GridEcho())
   {
     if (aNewPicked.IsNull())
     {
-      NCollection_Vec3<double> aPnt3d;
-      theView->ConvertToGrid(thePnt.x(), thePnt.y(), aPnt3d[0], aPnt3d[1], aPnt3d[2]);
-      theView->Viewer()->ShowGridEcho(theView, Graphic3d_Vertex(aPnt3d[0], aPnt3d[1], aPnt3d[2]));
+      Graphic3d_Vertex aGridPoint, anEchoPoint;
+      if (theView->ConvertToGridEcho(thePnt.x(), thePnt.y(), aGridPoint, anEchoPoint))
+      {
+        theView->Viewer()->ShowGridEcho(theView, anEchoPoint);
+      }
+      else
+      {
+        theView->Viewer()->HideGridEcho(theView);
+      }
       theView->InvalidateImmediate();
     }
     else

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -1801,9 +1801,7 @@ void V3d_View::ConvertToGrid(const int theXp,
 
 //=================================================================================================
 
-bool V3d_View::ConvertToGrid(const int         theXp,
-                             const int         theYp,
-                             Graphic3d_Vertex& theGridPoint) const
+bool V3d_View::ConvertToGrid(const int theXp, const int theYp, Graphic3d_Vertex& theGridPoint) const
 {
   if (myShaderGridActive)
   {

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -3605,11 +3605,7 @@ void V3d_View::GridDisplay(const Aspect_GridParams& theParams)
 
 void V3d_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
 {
-  if (!myView->GridDisplay(theParams, thePlane))
-  {
-    myShaderGridActive = false;
-    return;
-  }
+  myView->GridDisplay(theParams, thePlane);
 
   if (!MyGrid.IsNull() && MyGrid->IsDisplayed())
   {

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -1785,6 +1785,31 @@ void V3d_View::ConvertToGrid(const int theXp,
                              double&   theYg,
                              double&   theZg) const
 {
+  Graphic3d_Vertex aGridPoint;
+  if (ConvertToGrid(theXp, theYp, aGridPoint))
+  {
+    aGridPoint.Coord(theXg, theYg, theZg);
+    return;
+  }
+
+  NCollection_Vec3<double> anXYZ;
+  Convert(theXp, theYp, anXYZ.x(), anXYZ.y(), anXYZ.z());
+  theXg = anXYZ.x();
+  theYg = anXYZ.y();
+  theZg = anXYZ.z();
+}
+
+//=================================================================================================
+
+bool V3d_View::ConvertToGrid(const int         theXp,
+                             const int         theYp,
+                             Graphic3d_Vertex& theGridPoint) const
+{
+  if (myShaderGridActive)
+  {
+    return myView->ShaderGridEcho(theXp, theYp, theGridPoint);
+  }
+
   NCollection_Vec3<double> anXYZ;
   Convert(theXp, theYp, anXYZ.x(), anXYZ.y(), anXYZ.z());
 
@@ -1792,13 +1817,32 @@ void V3d_View::ConvertToGrid(const int theXp,
   aVrp.SetCoord(anXYZ.x(), anXYZ.y(), anXYZ.z());
   if (MyViewer->IsGridActive())
   {
-    Graphic3d_Vertex aNewVrp = Compute(aVrp);
-    aNewVrp.Coord(theXg, theYg, theZg);
+    theGridPoint = Compute(aVrp);
+    return true;
   }
-  else
+
+  return false;
+}
+
+//=================================================================================================
+
+bool V3d_View::ConvertToGridEcho(const int         theXp,
+                                 const int         theYp,
+                                 Graphic3d_Vertex& theGridPoint,
+                                 Graphic3d_Vertex& theEchoPoint) const
+{
+  if (myShaderGridActive)
   {
-    aVrp.Coord(theXg, theYg, theZg);
+    return myView->ShaderGridEcho(theXp, theYp, theGridPoint, theEchoPoint);
   }
+
+  if (!ConvertToGrid(theXp, theYp, theGridPoint))
+  {
+    return false;
+  }
+
+  theEchoPoint = theGridPoint;
+  return true;
 }
 
 //=================================================================================================
@@ -1810,6 +1854,23 @@ void V3d_View::ConvertToGrid(const double theX,
                              double&      theYg,
                              double&      theZg) const
 {
+  if (myShaderGridActive)
+  {
+    int aXp = 0, aYp = 0;
+    Convert(theX, theY, theZ, aXp, aYp);
+    Graphic3d_Vertex aShaderGridPoint;
+    if (myView->ShaderGridEcho(aXp, aYp, aShaderGridPoint))
+    {
+      aShaderGridPoint.Coord(theXg, theYg, theZg);
+      return;
+    }
+
+    theXg = theX;
+    theYg = theY;
+    theZg = theZ;
+    return;
+  }
+
   if (MyViewer->IsGridActive())
   {
     Graphic3d_Vertex aVrp(theX, theY, theZ);
@@ -3544,10 +3605,6 @@ void V3d_View::GridDisplay(const Aspect_GridParams& theParams)
 
 void V3d_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
 {
-  // Mutual exclusion: the CPU grid renders into a viewer-wide Graphic3d_Structure
-  // (visible in every active view), so enabling the per-view shader grid hides the
-  // CPU rendering at the viewer level. Snap geometry (Aspect_*Grid) is left alive
-  // and only the structure is erased; SetGrid / ActivateGrid restores it.
   if (!MyGrid.IsNull() && MyGrid->IsDisplayed())
   {
     MyGrid->Erase();

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -3582,6 +3582,10 @@ void V3d_View::SetGrid(const gp_Ax3& aPlane, const occ::handle<Aspect_Grid>& aGr
 
 void V3d_View::SetGridActivity(const bool AFlag)
 {
+  if (MyGrid.IsNull())
+  {
+    return;
+  }
   if (AFlag)
   {
     MyGrid->Activate();

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -1854,7 +1854,7 @@ void V3d_View::ConvertToGrid(const double theX,
   if (myShaderGridActive)
   {
     const Graphic3d_Vertex aPoint(theX, theY, theZ);
-    Graphic3d_Vertex aShaderGridPoint;
+    Graphic3d_Vertex       aShaderGridPoint;
     if (myView->ShaderGridSnapPoint(aPoint, aShaderGridPoint))
     {
       aShaderGridPoint.Coord(theXg, theYg, theZg);

--- a/src/Visualization/TKV3d/V3d/V3d_View.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.cxx
@@ -445,10 +445,9 @@ void V3d_View::AutoZFit() const
 
 void V3d_View::ZFitAll(const double theScaleFactor) const
 {
-  Bnd_Box aMinMaxBox = myView->MinMaxValues(false); // applicative min max boundaries
-                                                    // clang-format off
-  Bnd_Box aGraphicBox  = myView->MinMaxValues (true);  // real graphical boundaries (not accounting infinite flag).
-                                                    // clang-format on
+  Bnd_Box aMinMaxBox;
+  Bnd_Box aGraphicBox;
+  myView->ZFitAllBounds(aMinMaxBox, aGraphicBox);
 
   myView->Camera()->ZFitAll(theScaleFactor, aMinMaxBox, aGraphicBox);
 }
@@ -1854,10 +1853,9 @@ void V3d_View::ConvertToGrid(const double theX,
 {
   if (myShaderGridActive)
   {
-    int aXp = 0, aYp = 0;
-    Convert(theX, theY, theZ, aXp, aYp);
+    const Graphic3d_Vertex aPoint(theX, theY, theZ);
     Graphic3d_Vertex aShaderGridPoint;
-    if (myView->ShaderGridEcho(aXp, aYp, aShaderGridPoint))
+    if (myView->ShaderGridSnapPoint(aPoint, aShaderGridPoint))
     {
       aShaderGridPoint.Coord(theXg, theYg, theZg);
       return;
@@ -3607,12 +3605,17 @@ void V3d_View::GridDisplay(const Aspect_GridParams& theParams)
 
 void V3d_View::GridDisplay(const Aspect_GridParams& theParams, const gp_Ax3& thePlane)
 {
+  if (!myView->GridDisplay(theParams, thePlane))
+  {
+    myShaderGridActive = false;
+    return;
+  }
+
   if (!MyGrid.IsNull() && MyGrid->IsDisplayed())
   {
     MyGrid->Erase();
   }
-  myShaderGridActive = true;
-  myView->GridDisplay(theParams, thePlane);
+  myShaderGridActive = theParams.DrawMode() != Aspect_GDM_None;
 }
 
 //=================================================================================================

--- a/src/Visualization/TKV3d/V3d/V3d_View.hxx
+++ b/src/Visualization/TKV3d/V3d/V3d_View.hxx
@@ -36,6 +36,7 @@ class Aspect_Window;
 class Graphic3d_Group;
 class Graphic3d_Structure;
 class Graphic3d_TextureEnv;
+class Graphic3d_Vertex;
 
 //! Defines the application object VIEW for the
 //! VIEWER application.
@@ -671,6 +672,21 @@ public:
                                      double&   Yg,
                                      double&   Zg) const;
 
+  //! Converts the projected point into the nearest visible grid point.
+  //! @return TRUE when an active grid accepts the point; FALSE otherwise.
+  //! Unlike the double-output overload, this method has no unproject fallback
+  //! and is intended for grid echo / snap-hit callers.
+  Standard_EXPORT bool ConvertToGrid(const int         Xp,
+                                     const int         Yp,
+                                     Graphic3d_Vertex& theGridPoint) const;
+
+  //! Converts the projected point into the nearest visible grid point and echo display point.
+  //! The echo display point is suitable only for displaying the grid echo marker.
+  Standard_EXPORT bool ConvertToGridEcho(const int         Xp,
+                                         const int         Yp,
+                                         Graphic3d_Vertex& theGridPoint,
+                                         Graphic3d_Vertex& theEchoPoint) const;
+
   //! Converts the point into the nearest grid point
   //! and display the grid marker.
   Standard_EXPORT void ConvertToGrid(const double X,
@@ -907,11 +923,9 @@ public:
                                  const double                         theResolution = 0.0,
                                  const bool theToEnlargeIfLine                      = true) const;
 
-public: //! @name CPU grid plumbing (deprecated, fed by V3d_Viewer::ActivateGrid)
-  //! Snap + CPU rendering. The CPU grid lives on the viewer's structure manager
-  //! and is visible in every active view; SetGrid on a view that has the shader
-  //! grid enabled erases the shader grid on this view, the CPU grid is left
-  //! intact (or re-displayed by V3d_Viewer::ActivateGrid).
+public: //! @name Viewer grid plumbing
+  //! Viewer-managed grid plane and snap object. It is separate from the per-view
+  //! shader grid controlled by GridDisplay().
 
   //! Defines or updates the grid plane and snap object on this view.
   //! @param[in] aPlane grid plane (origin + axes)
@@ -922,11 +936,15 @@ public: //! @name CPU grid plumbing (deprecated, fed by V3d_Viewer::ActivateGrid
   //! @param[in] aFlag true to enable snap, false to disable
   Standard_EXPORT void SetGridActivity(const bool aFlag);
 
-public: //! @name GPU shader grid (recommended)
-  //! Per-view immediate-mode shader; supports unbounded extents, AA, background, arc range.
-  //! GridDisplay erases the viewer-wide CPU grid rendering on entry (snap geometry
-  //! on Aspect_*Grid is preserved). GridErase only tears down the shader grid on
-  //! this view; restoring the CPU rendering needs V3d_Viewer::ActivateGrid.
+  //! Return TRUE if either viewer-managed grid or per-view shader grid is active.
+  bool IsGridActive() const { return MyViewer->IsGridActive() || myShaderGridActive; }
+
+  //! Return TRUE if the per-view shader grid is active.
+  bool IsShaderGridActive() const { return myShaderGridActive; }
+
+public: //! @name Shader grid
+  //! Per-view immediate-mode shader grid; supports unbounded extents, AA, background,
+  //! circular grids, arc range and view-adaptive spacing.
 
   //! Display a shader-rendered grid on the viewer's privileged plane.
   //! @param[in] theParams appearance: color, scale, bounds, arc, draw-mode, background /

--- a/src/Visualization/TKV3d/V3d/V3d_Viewer.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_Viewer.cxx
@@ -797,7 +797,8 @@ void V3d_Viewer::ShowGridEcho(const occ::handle<V3d_View>& theView,
     myGridEchoGroup->SetPrimitivesAspect(myGridEchoAspect);
   }
 
-  if (theVertex.X() == myGridEchoLastVert.X() && theVertex.Y() == myGridEchoLastVert.Y()
+  if (!theView->IsShaderGridActive() && theVertex.X() == myGridEchoLastVert.X()
+      && theVertex.Y() == myGridEchoLastVert.Y()
       && theVertex.Z() == myGridEchoLastVert.Z())
   {
     return;

--- a/src/Visualization/TKV3d/V3d/V3d_Viewer.cxx
+++ b/src/Visualization/TKV3d/V3d/V3d_Viewer.cxx
@@ -798,8 +798,7 @@ void V3d_Viewer::ShowGridEcho(const occ::handle<V3d_View>& theView,
   }
 
   if (!theView->IsShaderGridActive() && theVertex.X() == myGridEchoLastVert.X()
-      && theVertex.Y() == myGridEchoLastVert.Y()
-      && theVertex.Z() == myGridEchoLastVert.Z())
+      && theVertex.Y() == myGridEchoLastVert.Y() && theVertex.Z() == myGridEchoLastVert.Z())
   {
     return;
   }

--- a/tests/v3d/grid/gpu_perspective_nomirror
+++ b/tests/v3d/grid/gpu_perspective_nomirror
@@ -1,0 +1,22 @@
+puts "=================================================================="
+puts "GPU shader grid keeps foreground plane semantics in perspective view"
+puts "=================================================================="
+
+pload MODELING VISUALIZATION
+
+vclear
+vinit View1 w=400 h=400
+vaxo
+
+box b 10 10 10
+vdisplay b -dispMode 1
+vfit
+
+vgrid -type gpu -size 100 100 -drawAxis 0
+vcamera -persp
+vdump $imagedir/${casename}_persp.png
+
+vrotate 0 0 0.5
+vdump $imagedir/${casename}_rotated.png
+
+vgrid off

--- a/tests/v3d/grid/gpu_visibility
+++ b/tests/v3d/grid/gpu_visibility
@@ -1,0 +1,20 @@
+puts "=================================================================="
+puts "GPU shader grid is visible without scene objects and without vfit"
+puts "=================================================================="
+
+pload MODELING VISUALIZATION
+
+vclear
+vinit View1 w=400 h=400
+vaxo
+
+# Empty view: shader grid must not depend on scene bounding boxes.
+vgrid -type gpu -size 100 100 -drawAxis 0
+vdump $imagedir/${casename}_empty.png
+
+# Adding an object without vfit must not be required to make the grid visible.
+box b 10 10 10
+vdisplay b -dispMode 1
+vdump $imagedir/${casename}_display_no_vfit.png
+
+vgrid off


### PR DESCRIPTION
- Updated shader grid rendering to intersect the grid plane in view space and draw it with a single full-screen triangle.
- Added shader grid bounds to camera Z-fit, so the grid is visible in empty views and after object display without an extra vfit.
- Fixed shader grid echo to use the active shader grid plane, effective scale, bounds and clip-safe display point.
- Kept the viewer-managed CPU grid path separate from the per-view shader grid path and preserved CPU grid type/mode handling in vgrid.
- Added grid tests for empty/no-vfit visibility and perspective rendering without mirrored fragments.