### PR TITLE
Foundation Classes - Add contiguous array views and mesh hashers

### DIFF
--- a/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.cxx
+++ b/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.cxx
@@ -27,218 +27,258 @@
 #include <StdFail_NotDone.hxx>
 
 Convert_GridPolynomialToPoles::Convert_GridPolynomialToPoles(
-  const int                                       MaxUDegree,
-  const int                                       MaxVDegree,
-  const occ::handle<NCollection_HArray1<int>>&    NumCoeffPerSurface,
-  const occ::handle<NCollection_HArray1<double>>& Coefficients,
-  const occ::handle<NCollection_HArray1<double>>& PolynomialUIntervals,
-  const occ::handle<NCollection_HArray1<double>>& PolynomialVIntervals)
+  const int                                       theMaxUDegree,
+  const int                                       theMaxVDegree,
+  const occ::handle<NCollection_HArray1<int>>&    theNumCoeff,
+  const occ::handle<NCollection_HArray1<double>>& theCoefficients,
+  const occ::handle<NCollection_HArray1<double>>& thePolynomialUIntervals,
+  const occ::handle<NCollection_HArray1<double>>& thePolynomialVIntervals)
+    : Convert_GridPolynomialToPoles(theMaxUDegree,
+                                    theMaxVDegree,
+                                    theNumCoeff->Array1(),
+                                    theCoefficients->Array1(),
+                                    thePolynomialUIntervals->Array1(),
+                                    thePolynomialVIntervals->Array1())
+{
+}
+
+Convert_GridPolynomialToPoles::Convert_GridPolynomialToPoles(
+  const int                                       theNbUSurfaces,
+  const int                                       theNbVSurfaces,
+  const int                                       theUContinuity,
+  const int                                       theVContinuity,
+  const int                                       theMaxUDegree,
+  const int                                       theMaxVDegree,
+  const occ::handle<NCollection_HArray2<int>>&    theNumCoeffPerSurface,
+  const occ::handle<NCollection_HArray1<double>>& theCoefficients,
+  const occ::handle<NCollection_HArray1<double>>& thePolynomialUIntervals,
+  const occ::handle<NCollection_HArray1<double>>& thePolynomialVIntervals,
+  const occ::handle<NCollection_HArray1<double>>& theTrueUIntervals,
+  const occ::handle<NCollection_HArray1<double>>& theTrueVIntervals)
+    : Convert_GridPolynomialToPoles(theNbUSurfaces,
+                                    theNbVSurfaces,
+                                    theUContinuity,
+                                    theVContinuity,
+                                    theMaxUDegree,
+                                    theMaxVDegree,
+                                    theNumCoeffPerSurface->Array2(),
+                                    theCoefficients->Array1(),
+                                    thePolynomialUIntervals->Array1(),
+                                    thePolynomialVIntervals->Array1(),
+                                    theTrueUIntervals->Array1(),
+                                    theTrueVIntervals->Array1())
+{
+}
+
+Convert_GridPolynomialToPoles::Convert_GridPolynomialToPoles(
+  const int                         theMaxUDegree,
+  const int                         theMaxVDegree,
+  const NCollection_Array1<int>&    theNumCoeff,
+  const NCollection_Array1<double>& theCoefficients,
+  const NCollection_Array1<double>& thePolynomialUIntervals,
+  const NCollection_Array1<double>& thePolynomialVIntervals)
     : myUDegree(0),
       myVDegree(0),
       myDone(false)
 {
-  // Les Controles
-  if ((NumCoeffPerSurface->Lower() != 1) || (NumCoeffPerSurface->Upper() != 2))
+  if (theNumCoeff.Lower() != 1 || theNumCoeff.Upper() != 2)
   {
     throw Standard_DomainError("Convert : Wrong Coefficients");
   }
-  if ((Coefficients->Lower() != 1)
-      || (Coefficients->Upper() != 3 * (MaxUDegree + 1) * (MaxVDegree + 1)))
+  if (theCoefficients.Lower() != 1
+      || theCoefficients.Upper() != 3 * (theMaxUDegree + 1) * (theMaxVDegree + 1))
   {
     throw Standard_DomainError("Convert : Wrong Coefficients");
   }
 
-  // Les Degres
-  myUDegree = NumCoeffPerSurface->Value(1) - 1;
-  myVDegree = NumCoeffPerSurface->Value(2) - 1;
+  myUDegree = theNumCoeff.Value(1) - 1;
+  myVDegree = theNumCoeff.Value(2) - 1;
 
-  if (myUDegree > MaxUDegree)
+  if (myUDegree > theMaxUDegree)
   {
     throw Standard_DomainError("Convert : Incoherence between NumCoeffPerSurface and MaxUDegree");
   }
-  if (myVDegree > MaxVDegree)
+  if (myVDegree > theMaxVDegree)
   {
     throw Standard_DomainError("Convert : Incoherence between NumCoeffPerSurface and MaxVDegree");
   }
 
-  occ::handle<NCollection_HArray2<int>> NumCoeff = new (NCollection_HArray2<int>)(1, 1, 1, 2);
-  NumCoeff->SetValue(1, 1, NumCoeffPerSurface->Value(1));
-  NumCoeff->SetValue(1, 2, NumCoeffPerSurface->Value(2));
+  NCollection_Array2<int> aNumCoeff2D(1, 1, 1, 2);
+  aNumCoeff2D.SetValue(1, 1, theNumCoeff.Value(1));
+  aNumCoeff2D.SetValue(1, 2, theNumCoeff.Value(2));
 
   Perform(0,
           0,
-          MaxUDegree,
-          MaxVDegree,
-          NumCoeff,
-          Coefficients,
-          PolynomialUIntervals,
-          PolynomialVIntervals,
-          PolynomialUIntervals,
-          PolynomialVIntervals);
+          theMaxUDegree,
+          theMaxVDegree,
+          aNumCoeff2D,
+          theCoefficients,
+          thePolynomialUIntervals,
+          thePolynomialVIntervals,
+          thePolynomialUIntervals,
+          thePolynomialVIntervals);
 }
 
 Convert_GridPolynomialToPoles::Convert_GridPolynomialToPoles(
-  const int                                       NbUSurfaces,
-  const int                                       NbVSurfaces,
-  const int                                       UContinuity,
-  const int                                       VContinuity,
-  const int                                       MaxUDegree,
-  const int                                       MaxVDegree,
-  const occ::handle<NCollection_HArray2<int>>&    NumCoeffPerSurface,
-  const occ::handle<NCollection_HArray1<double>>& Coefficients,
-  const occ::handle<NCollection_HArray1<double>>& PolynomialUIntervals,
-  const occ::handle<NCollection_HArray1<double>>& PolynomialVIntervals,
-  const occ::handle<NCollection_HArray1<double>>& TrueUIntervals,
-  const occ::handle<NCollection_HArray1<double>>& TrueVIntervals)
+  const int                         theNbUSurfaces,
+  const int                         theNbVSurfaces,
+  const int                         theUContinuity,
+  const int                         theVContinuity,
+  const int                         theMaxUDegree,
+  const int                         theMaxVDegree,
+  const NCollection_Array2<int>&    theNumCoeffPerSurface,
+  const NCollection_Array1<double>& theCoefficients,
+  const NCollection_Array1<double>& thePolynomialUIntervals,
+  const NCollection_Array1<double>& thePolynomialVIntervals,
+  const NCollection_Array1<double>& theTrueUIntervals,
+  const NCollection_Array1<double>& theTrueVIntervals)
     : myUDegree(0),
       myVDegree(0),
       myDone(false)
 {
-  int RealUDegree = std::max(MaxUDegree, 2 * UContinuity + 1);
-  int RealVDegree = std::max(MaxVDegree, 2 * VContinuity + 1);
+  const int aRealUDegree = std::max(theMaxUDegree, 2 * theUContinuity + 1);
+  const int aRealVDegree = std::max(theMaxVDegree, 2 * theVContinuity + 1);
 
-  // Les controles
-  if ((NumCoeffPerSurface->LowerRow() != 1)
-      || (NumCoeffPerSurface->UpperRow() != NbUSurfaces * NbVSurfaces)
-      || (NumCoeffPerSurface->LowerCol() != 1) || (NumCoeffPerSurface->UpperCol() != 2))
+  if (theNumCoeffPerSurface.LowerRow() != 1
+      || theNumCoeffPerSurface.UpperRow() != theNbUSurfaces * theNbVSurfaces
+      || theNumCoeffPerSurface.LowerCol() != 1 || theNumCoeffPerSurface.UpperCol() != 2)
   {
     throw Standard_DomainError("Convert : Wrong NumCoeffPerSurface");
   }
 
-  if ((Coefficients->Lower() != 1)
-      || (Coefficients->Upper()
-          != 3 * NbUSurfaces * NbVSurfaces * (RealUDegree + 1) * (RealVDegree + 1)))
+  if (theCoefficients.Lower() != 1
+      || theCoefficients.Upper()
+           != 3 * theNbUSurfaces * theNbVSurfaces * (aRealUDegree + 1) * (aRealVDegree + 1))
   {
     throw Standard_DomainError("Convert : Wrong Coefficients");
   }
 
-  // Calcul des degree
-  for (int ii = 1; ii <= NbUSurfaces * NbVSurfaces; ii++)
+  // Compute actual degrees from the supplied coefficient counts.
+  for (int ii = 1; ii <= theNbUSurfaces * theNbVSurfaces; ++ii)
   {
-    if (NumCoeffPerSurface->Value(ii, 1) > myUDegree + 1)
+    if (theNumCoeffPerSurface.Value(ii, 1) > myUDegree + 1)
     {
-      myUDegree = NumCoeffPerSurface->Value(ii, 1) - 1;
+      myUDegree = theNumCoeffPerSurface.Value(ii, 1) - 1;
     }
-    if (NumCoeffPerSurface->Value(ii, 2) > myVDegree + 1)
+    if (theNumCoeffPerSurface.Value(ii, 2) > myVDegree + 1)
     {
-      myVDegree = NumCoeffPerSurface->Value(ii, 2) - 1;
+      myVDegree = theNumCoeffPerSurface.Value(ii, 2) - 1;
     }
   }
 
-  if (myUDegree > RealUDegree)
+  if (myUDegree > aRealUDegree)
   {
     throw Standard_DomainError("Convert : Incoherence between NumCoeffPerSurface and MaxUDegree");
   }
-  if (myVDegree > RealVDegree)
+  if (myVDegree > aRealVDegree)
   {
     throw Standard_DomainError("Convert : Incoherence between NumCoeffPerSurface and MaxVDegree");
   }
 
-  Perform(UContinuity,
-          VContinuity,
-          RealUDegree,
-          RealVDegree,
-          NumCoeffPerSurface,
-          Coefficients,
-          PolynomialUIntervals,
-          PolynomialVIntervals,
-          TrueUIntervals,
-          TrueVIntervals);
+  Perform(theUContinuity,
+          theVContinuity,
+          aRealUDegree,
+          aRealVDegree,
+          theNumCoeffPerSurface,
+          theCoefficients,
+          thePolynomialUIntervals,
+          thePolynomialVIntervals,
+          theTrueUIntervals,
+          theTrueVIntervals);
 }
 
 void Convert_GridPolynomialToPoles::Perform(
-  const int                                       UContinuity,
-  const int                                       VContinuity,
-  const int                                       MaxUDegree,
-  const int                                       MaxVDegree,
-  const occ::handle<NCollection_HArray2<int>>&    NumCoeffPerSurface,
-  const occ::handle<NCollection_HArray1<double>>& Coefficients,
-  const occ::handle<NCollection_HArray1<double>>& PolynomialUIntervals,
-  const occ::handle<NCollection_HArray1<double>>& PolynomialVIntervals,
-  const occ::handle<NCollection_HArray1<double>>& TrueUIntervals,
-  const occ::handle<NCollection_HArray1<double>>& TrueVIntervals)
+  const int                         theUContinuity,
+  const int                         theVContinuity,
+  const int                         theMaxUDegree,
+  const int                         theMaxVDegree,
+  const NCollection_Array2<int>&    theNumCoeffPerSurface,
+  const NCollection_Array1<double>& theCoefficients,
+  const NCollection_Array1<double>& thePolynomialUIntervals,
+  const NCollection_Array1<double>& thePolynomialVIntervals,
+  const NCollection_Array1<double>& theTrueUIntervals,
+  const NCollection_Array1<double>& theTrueVIntervals)
 {
-  // (1) Construction des Tables monodimensionnelles ----------------------------
-  NCollection_Array1<double> UParameters, VParameters;
-  myUKnots = NCollection_Array1<double>(TrueUIntervals->Array1());
-  myVKnots = NCollection_Array1<double>(TrueVIntervals->Array1());
+  // (1) Build monodimensional knot/multiplicity/parameter tables.
+  NCollection_Array1<double> aUParameters;
+  NCollection_Array1<double> aVParameters;
+  myUKnots = NCollection_Array1<double>(theTrueUIntervals);
+  myVKnots = NCollection_Array1<double>(theTrueVIntervals);
 
-  BuildArray(myUDegree, myUKnots, UContinuity, myUFlatKnots, myUMults, UParameters);
+  BuildArray(myUDegree, myUKnots, theUContinuity, myUFlatKnots, myUMults, aUParameters);
+  BuildArray(myVDegree, myVKnots, theVContinuity, myVFlatKnots, myVMults, aVParameters);
 
-  BuildArray(myVDegree, myVKnots, VContinuity, myVFlatKnots, myVMults, VParameters);
+  // (2) Digitalisation
+  const int aDimension = 3 * (myVDegree + 1);
+  const int aSizPatch  = 3 * (theMaxUDegree + 1) * (theMaxVDegree + 1);
+  myPoles =
+    NCollection_Array2<gp_Pnt>(1, aUParameters.Length(), 1, aVParameters.Length());
 
-  // (2) Digitalisation -------------------------------------------------------
+  NCollection_Array1<double> aPatch(1, (myUDegree + 1) * aDimension);
+  NCollection_Array1<double> aPoint(1, 3);
+  double* const              aCoeffs = &aPatch.ChangeValue(1);
+  double* const              aDigit  = &aPoint.ChangeValue(1);
 
-  int    ii, jj, Uindex = 0, Vindex = 0;
-  int    Patch_Indice = 0;
-  double NValue, UValue, VValue;
-  int    dimension = 3 * (myVDegree + 1);
-  int    SizPatch  = 3 * (MaxUDegree + 1) * (MaxVDegree + 1);
-  myPoles          = NCollection_Array2<gp_Pnt>(1, UParameters.Length(), 1, VParameters.Length());
-
-  NCollection_Array1<double> Patch(1, (myUDegree + 1) * dimension);
-  NCollection_Array1<double> Point(1, 3);
-  double*                    Coeffs = (double*)&Patch.ChangeValue(1);
-  double*                    Digit  = (double*)&Point.ChangeValue(1);
-
-  for (ii = 1, Uindex = 1; ii <= UParameters.Length(); ii++)
+  int aPatchIndice = 0;
+  int aUIndex      = 1;
+  for (int ii = 1; ii <= aUParameters.Length(); ++ii)
   {
-
-    while (UParameters.Value(ii) > TrueUIntervals->Value(Uindex + 1)
-           && Uindex < myUKnots.Length() - 1)
+    while (aUParameters.Value(ii) > theTrueUIntervals.Value(aUIndex + 1)
+           && aUIndex < myUKnots.Length() - 1)
     {
-      Uindex++;
+      ++aUIndex;
     }
+    double aNValue = (aUParameters.Value(ii) - theTrueUIntervals.Value(aUIndex))
+                     / (theTrueUIntervals.Value(aUIndex + 1)
+                        - theTrueUIntervals.Value(aUIndex));
+    const double aUValue = (1.0 - aNValue) * thePolynomialUIntervals.Value(1)
+                           + aNValue * thePolynomialUIntervals.Value(2);
 
-    NValue = (UParameters.Value(ii) - TrueUIntervals->Value(Uindex))
-             / (TrueUIntervals->Value(Uindex + 1) - TrueUIntervals->Value(Uindex));
-    UValue =
-      (1 - NValue) * PolynomialUIntervals->Value(1) + NValue * PolynomialUIntervals->Value(2);
-
-    for (jj = 1, Vindex = 1; jj <= VParameters.Length(); jj++)
+    int aVIndex = 1;
+    for (int jj = 1; jj <= aVParameters.Length(); ++jj)
     {
-
-      while (VParameters.Value(jj) > TrueVIntervals->Value(Vindex + 1)
-             && Vindex < myVKnots.Length() - 1)
+      while (aVParameters.Value(jj) > theTrueVIntervals.Value(aVIndex + 1)
+             && aVIndex < myVKnots.Length() - 1)
       {
-        Vindex++;
+        ++aVIndex;
       }
+      aNValue = (aVParameters.Value(jj) - theTrueVIntervals.Value(aVIndex))
+                / (theTrueVIntervals.Value(aVIndex + 1) - theTrueVIntervals.Value(aVIndex));
+      const double aVValue = (1.0 - aNValue) * thePolynomialVIntervals.Value(1)
+                             + aNValue * thePolynomialVIntervals.Value(2);
 
-      NValue = (VParameters.Value(jj) - TrueVIntervals->Value(Vindex))
-               / (TrueVIntervals->Value(Vindex + 1) - TrueVIntervals->Value(Vindex));
-      VValue =
-        (1 - NValue) * PolynomialVIntervals->Value(1) + NValue * PolynomialVIntervals->Value(2);
-
-      // (2.1) Extraction du bon Patch
-      if (Patch_Indice != Uindex + (myUKnots.Length() - 1) * (Vindex - 1))
+      // (2.1) Extract the active patch coefficients.
+      if (aPatchIndice != aUIndex + (myUKnots.Length() - 1) * (aVIndex - 1))
       {
-        int k1, k2, pos, ll = 1;
-        Patch_Indice = Uindex + (myUKnots.Length() - 1) * (Vindex - 1);
-        for (k1 = 1; k1 <= NumCoeffPerSurface->Value(Patch_Indice, 1); k1++)
+        aPatchIndice = aUIndex + (myUKnots.Length() - 1) * (aVIndex - 1);
+        int ll       = 1;
+        for (int k1 = 1; k1 <= theNumCoeffPerSurface.Value(aPatchIndice, 1); ++k1)
         {
-          pos = SizPatch * (Patch_Indice - 1) + 3 * (MaxVDegree + 1) * (k1 - 1) + 1;
-          for (k2 = 1; k2 <= NumCoeffPerSurface->Value(Patch_Indice, 2); k2++, pos += 3)
+          int pos =
+            aSizPatch * (aPatchIndice - 1) + 3 * (theMaxVDegree + 1) * (k1 - 1) + 1;
+          for (int k2 = 1; k2 <= theNumCoeffPerSurface.Value(aPatchIndice, 2);
+               ++k2, pos += 3)
           {
-            Patch(ll)     = Coefficients->Value(pos);
-            Patch(ll + 1) = Coefficients->Value(pos + 1);
-            Patch(ll + 2) = Coefficients->Value(pos + 2);
+            aPatch(ll)     = theCoefficients.Value(pos);
+            aPatch(ll + 1) = theCoefficients.Value(pos + 1);
+            aPatch(ll + 2) = theCoefficients.Value(pos + 2);
             ll += 3;
           }
         }
       }
 
-      // (2.2) Positionnement en UValue,VValue
-      PLib::EvalPoly2Var(UValue,
-                         VValue,
+      // (2.2) Evaluate at (aUValue, aVValue).
+      PLib::EvalPoly2Var(aUValue,
+                         aVValue,
                          0,
                          0,
-                         NumCoeffPerSurface->Value(Patch_Indice, 1) - 1,
-                         NumCoeffPerSurface->Value(Patch_Indice, 2) - 1,
+                         theNumCoeffPerSurface.Value(aPatchIndice, 1) - 1,
+                         theNumCoeffPerSurface.Value(aPatchIndice, 2) - 1,
                          3,
-                         Coeffs[0],
-                         Digit[0]);
+                         aCoeffs[0],
+                         aDigit[0]);
 
-      myPoles.SetValue(ii, jj, gp_Pnt(Digit[0], Digit[1], Digit[2]));
+      myPoles.SetValue(ii, jj, gp_Pnt(aDigit[0], aDigit[1], aDigit[2]));
     }
   }
 
@@ -249,8 +289,8 @@ void Convert_GridPolynomialToPoles::Perform(
                         myVDegree,
                         myUFlatKnots,
                         myVFlatKnots,
-                        UParameters,
-                        VParameters,
+                        aUParameters,
+                        aVParameters,
                         myPoles,
                         InversionProblem);
   myDone = (InversionProblem == 0);

--- a/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.cxx
+++ b/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.cxx
@@ -211,8 +211,7 @@ void Convert_GridPolynomialToPoles::Perform(
   // (2) Digitalisation
   const int aDimension = 3 * (myVDegree + 1);
   const int aSizPatch  = 3 * (theMaxUDegree + 1) * (theMaxVDegree + 1);
-  myPoles =
-    NCollection_Array2<gp_Pnt>(1, aUParameters.Length(), 1, aVParameters.Length());
+  myPoles = NCollection_Array2<gp_Pnt>(1, aUParameters.Length(), 1, aVParameters.Length());
 
   NCollection_Array1<double> aPatch(1, (myUDegree + 1) * aDimension);
   NCollection_Array1<double> aPoint(1, 3);
@@ -229,8 +228,7 @@ void Convert_GridPolynomialToPoles::Perform(
       ++aUIndex;
     }
     double aNValue = (aUParameters.Value(ii) - theTrueUIntervals.Value(aUIndex))
-                     / (theTrueUIntervals.Value(aUIndex + 1)
-                        - theTrueUIntervals.Value(aUIndex));
+                     / (theTrueUIntervals.Value(aUIndex + 1) - theTrueUIntervals.Value(aUIndex));
     const double aUValue = (1.0 - aNValue) * thePolynomialUIntervals.Value(1)
                            + aNValue * thePolynomialUIntervals.Value(2);
 
@@ -254,10 +252,8 @@ void Convert_GridPolynomialToPoles::Perform(
         int ll       = 1;
         for (int k1 = 1; k1 <= theNumCoeffPerSurface.Value(aPatchIndice, 1); ++k1)
         {
-          int pos =
-            aSizPatch * (aPatchIndice - 1) + 3 * (theMaxVDegree + 1) * (k1 - 1) + 1;
-          for (int k2 = 1; k2 <= theNumCoeffPerSurface.Value(aPatchIndice, 2);
-               ++k2, pos += 3)
+          int pos = aSizPatch * (aPatchIndice - 1) + 3 * (theMaxVDegree + 1) * (k1 - 1) + 1;
+          for (int k2 = 1; k2 <= theNumCoeffPerSurface.Value(aPatchIndice, 2); ++k2, pos += 3)
           {
             aPatch(ll)     = theCoefficients.Value(pos);
             aPatch(ll + 1) = theCoefficients.Value(pos + 1);

--- a/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.hxx
+++ b/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.hxx
@@ -45,8 +45,8 @@ public:
   //! The <Coefficients> have to be formatted than an "C array"
   //! [MaxUDegree+1] [MaxVDegree+1] [3]
   Standard_EXPORT Convert_GridPolynomialToPoles(
-    int                               theMaxUDegree,
-    int                               theMaxVDegree,
+    const int                         theMaxUDegree,
+    const int                         theMaxVDegree,
     const NCollection_Array1<int>&    theNumCoeff,
     const NCollection_Array1<double>& theCoefficients,
     const NCollection_Array1<double>& thePolynomialUIntervals,
@@ -56,8 +56,8 @@ public:
   //! Provided for backward compatibility; new code should prefer the
   //! @c NCollection_Array1 form which avoids unnecessary heap allocation.
   Standard_EXPORT Convert_GridPolynomialToPoles(
-    int                                             theMaxUDegree,
-    int                                             theMaxVDegree,
+    const int                                       theMaxUDegree,
+    const int                                       theMaxVDegree,
     const occ::handle<NCollection_HArray1<int>>&    theNumCoeff,
     const occ::handle<NCollection_HArray1<double>>& theCoefficients,
     const occ::handle<NCollection_HArray1<double>>& thePolynomialUIntervals,
@@ -78,12 +78,12 @@ public:
   //! [1, NbVSurfaces*NbUSurfaces, 1,2] array.
   //! if <Coefficients> is not a
   Standard_EXPORT Convert_GridPolynomialToPoles(
-    int                               theNbUSurfaces,
-    int                               theNbVSurfaces,
-    int                               theUContinuity,
-    int                               theVContinuity,
-    int                               theMaxUDegree,
-    int                               theMaxVDegree,
+    const int                         theNbUSurfaces,
+    const int                         theNbVSurfaces,
+    const int                         theUContinuity,
+    const int                         theVContinuity,
+    const int                         theMaxUDegree,
+    const int                         theMaxVDegree,
     const NCollection_Array2<int>&    theNumCoeffPerSurface,
     const NCollection_Array1<double>& theCoefficients,
     const NCollection_Array1<double>& thePolynomialUIntervals,
@@ -93,12 +93,12 @@ public:
 
   //! Handle-based overload (delegates to the array-based constructor).
   Standard_EXPORT Convert_GridPolynomialToPoles(
-    int                                             theNbUSurfaces,
-    int                                             theNbVSurfaces,
-    int                                             theUContinuity,
-    int                                             theVContinuity,
-    int                                             theMaxUDegree,
-    int                                             theMaxVDegree,
+    const int                                       theNbUSurfaces,
+    const int                                       theNbVSurfaces,
+    const int                                       theUContinuity,
+    const int                                       theVContinuity,
+    const int                                       theMaxUDegree,
+    const int                                       theMaxVDegree,
     const occ::handle<NCollection_HArray2<int>>&    theNumCoeffPerSurface,
     const occ::handle<NCollection_HArray1<double>>& theCoefficients,
     const occ::handle<NCollection_HArray1<double>>& thePolynomialUIntervals,
@@ -143,10 +143,10 @@ public:
   [[nodiscard]] Standard_EXPORT bool IsDone() const;
 
 private:
-  Standard_EXPORT void Perform(int                               theUContinuity,
-                               int                               theVContinuity,
-                               int                               theMaxUDegree,
-                               int                               theMaxVDegree,
+  Standard_EXPORT void Perform(const int                         theUContinuity,
+                               const int                         theVContinuity,
+                               const int                         theMaxUDegree,
+                               const int                         theMaxVDegree,
                                const NCollection_Array2<int>&    theNumCoeffPerSurface,
                                const NCollection_Array1<double>& theCoefficients,
                                const NCollection_Array1<double>& thePolynomialUIntervals,

--- a/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.hxx
+++ b/src/FoundationClasses/TKMath/Convert/Convert_GridPolynomialToPoles.hxx
@@ -22,10 +22,10 @@
 #include <Standard_Handle.hxx>
 
 #include <NCollection_Array1.hxx>
-#include <NCollection_HArray1.hxx>
-#include <gp_Pnt.hxx>
 #include <NCollection_Array2.hxx>
+#include <NCollection_HArray1.hxx>
 #include <NCollection_HArray2.hxx>
+#include <gp_Pnt.hxx>
 
 //! Convert a grid of Polynomial Surfaces
 //! that are have continuity CM to an
@@ -45,12 +45,23 @@ public:
   //! The <Coefficients> have to be formatted than an "C array"
   //! [MaxUDegree+1] [MaxVDegree+1] [3]
   Standard_EXPORT Convert_GridPolynomialToPoles(
-    const int                                       MaxUDegree,
-    const int                                       MaxVDegree,
-    const occ::handle<NCollection_HArray1<int>>&    NumCoeff,
-    const occ::handle<NCollection_HArray1<double>>& Coefficients,
-    const occ::handle<NCollection_HArray1<double>>& PolynomialUIntervals,
-    const occ::handle<NCollection_HArray1<double>>& PolynomialVIntervals);
+    int                               theMaxUDegree,
+    int                               theMaxVDegree,
+    const NCollection_Array1<int>&    theNumCoeff,
+    const NCollection_Array1<double>& theCoefficients,
+    const NCollection_Array1<double>& thePolynomialUIntervals,
+    const NCollection_Array1<double>& thePolynomialVIntervals);
+
+  //! Handle-based overload (delegates to the array-based constructor).
+  //! Provided for backward compatibility; new code should prefer the
+  //! @c NCollection_Array1 form which avoids unnecessary heap allocation.
+  Standard_EXPORT Convert_GridPolynomialToPoles(
+    int                                             theMaxUDegree,
+    int                                             theMaxVDegree,
+    const occ::handle<NCollection_HArray1<int>>&    theNumCoeff,
+    const occ::handle<NCollection_HArray1<double>>& theCoefficients,
+    const occ::handle<NCollection_HArray1<double>>& thePolynomialUIntervals,
+    const occ::handle<NCollection_HArray1<double>>& thePolynomialVIntervals);
 
   //! To one grid of polynomial Surface.
   //! Warning!
@@ -67,18 +78,33 @@ public:
   //! [1, NbVSurfaces*NbUSurfaces, 1,2] array.
   //! if <Coefficients> is not a
   Standard_EXPORT Convert_GridPolynomialToPoles(
-    const int                                       NbUSurfaces,
-    const int                                       NBVSurfaces,
-    const int                                       UContinuity,
-    const int                                       VContinuity,
-    const int                                       MaxUDegree,
-    const int                                       MaxVDegree,
-    const occ::handle<NCollection_HArray2<int>>&    NumCoeffPerSurface,
-    const occ::handle<NCollection_HArray1<double>>& Coefficients,
-    const occ::handle<NCollection_HArray1<double>>& PolynomialUIntervals,
-    const occ::handle<NCollection_HArray1<double>>& PolynomialVIntervals,
-    const occ::handle<NCollection_HArray1<double>>& TrueUIntervals,
-    const occ::handle<NCollection_HArray1<double>>& TrueVIntervals);
+    int                               theNbUSurfaces,
+    int                               theNbVSurfaces,
+    int                               theUContinuity,
+    int                               theVContinuity,
+    int                               theMaxUDegree,
+    int                               theMaxVDegree,
+    const NCollection_Array2<int>&    theNumCoeffPerSurface,
+    const NCollection_Array1<double>& theCoefficients,
+    const NCollection_Array1<double>& thePolynomialUIntervals,
+    const NCollection_Array1<double>& thePolynomialVIntervals,
+    const NCollection_Array1<double>& theTrueUIntervals,
+    const NCollection_Array1<double>& theTrueVIntervals);
+
+  //! Handle-based overload (delegates to the array-based constructor).
+  Standard_EXPORT Convert_GridPolynomialToPoles(
+    int                                             theNbUSurfaces,
+    int                                             theNbVSurfaces,
+    int                                             theUContinuity,
+    int                                             theVContinuity,
+    int                                             theMaxUDegree,
+    int                                             theMaxVDegree,
+    const occ::handle<NCollection_HArray2<int>>&    theNumCoeffPerSurface,
+    const occ::handle<NCollection_HArray1<double>>& theCoefficients,
+    const occ::handle<NCollection_HArray1<double>>& thePolynomialUIntervals,
+    const occ::handle<NCollection_HArray1<double>>& thePolynomialVIntervals,
+    const occ::handle<NCollection_HArray1<double>>& theTrueUIntervals,
+    const occ::handle<NCollection_HArray1<double>>& theTrueVIntervals);
 
   //! Returns the number of poles in the U parametric direction.
   [[nodiscard]] Standard_EXPORT int NbUPoles() const;
@@ -117,16 +143,16 @@ public:
   [[nodiscard]] Standard_EXPORT bool IsDone() const;
 
 private:
-  Standard_EXPORT void Perform(const int                                       UContinuity,
-                               const int                                       VContinuity,
-                               const int                                       MaxUDegree,
-                               const int                                       MaxVDegree,
-                               const occ::handle<NCollection_HArray2<int>>&    NumCoeffPerSurface,
-                               const occ::handle<NCollection_HArray1<double>>& Coefficients,
-                               const occ::handle<NCollection_HArray1<double>>& PolynomialUIntervals,
-                               const occ::handle<NCollection_HArray1<double>>& PolynomialVIntervals,
-                               const occ::handle<NCollection_HArray1<double>>& TrueUIntervals,
-                               const occ::handle<NCollection_HArray1<double>>& TrueVIntervals);
+  Standard_EXPORT void Perform(int                               theUContinuity,
+                               int                               theVContinuity,
+                               int                               theMaxUDegree,
+                               int                               theMaxVDegree,
+                               const NCollection_Array2<int>&    theNumCoeffPerSurface,
+                               const NCollection_Array1<double>& theCoefficients,
+                               const NCollection_Array1<double>& thePolynomialUIntervals,
+                               const NCollection_Array1<double>& thePolynomialVIntervals,
+                               const NCollection_Array1<double>& theTrueUIntervals,
+                               const NCollection_Array1<double>& theTrueVIntervals);
 
   Standard_EXPORT void BuildArray(const int                         Degree,
                                   const NCollection_Array1<double>& Knots,

--- a/src/FoundationClasses/TKMath/GTests/Convert_GridPolynomialToPoles_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/Convert_GridPolynomialToPoles_Test.cxx
@@ -17,7 +17,6 @@
 #include <gp_Pnt.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_Array2.hxx>
-#include <NCollection_HArray1.hxx>
 
 TEST(Convert_GridPolynomialToPolesTest, SinglePlanarPatch)
 {
@@ -28,39 +27,39 @@ TEST(Convert_GridPolynomialToPolesTest, SinglePlanarPatch)
   const int aMaxUDeg = 1;
   const int aMaxVDeg = 1;
 
-  occ::handle<NCollection_HArray1<int>> aNumCoeff = new NCollection_HArray1<int>(1, 2);
-  aNumCoeff->SetValue(1, 2); // U degree + 1
-  aNumCoeff->SetValue(2, 2); // V degree + 1
+  NCollection_Array1<int> aNumCoeff(1, 2);
+  aNumCoeff.SetValue(1, 2); // U degree + 1
+  aNumCoeff.SetValue(2, 2); // V degree + 1
 
   // Coefficients [2][2][3] = 12 values
   // Layout: for u_i, v_j: coeff(u_i, v_j) = {x, y, z}
   // P(u,v) = sum c_{ij} * u^i * v^j
   // c_{00} = (0,0,0), c_{10} = (1,0,0), c_{01} = (0,1,0), c_{11} = (0,0,0)
-  occ::handle<NCollection_HArray1<double>> aCoeffs = new NCollection_HArray1<double>(1, 12);
+  NCollection_Array1<double> aCoeffs(1, 12);
   // c_{00}: x=0,y=0,z=0
-  aCoeffs->SetValue(1, 0.0);
-  aCoeffs->SetValue(2, 0.0);
-  aCoeffs->SetValue(3, 0.0);
+  aCoeffs.SetValue(1, 0.0);
+  aCoeffs.SetValue(2, 0.0);
+  aCoeffs.SetValue(3, 0.0);
   // c_{01}: x=0,y=1,z=0
-  aCoeffs->SetValue(4, 0.0);
-  aCoeffs->SetValue(5, 1.0);
-  aCoeffs->SetValue(6, 0.0);
+  aCoeffs.SetValue(4, 0.0);
+  aCoeffs.SetValue(5, 1.0);
+  aCoeffs.SetValue(6, 0.0);
   // c_{10}: x=1,y=0,z=0
-  aCoeffs->SetValue(7, 1.0);
-  aCoeffs->SetValue(8, 0.0);
-  aCoeffs->SetValue(9, 0.0);
+  aCoeffs.SetValue(7, 1.0);
+  aCoeffs.SetValue(8, 0.0);
+  aCoeffs.SetValue(9, 0.0);
   // c_{11}: x=0,y=0,z=0
-  aCoeffs->SetValue(10, 0.0);
-  aCoeffs->SetValue(11, 0.0);
-  aCoeffs->SetValue(12, 0.0);
+  aCoeffs.SetValue(10, 0.0);
+  aCoeffs.SetValue(11, 0.0);
+  aCoeffs.SetValue(12, 0.0);
 
-  occ::handle<NCollection_HArray1<double>> aPolyU = new NCollection_HArray1<double>(1, 2);
-  aPolyU->SetValue(1, 0.0);
-  aPolyU->SetValue(2, 1.0);
+  NCollection_Array1<double> aPolyU(1, 2);
+  aPolyU.SetValue(1, 0.0);
+  aPolyU.SetValue(2, 1.0);
 
-  occ::handle<NCollection_HArray1<double>> aPolyV = new NCollection_HArray1<double>(1, 2);
-  aPolyV->SetValue(1, 0.0);
-  aPolyV->SetValue(2, 1.0);
+  NCollection_Array1<double> aPolyV(1, 2);
+  aPolyV.SetValue(1, 0.0);
+  aPolyV.SetValue(2, 1.0);
 
   Convert_GridPolynomialToPoles aConv(aMaxUDeg, aMaxVDeg, aNumCoeff, aCoeffs, aPolyU, aPolyV);
 
@@ -72,7 +71,6 @@ TEST(Convert_GridPolynomialToPolesTest, SinglePlanarPatch)
   EXPECT_GT(aConv.NbUKnots(), 0);
   EXPECT_GT(aConv.NbVKnots(), 0);
 
-  // Check poles are accessible
   const NCollection_Array2<gp_Pnt>& aPoles = aConv.Poles();
   EXPECT_GT(aPoles.Size(), 0);
 }
@@ -82,33 +80,32 @@ TEST(Convert_GridPolynomialToPolesTest, QueryMethods)
   const int aMaxUDeg = 1;
   const int aMaxVDeg = 1;
 
-  occ::handle<NCollection_HArray1<int>> aNumCoeff = new NCollection_HArray1<int>(1, 2);
-  aNumCoeff->SetValue(1, 2);
-  aNumCoeff->SetValue(2, 2);
+  NCollection_Array1<int> aNumCoeff(1, 2);
+  aNumCoeff.SetValue(1, 2);
+  aNumCoeff.SetValue(2, 2);
 
-  occ::handle<NCollection_HArray1<double>> aCoeffs = new NCollection_HArray1<double>(1, 12);
+  NCollection_Array1<double> aCoeffs(1, 12);
   for (int i = 1; i <= 12; ++i)
   {
-    aCoeffs->SetValue(i, 0.0);
+    aCoeffs.SetValue(i, 0.0);
   }
   // Just set x = u coefficient
-  aCoeffs->SetValue(7, 1.0);
+  aCoeffs.SetValue(7, 1.0);
   // y = v coefficient
-  aCoeffs->SetValue(5, 1.0);
+  aCoeffs.SetValue(5, 1.0);
 
-  occ::handle<NCollection_HArray1<double>> aPolyU = new NCollection_HArray1<double>(1, 2);
-  aPolyU->SetValue(1, 0.0);
-  aPolyU->SetValue(2, 1.0);
+  NCollection_Array1<double> aPolyU(1, 2);
+  aPolyU.SetValue(1, 0.0);
+  aPolyU.SetValue(2, 1.0);
 
-  occ::handle<NCollection_HArray1<double>> aPolyV = new NCollection_HArray1<double>(1, 2);
-  aPolyV->SetValue(1, 0.0);
-  aPolyV->SetValue(2, 1.0);
+  NCollection_Array1<double> aPolyV(1, 2);
+  aPolyV.SetValue(1, 0.0);
+  aPolyV.SetValue(2, 1.0);
 
   Convert_GridPolynomialToPoles aConv(aMaxUDeg, aMaxVDeg, aNumCoeff, aCoeffs, aPolyU, aPolyV);
 
   ASSERT_TRUE(aConv.IsDone());
 
-  // Verify knot data is accessible
   const NCollection_Array1<double>& aUKnots = aConv.UKnots();
   const NCollection_Array1<double>& aVKnots = aConv.VKnots();
   const NCollection_Array1<int>&    aUMults = aConv.UMultiplicities();

--- a/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfNodes.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfNodes.hxx
@@ -101,9 +101,11 @@ public:
 public:
   //! A generalized accessor to point.
   inline gp_Pnt Value(int theIndex) const;
+  inline gp_Pnt Value(size_t theIndex) const;
 
   //! A generalized setter for point.
   inline void SetValue(int theIndex, const gp_Pnt& theValue);
+  inline void SetValue(size_t theIndex, const gp_Pnt& theValue);
 
   //! operator[] - alias to Value
   gp_Pnt operator[](int theIndex) const { return Value(theIndex); }
@@ -127,6 +129,15 @@ inline gp_Pnt Poly_ArrayOfNodes::Value(int theIndex) const
 
 //=================================================================================================
 
+inline gp_Pnt Poly_ArrayOfNodes::Value(size_t theIndex) const
+{
+  Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
+                               "Poly_ArrayOfNodes::Value(), out of range index");
+  return Value(static_cast<int>(theIndex));
+}
+
+//=================================================================================================
+
 inline void Poly_ArrayOfNodes::SetValue(int theIndex, const gp_Pnt& theValue)
 {
   if (myStride == (int)sizeof(gp_Pnt))
@@ -139,6 +150,15 @@ inline void Poly_ArrayOfNodes::SetValue(int theIndex, const gp_Pnt& theValue)
       NCollection_AliasedArray::ChangeValue<NCollection_Vec3<float>>(theIndex);
     aVec3.SetValues((float)theValue.X(), (float)theValue.Y(), (float)theValue.Z());
   }
+}
+
+//=================================================================================================
+
+inline void Poly_ArrayOfNodes::SetValue(size_t theIndex, const gp_Pnt& theValue)
+{
+  Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
+                               "Poly_ArrayOfNodes::SetValue(), out of range index");
+  SetValue(static_cast<int>(theIndex), theValue);
 }
 
 #endif // _Poly_ArrayOfNodes_HeaderFile

--- a/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfNodes.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfNodes.hxx
@@ -101,11 +101,11 @@ public:
 public:
   //! A generalized accessor to point.
   inline gp_Pnt Value(int theIndex) const;
-  inline gp_Pnt Value(size_t theIndex) const;
+  inline gp_Pnt Value(const size_t theIndex) const;
 
   //! A generalized setter for point.
   inline void SetValue(int theIndex, const gp_Pnt& theValue);
-  inline void SetValue(size_t theIndex, const gp_Pnt& theValue);
+  inline void SetValue(const size_t theIndex, const gp_Pnt& theValue);
 
   //! operator[] - alias to Value
   gp_Pnt operator[](int theIndex) const { return Value(theIndex); }
@@ -129,7 +129,7 @@ inline gp_Pnt Poly_ArrayOfNodes::Value(int theIndex) const
 
 //=================================================================================================
 
-inline gp_Pnt Poly_ArrayOfNodes::Value(size_t theIndex) const
+inline gp_Pnt Poly_ArrayOfNodes::Value(const size_t theIndex) const
 {
   Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
                                "Poly_ArrayOfNodes::Value(), out of range index");
@@ -154,7 +154,7 @@ inline void Poly_ArrayOfNodes::SetValue(int theIndex, const gp_Pnt& theValue)
 
 //=================================================================================================
 
-inline void Poly_ArrayOfNodes::SetValue(size_t theIndex, const gp_Pnt& theValue)
+inline void Poly_ArrayOfNodes::SetValue(const size_t theIndex, const gp_Pnt& theValue)
 {
   Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
                                "Poly_ArrayOfNodes::SetValue(), out of range index");

--- a/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfUVNodes.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfUVNodes.hxx
@@ -101,11 +101,11 @@ public:
 public:
   //! A generalized accessor to point.
   inline gp_Pnt2d Value(int theIndex) const;
-  inline gp_Pnt2d Value(size_t theIndex) const;
+  inline gp_Pnt2d Value(const size_t theIndex) const;
 
   //! A generalized setter for point.
   inline void SetValue(int theIndex, const gp_Pnt2d& theValue);
-  inline void SetValue(size_t theIndex, const gp_Pnt2d& theValue);
+  inline void SetValue(const size_t theIndex, const gp_Pnt2d& theValue);
 
   //! operator[] - alias to Value
   gp_Pnt2d operator[](int theIndex) const { return Value(theIndex); }
@@ -129,7 +129,7 @@ inline gp_Pnt2d Poly_ArrayOfUVNodes::Value(int theIndex) const
 
 //=================================================================================================
 
-inline gp_Pnt2d Poly_ArrayOfUVNodes::Value(size_t theIndex) const
+inline gp_Pnt2d Poly_ArrayOfUVNodes::Value(const size_t theIndex) const
 {
   Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
                                "Poly_ArrayOfUVNodes::Value(), out of range index");
@@ -154,7 +154,7 @@ inline void Poly_ArrayOfUVNodes::SetValue(int theIndex, const gp_Pnt2d& theValue
 
 //=================================================================================================
 
-inline void Poly_ArrayOfUVNodes::SetValue(size_t theIndex, const gp_Pnt2d& theValue)
+inline void Poly_ArrayOfUVNodes::SetValue(const size_t theIndex, const gp_Pnt2d& theValue)
 {
   Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
                                "Poly_ArrayOfUVNodes::SetValue(), out of range index");

--- a/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfUVNodes.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_ArrayOfUVNodes.hxx
@@ -101,9 +101,11 @@ public:
 public:
   //! A generalized accessor to point.
   inline gp_Pnt2d Value(int theIndex) const;
+  inline gp_Pnt2d Value(size_t theIndex) const;
 
   //! A generalized setter for point.
   inline void SetValue(int theIndex, const gp_Pnt2d& theValue);
+  inline void SetValue(size_t theIndex, const gp_Pnt2d& theValue);
 
   //! operator[] - alias to Value
   gp_Pnt2d operator[](int theIndex) const { return Value(theIndex); }
@@ -127,6 +129,15 @@ inline gp_Pnt2d Poly_ArrayOfUVNodes::Value(int theIndex) const
 
 //=================================================================================================
 
+inline gp_Pnt2d Poly_ArrayOfUVNodes::Value(size_t theIndex) const
+{
+  Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
+                               "Poly_ArrayOfUVNodes::Value(), out of range index");
+  return Value(static_cast<int>(theIndex));
+}
+
+//=================================================================================================
+
 inline void Poly_ArrayOfUVNodes::SetValue(int theIndex, const gp_Pnt2d& theValue)
 {
   if (myStride == (int)sizeof(gp_Pnt2d))
@@ -139,6 +150,15 @@ inline void Poly_ArrayOfUVNodes::SetValue(int theIndex, const gp_Pnt2d& theValue
       NCollection_AliasedArray::ChangeValue<NCollection_Vec2<float>>(theIndex);
     aVec2.SetValues((float)theValue.X(), (float)theValue.Y());
   }
+}
+
+//=================================================================================================
+
+inline void Poly_ArrayOfUVNodes::SetValue(size_t theIndex, const gp_Pnt2d& theValue)
+{
+  Standard_OutOfRange_Raise_if(theIndex >= static_cast<size_t>(mySize),
+                               "Poly_ArrayOfUVNodes::SetValue(), out of range index");
+  SetValue(static_cast<int>(theIndex), theValue);
 }
 
 #endif // _Poly_ArrayOfUVNodes_HeaderFile

--- a/src/FoundationClasses/TKMath/Poly/Poly_Polygon2D.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_Polygon2D.cxx
@@ -41,6 +41,16 @@ Poly_Polygon2D::Poly_Polygon2D(const NCollection_Array1<gp_Pnt2d>& Nodes)
 
 //=================================================================================================
 
+occ::handle<Poly_Polygon2D> Poly_Polygon2D::Copy() const
+{
+  occ::handle<Poly_Polygon2D> aCopy = new Poly_Polygon2D(NbNodes());
+  aCopy->ChangeNodes().CopyValues(myNodes);
+  aCopy->Deflection(myDeflection);
+  return aCopy;
+}
+
+//=================================================================================================
+
 void Poly_Polygon2D::DumpJson(Standard_OStream& theOStream, int) const
 {
   OCCT_DUMP_TRANSIENT_CLASS_BEGIN(theOStream)

--- a/src/FoundationClasses/TKMath/Poly/Poly_Polygon2D.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_Polygon2D.hxx
@@ -36,6 +36,9 @@ public:
   //! Constructs a 2D polygon defined by the table of points, <Nodes>.
   Standard_EXPORT Poly_Polygon2D(const NCollection_Array1<gp_Pnt2d>& Nodes);
 
+  //! Creates a copy of current polygon.
+  Standard_EXPORT virtual occ::handle<Poly_Polygon2D> Copy() const;
+
   //! Returns the deflection of this polygon.
   //! Deflection is used in cases where the polygon is an
   //! approximate representation of a curve. Deflection

--- a/src/FoundationClasses/TKMath/Poly/Poly_Polygon3D.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_Polygon3D.cxx
@@ -65,14 +65,11 @@ Poly_Polygon3D::Poly_Polygon3D(const NCollection_Array1<gp_Pnt>& Nodes,
 
 occ::handle<Poly_Polygon3D> Poly_Polygon3D::Copy() const
 {
-  occ::handle<Poly_Polygon3D> aCopy;
-  if (myParameters.IsNull())
+  occ::handle<Poly_Polygon3D> aCopy = new Poly_Polygon3D(NbNodes(), !myParameters.IsNull());
+  aCopy->ChangeNodes().CopyValues(myNodes);
+  if (!myParameters.IsNull())
   {
-    aCopy = new Poly_Polygon3D(myNodes);
-  }
-  else
-  {
-    aCopy = new Poly_Polygon3D(myNodes, myParameters->Array1());
+    aCopy->ChangeParameters().CopyValues(myParameters->Array1());
   }
   aCopy->Deflection(myDeflection);
   return aCopy;

--- a/src/FoundationClasses/TKMath/Poly/Poly_PolygonOnTriangulation.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_PolygonOnTriangulation.cxx
@@ -58,14 +58,12 @@ Poly_PolygonOnTriangulation::Poly_PolygonOnTriangulation(
 
 occ::handle<Poly_PolygonOnTriangulation> Poly_PolygonOnTriangulation::Copy() const
 {
-  occ::handle<Poly_PolygonOnTriangulation> aCopy;
-  if (myParameters.IsNull())
+  occ::handle<Poly_PolygonOnTriangulation> aCopy =
+    new Poly_PolygonOnTriangulation(NbNodes(), !myParameters.IsNull());
+  aCopy->ChangeNodeArray().CopyValues(myNodes);
+  if (!myParameters.IsNull())
   {
-    aCopy = new Poly_PolygonOnTriangulation(myNodes);
-  }
-  else
-  {
-    aCopy = new Poly_PolygonOnTriangulation(myNodes, myParameters->Array1());
+    aCopy->ChangeParameterArray().CopyValues(myParameters->Array1());
   }
   aCopy->Deflection(myDeflection);
   return aCopy;

--- a/src/FoundationClasses/TKMath/Poly/Poly_PolygonOnTriangulation.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_PolygonOnTriangulation.hxx
@@ -80,6 +80,9 @@ public:
   //! Returns node at the given index.
   int Node(int theIndex) const { return myNodes.Value(theIndex); }
 
+  //! Returns mutable node-index array.
+  NCollection_Array1<int>& ChangeNodeArray() { return myNodes; }
+
   //! Sets node at the given index.
   void SetNode(int theIndex, int theNode) { myNodes.SetValue(theIndex, theNode); }
 
@@ -100,6 +103,14 @@ public:
     Standard_NullObject_Raise_if(myParameters.IsNull(),
                                  "Poly_PolygonOnTriangulation::Parameter : parameters is NULL");
     myParameters->SetValue(theIndex, theValue);
+  }
+
+  //! Returns mutable parameter array.
+  NCollection_Array1<double>& ChangeParameterArray()
+  {
+    Standard_NullObject_Raise_if(myParameters.IsNull(),
+                                 "Poly_PolygonOnTriangulation::Parameter : parameters is NULL");
+    return myParameters->ChangeArray1();
   }
 
   //! Sets the table of the parameters associated with each node in this polygon.

--- a/src/FoundationClasses/TKMath/Poly/Poly_Triangulation.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_Triangulation.cxx
@@ -19,6 +19,7 @@
 #include <gp_Pnt.hxx>
 #include <OSD_FileSystem.hxx>
 #include <Poly_Triangle.hxx>
+#include <Poly_TriangulationParameters.hxx>
 #include <Standard_Dump.hxx>
 #include <Standard_Type.hxx>
 
@@ -109,9 +110,14 @@ Poly_Triangulation::Poly_Triangulation(const occ::handle<Poly_Triangulation>& th
       myTriangles(theTriangulation->myTriangles),
       myUVNodes(theTriangulation->myUVNodes),
       myNormals(theTriangulation->myNormals),
-      myPurpose(theTriangulation->myPurpose)
+      myPurpose(theTriangulation->myPurpose),
+      myParams(!theTriangulation->myParams.IsNull() ? theTriangulation->myParams->Copy()
+                                                     : occ::handle<Poly_TriangulationParameters>())
 {
-  SetCachedMinMax(theTriangulation->CachedMinMax());
+  if (theTriangulation->HasCachedMinMax())
+  {
+    SetCachedMinMax(theTriangulation->CachedMinMax());
+  }
 }
 
 //=================================================================================================

--- a/src/FoundationClasses/TKMath/Poly/Poly_Triangulation.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_Triangulation.cxx
@@ -112,7 +112,7 @@ Poly_Triangulation::Poly_Triangulation(const occ::handle<Poly_Triangulation>& th
       myNormals(theTriangulation->myNormals),
       myPurpose(theTriangulation->myPurpose),
       myParams(!theTriangulation->myParams.IsNull() ? theTriangulation->myParams->Copy()
-                                                     : occ::handle<Poly_TriangulationParameters>())
+                                                    : occ::handle<Poly_TriangulationParameters>())
 {
   if (theTriangulation->HasCachedMinMax())
   {

--- a/src/FoundationClasses/TKMath/Poly/Poly_TriangulationParameters.cxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_TriangulationParameters.cxx
@@ -16,3 +16,10 @@
 #include <Poly_TriangulationParameters.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(Poly_TriangulationParameters, Standard_Transient)
+
+//=================================================================================================
+
+occ::handle<Poly_TriangulationParameters> Poly_TriangulationParameters::Copy() const
+{
+  return new Poly_TriangulationParameters(myDeflection, myAngle, myMinSize);
+}

--- a/src/FoundationClasses/TKMath/Poly/Poly_TriangulationParameters.hxx
+++ b/src/FoundationClasses/TKMath/Poly/Poly_TriangulationParameters.hxx
@@ -40,6 +40,9 @@ public:
   //! Destructor.
   ~Poly_TriangulationParameters() override = default;
 
+  //! Creates a copy of current triangulation parameters.
+  Standard_EXPORT occ::handle<Poly_TriangulationParameters> Copy() const;
+
   //! Returns true if linear deflection is defined.
   bool HasDeflection() const { return !(myDeflection < 0.); }
 

--- a/src/FoundationClasses/TKernel/GTests/NCollection_Array1_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_Array1_Test.cxx
@@ -40,6 +40,44 @@ TEST(NCollection_Array1Test, ConstructorWithBounds)
   EXPECT_EQ(5, anArray.Upper());
 }
 
+TEST(NCollection_Array1Test, ConstructorWithSizeTUpperUsesBounds)
+{
+  const size_t            anUpper = 3;
+  NCollection_Array1<int> anArray(1, anUpper);
+
+  EXPECT_TRUE(anArray.IsDeletable());
+  EXPECT_EQ(3u, anArray.Size());
+  EXPECT_EQ(1, anArray.Lower());
+  EXPECT_EQ(3, anArray.Upper());
+
+  anArray.ChangeValue(1) = 10;
+  anArray.ChangeValue(2) = 20;
+  anArray.ChangeValue(3) = 30;
+
+  EXPECT_EQ(10, anArray.Value(1));
+  EXPECT_EQ(20, anArray.Value(2));
+  EXPECT_EQ(30, anArray.Value(3));
+}
+
+TEST(NCollection_Array1Test, ReferenceSizeConstructorRequiresExplicitBufferPolicy)
+{
+  int aBuffer[3] = {1, 2, 3};
+
+  NCollection_Array1<int> aView(aBuffer[0], size_t(3), true);
+  EXPECT_FALSE(aView.IsDeletable());
+  EXPECT_EQ(0, aView.Lower());
+  EXPECT_EQ(2, aView.Upper());
+  EXPECT_EQ(aBuffer, &aView.ChangeFirst());
+  aView.ChangeAt(1) = 20;
+  EXPECT_EQ(20, aBuffer[1]);
+
+  NCollection_Array1<int> anOwned(aBuffer[0], size_t(3), false);
+  EXPECT_TRUE(anOwned.IsDeletable());
+  EXPECT_EQ(0, anOwned.Lower());
+  EXPECT_EQ(2, anOwned.Upper());
+  EXPECT_NE(aBuffer, &anOwned.ChangeFirst());
+}
+
 TEST(NCollection_Array1Test, ConstructorWithNegativeBounds)
 {
   // Test constructor with negative bounds

--- a/src/FoundationClasses/TKernel/GTests/NCollection_Array1_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_Array1_Test.cxx
@@ -718,7 +718,7 @@ TEST(NCollection_Array1Test, SizeConstructor_BufferReuse_WritesGoToBuffer)
 
 TEST(NCollection_Array1Test, SizeConstructor_StdVectorBufferReuse)
 {
-  std::vector<int>       aVector = {1, 2, 3, 4};
+  std::vector<int>        aVector = {1, 2, 3, 4};
   NCollection_Array1<int> anArray(aVector.data(), aVector.size());
 
   EXPECT_FALSE(anArray.IsDeletable());

--- a/src/FoundationClasses/TKernel/GTests/NCollection_Array1_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_Array1_Test.cxx
@@ -716,6 +716,17 @@ TEST(NCollection_Array1Test, SizeConstructor_BufferReuse_WritesGoToBuffer)
   }
 }
 
+TEST(NCollection_Array1Test, SizeConstructor_StdVectorBufferReuse)
+{
+  std::vector<int>       aVector = {1, 2, 3, 4};
+  NCollection_Array1<int> anArray(aVector.data(), aVector.size());
+
+  EXPECT_FALSE(anArray.IsDeletable());
+  EXPECT_EQ(aVector.size(), anArray.Size());
+  anArray.ChangeAt(2) = 30;
+  EXPECT_EQ(30, aVector[2]);
+}
+
 TEST(NCollection_Array1Test, SizeConstructor_Resize_Grow)
 {
   NCollection_Array1<int> anArray(static_cast<size_t>(3));

--- a/src/FoundationClasses/TKernel/GTests/NCollection_DynamicArray_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_DynamicArray_Test.cxx
@@ -248,6 +248,59 @@ TEST(NCollection_DynamicArrayTest, STLIterators)
   EXPECT_EQ(60, aVector(2));
 }
 
+TEST(NCollection_DynamicArrayTest, STLIteratorSurvivesAppendAcrossBlocks)
+{
+  NCollection_DynamicArray<int> aVector(size_t(2));
+  for (int anIdx = 0; anIdx < 4; ++anIdx)
+  {
+    aVector.Append(anIdx + 1);
+  }
+
+  auto anIter = aVector.begin();
+  auto anEnd  = aVector.end();
+
+  for (int anIdx = 4; anIdx < 64; ++anIdx)
+  {
+    aVector.Append(anIdx + 1);
+  }
+
+  int aSum = 0;
+  for (; anIter != anEnd; ++anIter)
+  {
+    aSum += *anIter;
+  }
+
+  EXPECT_EQ(10, aSum);
+  EXPECT_EQ(64u, aVector.Size());
+}
+
+TEST(NCollection_DynamicArrayTest, ConstSTLIteratorSurvivesAppendAcrossBlocks)
+{
+  NCollection_DynamicArray<int> aVector(size_t(2));
+  for (int anIdx = 0; anIdx < 4; ++anIdx)
+  {
+    aVector.Append((anIdx + 1) * 10);
+  }
+
+  const NCollection_DynamicArray<int>& aConstVector = aVector;
+  auto                                 anIter       = aConstVector.begin();
+  auto                                 anEnd        = aConstVector.end();
+
+  for (int anIdx = 4; anIdx < 64; ++anIdx)
+  {
+    aVector.Append((anIdx + 1) * 10);
+  }
+
+  int aSum = 0;
+  for (; anIter != anEnd; ++anIter)
+  {
+    aSum += *anIter;
+  }
+
+  EXPECT_EQ(100, aSum);
+  EXPECT_EQ(64u, aVector.Size());
+}
+
 TEST(NCollection_DynamicArrayTest, Grow)
 {
   NCollection_DynamicArray<int> aVector;

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
@@ -885,9 +885,9 @@ TEST(NCollection_LinearVectorTest, ToArray1_ReadThrough)
   }
 
   const NCollection_Array1<int> aArr = aVec.ToArray1();
-  for (size_t i = 0; i < 7; ++i)
+  for (int i = 0; i < 7; ++i)
   {
-    EXPECT_EQ(static_cast<int>(i * 11), aArr[i]);
+    EXPECT_EQ(i * 11, aArr[i]);
   }
 }
 

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
@@ -17,6 +17,19 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <string>
+#include <type_traits>
+#include <utility>
+
+template <typename TheVector, typename = void>
+struct HasToArray1 : std::false_type
+{
+};
+
+template <typename TheVector>
+struct HasToArray1<TheVector, std::void_t<decltype(std::declval<TheVector&>().ToArray1())>>
+    : std::true_type
+{
+};
 
 // Helper struct for testing non-trivial types with move semantics.
 struct MoveOnly
@@ -801,4 +814,103 @@ TEST(NCollection_LinearVectorTest, OcctApiCoverage)
   aVec.Clear();
   EXPECT_TRUE(aVec.IsEmpty());
   EXPECT_EQ(0u, aVec.Size());
+}
+
+// ============ ToArray1 span tests ============
+
+static_assert(HasToArray1<NCollection_LinearVector<int>>::value,
+              "Mutable NCollection_LinearVector should expose mutable Array1 view");
+static_assert(HasToArray1<const NCollection_LinearVector<int>>::value,
+              "Const NCollection_LinearVector should expose read-only Array1 view");
+static_assert(std::is_same_v<decltype(std::declval<NCollection_LinearVector<int>&>().ToArray1()),
+                             NCollection_Array1<int>>,
+              "Mutable NCollection_LinearVector should expose mutable Array1 view");
+static_assert(
+  std::is_same_v<decltype(std::declval<const NCollection_LinearVector<int>&>().ToArray1()),
+                 NCollection_Array1<const int>>,
+  "Const NCollection_LinearVector should expose read-only Array1 view");
+
+// Verify that ToArray1() returns an Array1 sharing the same memory buffer.
+TEST(NCollection_LinearVectorTest, ToArray1_SamePointer)
+{
+  NCollection_LinearVector<int> aVec;
+  for (int i = 0; i < 10; ++i)
+  {
+    aVec.Append(i * 10);
+  }
+
+  NCollection_Array1<int> aArr = aVec.ToArray1();
+  EXPECT_EQ(10u, aArr.Size());
+
+  // Same memory -- pointer equality
+  EXPECT_EQ(aVec.Data(), &aArr[0]);
+}
+
+// Verify that modifications through ToArray1() are reflected in the source.
+TEST(NCollection_LinearVectorTest, ToArray1_ModifyReflectsInSource)
+{
+  NCollection_LinearVector<int> aVec;
+  aVec.Append(1);
+  aVec.Append(2);
+  aVec.Append(3);
+  aVec.Append(4);
+  aVec.Append(5);
+
+  NCollection_Array1<int> aArr = aVec.ToArray1();
+  aArr[0] = 99;
+  aArr[4] = 77;
+
+  EXPECT_EQ(99, aVec[0]);
+  EXPECT_EQ(2, aVec[1]);
+  EXPECT_EQ(77, aVec[4]);
+}
+
+// Verify that ToArray1() on an empty vector produces a zero-size Array1.
+TEST(NCollection_LinearVectorTest, ToArray1_EmptyVector)
+{
+  NCollection_LinearVector<int> aEmpty;
+  NCollection_Array1<int>      aArr = aEmpty.ToArray1();
+
+  EXPECT_EQ(0u, aArr.Size());
+  EXPECT_TRUE(aArr.IsEmpty());
+}
+
+// Reading through ToArray1() returns correct values without copying.
+TEST(NCollection_LinearVectorTest, ToArray1_ReadThrough)
+{
+  NCollection_LinearVector<int> aVec;
+  for (int i = 0; i < 7; ++i)
+  {
+    aVec.Append(i * 11);
+  }
+
+  const NCollection_Array1<int> aArr = aVec.ToArray1();
+  for (size_t i = 0; i < 7; ++i)
+  {
+    EXPECT_EQ(static_cast<int>(i * 11), aArr[i]);
+  }
+}
+
+// Verify that ToArray1() works with non-trivial types (span, not a copy).
+TEST(NCollection_LinearVectorTest, ToArray1_NonTrivial)
+{
+  NCollection_LinearVector<std::string> aVec;
+  aVec.Append("alpha");
+  aVec.Append("beta");
+  aVec.Append("gamma");
+
+  NCollection_Array1<std::string> aArr = aVec.ToArray1();
+  EXPECT_EQ(3u, aArr.Size());
+
+  // Same memory
+  EXPECT_EQ(&aVec[0], &aArr[0]);
+
+  // Reading through returns correct values
+  EXPECT_EQ("alpha", aArr[0]);
+  EXPECT_EQ("beta", aArr[1]);
+  EXPECT_EQ("gamma", aArr[2]);
+
+  // Modify through Array1 and check vector
+  aArr[1] = "modified";
+  EXPECT_EQ("modified", aVec[1]);
 }

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LinearVector_Test.cxx
@@ -857,8 +857,8 @@ TEST(NCollection_LinearVectorTest, ToArray1_ModifyReflectsInSource)
   aVec.Append(5);
 
   NCollection_Array1<int> aArr = aVec.ToArray1();
-  aArr[0] = 99;
-  aArr[4] = 77;
+  aArr[0]                      = 99;
+  aArr[4]                      = 77;
 
   EXPECT_EQ(99, aVec[0]);
   EXPECT_EQ(2, aVec[1]);
@@ -869,7 +869,7 @@ TEST(NCollection_LinearVectorTest, ToArray1_ModifyReflectsInSource)
 TEST(NCollection_LinearVectorTest, ToArray1_EmptyVector)
 {
   NCollection_LinearVector<int> aEmpty;
-  NCollection_Array1<int>      aArr = aEmpty.ToArray1();
+  NCollection_Array1<int>       aArr = aEmpty.ToArray1();
 
   EXPECT_EQ(0u, aArr.Size());
   EXPECT_TRUE(aArr.IsEmpty());

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LocalArray_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LocalArray_Test.cxx
@@ -701,8 +701,8 @@ TEST(NCollection_LocalArrayTest, ToArray1_ReadThrough)
   }
 
   const NCollection_Array1<int> aArr = aSrc.ToArray1();
-  for (size_t i = 0; i < 7; ++i)
+  for (int i = 0; i < 7; ++i)
   {
-    EXPECT_EQ(static_cast<int>(i * 11), aArr[i]);
+    EXPECT_EQ(i * 11, aArr[i]);
   }
 }

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LocalArray_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LocalArray_Test.cxx
@@ -14,6 +14,19 @@
 #include <NCollection_LocalArray.hxx>
 
 #include <gtest/gtest.h>
+#include <type_traits>
+#include <utility>
+
+template <typename TheArray, typename = void>
+struct HasToArray1 : std::false_type
+{
+};
+
+template <typename TheArray>
+struct HasToArray1<TheArray, std::void_t<decltype(std::declval<TheArray&>().ToArray1())>>
+    : std::true_type
+{
+};
 
 // Test default constructor and initial state
 TEST(NCollection_LocalArrayTest, DefaultConstructor)
@@ -602,4 +615,94 @@ TEST(NCollection_LocalArrayTest, NonTrivial_DestructorCallBalance)
   }
   // Total constructions (ctor + move) must equal total destructions.
   EXPECT_EQ(THE_CTOR_COUNT + THE_MOVE_COUNT, THE_DTOR_COUNT);
+}
+
+// ============ ToArray1 span tests ============
+
+static_assert(HasToArray1<NCollection_LocalArray<int>>::value,
+              "Mutable NCollection_LocalArray should expose mutable Array1 view");
+static_assert(HasToArray1<const NCollection_LocalArray<int>>::value,
+              "Const NCollection_LocalArray should expose read-only Array1 view");
+static_assert(std::is_same_v<decltype(std::declval<NCollection_LocalArray<int>&>().ToArray1()),
+                             NCollection_Array1<int>>,
+              "Mutable NCollection_LocalArray should expose mutable Array1 view");
+static_assert(
+  std::is_same_v<decltype(std::declval<const NCollection_LocalArray<int>&>().ToArray1()),
+                 NCollection_Array1<const int>>,
+  "Const NCollection_LocalArray should expose read-only Array1 view");
+
+// Verify that ToArray1() returns an Array1 sharing the same memory buffer.
+TEST(NCollection_LocalArrayTest, ToArray1_SamePointer)
+{
+  NCollection_LocalArray<int> aSrc(10);
+  for (size_t i = 0; i < 10; ++i)
+  {
+    static_cast<int*>(aSrc)[i] = static_cast<int>(i * 10);
+  }
+
+  NCollection_Array1<int> aArr = aSrc.ToArray1();
+  EXPECT_EQ(10u, aArr.Size());
+
+  // Same memory -- pointer equality
+  EXPECT_EQ(static_cast<int*>(aSrc), &aArr[0]);
+}
+
+// Verify that modifications through ToArray1() are reflected in the source.
+TEST(NCollection_LocalArrayTest, ToArray1_ModifyReflectsInSource)
+{
+  NCollection_LocalArray<int> aSrc(5);
+  for (size_t i = 0; i < 5; ++i)
+  {
+    static_cast<int*>(aSrc)[i] = static_cast<int>(i);
+  }
+
+  NCollection_Array1<int> aArr = aSrc.ToArray1();
+  aArr[0] = 99;
+  aArr[4] = 77;
+
+  EXPECT_EQ(99, static_cast<int*>(aSrc)[0]);
+  EXPECT_EQ(1, static_cast<int*>(aSrc)[1]);
+  EXPECT_EQ(77, static_cast<int*>(aSrc)[4]);
+}
+
+// Verify that ToArray1() on an empty LocalArray produces a zero-size Array1.
+TEST(NCollection_LocalArrayTest, ToArray1_EmptyVector)
+{
+  NCollection_LocalArray<int> aEmpty;
+  NCollection_Array1<int>     aArr = aEmpty.ToArray1();
+
+  EXPECT_EQ(0u, aArr.Size());
+  EXPECT_TRUE(aArr.IsEmpty());
+}
+
+// Verify that ToArray1() works with heap-allocated buffers.
+TEST(NCollection_LocalArrayTest, ToArray1_HeapBuffer)
+{
+  NCollection_LocalArray<int, 8> aSrc(16);
+  for (size_t i = 0; i < 16; ++i)
+  {
+    static_cast<int*>(aSrc)[i] = static_cast<int>(i * 3);
+  }
+
+  NCollection_Array1<int> aArr = aSrc.ToArray1();
+  EXPECT_EQ(16u, aArr.Size());
+  EXPECT_EQ(static_cast<int*>(aSrc), &aArr[0]);
+  EXPECT_EQ(0, aArr[0]);
+  EXPECT_EQ(45, aArr[15]);
+}
+
+// Reading through ToArray1() returns correct values without copying.
+TEST(NCollection_LocalArrayTest, ToArray1_ReadThrough)
+{
+  NCollection_LocalArray<int> aSrc(7);
+  for (size_t i = 0; i < 7; ++i)
+  {
+    static_cast<int*>(aSrc)[i] = static_cast<int>(i * 11);
+  }
+
+  const NCollection_Array1<int> aArr = aSrc.ToArray1();
+  for (size_t i = 0; i < 7; ++i)
+  {
+    EXPECT_EQ(static_cast<int>(i * 11), aArr[i]);
+  }
 }

--- a/src/FoundationClasses/TKernel/GTests/NCollection_LocalArray_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_LocalArray_Test.cxx
@@ -657,8 +657,8 @@ TEST(NCollection_LocalArrayTest, ToArray1_ModifyReflectsInSource)
   }
 
   NCollection_Array1<int> aArr = aSrc.ToArray1();
-  aArr[0] = 99;
-  aArr[4] = 77;
+  aArr[0]                      = 99;
+  aArr[4]                      = 77;
 
   EXPECT_EQ(99, static_cast<int*>(aSrc)[0]);
   EXPECT_EQ(1, static_cast<int*>(aSrc)[1]);

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Allocator.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Allocator.hxx
@@ -75,7 +75,12 @@ public:
   }
 
   //! Returns an object address.
-  pointer address(reference theItem) const noexcept { return &theItem; }
+  template <typename Type = value_type>
+  typename std::enable_if<!std::is_const<Type>::value, pointer>::type address(
+    reference theItem) const noexcept
+  {
+    return &theItem;
+  }
 
   //! Returns an object address.
   const_pointer address(const_reference theItem) const noexcept { return &theItem; }
@@ -89,7 +94,8 @@ public:
   //! Frees previously allocated memory.
   void deallocate(pointer thePnt, const size_type) const
   {
-    Standard::Free(static_cast<void*>(thePnt));
+    typedef typename std::remove_const<value_type>::type non_const_value_type;
+    Standard::Free(static_cast<void*>(const_cast<non_const_value_type*>(thePnt)));
   }
 
   //! Reallocates memory for theSize objects.

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Array1.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Array1.hxx
@@ -149,6 +149,23 @@ public:
     construct(0, mySize);
   }
 
+  explicit NCollection_Array1(const_reference theBegin,
+                              const size_t    theSize,
+                              const bool      theUseBuffer = true)
+      : myLowerBound(0),
+        mySize(theSize),
+        myPointer(theUseBuffer ? const_cast<pointer>(&theBegin) : nullptr),
+        myIsOwner(!theUseBuffer)
+  {
+    if (!myIsOwner)
+    {
+      return;
+    }
+    myPointer = myAllocator.allocate(mySize);
+    myIsOwner = true;
+    construct(0, mySize);
+  }
+
   //! Zero-based constructor: allocates theSize elements with lower bound 0.
   //! Use At()/ChangeAt() or STL iterators for optimal access (no offset subtraction).
   explicit NCollection_Array1(const size_t theSize)
@@ -437,15 +454,21 @@ protected:
     if (myIsOwner)
     {
       if (theToCopyData)
+      {
         destroy(myPointer, theNewSize, mySize);
+      }
       else
+      {
         destroy(myPointer, 0, mySize);
+      }
     }
     myLowerBound = theNewLower;
     if (theNewSize == 0)
     {
       if (myIsOwner)
+      {
         myAllocator.deallocate(aPrevPtr, mySize);
+      }
       myPointer = nullptr;
       mySize    = 0;
       myIsOwner = false;
@@ -468,7 +491,9 @@ protected:
     else
     {
       if (myIsOwner)
+      {
         myAllocator.deallocate(aPrevPtr, mySize);
+      }
       myPointer = myAllocator.allocate(theNewSize);
       construct(0, theNewSize);
     }

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Array1.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Array1.hxx
@@ -149,9 +149,12 @@ public:
     construct(0, mySize);
   }
 
+  //! Zero-based constructor from first element reference.
+  //! When theUseBuffer is true, wraps contiguous storage starting at theBegin.
+  //! Otherwise allocates own storage of theSize elements.
   explicit NCollection_Array1(const_reference theBegin,
                               const size_t    theSize,
-                              const bool      theUseBuffer = true)
+                              const bool      theUseBuffer)
       : myLowerBound(0),
         mySize(theSize),
         myPointer(theUseBuffer ? const_cast<pointer>(&theBegin) : nullptr),

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_BaseAllocator.cxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_BaseAllocator.cxx
@@ -42,6 +42,9 @@ void NCollection_BaseAllocator::Free(void* theAddress)
 //=======================================================================
 const occ::handle<NCollection_BaseAllocator>& NCollection_BaseAllocator::CommonBaseAllocator()
 {
-  static occ::handle<NCollection_BaseAllocator> THE_SINGLETON_ALLOC = new NCollection_BaseAllocator;
-  return THE_SINGLETON_ALLOC;
+  // Intentionally never destroyed: collection statics in other toolkits may
+  // free their nodes through this allocator during process finalization.
+  static occ::handle<NCollection_BaseAllocator>* THE_SINGLETON_ALLOC =
+    new occ::handle<NCollection_BaseAllocator>(new NCollection_BaseAllocator);
+  return *THE_SINGLETON_ALLOC;
 }

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_DynamicArray.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_DynamicArray.hxx
@@ -25,7 +25,6 @@
 #include <NCollection_Iterator.hxx>
 #include <NCollection_OccAllocator.hxx>
 #include <StdFail_NotDone.hxx>
-#include <NCollection_IndexedIterator.hxx>
 
 #include <cstring>
 #include <locale>
@@ -75,14 +74,240 @@ public:
   using const_reference = const TheItemType&;
 
 public:
-  using iterator       = NCollection_IndexedIterator<std::random_access_iterator_tag,
-                                                     NCollection_DynamicArray,
-                                                     value_type,
-                                                     false>;
-  using const_iterator = NCollection_IndexedIterator<std::random_access_iterator_tag,
-                                                     NCollection_DynamicArray,
-                                                     value_type,
-                                                     true>;
+  template <bool IsConstant>
+  class DynamicIterator
+  {
+  public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type        = TheItemType;
+    using difference_type   = ptrdiff_t;
+    using pointer   = typename std::conditional<IsConstant, const TheItemType*, TheItemType*>::type;
+    using reference = typename std::conditional<IsConstant, const TheItemType&, TheItemType&>::type;
+
+  public:
+    DynamicIterator() noexcept
+        : myArray(nullptr),
+          myIndex(0),
+          myUsedSize(0),
+          myInternalSize(1),
+          myBlockShift(0),
+          myBlockMask(0),
+          myBlockIndex(0),
+          myCurrPtr(nullptr),
+          myBlockEnd(nullptr)
+    {
+    }
+
+    DynamicIterator(const NCollection_DynamicArray& theArray) noexcept
+        : DynamicIterator(0, theArray)
+    {
+    }
+
+    DynamicIterator(const size_t theIndex, const NCollection_DynamicArray& theArray) noexcept
+        : myArray(const_cast<NCollection_DynamicArray&>(theArray).getArray()),
+          myIndex(theIndex),
+          myUsedSize(theArray.myUsedSize),
+          myInternalSize(theArray.myInternalSize),
+          myBlockShift(theArray.myBlockShift),
+          myBlockMask(theArray.myBlockMask),
+          myBlockIndex(0),
+          myCurrPtr(nullptr),
+          myBlockEnd(nullptr)
+    {
+      setIndex(theIndex);
+    }
+
+    DynamicIterator(const DynamicIterator<false>& theOther) noexcept
+        : myArray(theOther.myArray),
+          myIndex(theOther.myIndex),
+          myUsedSize(theOther.myUsedSize),
+          myInternalSize(theOther.myInternalSize),
+          myBlockShift(theOther.myBlockShift),
+          myBlockMask(theOther.myBlockMask),
+          myBlockIndex(theOther.myBlockIndex),
+          myCurrPtr(theOther.myCurrPtr),
+          myBlockEnd(theOther.myBlockEnd)
+    {
+    }
+
+    DynamicIterator& operator=(const DynamicIterator<false>& theOther) noexcept
+    {
+      myArray        = theOther.myArray;
+      myIndex        = theOther.myIndex;
+      myUsedSize     = theOther.myUsedSize;
+      myInternalSize = theOther.myInternalSize;
+      myBlockShift   = theOther.myBlockShift;
+      myBlockMask    = theOther.myBlockMask;
+      myBlockIndex   = theOther.myBlockIndex;
+      myCurrPtr      = theOther.myCurrPtr;
+      myBlockEnd     = theOther.myBlockEnd;
+      return *this;
+    }
+
+  public:
+    bool operator==(const DynamicIterator& theOther) const noexcept
+    {
+      return myArray == theOther.myArray && myIndex == theOther.myIndex;
+    }
+
+    template <bool theOtherIsConstant>
+    bool operator==(const DynamicIterator<theOtherIsConstant>& theOther) const noexcept
+    {
+      return myArray == theOther.myArray && myIndex == theOther.myIndex;
+    }
+
+    template <bool theOtherIsConstant>
+    bool operator!=(const DynamicIterator<theOtherIsConstant>& theOther) const noexcept
+    {
+      return myArray != theOther.myArray || myIndex != theOther.myIndex;
+    }
+
+    bool operator!=(const DynamicIterator& theOther) const noexcept { return !(*this == theOther); }
+
+    reference operator*() const noexcept { return *myCurrPtr; }
+
+    pointer operator->() const noexcept { return myCurrPtr; }
+
+    DynamicIterator& operator++() noexcept
+    {
+      ++myIndex;
+      ++myCurrPtr;
+      if (myIndex >= myUsedSize)
+      {
+        myCurrPtr  = nullptr;
+        myBlockEnd = nullptr;
+      }
+      else if (myCurrPtr == myBlockEnd)
+      {
+        ++myBlockIndex;
+        myCurrPtr  = myArray[myBlockIndex];
+        myBlockEnd = myCurrPtr + myInternalSize;
+      }
+      return *this;
+    }
+
+    DynamicIterator operator++(int) noexcept
+    {
+      DynamicIterator theOld(*this);
+      ++(*this);
+      return theOld;
+    }
+
+    DynamicIterator& operator--() noexcept
+    {
+      if (myIndex == myUsedSize)
+      {
+        setIndex(myUsedSize - 1);
+        return *this;
+      }
+
+      --myIndex;
+      if (myCurrPtr > myArray[myBlockIndex])
+      {
+        --myCurrPtr;
+      }
+      else
+      {
+        --myBlockIndex;
+        myCurrPtr  = myArray[myBlockIndex] + (myInternalSize - 1);
+        myBlockEnd = myArray[myBlockIndex] + myInternalSize;
+      }
+      return *this;
+    }
+
+    DynamicIterator operator--(int) noexcept
+    {
+      DynamicIterator theOld(*this);
+      --(*this);
+      return theOld;
+    }
+
+    DynamicIterator& operator+=(const difference_type theOffset) noexcept
+    {
+      setIndex(static_cast<size_t>(static_cast<difference_type>(myIndex) + theOffset));
+      return *this;
+    }
+
+    DynamicIterator operator+(const difference_type theOffset) const noexcept
+    {
+      DynamicIterator aTemp(*this);
+      aTemp += theOffset;
+      return aTemp;
+    }
+
+    DynamicIterator& operator-=(const difference_type theOffset) noexcept
+    {
+      return *this += -theOffset;
+    }
+
+    DynamicIterator operator-(const difference_type theOffset) const noexcept
+    {
+      DynamicIterator aTemp(*this);
+      aTemp += -theOffset;
+      return aTemp;
+    }
+
+    difference_type operator-(const DynamicIterator& theOther) const noexcept
+    {
+      return static_cast<difference_type>(myIndex) - static_cast<difference_type>(theOther.myIndex);
+    }
+
+    reference operator[](const difference_type theOffset) const noexcept
+    {
+      return *(*this + theOffset);
+    }
+
+    bool operator<(const DynamicIterator& theOther) const noexcept
+    {
+      return (*this - theOther) < 0;
+    }
+
+    bool operator>(const DynamicIterator& theOther) const noexcept { return theOther < *this; }
+
+    bool operator<=(const DynamicIterator& theOther) const noexcept { return !(theOther < *this); }
+
+    bool operator>=(const DynamicIterator& theOther) const noexcept { return !(*this < theOther); }
+
+    friend DynamicIterator operator+(const difference_type  theOffset,
+                                     const DynamicIterator& theIter) noexcept
+    {
+      return theIter + theOffset;
+    }
+
+    friend class DynamicIterator<!IsConstant>;
+
+  private:
+    void setIndex(const size_t theIndex) noexcept
+    {
+      myIndex = theIndex;
+      if (myIndex >= myUsedSize || myArray == nullptr)
+      {
+        myCurrPtr    = nullptr;
+        myBlockEnd   = nullptr;
+        myBlockIndex = 0;
+        return;
+      }
+
+      myBlockIndex             = myIndex >> myBlockShift;
+      const size_t aLocalIndex = myIndex & myBlockMask;
+      myCurrPtr                = myArray[myBlockIndex] + aLocalIndex;
+      myBlockEnd               = myArray[myBlockIndex] + myInternalSize;
+    }
+
+  private:
+    TheItemType** myArray;
+    size_t        myIndex;
+    size_t        myUsedSize;
+    size_t        myInternalSize;
+    size_t        myBlockShift;
+    size_t        myBlockMask;
+    size_t        myBlockIndex;
+    TheItemType*  myCurrPtr;
+    TheItemType*  myBlockEnd;
+  };
+
+  using iterator       = DynamicIterator<false>;
+  using const_iterator = DynamicIterator<true>;
   using Iterator       = NCollection_Iterator<NCollection_DynamicArray<TheItemType>>;
 
 public:
@@ -278,7 +503,9 @@ public: //! @name public methods
                                  "NCollection_DynamicArray::InsertAfter: index out of range");
     Appended();
     for (size_t i = myUsedSize - 1; i > theIndex + 1; --i)
+    {
       at(i) = std::move(at(i - 1));
+    }
     at(theIndex + 1) = theValue;
     return at(theIndex + 1);
   }
@@ -290,7 +517,9 @@ public: //! @name public methods
                                  "NCollection_DynamicArray::InsertAfter: index out of range");
     Appended();
     for (size_t i = myUsedSize - 1; i > theIndex + 1; --i)
+    {
       at(i) = std::move(at(i - 1));
+    }
     at(theIndex + 1) = std::forward<TheItemType>(theValue);
     return at(theIndex + 1);
   }
