### PR TITLE
DRAW - Continue pload after missing plugins

### DIFF
--- a/src/Draw/TKDraw/Draw/Draw_PloadCommands.cxx
+++ b/src/Draw/TKDraw/Draw/Draw_PloadCommands.cxx
@@ -14,6 +14,7 @@
 // commercial license or contractual agreement.
 
 #include <Draw_Interpretor.hxx>
+#include <Draw_Failure.hxx>
 #include <TCollection_AsciiString.hxx>
 #include <NCollection_IndexedMap.hxx>
 #include <Draw.hxx>
@@ -203,6 +204,8 @@ static int Pload(Draw_Interpretor& theDI, int theNbArgs, const char** theArgVec)
   resolveKeys(aMap, aResMgr);
 
   const int aMapExtent = aMap.Extent();
+  int       aNbLoaded  = 0;
+  int       aNbSkipped = 0;
   for (int aResIter = 1; aResIter <= aMapExtent; ++aResIter)
   {
     const TCollection_AsciiString& aResource = aMap.FindKey(aResIter);
@@ -213,6 +216,7 @@ static int Pload(Draw_Interpretor& theDI, int theNbArgs, const char** theArgVec)
     if (!aResMgr->Find(aResource, aValue))
     {
       Message::SendWarning() << "Pload : Resource = " << aResource << " is not found";
+      ++aNbSkipped;
       continue;
     }
 
@@ -220,7 +224,18 @@ static int Pload(Draw_Interpretor& theDI, int theNbArgs, const char** theArgVec)
     std::cout << "Value ==> " << aValue << std::endl;
 #endif
 
-    Draw::Load(theDI, aResource, aPluginFileName, aPluginDir, aPluginDir2, false);
+    try
+    {
+      Draw::Load(theDI, aResource, aPluginFileName, aPluginDir, aPluginDir2, false);
+    }
+    catch (const Draw_Failure& theFailure)
+    {
+      Message::SendWarning() << "Pload : Cannot load plugin " << aResource << ": "
+                             << theFailure.what();
+      ++aNbSkipped;
+      continue;
+    }
+    ++aNbLoaded;
 
     // Load TclScript
     const TCollection_AsciiString aTclScriptDir = OSD_Environment("CSF_DrawPluginTclDir").Value();
@@ -242,6 +257,16 @@ static int Pload(Draw_Interpretor& theDI, int theNbArgs, const char** theArgVec)
 #endif
       theDI.EvalFile(aTclScriptFileNameDefaults.ToCString());
     }
+  }
+  if (aNbSkipped > 0)
+  {
+    Message::SendWarning() << "Pload : Loaded " << aNbLoaded << " plugin(s), skipped " << aNbSkipped
+                           << " plugin(s)";
+  }
+  if (aNbLoaded == 0 && aNbSkipped > 0)
+  {
+    Message::SendFail() << "Pload : No plugins loaded";
+    return 1;
   }
   return 0;
 }

--- a/tests/bugs/fclasses/bug1281
+++ b/tests/bugs/fclasses/bug1281
@@ -1,0 +1,54 @@
+puts "============"
+puts "GH1281"
+puts "============"
+puts ""
+#######################################################################
+# pload ALL should keep loading remaining plugins when one plugin library
+# from the resource list is absent.
+#######################################################################
+
+set aPluginFileName "Bug1281DrawPlugin"
+set aPluginFilePath "${imagedir}/${aPluginFileName}"
+set aScriptFilePath "${imagedir}/TKTopTest.tcl"
+set aPluginVar "CSF_${aPluginFileName}Defaults"
+set aMarker "::bug1281_plugin_after_missing"
+set anOldDefaults [dgetenv ${aPluginVar}]
+unset -nocomplain ${aMarker}
+
+set aFile [open ${aPluginFilePath} w]
+puts ${aFile} "ALL : MISSING, VALID"
+puts ${aFile} "MISSING : TKMissingDrawPluginForBug1281"
+puts ${aFile} "VALID : TKTopTest"
+close ${aFile}
+
+set aFile [open ${aScriptFilePath} w]
+puts ${aFile} "set ${aMarker} 1"
+close ${aFile}
+
+dsetenv ${aPluginVar} ${imagedir}
+
+if {[catch {pload -${aPluginFileName} ALL} aResult]} {
+  puts "Error: pload ALL aborted on a missing plugin: ${aResult}"
+}
+
+if {![info exists ${aMarker}]} {
+  puts "Error: pload ALL did not continue loading plugins after a missing plugin"
+}
+
+set aFile [open ${aPluginFilePath} w]
+puts ${aFile} "ALL : MISSING"
+puts ${aFile} "MISSING : TKMissingDrawPluginForBug1281"
+close ${aFile}
+
+if {![catch {pload -${aPluginFileName} ALL} aResult]} {
+  puts "Error: pload ALL did not report an error when every plugin was missing"
+}
+
+if {${anOldDefaults} == ""} {
+  dsetenv ${aPluginVar}
+} else {
+  dsetenv ${aPluginVar} ${anOldDefaults}
+}
+unset -nocomplain ${aMarker}
+file delete -force ${aPluginFilePath}
+file delete -force ${aScriptFilePath}


### PR DESCRIPTION
- Catch Draw plugin load errors per resource so group loads can continue after an optional toolkit is absent.
- Report loaded and skipped plugin counts, and return an error only when no requested plugins were loaded.
- Add a regression test covering mixed missing/valid plugins and the all-missing error path.