### PR TITLE
Modeling - Fix SIGSEGV in BRepFill_CompatibleWires::SameNumberByPolarMethod on mismatched ThruSections profiles

### DIFF
--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
@@ -1307,11 +1307,22 @@ void BRepFill_CompatibleWires::SameNumberByPolarMethod(const bool WithRotation)
     gp_Pnt                                   PPs = Curve.Value(0.1 * (U1 + 9 * U2));
     NCollection_List<TopoDS_Shape>::Iterator itF(MapVLV(VF)), itL(MapVLV(VL));
     int                                      rang = ideb;
-    while (rang < i)
+    while (rang < i && itF.More() && itL.More())
     {
       itF.Next();
       itL.Next();
       rang++;
+    }
+    if (!itF.More() || !itL.More())
+    {
+      // The vertex-correspondence chain in MapVLV is shorter than the section
+      // index: the polar method failed to propagate a correspondence to every
+      // section (e.g. wildly mismatched / non-coaxial closed profiles). Without
+      // this guard the iterators advance past the end of the list and
+      // itF.Value()/itL.Value() dereference a null node (Address 8) -> SIGSEGV
+      // in release builds. Fail gracefully instead.
+      myStatus = BRepFill_ThruSectionErrorStatus_Failed;
+      return;
     }
     TopoDS_Vertex   V1 = TopoDS::Vertex(itF.Value()), V2 = TopoDS::Vertex(itL.Value());
     TopoDS_Edge     Esol;

--- a/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
+++ b/src/ModelingAlgorithms/TKBool/BRepFill/BRepFill_CompatibleWires.cxx
@@ -1315,12 +1315,7 @@ void BRepFill_CompatibleWires::SameNumberByPolarMethod(const bool WithRotation)
     }
     if (!itF.More() || !itL.More())
     {
-      // The vertex-correspondence chain in MapVLV is shorter than the section
-      // index: the polar method failed to propagate a correspondence to every
-      // section (e.g. wildly mismatched / non-coaxial closed profiles). Without
-      // this guard the iterators advance past the end of the list and
-      // itF.Value()/itL.Value() dereference a null node (Address 8) -> SIGSEGV
-      // in release builds. Fail gracefully instead.
+      // Correspondence chain shorter than the section index; fail gracefully.
       myStatus = BRepFill_ThruSectionErrorStatus_Failed;
       return;
     }


### PR DESCRIPTION
## Problem

`BRepOffsetAPI_ThruSections::Build()` SIGSEGVs (null deref, faulting address `0x8`) on closed profile wires with **different vertex counts** that are not vertically coaxial. Deterministic, single-threaded. Details and a self-contained C++ reproducer in #1297.

The fault is in `BRepFill_CompatibleWires::SameNumberByPolarMethod`. The wire-regularisation loop advances the `MapVLV` per-vertex correspondence-list iterators (`itF`/`itL`) with no `More()` guard, then dereferences them:

```cpp
while (rang < i)        // no More() guard
{
  itF.Next();
  itL.Next();
  rang++;
}
TopoDS_Vertex V1 = TopoDS::Vertex(itF.Value()), V2 = TopoDS::Vertex(itL.Value());
```

When the polar method fails to propagate a vertex correspondence to every section, `MapVLV(VF)`/`MapVLV(VL)` are shorter than `i - ideb + 1`; the iterators advance past the end and `itF.Value()`/`itL.Value()` read the value field of a null node → SIGSEGV. It is undefined behaviour that only Release codegen makes fatal (Debug reads adjacent memory and ends up on the `ProfilesInconsistent` path).

## Fix

Guard the advance and bail out gracefully — `myStatus = BRepFill_ThruSectionErrorStatus_Failed; return;` — consistent with the other failure exits already present in this function. The maker then reports `IsDone() == false` instead of aborting the process.

## Verification

- The #1297 reproducer returns `IsDone=0` instead of crashing.
- Confirmed by compiling the patched translation unit and linking it ahead of an otherwise-unmodified Release OCCT 8.0.0 static archive: the SIGSEGV is gone.
- Source is `clang-format`-clean against the repository `.clang-format`; the diff is limited to the guard (1 line changed, 11 added).

Closes #1297.