@@ -319,7 +548,9 @@ public: //! @name public methods
                                  "NCollection_DynamicArray::InsertBefore: index out of range");
     Appended();
     for (size_t i = myUsedSize - 1; i > theIndex; --i)
+    {
       at(i) = std::move(at(i - 1));
+    }
     at(theIndex) = theValue;
     return at(theIndex);
   }
@@ -331,7 +562,9 @@ public: //! @name public methods
                                  "NCollection_DynamicArray::InsertBefore: index out of range");
     Appended();
     for (size_t i = myUsedSize - 1; i > theIndex; --i)
+    {
       at(i) = std::move(at(i - 1));
+    }
     at(theIndex) = std::forward<TheItemType>(theValue);
     return at(theIndex);
   }
@@ -562,10 +795,14 @@ public: //! @name public methods
         }
       }
       if (theReleaseMemory)
+      {
         myAlloc.deallocate(aCurStart, myInternalSize);
+      }
     }
     if (theReleaseMemory)
+    {
       myContainer.Clear(theReleaseMemory);
+    }
     myUsedSize = 0;
   }
 

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_DynamicArray.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_DynamicArray.hxx
@@ -86,7 +86,7 @@ public:
 
   public:
     DynamicIterator() noexcept
-        : myArray(nullptr),
+        : myOwner(nullptr),
           myIndex(0),
           myUsedSize(0),
           myInternalSize(1),
@@ -104,7 +104,7 @@ public:
     }
 
     DynamicIterator(const size_t theIndex, const NCollection_DynamicArray& theArray) noexcept
-        : myArray(const_cast<NCollection_DynamicArray&>(theArray).getArray()),
+        : myOwner(&theArray),
           myIndex(theIndex),
           myUsedSize(theArray.myUsedSize),
           myInternalSize(theArray.myInternalSize),
@@ -118,7 +118,7 @@ public:
     }
 
     DynamicIterator(const DynamicIterator<false>& theOther) noexcept
-        : myArray(theOther.myArray),
+        : myOwner(theOther.myOwner),
           myIndex(theOther.myIndex),
           myUsedSize(theOther.myUsedSize),
           myInternalSize(theOther.myInternalSize),
@@ -132,7 +132,7 @@ public:
 
     DynamicIterator& operator=(const DynamicIterator<false>& theOther) noexcept
     {
-      myArray        = theOther.myArray;
+      myOwner        = theOther.myOwner;
       myIndex        = theOther.myIndex;
       myUsedSize     = theOther.myUsedSize;
       myInternalSize = theOther.myInternalSize;
@@ -147,19 +147,19 @@ public:
   public:
     bool operator==(const DynamicIterator& theOther) const noexcept
     {
-      return myArray == theOther.myArray && myIndex == theOther.myIndex;
+      return myOwner == theOther.myOwner && myIndex == theOther.myIndex;
     }
 
     template <bool theOtherIsConstant>
     bool operator==(const DynamicIterator<theOtherIsConstant>& theOther) const noexcept
     {
-      return myArray == theOther.myArray && myIndex == theOther.myIndex;
+      return myOwner == theOther.myOwner && myIndex == theOther.myIndex;
     }
 
     template <bool theOtherIsConstant>
     bool operator!=(const DynamicIterator<theOtherIsConstant>& theOther) const noexcept
     {
-      return myArray != theOther.myArray || myIndex != theOther.myIndex;
+      return myOwner != theOther.myOwner || myIndex != theOther.myIndex;
     }
 
     bool operator!=(const DynamicIterator& theOther) const noexcept { return !(*this == theOther); }
@@ -180,7 +180,7 @@ public:
       else if (myCurrPtr == myBlockEnd)
       {
         ++myBlockIndex;
-        myCurrPtr  = myArray[myBlockIndex];
+        myCurrPtr  = blockStart(myBlockIndex);
         myBlockEnd = myCurrPtr + myInternalSize;
       }
       return *this;
@@ -202,15 +202,15 @@ public:
       }
 
       --myIndex;
-      if (myCurrPtr > myArray[myBlockIndex])
+      if (myCurrPtr > blockStart(myBlockIndex))
       {
         --myCurrPtr;
       }
       else
       {
         --myBlockIndex;
-        myCurrPtr  = myArray[myBlockIndex] + (myInternalSize - 1);
-        myBlockEnd = myArray[myBlockIndex] + myInternalSize;
+        myCurrPtr  = blockStart(myBlockIndex) + (myInternalSize - 1);
+        myBlockEnd = blockStart(myBlockIndex) + myInternalSize;
       }
       return *this;
     }
@@ -280,7 +280,7 @@ public:
     void setIndex(const size_t theIndex) noexcept
     {
       myIndex = theIndex;
-      if (myIndex >= myUsedSize || myArray == nullptr)
+      if (myIndex >= myUsedSize || myOwner == nullptr)
       {
         myCurrPtr    = nullptr;
         myBlockEnd   = nullptr;
@@ -290,20 +290,25 @@ public:
 
       myBlockIndex             = myIndex >> myBlockShift;
       const size_t aLocalIndex = myIndex & myBlockMask;
-      myCurrPtr                = myArray[myBlockIndex] + aLocalIndex;
-      myBlockEnd               = myArray[myBlockIndex] + myInternalSize;
+      myCurrPtr                = blockStart(myBlockIndex) + aLocalIndex;
+      myBlockEnd               = blockStart(myBlockIndex) + myInternalSize;
+    }
+
+    TheItemType* blockStart(const size_t theBlockIndex) const noexcept
+    {
+      return myOwner->getArray()[theBlockIndex];
     }
 
   private:
-    TheItemType** myArray;
-    size_t        myIndex;
-    size_t        myUsedSize;
-    size_t        myInternalSize;
-    size_t        myBlockShift;
-    size_t        myBlockMask;
-    size_t        myBlockIndex;
-    TheItemType*  myCurrPtr;
-    TheItemType*  myBlockEnd;
+    const NCollection_DynamicArray* myOwner;
+    size_t                          myIndex;
+    size_t                          myUsedSize;
+    size_t                          myInternalSize;
+    size_t                          myBlockShift;
+    size_t                          myBlockMask;
+    size_t                          myBlockIndex;
+    TheItemType*                    myCurrPtr;
+    TheItemType*                    myBlockEnd;
   };
 
   using iterator       = DynamicIterator<false>;

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_FlatDataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_FlatDataMap.hxx
@@ -711,7 +711,7 @@ public:
   }
 
   //! Reserve capacity for at least theN elements
-  void Reserve(size_t theN) { reserve(theN); }
+  void Reserve(const size_t theN) { reserve(theN); }
 
 public:
   // **************** Iterator access ****************

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_FlatDataMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_FlatDataMap.hxx
@@ -710,6 +710,9 @@ public:
     }
   }
 
+  //! Reserve capacity for at least theN elements
+  void Reserve(size_t theN) { reserve(theN); }
+
 public:
   // **************** Iterator access ****************
 

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_FlatMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_FlatMap.hxx
@@ -539,7 +539,7 @@ public:
   }
 
   //! Reserve capacity for at least theN elements
-  void Reserve(size_t theN) { reserve(theN); }
+  void Reserve(const size_t theN) { reserve(theN); }
 
 public:
   // **************** Iterator access ****************

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_FlatMap.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_FlatMap.hxx
@@ -538,6 +538,9 @@ public:
     }
   }
 
+  //! Reserve capacity for at least theN elements
+  void Reserve(size_t theN) { reserve(theN); }
+
 public:
   // **************** Iterator access ****************
 

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_LinearVector.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_LinearVector.hxx
@@ -15,6 +15,7 @@
 #define NCollection_LinearVector_HeaderFile
 
 #include <NCollection_Allocator.hxx>
+#include <NCollection_Array1.hxx>
 #include <Standard_OutOfMemory.hxx>
 #include <Standard_OutOfRange.hxx>
 
@@ -487,6 +488,22 @@ public:
     }
   }
 
+  //! Returns a span as Array1 with shared memory.
+  //! Modifying the vector or the array may invalidate the shared buffer.
+  //! @return array view of the vector data
+  NCollection_Array1<TheItemType> ToArray1()
+  {
+    return NCollection_Array1<TheItemType>(myData, mySize);
+  }
+
+  //! Returns a read-only span as Array1 with shared memory.
+  //! Modifying the vector may invalidate the shared buffer.
+  //! @return const array view of the vector data
+  NCollection_Array1<const TheItemType> ToArray1() const
+  {
+    return NCollection_Array1<const TheItemType>(myData, mySize);
+  }
+
   //! @return iterator to the first element.
   iterator begin() noexcept { return myData; }
 
@@ -510,7 +527,7 @@ private:
   void grow(const size_t theMinCapacity)
   {
     Standard_OutOfMemory_Raise_if(theMinCapacity > MaxSize(), "NCollection_LinearVector::grow");
-    size_t aNewCap = myCapacity > 0 ? myCapacity * 2 : 8;
+    size_t aNewCap = myCapacity > 0 ? myCapacity * 2 : 2;
     if (myCapacity > MaxSize() / 2)
     {
       aNewCap = MaxSize();

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_LocalArray.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_LocalArray.hxx
@@ -305,10 +305,7 @@ public:
   //! Returns a span as Array1 with shared memory.
   //! Modifying the local array or the array view may invalidate the shared buffer.
   //! @return array view of the local array data
-  NCollection_Array1<theItem> ToArray1()
-  {
-    return NCollection_Array1<theItem>(myPtr, mySize);
-  }
+  NCollection_Array1<theItem> ToArray1() { return NCollection_Array1<theItem>(myPtr, mySize); }
 
   //! Returns a read-only span as Array1 with shared memory.
   //! Modifying the local array may invalidate the shared buffer.

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_LocalArray.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_LocalArray.hxx
@@ -16,6 +16,7 @@
 #define _NCollection_LocalArray_HeaderFile
 
 #include <Standard.hxx>
+#include <NCollection_Array1.hxx>
 #include <Standard_TypeDef.hxx>
 
 #include <cstring>
@@ -57,7 +58,9 @@ public:
     if constexpr (!IS_TRIVIAL)
     {
       for (size_t i = 0; i < mySize; ++i)
+      {
         myPtr[i].~theItem();
+      }
     }
     Deallocate();
   }
@@ -75,7 +78,9 @@ public:
       if constexpr (!IS_TRIVIAL)
       {
         for (size_t i = theNewSize; i < mySize; ++i)
+        {
           myPtr[i].~theItem();
+        }
       }
       mySize = theNewSize;
       return;
@@ -104,11 +109,17 @@ public:
           const size_t aCopy     = theToCopy ? std::min(anOldSize, theNewSize) : 0;
           myPtr                  = inlinePtr();
           for (size_t i = 0; i < aCopy; ++i)
+          {
             new (myPtr + i) theItem(std::move(anOldPtr[i]));
+          }
           for (size_t i = aCopy; i < theNewSize; ++i)
+          {
             new (myPtr + i) theItem();
+          }
           for (size_t i = 0; i < anOldSize; ++i)
+          {
             anOldPtr[i].~theItem();
+          }
           Standard::Free(anOldPtr);
         }
         myPtr = inlinePtr();
@@ -119,7 +130,9 @@ public:
         if constexpr (!IS_TRIVIAL)
         {
           for (size_t i = mySize; i < theNewSize; ++i)
+          {
             new (myPtr + i) theItem();
+          }
         }
       }
       mySize = theNewSize;
@@ -158,13 +171,21 @@ public:
       theItem*     aNewPtr = static_cast<theItem*>(Standard::Allocate(aNewBytes));
       const size_t aCopy   = theToCopy ? std::min(mySize, theNewSize) : 0;
       for (size_t i = 0; i < aCopy; ++i)
+      {
         new (aNewPtr + i) theItem(std::move(myPtr[i]));
+      }
       for (size_t i = aCopy; i < theNewSize; ++i)
+      {
         new (aNewPtr + i) theItem();
+      }
       for (size_t i = 0; i < mySize; ++i)
+      {
         myPtr[i].~theItem();
+      }
       if (!aWasInline)
+      {
         Standard::Free(myPtr);
+      }
       myPtr = aNewPtr;
     }
     mySize = theNewSize;
@@ -189,9 +210,13 @@ public:
       else
       {
         for (size_t i = 0; i < aNb; ++i)
+        {
           new (inlinePtr() + i) theItem(std::move(theOther.inlinePtr()[i]));
+        }
         for (size_t i = 0; i < aNb; ++i)
+        {
           theOther.inlinePtr()[i].~theItem();
+        }
       }
     }
     else
@@ -205,7 +230,9 @@ public:
   NCollection_LocalArray& operator=(NCollection_LocalArray&& theOther) noexcept
   {
     if (this == &theOther)
+    {
       return *this;
+    }
 
     if constexpr (IS_TRIVIAL)
     {
@@ -236,26 +263,36 @@ public:
     {
       // Destroy our current elements.
       for (size_t i = 0; i < mySize; ++i)
+      {
         myPtr[i].~theItem();
+      }
 
       if (theOther.isInline())
       {
         if (!isInline())
+        {
           Standard::Free(myPtr);
+        }
         myPtr  = inlinePtr();
         mySize = theOther.mySize;
         // When the source is inline, mySize is bounded by MAX_ARRAY_SIZE.
         const size_t aNb = std::min(mySize, static_cast<size_t>(MAX_ARRAY_SIZE));
         for (size_t i = 0; i < aNb; ++i)
+        {
           new (inlinePtr() + i) theItem(std::move(theOther.inlinePtr()[i]));
+        }
         for (size_t i = 0; i < aNb; ++i)
+        {
           theOther.inlinePtr()[i].~theItem();
+        }
       }
       else
       {
         // Take ownership of theOther's heap allocation directly.
         if (!isInline())
+        {
           Standard::Free(myPtr);
+        }
         myPtr          = theOther.myPtr;
         mySize         = theOther.mySize;
         theOther.myPtr = theOther.inlinePtr();
@@ -265,6 +302,22 @@ public:
     return *this;
   }
 
+  //! Returns a span as Array1 with shared memory.
+  //! Modifying the local array or the array view may invalidate the shared buffer.
+  //! @return array view of the local array data
+  NCollection_Array1<theItem> ToArray1()
+  {
+    return NCollection_Array1<theItem>(myPtr, mySize);
+  }
+
+  //! Returns a read-only span as Array1 with shared memory.
+  //! Modifying the local array may invalidate the shared buffer.
+  //! @return const array view of the array data
+  NCollection_Array1<const theItem> ToArray1() const
+  {
+    return NCollection_Array1<const theItem>(myPtr, mySize);
+  }
+
   NCollection_LocalArray(const NCollection_LocalArray&)            = delete;
   NCollection_LocalArray& operator=(const NCollection_LocalArray&) = delete;
 
@@ -272,7 +325,9 @@ protected:
   void Deallocate()
   {
     if (!isInline())
+    {
       Standard::Free(myPtr);
+    }
   }
 
   //! Pointer to inline buffer storage.

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_OccAllocator.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_OccAllocator.hxx
@@ -136,7 +136,9 @@ public:
   //! Frees previously allocated memory.
   void deallocate(pointer thePnt, size_type)
   {
-    myAllocator.IsNull() ? Standard::Free(thePnt) : myAllocator->Free(thePnt);
+    typedef typename std::remove_const<value_type>::type non_const_value_type;
+    non_const_value_type* aPnt = const_cast<non_const_value_type*>(thePnt);
+    myAllocator.IsNull() ? Standard::Free(aPnt) : myAllocator->Free(aPnt);
   }
 
   //! Constructs an object.
@@ -148,7 +150,12 @@ public:
   }
 
   //! Returns an object address.
-  pointer address(reference theItem) const noexcept { return &theItem; }
+  template <typename Type = value_type>
+  typename std::enable_if<!std::is_const<Type>::value, pointer>::type address(
+    reference theItem) const noexcept
+  {
+    return &theItem;
+  }
 
   //! Returns an object address.
   const_pointer address(const_reference theItem) const noexcept { return &theItem; }

--- a/src/ModelingData/TKG3d/GTests/FILES.cmake
+++ b/src/ModelingData/TKG3d/GTests/FILES.cmake
@@ -45,5 +45,6 @@ set(OCCT_TKG3d_GTests_FILES
   GeomGridEval_SurfaceOfRevolution_Test.cxx
   GeomGridEval_Torus_Test.cxx
   GeomHash_CurveHasher_Test.cxx
+  GeomHash_MeshHasher_Test.cxx
   GeomHash_SurfaceHasher_Test.cxx
 )

--- a/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
@@ -153,14 +153,14 @@ TEST(GeomHash_MeshHasherTest, Triangulation_DifferentSameCountGeometryChangesHas
 
 TEST(GeomHash_MeshHasherTest, NullHandlesDoNotCrash)
 {
-  const GeomHash_Polygon2DHasher        aPoly2dHasher;
-  const GeomHash_Polygon3DHasher        aPoly3dHasher;
-  const GeomHash_PolygonOnTriHasher     aPolyOnTriHasher;
-  const GeomHash_TriangulationHasher    aTriHasher;
-  occ::handle<Poly_Polygon2D>           aNullPoly2d;
-  occ::handle<Poly_Polygon3D>           aNullPoly3d;
+  const GeomHash_Polygon2DHasher           aPoly2dHasher;
+  const GeomHash_Polygon3DHasher           aPoly3dHasher;
+  const GeomHash_PolygonOnTriHasher        aPolyOnTriHasher;
+  const GeomHash_TriangulationHasher       aTriHasher;
+  occ::handle<Poly_Polygon2D>              aNullPoly2d;
+  occ::handle<Poly_Polygon3D>              aNullPoly3d;
   occ::handle<Poly_PolygonOnTriangulation> aNullPolyOnTri;
-  occ::handle<Poly_Triangulation>       aNullTri;
+  occ::handle<Poly_Triangulation>          aNullTri;
 
   EXPECT_EQ(0u, aPoly2dHasher(aNullPoly2d));
   EXPECT_TRUE(aPoly2dHasher(aNullPoly2d, aNullPoly2d));
@@ -179,7 +179,8 @@ TEST(GeomHash_MeshHasherTest, NullHandlesDoNotCrash)
   const PolygonOnTriHashKey aNullKey3{aNullPolyOnTri, 8};
   EXPECT_TRUE(aPolyOnTriHasher(aNullKey1, aNullKey2));
   EXPECT_FALSE(aPolyOnTriHasher(aNullKey1, aNullKey3));
-  EXPECT_FALSE(aPolyOnTriHasher(aNullKey1, PolygonOnTriHashKey{makePolygonOnTriangulation(0.004), 7}));
+  EXPECT_FALSE(
+    aPolyOnTriHasher(aNullKey1, PolygonOnTriHashKey{makePolygonOnTriangulation(0.004), 7}));
 }
 
 TEST(GeomHash_MeshHasherTest, HashToleranceAffectsNumericFields)

--- a/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
@@ -48,8 +48,7 @@ occ::handle<Poly_Polygon3D> makePolygon3D(const double theDeflection)
 
 occ::handle<Poly_PolygonOnTriangulation> makePolygonOnTriangulation(const double theDeflection)
 {
-  occ::handle<Poly_PolygonOnTriangulation> aPoly =
-    new Poly_PolygonOnTriangulation(2, false);
+  occ::handle<Poly_PolygonOnTriangulation> aPoly = new Poly_PolygonOnTriangulation(2, false);
   aPoly->SetNode(1, 1);
   aPoly->SetNode(2, 2);
   aPoly->Deflection(theDeflection);
@@ -70,7 +69,7 @@ occ::handle<Poly_Triangulation> makeTriangulation(const double theDeflection)
 
 TEST(GeomHash_MeshHasherTest, Polygon2D_CloseDeflectionKeepsEqualHash)
 {
-  const GeomHash_Polygon2DHasher aHasher(0.1, 0.01);
+  const GeomHash_Polygon2DHasher    aHasher(0.1, 0.01);
   const occ::handle<Poly_Polygon2D> aPoly1 = makePolygon2D(0.004);
   const occ::handle<Poly_Polygon2D> aPoly2 = makePolygon2D(0.015);
 
@@ -80,7 +79,7 @@ TEST(GeomHash_MeshHasherTest, Polygon2D_CloseDeflectionKeepsEqualHash)
 
 TEST(GeomHash_MeshHasherTest, Polygon3D_CloseDeflectionKeepsEqualHash)
 {
-  const GeomHash_Polygon3DHasher aHasher(0.1, 0.01);
+  const GeomHash_Polygon3DHasher    aHasher(0.1, 0.01);
   const occ::handle<Poly_Polygon3D> aPoly1 = makePolygon3D(0.004);
   const occ::handle<Poly_Polygon3D> aPoly2 = makePolygon3D(0.015);
 
@@ -100,7 +99,7 @@ TEST(GeomHash_MeshHasherTest, PolygonOnTriangulation_CloseDeflectionKeepsEqualHa
 
 TEST(GeomHash_MeshHasherTest, Triangulation_CloseDeflectionKeepsEqualHash)
 {
-  const GeomHash_TriangulationHasher aHasher(0.1, 0.01);
+  const GeomHash_TriangulationHasher    aHasher(0.1, 0.01);
   const occ::handle<Poly_Triangulation> aTri1 = makeTriangulation(0.004);
   const occ::handle<Poly_Triangulation> aTri2 = makeTriangulation(0.015);
 

--- a/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <GeomHash_Polygon2DHasher.hxx>
+#include <GeomHash_Polygon3DHasher.hxx>
+#include <GeomHash_PolygonOnTriHasher.hxx>
+#include <GeomHash_TriangulationHasher.hxx>
+#include <NCollection_Array1.hxx>
+#include <Poly_Polygon2D.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Poly_Triangulation.hxx>
+#include <Poly_Triangle.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+
+namespace
+{
+occ::handle<Poly_Polygon2D> makePolygon2D(const double theDeflection)
+{
+  occ::handle<Poly_Polygon2D> aPoly = new Poly_Polygon2D(2);
+  aPoly->ChangeNodes().SetValue(1, gp_Pnt2d(0.0, 0.0));
+  aPoly->ChangeNodes().SetValue(2, gp_Pnt2d(1.0, 0.0));
+  aPoly->Deflection(theDeflection);
+  return aPoly;
+}
+
+occ::handle<Poly_Polygon3D> makePolygon3D(const double theDeflection)
+{
+  occ::handle<Poly_Polygon3D> aPoly = new Poly_Polygon3D(2, false);
+  aPoly->ChangeNodes().SetValue(1, gp_Pnt(0.0, 0.0, 0.0));
+  aPoly->ChangeNodes().SetValue(2, gp_Pnt(1.0, 0.0, 0.0));
+  aPoly->Deflection(theDeflection);
+  return aPoly;
+}
+
+occ::handle<Poly_PolygonOnTriangulation> makePolygonOnTriangulation(const double theDeflection)
+{
+  occ::handle<Poly_PolygonOnTriangulation> aPoly =
+    new Poly_PolygonOnTriangulation(2, false);
+  aPoly->SetNode(1, 1);
+  aPoly->SetNode(2, 2);
+  aPoly->Deflection(theDeflection);
+  return aPoly;
+}
+
+occ::handle<Poly_Triangulation> makeTriangulation(const double theDeflection)
+{
+  occ::handle<Poly_Triangulation> aTri = new Poly_Triangulation(3, 1, false);
+  aTri->SetNode(1, gp_Pnt(0.0, 0.0, 0.0));
+  aTri->SetNode(2, gp_Pnt(1.0, 0.0, 0.0));
+  aTri->SetNode(3, gp_Pnt(0.0, 1.0, 0.0));
+  aTri->SetTriangle(1, Poly_Triangle(1, 2, 3));
+  aTri->Deflection(theDeflection);
+  return aTri;
+}
+} // namespace
+
+TEST(GeomHash_MeshHasherTest, Polygon2D_CloseDeflectionKeepsEqualHash)
+{
+  const GeomHash_Polygon2DHasher aHasher(0.1, 0.01);
+  const occ::handle<Poly_Polygon2D> aPoly1 = makePolygon2D(0.004);
+  const occ::handle<Poly_Polygon2D> aPoly2 = makePolygon2D(0.015);
+
+  ASSERT_TRUE(aHasher(aPoly1, aPoly2));
+  EXPECT_EQ(aHasher(aPoly1), aHasher(aPoly2));
+}
+
+TEST(GeomHash_MeshHasherTest, Polygon3D_CloseDeflectionKeepsEqualHash)
+{
+  const GeomHash_Polygon3DHasher aHasher(0.1, 0.01);
+  const occ::handle<Poly_Polygon3D> aPoly1 = makePolygon3D(0.004);
+  const occ::handle<Poly_Polygon3D> aPoly2 = makePolygon3D(0.015);
+
+  ASSERT_TRUE(aHasher(aPoly1, aPoly2));
+  EXPECT_EQ(aHasher(aPoly1), aHasher(aPoly2));
+}
+
+TEST(GeomHash_MeshHasherTest, PolygonOnTriangulation_CloseDeflectionKeepsEqualHash)
+{
+  const GeomHash_PolygonOnTriHasher aHasher(0.1, 0.01);
+  const PolygonOnTriHashKey         aKey1{makePolygonOnTriangulation(0.004), 7};
+  const PolygonOnTriHashKey         aKey2{makePolygonOnTriangulation(0.015), 7};
+
+  ASSERT_TRUE(aHasher(aKey1, aKey2));
+  EXPECT_EQ(aHasher(aKey1), aHasher(aKey2));
+}
+
+TEST(GeomHash_MeshHasherTest, Triangulation_CloseDeflectionKeepsEqualHash)
+{
+  const GeomHash_TriangulationHasher aHasher(0.1, 0.01);
+  const occ::handle<Poly_Triangulation> aTri1 = makeTriangulation(0.004);
+  const occ::handle<Poly_Triangulation> aTri2 = makeTriangulation(0.015);
+
+  ASSERT_TRUE(aHasher(aTri1, aTri2));
+  EXPECT_EQ(aHasher(aTri1), aHasher(aTri2));
+}

--- a/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomHash_MeshHasher_Test.cxx
@@ -71,7 +71,7 @@ TEST(GeomHash_MeshHasherTest, Polygon2D_CloseDeflectionKeepsEqualHash)
 {
   const GeomHash_Polygon2DHasher    aHasher(0.1, 0.01);
   const occ::handle<Poly_Polygon2D> aPoly1 = makePolygon2D(0.004);
-  const occ::handle<Poly_Polygon2D> aPoly2 = makePolygon2D(0.015);
+  const occ::handle<Poly_Polygon2D> aPoly2 = makePolygon2D(0.0044);
 
   ASSERT_TRUE(aHasher(aPoly1, aPoly2));
   EXPECT_EQ(aHasher(aPoly1), aHasher(aPoly2));
@@ -81,7 +81,7 @@ TEST(GeomHash_MeshHasherTest, Polygon3D_CloseDeflectionKeepsEqualHash)
 {
   const GeomHash_Polygon3DHasher    aHasher(0.1, 0.01);
   const occ::handle<Poly_Polygon3D> aPoly1 = makePolygon3D(0.004);
-  const occ::handle<Poly_Polygon3D> aPoly2 = makePolygon3D(0.015);
+  const occ::handle<Poly_Polygon3D> aPoly2 = makePolygon3D(0.0044);
 
   ASSERT_TRUE(aHasher(aPoly1, aPoly2));
   EXPECT_EQ(aHasher(aPoly1), aHasher(aPoly2));
@@ -91,7 +91,7 @@ TEST(GeomHash_MeshHasherTest, PolygonOnTriangulation_CloseDeflectionKeepsEqualHa
 {
   const GeomHash_PolygonOnTriHasher aHasher(0.1, 0.01);
   const PolygonOnTriHashKey         aKey1{makePolygonOnTriangulation(0.004), 7};
-  const PolygonOnTriHashKey         aKey2{makePolygonOnTriangulation(0.015), 7};
+  const PolygonOnTriHashKey         aKey2{makePolygonOnTriangulation(0.0044), 7};
 
   ASSERT_TRUE(aHasher(aKey1, aKey2));
   EXPECT_EQ(aHasher(aKey1), aHasher(aKey2));
@@ -101,8 +101,93 @@ TEST(GeomHash_MeshHasherTest, Triangulation_CloseDeflectionKeepsEqualHash)
 {
   const GeomHash_TriangulationHasher    aHasher(0.1, 0.01);
   const occ::handle<Poly_Triangulation> aTri1 = makeTriangulation(0.004);
-  const occ::handle<Poly_Triangulation> aTri2 = makeTriangulation(0.015);
+  const occ::handle<Poly_Triangulation> aTri2 = makeTriangulation(0.0044);
 
   ASSERT_TRUE(aHasher(aTri1, aTri2));
   EXPECT_EQ(aHasher(aTri1), aHasher(aTri2));
+}
+
+TEST(GeomHash_MeshHasherTest, Polygon2D_DifferentSameCountGeometryChangesHash)
+{
+  const GeomHash_Polygon2DHasher    aHasher(0.1, 0.01);
+  const occ::handle<Poly_Polygon2D> aPoly1 = makePolygon2D(0.004);
+  const occ::handle<Poly_Polygon2D> aPoly2 = makePolygon2D(0.004);
+  aPoly2->ChangeNodes().SetValue(2, gp_Pnt2d(2.0, 0.0));
+
+  EXPECT_FALSE(aHasher(aPoly1, aPoly2));
+  EXPECT_NE(aHasher(aPoly1), aHasher(aPoly2));
+}
+
+TEST(GeomHash_MeshHasherTest, Polygon3D_DifferentSameCountGeometryChangesHash)
+{
+  const GeomHash_Polygon3DHasher    aHasher(0.1, 0.01);
+  const occ::handle<Poly_Polygon3D> aPoly1 = makePolygon3D(0.004);
+  const occ::handle<Poly_Polygon3D> aPoly2 = makePolygon3D(0.004);
+  aPoly2->ChangeNodes().SetValue(2, gp_Pnt(2.0, 0.0, 0.0));
+
+  EXPECT_FALSE(aHasher(aPoly1, aPoly2));
+  EXPECT_NE(aHasher(aPoly1), aHasher(aPoly2));
+}
+
+TEST(GeomHash_MeshHasherTest, PolygonOnTriangulation_DifferentSameCountIndicesChangesHash)
+{
+  const GeomHash_PolygonOnTriHasher aHasher(0.1, 0.01);
+  PolygonOnTriHashKey               aKey1{makePolygonOnTriangulation(0.004), 7};
+  PolygonOnTriHashKey               aKey2{makePolygonOnTriangulation(0.004), 7};
+  aKey2.Poly->SetNode(2, 3);
+
+  EXPECT_FALSE(aHasher(aKey1, aKey2));
+  EXPECT_NE(aHasher(aKey1), aHasher(aKey2));
+}
+
+TEST(GeomHash_MeshHasherTest, Triangulation_DifferentSameCountGeometryChangesHash)
+{
+  const GeomHash_TriangulationHasher    aHasher(0.1, 0.01);
+  const occ::handle<Poly_Triangulation> aTri1 = makeTriangulation(0.004);
+  const occ::handle<Poly_Triangulation> aTri2 = makeTriangulation(0.004);
+  aTri2->SetNode(3, gp_Pnt(0.0, 2.0, 0.0));
+
+  EXPECT_FALSE(aHasher(aTri1, aTri2));
+  EXPECT_NE(aHasher(aTri1), aHasher(aTri2));
+}
+
+TEST(GeomHash_MeshHasherTest, NullHandlesDoNotCrash)
+{
+  const GeomHash_Polygon2DHasher        aPoly2dHasher;
+  const GeomHash_Polygon3DHasher        aPoly3dHasher;
+  const GeomHash_PolygonOnTriHasher     aPolyOnTriHasher;
+  const GeomHash_TriangulationHasher    aTriHasher;
+  occ::handle<Poly_Polygon2D>           aNullPoly2d;
+  occ::handle<Poly_Polygon3D>           aNullPoly3d;
+  occ::handle<Poly_PolygonOnTriangulation> aNullPolyOnTri;
+  occ::handle<Poly_Triangulation>       aNullTri;
+
+  EXPECT_EQ(0u, aPoly2dHasher(aNullPoly2d));
+  EXPECT_TRUE(aPoly2dHasher(aNullPoly2d, aNullPoly2d));
+  EXPECT_FALSE(aPoly2dHasher(aNullPoly2d, makePolygon2D(0.004)));
+
+  EXPECT_EQ(0u, aPoly3dHasher(aNullPoly3d));
+  EXPECT_TRUE(aPoly3dHasher(aNullPoly3d, aNullPoly3d));
+  EXPECT_FALSE(aPoly3dHasher(aNullPoly3d, makePolygon3D(0.004)));
+
+  EXPECT_EQ(0u, aTriHasher(aNullTri));
+  EXPECT_TRUE(aTriHasher(aNullTri, aNullTri));
+  EXPECT_FALSE(aTriHasher(aNullTri, makeTriangulation(0.004)));
+
+  const PolygonOnTriHashKey aNullKey1{aNullPolyOnTri, 7};
+  const PolygonOnTriHashKey aNullKey2{aNullPolyOnTri, 7};
+  const PolygonOnTriHashKey aNullKey3{aNullPolyOnTri, 8};
+  EXPECT_TRUE(aPolyOnTriHasher(aNullKey1, aNullKey2));
+  EXPECT_FALSE(aPolyOnTriHasher(aNullKey1, aNullKey3));
+  EXPECT_FALSE(aPolyOnTriHasher(aNullKey1, PolygonOnTriHashKey{makePolygonOnTriangulation(0.004), 7}));
+}
+
+TEST(GeomHash_MeshHasherTest, HashToleranceAffectsNumericFields)
+{
+  const occ::handle<Poly_Polygon2D> aPoly = makePolygon2D(0.06);
+
+  const GeomHash_Polygon2DHasher aFineHasher(0.1, 0.01);
+  const GeomHash_Polygon2DHasher aCoarseHasher(0.1, 0.1);
+
+  EXPECT_NE(aFineHasher(aPoly), aCoarseHasher(aPoly));
 }

--- a/src/ModelingData/TKG3d/GeomHash/FILES.cmake
+++ b/src/ModelingData/TKG3d/GeomHash/FILES.cmake
@@ -35,4 +35,14 @@ set(OCCT_GeomHash_FILES
   GeomHash_OffsetCurveHasher.pxx
   GeomHash_CurveHasher.hxx
   GeomHash_CurveHasher.cxx
+
+  # Mesh Hashers
+  GeomHash_TriangulationHasher.hxx
+  GeomHash_TriangulationHasher.cxx
+  GeomHash_Polygon3DHasher.hxx
+  GeomHash_Polygon3DHasher.cxx
+  GeomHash_Polygon2DHasher.hxx
+  GeomHash_Polygon2DHasher.cxx
+  GeomHash_PolygonOnTriHasher.hxx
+  GeomHash_PolygonOnTriHasher.cxx
 )

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
@@ -47,16 +47,16 @@ std::size_t GeomHash_Polygon2DHasher::operator()(
   const double aFactor = 1.0 / HashTolerance;
 
   size_t aCombined[6] = {};
-  aCombined[0]             = opencascade::hash(thePoly->NbNodes());
-  aCombined[1]             = quantizedHash(thePoly->Deflection(), aFactor);
+  aCombined[0]        = opencascade::hash(thePoly->NbNodes());
+  aCombined[1]        = quantizedHash(thePoly->Deflection(), aFactor);
 
   if (thePoly->NbNodes() > 0)
   {
     const NCollection_Array1<gp_Pnt2d>& aNodes = thePoly->Nodes();
-    aCombined[2]                                   = quantizedHash(aNodes.First().X(), aFactor);
-    aCombined[3]                                   = quantizedHash(aNodes.First().Y(), aFactor);
-    aCombined[4]                                   = quantizedHash(aNodes.Last().X(), aFactor);
-    aCombined[5]                                   = quantizedHash(aNodes.Last().Y(), aFactor);
+    aCombined[2]                               = quantizedHash(aNodes.First().X(), aFactor);
+    aCombined[3]                               = quantizedHash(aNodes.First().Y(), aFactor);
+    aCombined[4]                               = quantizedHash(aNodes.Last().X(), aFactor);
+    aCombined[5]                               = quantizedHash(aNodes.Last().Y(), aFactor);
   }
 
   return opencascade::hashBytes(aCombined, sizeof(aCombined));

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
@@ -35,9 +35,9 @@ std::size_t GeomHash_Polygon2DHasher::operator()(
   return opencascade::hashBytes(aHashes, sizeof(aHashes));
 }
 
-bool GeomHash_Polygon2DHasher::operator()(const occ::handle<Poly_Polygon2D>& thePoly1,
-                                          const occ::handle<Poly_Polygon2D>& thePoly2) const
-  noexcept
+bool GeomHash_Polygon2DHasher::operator()(
+  const occ::handle<Poly_Polygon2D>& thePoly1,
+  const occ::handle<Poly_Polygon2D>& thePoly2) const noexcept
 {
   if (thePoly1->NbNodes() != thePoly2->NbNodes())
   {
@@ -54,8 +54,7 @@ bool GeomHash_Polygon2DHasher::operator()(const occ::handle<Poly_Polygon2D>& the
   {
     const gp_Pnt2d& aP1 = aNodes1.Value(aIdx);
     const gp_Pnt2d& aP2 = aNodes2.Value(aIdx);
-    if (std::abs(aP1.X() - aP2.X()) > CompTolerance
-        || std::abs(aP1.Y() - aP2.Y()) > CompTolerance)
+    if (std::abs(aP1.X() - aP2.X()) > CompTolerance || std::abs(aP1.Y() - aP2.Y()) > CompTolerance)
     {
       return false;
     }

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <GeomHash_Polygon2DHasher.hxx>
+
+#include <NCollection_Array1.hxx>
+#include <Poly_Polygon2D.hxx>
+#include <Standard_HashUtils.hxx>
+#include <gp_Pnt2d.hxx>
+
+#include <cmath>
+
+GeomHash_Polygon2DHasher::GeomHash_Polygon2DHasher(const double theCompTolerance,
+                                                   const double theHashTolerance)
+    : CompTolerance(theCompTolerance),
+      HashTolerance(theHashTolerance)
+{
+}
+
+std::size_t GeomHash_Polygon2DHasher::operator()(
+  const occ::handle<Poly_Polygon2D>& thePoly) const noexcept
+{
+  const std::size_t aHashes[1] = {opencascade::hash(thePoly->NbNodes())};
+
+  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+}
+
+bool GeomHash_Polygon2DHasher::operator()(const occ::handle<Poly_Polygon2D>& thePoly1,
+                                          const occ::handle<Poly_Polygon2D>& thePoly2) const
+  noexcept
+{
+  if (thePoly1->NbNodes() != thePoly2->NbNodes())
+  {
+    return false;
+  }
+  if (std::abs(thePoly1->Deflection() - thePoly2->Deflection()) > CompTolerance)
+  {
+    return false;
+  }
+
+  const NCollection_Array1<gp_Pnt2d>& aNodes1 = thePoly1->Nodes();
+  const NCollection_Array1<gp_Pnt2d>& aNodes2 = thePoly2->Nodes();
+  for (int aIdx = aNodes1.Lower(); aIdx <= aNodes1.Upper(); ++aIdx)
+  {
+    const gp_Pnt2d& aP1 = aNodes1.Value(aIdx);
+    const gp_Pnt2d& aP2 = aNodes2.Value(aIdx);
+    if (std::abs(aP1.X() - aP2.X()) > CompTolerance
+        || std::abs(aP1.Y() - aP2.Y()) > CompTolerance)
+    {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.cxx
@@ -19,6 +19,15 @@
 #include <gp_Pnt2d.hxx>
 
 #include <cmath>
+#include <cstdint>
+
+namespace
+{
+std::size_t quantizedHash(const double theValue, const double theFactor) noexcept
+{
+  return opencascade::hash(static_cast<int64_t>(std::round(theValue * theFactor)));
+}
+} // namespace
 
 GeomHash_Polygon2DHasher::GeomHash_Polygon2DHasher(const double theCompTolerance,
                                                    const double theHashTolerance)
@@ -30,15 +39,38 @@ GeomHash_Polygon2DHasher::GeomHash_Polygon2DHasher(const double theCompTolerance
 std::size_t GeomHash_Polygon2DHasher::operator()(
   const occ::handle<Poly_Polygon2D>& thePoly) const noexcept
 {
-  const std::size_t aHashes[1] = {opencascade::hash(thePoly->NbNodes())};
+  if (thePoly.IsNull())
+  {
+    return 0;
+  }
 
-  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+  const double aFactor = 1.0 / HashTolerance;
+
+  size_t aCombined[6] = {};
+  aCombined[0]             = opencascade::hash(thePoly->NbNodes());
+  aCombined[1]             = quantizedHash(thePoly->Deflection(), aFactor);
+
+  if (thePoly->NbNodes() > 0)
+  {
+    const NCollection_Array1<gp_Pnt2d>& aNodes = thePoly->Nodes();
+    aCombined[2]                                   = quantizedHash(aNodes.First().X(), aFactor);
+    aCombined[3]                                   = quantizedHash(aNodes.First().Y(), aFactor);
+    aCombined[4]                                   = quantizedHash(aNodes.Last().X(), aFactor);
+    aCombined[5]                                   = quantizedHash(aNodes.Last().Y(), aFactor);
+  }
+
+  return opencascade::hashBytes(aCombined, sizeof(aCombined));
 }
 
 bool GeomHash_Polygon2DHasher::operator()(
   const occ::handle<Poly_Polygon2D>& thePoly1,
   const occ::handle<Poly_Polygon2D>& thePoly2) const noexcept
 {
+  if (thePoly1.IsNull() || thePoly2.IsNull())
+  {
+    return thePoly1.IsNull() && thePoly2.IsNull();
+  }
+
   if (thePoly1->NbNodes() != thePoly2->NbNodes())
   {
     return false;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.hxx
@@ -26,12 +26,10 @@ struct GeomHash_Polygon2DHasher
   double CompTolerance;
   double HashTolerance;
 
-  Standard_EXPORT GeomHash_Polygon2DHasher(
-    double theCompTolerance = Precision::Computational(),
-    double theHashTolerance = Precision::Computational());
+  Standard_EXPORT GeomHash_Polygon2DHasher(double theCompTolerance = Precision::Computational(),
+                                           double theHashTolerance = Precision::Computational());
 
-  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon2D>& thePoly) const
-    noexcept;
+  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon2D>& thePoly) const noexcept;
 
   Standard_EXPORT bool operator()(const occ::handle<Poly_Polygon2D>& thePoly1,
                                   const occ::handle<Poly_Polygon2D>& thePoly2) const noexcept;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.hxx
@@ -26,8 +26,9 @@ struct GeomHash_Polygon2DHasher
   double CompTolerance;
   double HashTolerance;
 
-  Standard_EXPORT GeomHash_Polygon2DHasher(double theCompTolerance = Precision::Computational(),
-                                           double theHashTolerance = Precision::Computational());
+  Standard_EXPORT GeomHash_Polygon2DHasher(
+    const double theCompTolerance = Precision::Computational(),
+    const double theHashTolerance = Precision::Computational());
 
   Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon2D>& thePoly) const noexcept;
 

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon2DHasher.hxx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _GeomHash_Polygon2DHasher_HeaderFile
+#define _GeomHash_Polygon2DHasher_HeaderFile
+
+#include <Precision.hxx>
+#include <Standard_Handle.hxx>
+
+#include <cstddef>
+
+class Poly_Polygon2D;
+
+struct GeomHash_Polygon2DHasher
+{
+  double CompTolerance;
+  double HashTolerance;
+
+  Standard_EXPORT GeomHash_Polygon2DHasher(
+    double theCompTolerance = Precision::Computational(),
+    double theHashTolerance = Precision::Computational());
+
+  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon2D>& thePoly) const
+    noexcept;
+
+  Standard_EXPORT bool operator()(const occ::handle<Poly_Polygon2D>& thePoly1,
+                                  const occ::handle<Poly_Polygon2D>& thePoly2) const noexcept;
+};
+
+#endif // _GeomHash_Polygon2DHasher_HeaderFile

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
@@ -19,6 +19,15 @@
 #include <gp_Pnt.hxx>
 
 #include <cmath>
+#include <cstdint>
+
+namespace
+{
+std::size_t quantizedHash(const double theValue, const double theFactor) noexcept
+{
+  return opencascade::hash(static_cast<int64_t>(std::round(theValue * theFactor)));
+}
+} // namespace
 
 GeomHash_Polygon3DHasher::GeomHash_Polygon3DHasher(const double theCompTolerance,
                                                    const double theHashTolerance)
@@ -30,16 +39,47 @@ GeomHash_Polygon3DHasher::GeomHash_Polygon3DHasher(const double theCompTolerance
 std::size_t GeomHash_Polygon3DHasher::operator()(
   const occ::handle<Poly_Polygon3D>& thePoly) const noexcept
 {
-  const std::size_t aHashes[2] = {opencascade::hash(thePoly->NbNodes()),
-                                  opencascade::hash(thePoly->HasParameters() ? 1 : 0)};
+  if (thePoly.IsNull())
+  {
+    return 0;
+  }
 
-  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+  const double aFactor = 1.0 / HashTolerance;
+
+  size_t aCombined[11] = {};
+  aCombined[0]              = opencascade::hash(thePoly->NbNodes());
+  aCombined[1]              = opencascade::hash(thePoly->HasParameters() ? 1 : 0);
+  aCombined[2]              = quantizedHash(thePoly->Deflection(), aFactor);
+
+  if (thePoly->NbNodes() > 0)
+  {
+    const NCollection_Array1<gp_Pnt>& aNodes = thePoly->Nodes();
+    aCombined[3]                                 = quantizedHash(aNodes.First().X(), aFactor);
+    aCombined[4]                                 = quantizedHash(aNodes.First().Y(), aFactor);
+    aCombined[5]                                 = quantizedHash(aNodes.First().Z(), aFactor);
+    aCombined[6]                                 = quantizedHash(aNodes.Last().X(), aFactor);
+    aCombined[7]                                 = quantizedHash(aNodes.Last().Y(), aFactor);
+    aCombined[8]                                 = quantizedHash(aNodes.Last().Z(), aFactor);
+    if (thePoly->HasParameters())
+    {
+      const NCollection_Array1<double>& aParams = thePoly->Parameters();
+      aCombined[9]                                  = quantizedHash(aParams.First(), aFactor);
+      aCombined[10]                                 = quantizedHash(aParams.Last(), aFactor);
+    }
+  }
+
+  return opencascade::hashBytes(aCombined, sizeof(aCombined));
 }
 
 bool GeomHash_Polygon3DHasher::operator()(
   const occ::handle<Poly_Polygon3D>& thePoly1,
   const occ::handle<Poly_Polygon3D>& thePoly2) const noexcept
 {
+  if (thePoly1.IsNull() || thePoly2.IsNull())
+  {
+    return thePoly1.IsNull() && thePoly2.IsNull();
+  }
+
   if (thePoly1->NbNodes() != thePoly2->NbNodes())
   {
     return false;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
@@ -47,24 +47,24 @@ std::size_t GeomHash_Polygon3DHasher::operator()(
   const double aFactor = 1.0 / HashTolerance;
 
   size_t aCombined[11] = {};
-  aCombined[0]              = opencascade::hash(thePoly->NbNodes());
-  aCombined[1]              = opencascade::hash(thePoly->HasParameters() ? 1 : 0);
-  aCombined[2]              = quantizedHash(thePoly->Deflection(), aFactor);
+  aCombined[0]         = opencascade::hash(thePoly->NbNodes());
+  aCombined[1]         = opencascade::hash(thePoly->HasParameters() ? 1 : 0);
+  aCombined[2]         = quantizedHash(thePoly->Deflection(), aFactor);
 
   if (thePoly->NbNodes() > 0)
   {
     const NCollection_Array1<gp_Pnt>& aNodes = thePoly->Nodes();
-    aCombined[3]                                 = quantizedHash(aNodes.First().X(), aFactor);
-    aCombined[4]                                 = quantizedHash(aNodes.First().Y(), aFactor);
-    aCombined[5]                                 = quantizedHash(aNodes.First().Z(), aFactor);
-    aCombined[6]                                 = quantizedHash(aNodes.Last().X(), aFactor);
-    aCombined[7]                                 = quantizedHash(aNodes.Last().Y(), aFactor);
-    aCombined[8]                                 = quantizedHash(aNodes.Last().Z(), aFactor);
+    aCombined[3]                             = quantizedHash(aNodes.First().X(), aFactor);
+    aCombined[4]                             = quantizedHash(aNodes.First().Y(), aFactor);
+    aCombined[5]                             = quantizedHash(aNodes.First().Z(), aFactor);
+    aCombined[6]                             = quantizedHash(aNodes.Last().X(), aFactor);
+    aCombined[7]                             = quantizedHash(aNodes.Last().Y(), aFactor);
+    aCombined[8]                             = quantizedHash(aNodes.Last().Z(), aFactor);
     if (thePoly->HasParameters())
     {
       const NCollection_Array1<double>& aParams = thePoly->Parameters();
-      aCombined[9]                                  = quantizedHash(aParams.First(), aFactor);
-      aCombined[10]                                 = quantizedHash(aParams.Last(), aFactor);
+      aCombined[9]                              = quantizedHash(aParams.First(), aFactor);
+      aCombined[10]                             = quantizedHash(aParams.Last(), aFactor);
     }
   }
 

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
@@ -30,16 +30,15 @@ GeomHash_Polygon3DHasher::GeomHash_Polygon3DHasher(const double theCompTolerance
 std::size_t GeomHash_Polygon3DHasher::operator()(
   const occ::handle<Poly_Polygon3D>& thePoly) const noexcept
 {
-  const std::size_t aHashes[2] = {
-    opencascade::hash(thePoly->NbNodes()),
-    opencascade::hash(thePoly->HasParameters() ? 1 : 0)};
+  const std::size_t aHashes[2] = {opencascade::hash(thePoly->NbNodes()),
+                                  opencascade::hash(thePoly->HasParameters() ? 1 : 0)};
 
   return opencascade::hashBytes(aHashes, sizeof(aHashes));
 }
 
-bool GeomHash_Polygon3DHasher::operator()(const occ::handle<Poly_Polygon3D>& thePoly1,
-                                          const occ::handle<Poly_Polygon3D>& thePoly2) const
-  noexcept
+bool GeomHash_Polygon3DHasher::operator()(
+  const occ::handle<Poly_Polygon3D>& thePoly1,
+  const occ::handle<Poly_Polygon3D>& thePoly2) const noexcept
 {
   if (thePoly1->NbNodes() != thePoly2->NbNodes())
   {
@@ -60,8 +59,7 @@ bool GeomHash_Polygon3DHasher::operator()(const occ::handle<Poly_Polygon3D>& the
   {
     const gp_Pnt& aP1 = aNodes1.Value(aIdx);
     const gp_Pnt& aP2 = aNodes2.Value(aIdx);
-    if (std::abs(aP1.X() - aP2.X()) > CompTolerance
-        || std::abs(aP1.Y() - aP2.Y()) > CompTolerance
+    if (std::abs(aP1.X() - aP2.X()) > CompTolerance || std::abs(aP1.Y() - aP2.Y()) > CompTolerance
         || std::abs(aP1.Z() - aP2.Z()) > CompTolerance)
     {
       return false;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.cxx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <GeomHash_Polygon3DHasher.hxx>
+
+#include <NCollection_Array1.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Standard_HashUtils.hxx>
+#include <gp_Pnt.hxx>
+
+#include <cmath>
+
+GeomHash_Polygon3DHasher::GeomHash_Polygon3DHasher(const double theCompTolerance,
+                                                   const double theHashTolerance)
+    : CompTolerance(theCompTolerance),
+      HashTolerance(theHashTolerance)
+{
+}
+
+std::size_t GeomHash_Polygon3DHasher::operator()(
+  const occ::handle<Poly_Polygon3D>& thePoly) const noexcept
+{
+  const std::size_t aHashes[2] = {
+    opencascade::hash(thePoly->NbNodes()),
+    opencascade::hash(thePoly->HasParameters() ? 1 : 0)};
+
+  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+}
+
+bool GeomHash_Polygon3DHasher::operator()(const occ::handle<Poly_Polygon3D>& thePoly1,
+                                          const occ::handle<Poly_Polygon3D>& thePoly2) const
+  noexcept
+{
+  if (thePoly1->NbNodes() != thePoly2->NbNodes())
+  {
+    return false;
+  }
+  if (thePoly1->HasParameters() != thePoly2->HasParameters())
+  {
+    return false;
+  }
+  if (std::abs(thePoly1->Deflection() - thePoly2->Deflection()) > CompTolerance)
+  {
+    return false;
+  }
+
+  const NCollection_Array1<gp_Pnt>& aNodes1 = thePoly1->Nodes();
+  const NCollection_Array1<gp_Pnt>& aNodes2 = thePoly2->Nodes();
+  for (int aIdx = aNodes1.Lower(); aIdx <= aNodes1.Upper(); ++aIdx)
+  {
+    const gp_Pnt& aP1 = aNodes1.Value(aIdx);
+    const gp_Pnt& aP2 = aNodes2.Value(aIdx);
+    if (std::abs(aP1.X() - aP2.X()) > CompTolerance
+        || std::abs(aP1.Y() - aP2.Y()) > CompTolerance
+        || std::abs(aP1.Z() - aP2.Z()) > CompTolerance)
+    {
+      return false;
+    }
+  }
+
+  if (thePoly1->HasParameters())
+  {
+    const NCollection_Array1<double>& aParams1 = thePoly1->Parameters();
+    const NCollection_Array1<double>& aParams2 = thePoly2->Parameters();
+    for (int aIdx = aParams1.Lower(); aIdx <= aParams1.Upper(); ++aIdx)
+    {
+      if (std::abs(aParams1.Value(aIdx) - aParams2.Value(aIdx)) > CompTolerance)
+      {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.hxx
@@ -26,12 +26,10 @@ struct GeomHash_Polygon3DHasher
   double CompTolerance;
   double HashTolerance;
 
-  Standard_EXPORT GeomHash_Polygon3DHasher(
-    double theCompTolerance = Precision::Computational(),
-    double theHashTolerance = Precision::Computational());
+  Standard_EXPORT GeomHash_Polygon3DHasher(double theCompTolerance = Precision::Computational(),
+                                           double theHashTolerance = Precision::Computational());
 
-  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon3D>& thePoly) const
-    noexcept;
+  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon3D>& thePoly) const noexcept;
 
   Standard_EXPORT bool operator()(const occ::handle<Poly_Polygon3D>& thePoly1,
                                   const occ::handle<Poly_Polygon3D>& thePoly2) const noexcept;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.hxx
@@ -26,8 +26,9 @@ struct GeomHash_Polygon3DHasher
   double CompTolerance;
   double HashTolerance;
 
-  Standard_EXPORT GeomHash_Polygon3DHasher(double theCompTolerance = Precision::Computational(),
-                                           double theHashTolerance = Precision::Computational());
+  Standard_EXPORT GeomHash_Polygon3DHasher(
+    const double theCompTolerance = Precision::Computational(),
+    const double theHashTolerance = Precision::Computational());
 
   Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon3D>& thePoly) const noexcept;
 

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_Polygon3DHasher.hxx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _GeomHash_Polygon3DHasher_HeaderFile
+#define _GeomHash_Polygon3DHasher_HeaderFile
+
+#include <Precision.hxx>
+#include <Standard_Handle.hxx>
+
+#include <cstddef>
+
+class Poly_Polygon3D;
+
+struct GeomHash_Polygon3DHasher
+{
+  double CompTolerance;
+  double HashTolerance;
+
+  Standard_EXPORT GeomHash_Polygon3DHasher(
+    double theCompTolerance = Precision::Computational(),
+    double theHashTolerance = Precision::Computational());
+
+  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Polygon3D>& thePoly) const
+    noexcept;
+
+  Standard_EXPORT bool operator()(const occ::handle<Poly_Polygon3D>& thePoly1,
+                                  const occ::handle<Poly_Polygon3D>& thePoly2) const noexcept;
+};
+
+#endif // _GeomHash_Polygon3DHasher_HeaderFile

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <GeomHash_PolygonOnTriHasher.hxx>
+
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Standard_HashUtils.hxx>
+
+#include <cmath>
+
+GeomHash_PolygonOnTriHasher::GeomHash_PolygonOnTriHasher(const double theCompTolerance,
+                                                         const double theHashTolerance)
+    : CompTolerance(theCompTolerance),
+      HashTolerance(theHashTolerance)
+{
+}
+
+std::size_t GeomHash_PolygonOnTriHasher::operator()(const PolygonOnTriHashKey& theKey) const
+  noexcept
+{
+  const occ::handle<Poly_PolygonOnTriangulation>& aPoly = theKey.Poly;
+  const std::size_t aHashes[3] = {
+    opencascade::hash(aPoly->NbNodes()),
+    opencascade::hash(aPoly->HasParameters() ? 1 : 0),
+    opencascade::hash(static_cast<int64_t>(theKey.TriRepId))};
+
+  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+}
+
+bool GeomHash_PolygonOnTriHasher::operator()(const PolygonOnTriHashKey& theKey1,
+                                             const PolygonOnTriHashKey& theKey2) const noexcept
+{
+  const occ::handle<Poly_PolygonOnTriangulation>& aPoly1 = theKey1.Poly;
+  const occ::handle<Poly_PolygonOnTriangulation>& aPoly2 = theKey2.Poly;
+
+  if (theKey1.TriRepId != theKey2.TriRepId)
+  {
+    return false;
+  }
+  if (aPoly1->NbNodes() != aPoly2->NbNodes())
+  {
+    return false;
+  }
+  if (aPoly1->HasParameters() != aPoly2->HasParameters())
+  {
+    return false;
+  }
+  if (std::abs(aPoly1->Deflection() - aPoly2->Deflection()) > CompTolerance)
+  {
+    return false;
+  }
+
+  for (int aIdx = 1; aIdx <= aPoly1->NbNodes(); ++aIdx)
+  {
+    if (aPoly1->Node(aIdx) != aPoly2->Node(aIdx))
+    {
+      return false;
+    }
+  }
+
+  if (aPoly1->HasParameters())
+  {
+    for (int aIdx = 1; aIdx <= aPoly1->NbNodes(); ++aIdx)
+    {
+      if (std::abs(aPoly1->Parameter(aIdx) - aPoly2->Parameter(aIdx)) > CompTolerance)
+      {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
@@ -17,6 +17,15 @@
 #include <Standard_HashUtils.hxx>
 
 #include <cmath>
+#include <cstdint>
+
+namespace
+{
+std::size_t quantizedHash(const double theValue, const double theFactor) noexcept
+{
+  return opencascade::hash(static_cast<int64_t>(std::round(theValue * theFactor)));
+}
+} // namespace
 
 GeomHash_PolygonOnTriHasher::GeomHash_PolygonOnTriHasher(const double theCompTolerance,
                                                          const double theHashTolerance)
@@ -29,11 +38,32 @@ std::size_t GeomHash_PolygonOnTriHasher::operator()(
   const PolygonOnTriHashKey& theKey) const noexcept
 {
   const occ::handle<Poly_PolygonOnTriangulation>& aPoly      = theKey.Poly;
-  const std::size_t                               aHashes[3] = {opencascade::hash(aPoly->NbNodes()),
-                                                                opencascade::hash(aPoly->HasParameters() ? 1 : 0),
-                                                                opencascade::hash(static_cast<int64_t>(theKey.TriRepId))};
+  size_t                                          aCombined[9]     = {};
+  aCombined[0]                                                     = opencascade::hash(static_cast<int64_t>(theKey.TriRepId));
+  if (aPoly.IsNull())
+  {
+    aCombined[1] = opencascade::hash(1);
+    return opencascade::hashBytes(aCombined, sizeof(aCombined));
+  }
 
-  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+  const double aFactor = 1.0 / HashTolerance;
+
+  aCombined[2] = opencascade::hash(aPoly->NbNodes());
+  aCombined[3] = opencascade::hash(aPoly->HasParameters() ? 1 : 0);
+  aCombined[4] = quantizedHash(aPoly->Deflection(), aFactor);
+
+  if (aPoly->NbNodes() > 0)
+  {
+    aCombined[5] = opencascade::hash(aPoly->Node(1));
+    aCombined[6] = opencascade::hash(aPoly->Node(aPoly->NbNodes()));
+    if (aPoly->HasParameters())
+    {
+      aCombined[7] = quantizedHash(aPoly->Parameter(1), aFactor);
+      aCombined[8] = quantizedHash(aPoly->Parameter(aPoly->NbNodes()), aFactor);
+    }
+  }
+
+  return opencascade::hashBytes(aCombined, sizeof(aCombined));
 }
 
 bool GeomHash_PolygonOnTriHasher::operator()(const PolygonOnTriHashKey& theKey1,
@@ -46,6 +76,11 @@ bool GeomHash_PolygonOnTriHasher::operator()(const PolygonOnTriHashKey& theKey1,
   {
     return false;
   }
+  if (aPoly1.IsNull() || aPoly2.IsNull())
+  {
+    return aPoly1.IsNull() && aPoly2.IsNull();
+  }
+
   if (aPoly1->NbNodes() != aPoly2->NbNodes())
   {
     return false;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
@@ -37,9 +37,9 @@ GeomHash_PolygonOnTriHasher::GeomHash_PolygonOnTriHasher(const double theCompTol
 std::size_t GeomHash_PolygonOnTriHasher::operator()(
   const PolygonOnTriHashKey& theKey) const noexcept
 {
-  const occ::handle<Poly_PolygonOnTriangulation>& aPoly      = theKey.Poly;
-  size_t                                          aCombined[9]     = {};
-  aCombined[0]                                                     = opencascade::hash(static_cast<int64_t>(theKey.TriRepId));
+  const occ::handle<Poly_PolygonOnTriangulation>& aPoly        = theKey.Poly;
+  size_t                                          aCombined[9] = {};
+  aCombined[0] = opencascade::hash(static_cast<int64_t>(theKey.TriRepId));
   if (aPoly.IsNull())
   {
     aCombined[1] = opencascade::hash(1);

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.cxx
@@ -25,14 +25,13 @@ GeomHash_PolygonOnTriHasher::GeomHash_PolygonOnTriHasher(const double theCompTol
 {
 }
 
-std::size_t GeomHash_PolygonOnTriHasher::operator()(const PolygonOnTriHashKey& theKey) const
-  noexcept
+std::size_t GeomHash_PolygonOnTriHasher::operator()(
+  const PolygonOnTriHashKey& theKey) const noexcept
 {
-  const occ::handle<Poly_PolygonOnTriangulation>& aPoly = theKey.Poly;
-  const std::size_t aHashes[3] = {
-    opencascade::hash(aPoly->NbNodes()),
-    opencascade::hash(aPoly->HasParameters() ? 1 : 0),
-    opencascade::hash(static_cast<int64_t>(theKey.TriRepId))};
+  const occ::handle<Poly_PolygonOnTriangulation>& aPoly      = theKey.Poly;
+  const std::size_t                               aHashes[3] = {opencascade::hash(aPoly->NbNodes()),
+                                                                opencascade::hash(aPoly->HasParameters() ? 1 : 0),
+                                                                opencascade::hash(static_cast<int64_t>(theKey.TriRepId))};
 
   return opencascade::hashBytes(aHashes, sizeof(aHashes));
 }

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.hxx
@@ -25,7 +25,7 @@ class Poly_PolygonOnTriangulation;
 struct PolygonOnTriHashKey
 {
   occ::handle<Poly_PolygonOnTriangulation> Poly;
-  uint32_t TriRepId;
+  uint32_t                                 TriRepId;
 };
 
 struct GeomHash_PolygonOnTriHasher
@@ -33,9 +33,8 @@ struct GeomHash_PolygonOnTriHasher
   double CompTolerance;
   double HashTolerance;
 
-  Standard_EXPORT GeomHash_PolygonOnTriHasher(
-    double theCompTolerance = Precision::Computational(),
-    double theHashTolerance = Precision::Computational());
+  Standard_EXPORT GeomHash_PolygonOnTriHasher(double theCompTolerance = Precision::Computational(),
+                                              double theHashTolerance = Precision::Computational());
 
   Standard_EXPORT std::size_t operator()(const PolygonOnTriHashKey& theKey) const noexcept;
 

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.hxx
@@ -33,8 +33,9 @@ struct GeomHash_PolygonOnTriHasher
   double CompTolerance;
   double HashTolerance;
 
-  Standard_EXPORT GeomHash_PolygonOnTriHasher(double theCompTolerance = Precision::Computational(),
-                                              double theHashTolerance = Precision::Computational());
+  Standard_EXPORT GeomHash_PolygonOnTriHasher(
+    const double theCompTolerance = Precision::Computational(),
+    const double theHashTolerance = Precision::Computational());
 
   Standard_EXPORT std::size_t operator()(const PolygonOnTriHashKey& theKey) const noexcept;
 

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_PolygonOnTriHasher.hxx
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _GeomHash_PolygonOnTriHasher_HeaderFile
+#define _GeomHash_PolygonOnTriHasher_HeaderFile
+
+#include <Precision.hxx>
+#include <Standard_Handle.hxx>
+
+#include <cstddef>
+#include <cstdint>
+
+class Poly_PolygonOnTriangulation;
+
+struct PolygonOnTriHashKey
+{
+  occ::handle<Poly_PolygonOnTriangulation> Poly;
+  uint32_t TriRepId;
+};
+
+struct GeomHash_PolygonOnTriHasher
+{
+  double CompTolerance;
+  double HashTolerance;
+
+  Standard_EXPORT GeomHash_PolygonOnTriHasher(
+    double theCompTolerance = Precision::Computational(),
+    double theHashTolerance = Precision::Computational());
+
+  Standard_EXPORT std::size_t operator()(const PolygonOnTriHashKey& theKey) const noexcept;
+
+  Standard_EXPORT bool operator()(const PolygonOnTriHashKey& theKey1,
+                                  const PolygonOnTriHashKey& theKey2) const noexcept;
+};
+
+#endif // _GeomHash_PolygonOnTriHasher_HeaderFile

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
@@ -48,21 +48,21 @@ std::size_t GeomHash_TriangulationHasher::operator()(
   const double aFactor = 1.0 / HashTolerance;
 
   size_t aCombined[20] = {};
-  aCombined[0]              = opencascade::hash(theTri->NbNodes());
-  aCombined[1]              = opencascade::hash(theTri->NbTriangles());
-  aCombined[2]              = opencascade::hash(theTri->HasUVNodes() ? 1 : 0);
-  aCombined[3]              = quantizedHash(theTri->Deflection(), aFactor);
+  aCombined[0]         = opencascade::hash(theTri->NbNodes());
+  aCombined[1]         = opencascade::hash(theTri->NbTriangles());
+  aCombined[2]         = opencascade::hash(theTri->HasUVNodes() ? 1 : 0);
+  aCombined[3]         = quantizedHash(theTri->Deflection(), aFactor);
 
   if (theTri->NbNodes() > 0)
   {
     const gp_Pnt& aFirstNode = theTri->Node(1);
     const gp_Pnt& aLastNode  = theTri->Node(theTri->NbNodes());
-    aCombined[4]                  = quantizedHash(aFirstNode.X(), aFactor);
-    aCombined[5]                  = quantizedHash(aFirstNode.Y(), aFactor);
-    aCombined[6]                  = quantizedHash(aFirstNode.Z(), aFactor);
-    aCombined[7]                  = quantizedHash(aLastNode.X(), aFactor);
-    aCombined[8]                  = quantizedHash(aLastNode.Y(), aFactor);
-    aCombined[9]                  = quantizedHash(aLastNode.Z(), aFactor);
+    aCombined[4]             = quantizedHash(aFirstNode.X(), aFactor);
+    aCombined[5]             = quantizedHash(aFirstNode.Y(), aFactor);
+    aCombined[6]             = quantizedHash(aFirstNode.Z(), aFactor);
+    aCombined[7]             = quantizedHash(aLastNode.X(), aFactor);
+    aCombined[8]             = quantizedHash(aLastNode.Y(), aFactor);
+    aCombined[9]             = quantizedHash(aLastNode.Z(), aFactor);
   }
 
   if (theTri->NbTriangles() > 0)
@@ -82,10 +82,10 @@ std::size_t GeomHash_TriangulationHasher::operator()(
   {
     const gp_Pnt2d& aFirstUV = theTri->UVNode(1);
     const gp_Pnt2d& aLastUV  = theTri->UVNode(theTri->NbNodes());
-    aCombined[16]                 = quantizedHash(aFirstUV.X(), aFactor);
-    aCombined[17]                 = quantizedHash(aFirstUV.Y(), aFactor);
-    aCombined[18]                 = quantizedHash(aLastUV.X(), aFactor);
-    aCombined[19]                 = quantizedHash(aLastUV.Y(), aFactor);
+    aCombined[16]            = quantizedHash(aFirstUV.X(), aFactor);
+    aCombined[17]            = quantizedHash(aFirstUV.Y(), aFactor);
+    aCombined[18]            = quantizedHash(aLastUV.X(), aFactor);
+    aCombined[19]            = quantizedHash(aLastUV.Y(), aFactor);
   }
 
   return opencascade::hashBytes(aCombined, sizeof(aCombined));

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
@@ -31,10 +31,9 @@ GeomHash_TriangulationHasher::GeomHash_TriangulationHasher(const double theCompT
 std::size_t GeomHash_TriangulationHasher::operator()(
   const occ::handle<Poly_Triangulation>& theTri) const noexcept
 {
-  const std::size_t aHashes[3] = {
-    opencascade::hash(theTri->NbNodes()),
-    opencascade::hash(theTri->NbTriangles()),
-    opencascade::hash(theTri->HasUVNodes() ? 1 : 0)};
+  const std::size_t aHashes[3] = {opencascade::hash(theTri->NbNodes()),
+                                  opencascade::hash(theTri->NbTriangles()),
+                                  opencascade::hash(theTri->HasUVNodes() ? 1 : 0)};
 
   return opencascade::hashBytes(aHashes, sizeof(aHashes));
 }
@@ -64,8 +63,7 @@ bool GeomHash_TriangulationHasher::operator()(
   {
     const gp_Pnt& aP1 = theTri1->Node(aIdx);
     const gp_Pnt& aP2 = theTri2->Node(aIdx);
-    if (std::abs(aP1.X() - aP2.X()) > CompTolerance
-        || std::abs(aP1.Y() - aP2.Y()) > CompTolerance
+    if (std::abs(aP1.X() - aP2.X()) > CompTolerance || std::abs(aP1.Y() - aP2.Y()) > CompTolerance
         || std::abs(aP1.Z() - aP2.Z()) > CompTolerance)
     {
       return false;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <GeomHash_TriangulationHasher.hxx>
+
+#include <Poly_Triangle.hxx>
+#include <Poly_Triangulation.hxx>
+#include <Standard_HashUtils.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+
+#include <cmath>
+
+GeomHash_TriangulationHasher::GeomHash_TriangulationHasher(const double theCompTolerance,
+                                                           const double theHashTolerance)
+    : CompTolerance(theCompTolerance),
+      HashTolerance(theHashTolerance)
+{
+}
+
+std::size_t GeomHash_TriangulationHasher::operator()(
+  const occ::handle<Poly_Triangulation>& theTri) const noexcept
+{
+  const std::size_t aHashes[3] = {
+    opencascade::hash(theTri->NbNodes()),
+    opencascade::hash(theTri->NbTriangles()),
+    opencascade::hash(theTri->HasUVNodes() ? 1 : 0)};
+
+  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+}
+
+bool GeomHash_TriangulationHasher::operator()(
+  const occ::handle<Poly_Triangulation>& theTri1,
+  const occ::handle<Poly_Triangulation>& theTri2) const noexcept
+{
+  if (theTri1->NbNodes() != theTri2->NbNodes())
+  {
+    return false;
+  }
+  if (theTri1->NbTriangles() != theTri2->NbTriangles())
+  {
+    return false;
+  }
+  if (theTri1->HasUVNodes() != theTri2->HasUVNodes())
+  {
+    return false;
+  }
+  if (std::abs(theTri1->Deflection() - theTri2->Deflection()) > CompTolerance)
+  {
+    return false;
+  }
+
+  for (int aIdx = 1; aIdx <= theTri1->NbNodes(); ++aIdx)
+  {
+    const gp_Pnt& aP1 = theTri1->Node(aIdx);
+    const gp_Pnt& aP2 = theTri2->Node(aIdx);
+    if (std::abs(aP1.X() - aP2.X()) > CompTolerance
+        || std::abs(aP1.Y() - aP2.Y()) > CompTolerance
+        || std::abs(aP1.Z() - aP2.Z()) > CompTolerance)
+    {
+      return false;
+    }
+  }
+
+  for (int aIdx = 1; aIdx <= theTri1->NbTriangles(); ++aIdx)
+  {
+    int aN11 = 0, aN12 = 0, aN13 = 0;
+    int aN21 = 0, aN22 = 0, aN23 = 0;
+    theTri1->Triangle(aIdx).Get(aN11, aN12, aN13);
+    theTri2->Triangle(aIdx).Get(aN21, aN22, aN23);
+    if (aN11 != aN21 || aN12 != aN22 || aN13 != aN23)
+    {
+      return false;
+    }
+  }
+
+  if (theTri1->HasUVNodes())
+  {
+    for (int aIdx = 1; aIdx <= theTri1->NbNodes(); ++aIdx)
+    {
+      const gp_Pnt2d& aU1 = theTri1->UVNode(aIdx);
+      const gp_Pnt2d& aU2 = theTri2->UVNode(aIdx);
+      if (std::abs(aU1.X() - aU2.X()) > CompTolerance
+          || std::abs(aU1.Y() - aU2.Y()) > CompTolerance)
+      {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.cxx
@@ -20,6 +20,15 @@
 #include <gp_Pnt2d.hxx>
 
 #include <cmath>
+#include <cstdint>
+
+namespace
+{
+std::size_t quantizedHash(const double theValue, const double theFactor) noexcept
+{
+  return opencascade::hash(static_cast<int64_t>(std::round(theValue * theFactor)));
+}
+} // namespace
 
 GeomHash_TriangulationHasher::GeomHash_TriangulationHasher(const double theCompTolerance,
                                                            const double theHashTolerance)
@@ -31,17 +40,66 @@ GeomHash_TriangulationHasher::GeomHash_TriangulationHasher(const double theCompT
 std::size_t GeomHash_TriangulationHasher::operator()(
   const occ::handle<Poly_Triangulation>& theTri) const noexcept
 {
-  const std::size_t aHashes[3] = {opencascade::hash(theTri->NbNodes()),
-                                  opencascade::hash(theTri->NbTriangles()),
-                                  opencascade::hash(theTri->HasUVNodes() ? 1 : 0)};
+  if (theTri.IsNull())
+  {
+    return 0;
+  }
 
-  return opencascade::hashBytes(aHashes, sizeof(aHashes));
+  const double aFactor = 1.0 / HashTolerance;
+
+  size_t aCombined[20] = {};
+  aCombined[0]              = opencascade::hash(theTri->NbNodes());
+  aCombined[1]              = opencascade::hash(theTri->NbTriangles());
+  aCombined[2]              = opencascade::hash(theTri->HasUVNodes() ? 1 : 0);
+  aCombined[3]              = quantizedHash(theTri->Deflection(), aFactor);
+
+  if (theTri->NbNodes() > 0)
+  {
+    const gp_Pnt& aFirstNode = theTri->Node(1);
+    const gp_Pnt& aLastNode  = theTri->Node(theTri->NbNodes());
+    aCombined[4]                  = quantizedHash(aFirstNode.X(), aFactor);
+    aCombined[5]                  = quantizedHash(aFirstNode.Y(), aFactor);
+    aCombined[6]                  = quantizedHash(aFirstNode.Z(), aFactor);
+    aCombined[7]                  = quantizedHash(aLastNode.X(), aFactor);
+    aCombined[8]                  = quantizedHash(aLastNode.Y(), aFactor);
+    aCombined[9]                  = quantizedHash(aLastNode.Z(), aFactor);
+  }
+
+  if (theTri->NbTriangles() > 0)
+  {
+    int aN1 = 0, aN2 = 0, aN3 = 0;
+    theTri->Triangle(1).Get(aN1, aN2, aN3);
+    aCombined[10] = opencascade::hash(aN1);
+    aCombined[11] = opencascade::hash(aN2);
+    aCombined[12] = opencascade::hash(aN3);
+    theTri->Triangle(theTri->NbTriangles()).Get(aN1, aN2, aN3);
+    aCombined[13] = opencascade::hash(aN1);
+    aCombined[14] = opencascade::hash(aN2);
+    aCombined[15] = opencascade::hash(aN3);
+  }
+
+  if (theTri->HasUVNodes() && theTri->NbNodes() > 0)
+  {
+    const gp_Pnt2d& aFirstUV = theTri->UVNode(1);
+    const gp_Pnt2d& aLastUV  = theTri->UVNode(theTri->NbNodes());
+    aCombined[16]                 = quantizedHash(aFirstUV.X(), aFactor);
+    aCombined[17]                 = quantizedHash(aFirstUV.Y(), aFactor);
+    aCombined[18]                 = quantizedHash(aLastUV.X(), aFactor);
+    aCombined[19]                 = quantizedHash(aLastUV.Y(), aFactor);
+  }
+
+  return opencascade::hashBytes(aCombined, sizeof(aCombined));
 }
 
 bool GeomHash_TriangulationHasher::operator()(
   const occ::handle<Poly_Triangulation>& theTri1,
   const occ::handle<Poly_Triangulation>& theTri2) const noexcept
 {
+  if (theTri1.IsNull() || theTri2.IsNull())
+  {
+    return theTri1.IsNull() && theTri2.IsNull();
+  }
+
   if (theTri1->NbNodes() != theTri2->NbNodes())
   {
     return false;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.hxx
@@ -27,8 +27,8 @@ struct GeomHash_TriangulationHasher
   double HashTolerance;
 
   Standard_EXPORT GeomHash_TriangulationHasher(
-    double theCompTolerance = Precision::Computational(),
-    double theHashTolerance = Precision::Computational());
+    const double theCompTolerance = Precision::Computational(),
+    const double theHashTolerance = Precision::Computational());
 
   Standard_EXPORT std::size_t operator()(
     const occ::handle<Poly_Triangulation>& theTri) const noexcept;

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.hxx
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _GeomHash_TriangulationHasher_HeaderFile
+#define _GeomHash_TriangulationHasher_HeaderFile
+
+#include <Precision.hxx>
+#include <Standard_Handle.hxx>
+
+#include <cstddef>
+
+class Poly_Triangulation;
+
+struct GeomHash_TriangulationHasher
+{
+  double CompTolerance;
+  double HashTolerance;
+
+  Standard_EXPORT GeomHash_TriangulationHasher(
+    double theCompTolerance = Precision::Computational(),
+    double theHashTolerance = Precision::Computational());
+
+  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Triangulation>& theTri) const
+    noexcept;
+
+  Standard_EXPORT bool operator()(const occ::handle<Poly_Triangulation>& theTri1,
+                                  const occ::handle<Poly_Triangulation>& theTri2) const noexcept;
+};
+
+#endif // _GeomHash_TriangulationHasher_HeaderFile

--- a/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.hxx
+++ b/src/ModelingData/TKG3d/GeomHash/GeomHash_TriangulationHasher.hxx
@@ -30,8 +30,8 @@ struct GeomHash_TriangulationHasher
     double theCompTolerance = Precision::Computational(),
     double theHashTolerance = Precision::Computational());
 
-  Standard_EXPORT std::size_t operator()(const occ::handle<Poly_Triangulation>& theTri) const
-    noexcept;
+  Standard_EXPORT std::size_t operator()(
+    const occ::handle<Poly_Triangulation>& theTri) const noexcept;
 
   Standard_EXPORT bool operator()(const occ::handle<Poly_Triangulation>& theTri1,
                                   const occ::handle<Poly_Triangulation>& theTri2) const noexcept;

--- a/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_ApproxAFunc2Var.cxx
+++ b/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_ApproxAFunc2Var.cxx
@@ -967,12 +967,12 @@ void AdvApp2Var_ApproxAFunc2Var::ConvertBS()
                                       iv,
                                       myMaxDegInU,
                                       myMaxDegInV,
-                                      NbCoeff,
-                                      Poly,
-                                      Uint1,
-                                      Vint1,
-                                      Uint2,
-                                      Vint2);
+                                      NbCoeff->Array2(),
+                                      Poly->Array1(),
+                                      Uint1->Array1(),
+                                      Vint1->Array1(),
+                                      Uint2->Array1(),
+                                      Vint2->Array1());
     if (!CvP.IsDone())
     {
       myDone = false;

--- a/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_Patch.cxx
+++ b/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_Patch.cxx
@@ -1126,19 +1126,18 @@ occ::handle<NCollection_HArray2<gp_Pnt>> AdvApp2Var_Patch::Poles(
   {
     throw Standard_ConstructionError("AdvApp2Var_Patch::Poles :  SSPIndex out of range");
   }
-  occ::handle<NCollection_HArray1<double>> Intervalle = new (NCollection_HArray1<double>)(1, 2);
-  Intervalle->SetValue(1, -1);
-  Intervalle->SetValue(2, 1);
+  NCollection_Array1<double> Intervalle(1, 2);
+  Intervalle.SetValue(1, -1);
+  Intervalle.SetValue(2, 1);
 
-  occ::handle<NCollection_HArray1<int>> NbCoeff = new (NCollection_HArray1<int>)(1, 2);
-  NbCoeff->SetValue(1, myNbCoeffInU);
-  NbCoeff->SetValue(2, myNbCoeffInV);
+  NCollection_Array1<int> NbCoeff(1, 2);
+  NbCoeff.SetValue(1, myNbCoeffInU);
+  NbCoeff.SetValue(2, myNbCoeffInV);
 
-  // Conversion
   Convert_GridPolynomialToPoles Conv(Cond.ULimit() - 1,
                                      Cond.VLimit() - 1,
                                      NbCoeff,
-                                     SousEquation,
+                                     SousEquation->Array1(),
                                      Intervalle,
                                      Intervalle);
 


### PR DESCRIPTION
- Added Array1 views for contiguous NCollection containers, including const read-only views for LinearVector and LocalArray.
- Updated Poly mesh containers and copy paths to preserve contiguous data, deflection, cached bounds, and triangulation parameters.
- Added mesh hashers for polygons and triangulations with tests covering tolerant equality and hash consistency.
- Kept the common base allocator alive through process finalization to avoid static destruction order crashes.