### PR TITLE
Visualization - Add back-face vertex color policy

### DIFF
--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest.cxx
@@ -1730,6 +1730,9 @@ struct ViewerTest_AspectsChangeSet
   int                             ToSetFaceCulling;
   Graphic3d_TypeOfBackfacingModel FaceCulling;
 
+  int  ToSetUseVertexColorForBackFaces;
+  bool UseVertexColorForBackFaces;
+
   int                      ToSetMaterial;
   Graphic3d_NameOfMaterial Material;
   TCollection_AsciiString  MatName;
@@ -1813,6 +1816,8 @@ struct ViewerTest_AspectsChangeSet
         AlphaCutoff(0.5f),
         ToSetFaceCulling(0),
         FaceCulling(Graphic3d_TypeOfBackfacingModel_Auto),
+        ToSetUseVertexColorForBackFaces(0),
+        UseVertexColorForBackFaces(true),
         ToSetMaterial(0),
         Material(Graphic3d_NameOfMaterial_DEFAULT),
         ToSetShowFreeBoundary(0),
@@ -1859,6 +1864,7 @@ struct ViewerTest_AspectsChangeSet
   {
     return ToSetVisibility == 0 && ToSetLineWidth == 0 && ToSetTransparency == 0
            && ToSetAlphaMode == 0 && ToSetFaceCulling == 0 && ToSetColor == 0
+           && ToSetUseVertexColorForBackFaces == 0
            && ToSetBackFaceColor == 0 && ToSetMaterial == 0 && ToSetShowFreeBoundary == 0
            && ToSetFreeBoundaryColor == 0 && ToSetFreeBoundaryWidth == 0
            && ToEnableIsoOnTriangulation == 0 && ToSetFaceBoundaryDraw == 0
@@ -2100,6 +2106,14 @@ struct ViewerTest_AspectsChangeSet
       {
         toRecompute = theDrawer->SetupOwnShadingAspect(aDefDrawer) || toRecompute;
         theDrawer->ShadingAspect()->Aspect()->SetFaceCulling(FaceCulling);
+      }
+    }
+    if (ToSetUseVertexColorForBackFaces != 0)
+    {
+      if (ToSetUseVertexColorForBackFaces != -1 || theDrawer->HasOwnShadingAspect())
+      {
+        toRecompute = theDrawer->SetupOwnShadingAspect(aDefDrawer) || toRecompute;
+        theDrawer->ShadingAspect()->SetUseVertexColorForBackFaces(UseVertexColorForBackFaces);
       }
     }
     if (ToSetHatch != 0)
@@ -2591,6 +2605,37 @@ static int VAspects(Draw_Interpretor& theDI, int theArgNb, const char** theArgVe
           return 1;
         }
       }
+    }
+    else if (anArg == "-usevertexcolorforbackfaces" || anArg == "-usebackvertexcolor"
+             || anArg == "-usebackfacevertexcolor")
+    {
+      bool toUse = true;
+      if (!Draw::ParseOnOff(anArgIter + 1 < theArgNb ? theArgVec[anArgIter + 1] : "", toUse))
+      {
+        Message::SendFail() << "Error: wrong syntax at " << anArg;
+        return 1;
+      }
+      ++anArgIter;
+      aChangeSet->ToSetUseVertexColorForBackFaces = 1;
+      aChangeSet->UseVertexColorForBackFaces      = toUse;
+    }
+    else if (anArg == "-frontonlyvertexcolor" || anArg == "-frontonlyvertexcolorforbackfaces")
+    {
+      bool toUseFrontOnly = true;
+      if (!Draw::ParseOnOff(anArgIter + 1 < theArgNb ? theArgVec[anArgIter + 1] : "",
+                            toUseFrontOnly))
+      {
+        Message::SendFail() << "Error: wrong syntax at " << anArg;
+        return 1;
+      }
+      ++anArgIter;
+      aChangeSet->ToSetUseVertexColorForBackFaces = 1;
+      aChangeSet->UseVertexColorForBackFaces      = !toUseFrontOnly;
+    }
+    else if (anArg == "-unsetusevertexcolorforbackfaces" || anArg == "-unsetbackvertexcolor")
+    {
+      aChangeSet->ToSetUseVertexColorForBackFaces = -1;
+      aChangeSet->UseVertexColorForBackFaces      = true;
     }
     else if (anArg == "-setvis" || anArg == "-setvisibility" || anArg == "-visibility")
     {
@@ -3141,10 +3186,12 @@ static int VAspects(Draw_Interpretor& theDI, int theArgNb, const char** theArgVe
       aChangeSet->ToSetAlphaMode     = -1;
       aChangeSet->AlphaMode          = Graphic3d_AlphaMode_BlendAuto;
       aChangeSet->AlphaCutoff        = 0.5f;
-      aChangeSet->ToSetFaceCulling   = -1;
-      aChangeSet->FaceCulling        = Graphic3d_TypeOfBackfacingModel_Auto;
-      aChangeSet->ToSetColor         = -1;
-      aChangeSet->Color              = DEFAULT_COLOR;
+      aChangeSet->ToSetFaceCulling                 = -1;
+      aChangeSet->FaceCulling                      = Graphic3d_TypeOfBackfacingModel_Auto;
+      aChangeSet->ToSetUseVertexColorForBackFaces = -1;
+      aChangeSet->UseVertexColorForBackFaces      = true;
+      aChangeSet->ToSetColor                       = -1;
+      aChangeSet->Color                            = DEFAULT_COLOR;
       // aChangeSet->ToSetBackFaceColor = -1; // should be reset by ToSetColor
       // aChangeSet->BackFaceColor = DEFAULT_COLOR;
       aChangeSet->ToSetMaterial              = -1;
@@ -6795,6 +6842,7 @@ vaspects [-noupdate|-update] [name1 [name2 [...]] | -defaults] [-subshapes subna
          [-visibility {0|1}]
          [-color {ColorName | R G B}] [-unsetColor]
          [-backfaceColor Color] [-faceCulling {auto|back|front|doublesided}]
+         [-useVertexColorForBackFaces {0|1}] [-unsetUseVertexColorForBackFaces]
          [-material MatName] [-unsetMaterial]
          [-transparency Transp] [-unsetTransparency]
          [-width LineWidth] [-unsetWidth]

--- a/src/Draw/TKViewerTest/ViewerTest/ViewerTest.cxx
+++ b/src/Draw/TKViewerTest/ViewerTest/ViewerTest.cxx
@@ -1864,16 +1864,15 @@ struct ViewerTest_AspectsChangeSet
   {
     return ToSetVisibility == 0 && ToSetLineWidth == 0 && ToSetTransparency == 0
            && ToSetAlphaMode == 0 && ToSetFaceCulling == 0 && ToSetColor == 0
-           && ToSetUseVertexColorForBackFaces == 0
-           && ToSetBackFaceColor == 0 && ToSetMaterial == 0 && ToSetShowFreeBoundary == 0
-           && ToSetFreeBoundaryColor == 0 && ToSetFreeBoundaryWidth == 0
-           && ToEnableIsoOnTriangulation == 0 && ToSetFaceBoundaryDraw == 0
-           && ToSetFaceBoundaryUpperContinuity == 0 && ToSetFaceBoundaryColor == 0
-           && ToSetFaceBoundaryWidth == 0 && ToSetTypeOfFaceBoundaryLine == 0
-           && ToSetMaxParamValue == 0 && ToSetSensitivity == 0 && ToSetHatch == 0
-           && ToSetShadingModel == 0 && ToSetInterior == 0 && ToSetDrawSilhouette == 0
-           && ToSetDrawEdges == 0 && ToSetQuadEdges == 0 && ToSetEdgeColor == 0
-           && ToSetEdgeWidth == 0 && ToSetTypeOfEdge == 0;
+           && ToSetUseVertexColorForBackFaces == 0 && ToSetBackFaceColor == 0 && ToSetMaterial == 0
+           && ToSetShowFreeBoundary == 0 && ToSetFreeBoundaryColor == 0
+           && ToSetFreeBoundaryWidth == 0 && ToEnableIsoOnTriangulation == 0
+           && ToSetFaceBoundaryDraw == 0 && ToSetFaceBoundaryUpperContinuity == 0
+           && ToSetFaceBoundaryColor == 0 && ToSetFaceBoundaryWidth == 0
+           && ToSetTypeOfFaceBoundaryLine == 0 && ToSetMaxParamValue == 0 && ToSetSensitivity == 0
+           && ToSetHatch == 0 && ToSetShadingModel == 0 && ToSetInterior == 0
+           && ToSetDrawSilhouette == 0 && ToSetDrawEdges == 0 && ToSetQuadEdges == 0
+           && ToSetEdgeColor == 0 && ToSetEdgeWidth == 0 && ToSetTypeOfEdge == 0;
   }
 
   //! @return true if properties are valid
@@ -3170,28 +3169,28 @@ static int VAspects(Draw_Interpretor& theDI, int theArgNb, const char** theArgVe
     }
     else if (anArg == "-unset")
     {
-      aChangeSet->ToSetVisibility    = 1;
-      aChangeSet->Visibility         = 1;
-      aChangeSet->ToSetLineWidth     = -1;
-      aChangeSet->LineWidth          = 1.0;
-      aChangeSet->ToSetTypeOfLine    = -1;
-      aChangeSet->StippleLinePattern = 0xFFFF;
-      aChangeSet->StippleLineFactor  = 1;
-      aChangeSet->ToSetTypeOfMarker  = -1;
-      aChangeSet->TypeOfMarker       = Aspect_TOM_PLUS;
-      aChangeSet->ToSetMarkerSize    = -1;
-      aChangeSet->MarkerSize         = 1.0;
-      aChangeSet->ToSetTransparency  = -1;
-      aChangeSet->Transparency       = 0.0;
-      aChangeSet->ToSetAlphaMode     = -1;
-      aChangeSet->AlphaMode          = Graphic3d_AlphaMode_BlendAuto;
-      aChangeSet->AlphaCutoff        = 0.5f;
-      aChangeSet->ToSetFaceCulling                 = -1;
-      aChangeSet->FaceCulling                      = Graphic3d_TypeOfBackfacingModel_Auto;
+      aChangeSet->ToSetVisibility                 = 1;
+      aChangeSet->Visibility                      = 1;
+      aChangeSet->ToSetLineWidth                  = -1;
+      aChangeSet->LineWidth                       = 1.0;
+      aChangeSet->ToSetTypeOfLine                 = -1;
+      aChangeSet->StippleLinePattern              = 0xFFFF;
+      aChangeSet->StippleLineFactor               = 1;
+      aChangeSet->ToSetTypeOfMarker               = -1;
+      aChangeSet->TypeOfMarker                    = Aspect_TOM_PLUS;
+      aChangeSet->ToSetMarkerSize                 = -1;
+      aChangeSet->MarkerSize                      = 1.0;
+      aChangeSet->ToSetTransparency               = -1;
+      aChangeSet->Transparency                    = 0.0;
+      aChangeSet->ToSetAlphaMode                  = -1;
+      aChangeSet->AlphaMode                       = Graphic3d_AlphaMode_BlendAuto;
+      aChangeSet->AlphaCutoff                     = 0.5f;
+      aChangeSet->ToSetFaceCulling                = -1;
+      aChangeSet->FaceCulling                     = Graphic3d_TypeOfBackfacingModel_Auto;
       aChangeSet->ToSetUseVertexColorForBackFaces = -1;
       aChangeSet->UseVertexColorForBackFaces      = true;
-      aChangeSet->ToSetColor                       = -1;
-      aChangeSet->Color                            = DEFAULT_COLOR;
+      aChangeSet->ToSetColor                      = -1;
+      aChangeSet->Color                           = DEFAULT_COLOR;
       // aChangeSet->ToSetBackFaceColor = -1; // should be reset by ToSetColor
       // aChangeSet->BackFaceColor = DEFAULT_COLOR;
       aChangeSet->ToSetMaterial              = -1;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.cxx
@@ -2359,8 +2359,6 @@ void OpenGl_Context::SetShadingMaterial(
     myMaterial.Pbr[1].BaseColor.a() = anAlphaBack;
   }
 
-  // do not update material properties in case of zero reflection mode,
-  // because GL lighting will be disabled by OpenGl_PrimitiveArray::DrawArray() anyway.
   const OpenGl_MaterialState& aMatState     = myShaderManager->MaterialState();
   float                       anAlphaCutoff = (anAspect->AlphaMode() == Graphic3d_AlphaMode_Mask
                          || anAspect->AlphaMode() == Graphic3d_AlphaMode_MaskBlend)
@@ -2383,7 +2381,8 @@ void OpenGl_Context::SetShadingMaterial(
     }
   }
   else if (myMaterial.IsEqual(aMatState.Material()) && toDistinguish == aMatState.ToDistinguish()
-           && toMapTexture == aMatState.ToMapTexture() && anAlphaCutoff == aMatState.AlphaCutoff())
+           && toMapTexture == aMatState.ToMapTexture()
+           && anAlphaCutoff == aMatState.AlphaCutoff())
   {
     return;
   }
@@ -2433,17 +2432,30 @@ bool OpenGl_Context::CheckIsTransparent(
 
 void OpenGl_Context::SetColor4fv(const NCollection_Vec4<float>& theColor)
 {
+  SetColor4fv(theColor, theColor);
+}
+
+//=================================================================================================
+
+void OpenGl_Context::SetColor4fv(const NCollection_Vec4<float>& theFrontColor,
+                                 const NCollection_Vec4<float>& theBackColor)
+{
   if (!myActiveProgram.IsNull())
   {
     if (const OpenGl_ShaderUniformLocation& aLoc =
           myActiveProgram->GetStateLocation(OpenGl_OCCT_COLOR))
     {
-      myActiveProgram->SetUniform(this, aLoc, Vec4FromQuantityColor(theColor));
+      myActiveProgram->SetUniform(this, aLoc, Vec4FromQuantityColor(theFrontColor));
+    }
+    if (const OpenGl_ShaderUniformLocation& aLoc =
+          myActiveProgram->GetStateLocation(OpenGl_OCCT_BACK_COLOR))
+    {
+      myActiveProgram->SetUniform(this, aLoc, Vec4FromQuantityColor(theBackColor));
     }
   }
   else if (core11ffp != nullptr)
   {
-    core11ffp->glColor4fv(theColor.GetData());
+    core11ffp->glColor4fv(theFrontColor.GetData());
   }
 }
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.cxx
@@ -2381,8 +2381,7 @@ void OpenGl_Context::SetShadingMaterial(
     }
   }
   else if (myMaterial.IsEqual(aMatState.Material()) && toDistinguish == aMatState.ToDistinguish()
-           && toMapTexture == aMatState.ToMapTexture()
-           && anAlphaCutoff == aMatState.AlphaCutoff())
+           && toMapTexture == aMatState.ToMapTexture() && anAlphaCutoff == aMatState.AlphaCutoff())
   {
     return;
   }

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Context.hxx
@@ -887,6 +887,10 @@ public: //! @name methods to alter or retrieve current state
   //! Setup current color.
   Standard_EXPORT void SetColor4fv(const NCollection_Vec4<float>& theColor);
 
+  //! Setup current front and back colors.
+  Standard_EXPORT void SetColor4fv(const NCollection_Vec4<float>& theFrontColor,
+                                   const NCollection_Vec4<float>& theBackColor);
+
   //! Setup type of line.
   Standard_EXPORT void SetTypeOfLine(const Aspect_TypeOfLine theType, const float theFactor = 1.0f);
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
@@ -1003,7 +1003,7 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
           aTextureSet,
           aShadingModel,
           aCtx->ShaderManager()->MaterialState().HasAlphaCutoff() ? Graphic3d_AlphaMode_Mask
-                                                                   : Graphic3d_AlphaMode_Opaque,
+                                                                  : Graphic3d_AlphaMode_Opaque,
           toDrawInteriorEdges == 1 ? anAspectFace->Aspect()->InteriorStyle() : Aspect_IS_SOLID,
           hasVertColor,
           anAspectFace->Aspect()->ToUseVertexColorForBackFaces(),
@@ -1046,7 +1046,7 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
           && anAspectFace->Aspect()->InteriorStyle() != Aspect_IS_HIDDENLINE
         ? myBounds->Colors
         : nullptr;
-    const NCollection_Vec4<float>& anInteriorColor = theWorkspace->InteriorColor();
+    const NCollection_Vec4<float>& anInteriorColor    = theWorkspace->InteriorColor();
     const NCollection_Vec4<float>& aBackInteriorColor = theWorkspace->BackInteriorColor();
     aCtx->SetColor4fv(anInteriorColor, aBackInteriorColor);
     if (!myIsFillType)

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.cxx
@@ -447,7 +447,9 @@ void OpenGl_PrimitiveArray::updateVBO(const occ::handle<OpenGl_Context>& theCtx)
 
 void OpenGl_PrimitiveArray::drawArray(const occ::handle<OpenGl_Workspace>& theWorkspace,
                                       const NCollection_Vec4<float>*       theFaceColors,
-                                      const bool                           theHasVertColor) const
+                                      const NCollection_Vec4<float>&       theBackColor,
+                                      const bool                           theHasVertColor,
+                                      const bool theToUseVertexColorForBackFaces) const
 {
   const occ::handle<OpenGl_Context>& aGlContext = theWorkspace->GetGlContext();
   if (myVboAttribs.IsNull())
@@ -466,6 +468,12 @@ void OpenGl_PrimitiveArray::drawArray(const occ::handle<OpenGl_Workspace>& theWo
       ? GL_PATCHES
       : myDrawMode;
   myVboAttribs->BindAllAttributes(aGlContext);
+  if (theHasVertColor && !toHilight && myIsFillType && !theToUseVertexColorForBackFaces
+      && aGlContext->ActiveProgram().IsNull() && aGlContext->core11ffp != nullptr)
+  {
+    // This affects FFP lighting. Unlit FFP uses primary color directly for both sides.
+    aGlContext->core11ffp->glColorMaterial(GL_FRONT, GL_AMBIENT_AND_DIFFUSE);
+  }
   if (theHasVertColor && toHilight)
   {
     // disable per-vertex color
@@ -486,7 +494,7 @@ void OpenGl_PrimitiveArray::drawArray(const occ::handle<OpenGl_Workspace>& theWo
         const GLint aNbElemsInGroup = myBounds->Bounds[aGroupIter];
         if (theFaceColors != nullptr)
         {
-          aGlContext->SetColor4fv(theFaceColors[aGroupIter]);
+          aGlContext->SetColor4fv(theFaceColors[aGroupIter], theBackColor);
         }
         aGlContext->core11fwd->glDrawElements(aDrawMode,
                                               aNbElemsInGroup,
@@ -513,7 +521,7 @@ void OpenGl_PrimitiveArray::drawArray(const occ::handle<OpenGl_Workspace>& theWo
       const GLint aNbElemsInGroup = myBounds->Bounds[aGroupIter];
       if (theFaceColors != nullptr)
       {
-        aGlContext->SetColor4fv(theFaceColors[aGroupIter]);
+        aGlContext->SetColor4fv(theFaceColors[aGroupIter], theBackColor);
       }
       aGlContext->core11fwd->glDrawArrays(aDrawMode, aFirstElem, aNbElemsInGroup);
       aFirstElem += aNbElemsInGroup;
@@ -995,9 +1003,10 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
           aTextureSet,
           aShadingModel,
           aCtx->ShaderManager()->MaterialState().HasAlphaCutoff() ? Graphic3d_AlphaMode_Mask
-                                                                  : Graphic3d_AlphaMode_Opaque,
+                                                                   : Graphic3d_AlphaMode_Opaque,
           toDrawInteriorEdges == 1 ? anAspectFace->Aspect()->InteriorStyle() : Aspect_IS_SOLID,
           hasVertColor,
+          anAspectFace->Aspect()->ToUseVertexColorForBackFaces(),
           toEnableEnvMap,
           toDrawInteriorEdges == 1,
           anAspectFace->ShaderProgramRes(aCtx));
@@ -1038,7 +1047,8 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
         ? myBounds->Colors
         : nullptr;
     const NCollection_Vec4<float>& anInteriorColor = theWorkspace->InteriorColor();
-    aCtx->SetColor4fv(anInteriorColor);
+    const NCollection_Vec4<float>& aBackInteriorColor = theWorkspace->BackInteriorColor();
+    aCtx->SetColor4fv(anInteriorColor, aBackInteriorColor);
     if (!myIsFillType)
     {
       if (myDrawMode == GL_LINES || myDrawMode == GL_LINE_STRIP)
@@ -1048,7 +1058,11 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
         aCtx->SetLineWidth(anAspectFace->Aspect()->LineWidth());
       }
 
-      drawArray(theWorkspace, aFaceColors, hasColorAttrib);
+      drawArray(theWorkspace,
+                aFaceColors,
+                aBackInteriorColor,
+                hasColorAttrib,
+                anAspectFace->Aspect()->ToUseVertexColorForBackFaces());
       if (isForcedBlend)
       {
         aCtx->core11fwd->glDisable(GL_BLEND);
@@ -1056,7 +1070,11 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
       return;
     }
 
-    drawArray(theWorkspace, aFaceColors, hasColorAttrib);
+    drawArray(theWorkspace,
+              aFaceColors,
+              aBackInteriorColor,
+              hasColorAttrib,
+              anAspectFace->Aspect()->ToUseVertexColorForBackFaces());
 
     // draw outline - only closed triangulation with defined vertex normals can be drawn in this way
     if (anAspectFace->Aspect()->ToDrawSilhouette() && aCtx->ToCullBackFaces()
@@ -1080,7 +1098,7 @@ void OpenGl_PrimitiveArray::Render(const occ::handle<OpenGl_Workspace>& theWorks
       aCtx->SetColor4fv(anAspectFace->Aspect()->EdgeColorRGBA());
 
       aCtx->SetFaceCulling(Graphic3d_TypeOfBackfacingModel_FrontCulled);
-      drawArray(theWorkspace, nullptr, false);
+      drawArray(theWorkspace, nullptr, aBackInteriorColor, false, true);
       aCtx->SetFaceCulling(Graphic3d_TypeOfBackfacingModel_BackCulled);
     }
 

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_PrimitiveArray.hxx
@@ -128,7 +128,9 @@ private:
   //! Main procedure to draw array
   void drawArray(const occ::handle<OpenGl_Workspace>& theWorkspace,
                  const NCollection_Vec4<float>*       theFaceColors,
-                 const bool                           theHasVertColor) const;
+                 const NCollection_Vec4<float>&       theBackColor,
+                 const bool                           theHasVertColor,
+                 const bool                           theToUseVertexColorForBackFaces) const;
 
   //! Auxiliary procedures
   void drawEdges(const occ::handle<OpenGl_Workspace>& theWorkspace) const;

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.cxx
@@ -1533,8 +1533,13 @@ bool OpenGl_ShaderManager::BindMarkerProgram(
     return bindProgramWithState(theCustomProgram, theShadingModel);
   }
 
-  int aBits =
-    getProgramBits(theTextures, theAlphaMode, Aspect_IS_SOLID, theHasVertColor, false, false);
+  int aBits = getProgramBits(theTextures,
+                             theAlphaMode,
+                             Aspect_IS_SOLID,
+                             theHasVertColor,
+                             true, // markers have no front/back face semantics
+                             false,
+                             false);
   if (!theTextures.IsNull() && theTextures->HasPointSprite())
   {
     aBits |= theTextures->Last()->IsAlpha() ? Graphic3d_ShaderFlags_PointSpriteA

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
@@ -135,12 +135,12 @@ public:
     }
 
     const int                          aBits    = getProgramBits(theTextures,
-                                      theAlphaMode,
-                                      theInteriorStyle,
-                                      theHasVertColor,
-                                      theToUseVertexColorForBackFaces,
-                                      theEnableEnvMap,
-                                      theEnableMeshEdges);
+                                     theAlphaMode,
+                                     theInteriorStyle,
+                                     theHasVertColor,
+                                     theToUseVertexColorForBackFaces,
+                                     theEnableEnvMap,
+                                     theEnableMeshEdges);
     occ::handle<OpenGl_ShaderProgram>& aProgram = getStdProgram(aShadeModelOnFace, aBits);
     return bindProgramWithState(aProgram, aShadeModelOnFace);
   }
@@ -607,11 +607,11 @@ protected:
   //! Define program bits.
   int getProgramBits(const occ::handle<OpenGl_TextureSet>& theTextures,
                      Graphic3d_AlphaMode                   theAlphaMode,
-                      Aspect_InteriorStyle                  theInteriorStyle,
-                      bool                                  theHasVertColor,
-                      bool                                  theToUseVertexColorForBackFaces,
-                      bool                                  theEnableEnvMap,
-                      bool                                  theEnableMeshEdges) const
+                     Aspect_InteriorStyle                  theInteriorStyle,
+                     bool                                  theHasVertColor,
+                     bool                                  theToUseVertexColorForBackFaces,
+                     bool                                  theEnableEnvMap,
+                     bool                                  theEnableMeshEdges) const
   {
     int aBits = 0;
     if (theAlphaMode == Graphic3d_AlphaMode_Mask || theAlphaMode == Graphic3d_AlphaMode_MaskBlend)

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderManager.hxx
@@ -107,6 +107,7 @@ public:
                            theAlphaMode,
                            Aspect_IS_SOLID,
                            theHasVertColor,
+                           true, // use vertex color for back faces by default for compatibility
                            theEnableEnvMap,
                            false,
                            theCustomProgram);
@@ -118,6 +119,7 @@ public:
                        Graphic3d_AlphaMode                      theAlphaMode,
                        Aspect_InteriorStyle                     theInteriorStyle,
                        bool                                     theHasVertColor,
+                       bool                                     theToUseVertexColorForBackFaces,
                        bool                                     theEnableEnvMap,
                        bool                                     theEnableMeshEdges,
                        const occ::handle<OpenGl_ShaderProgram>& theCustomProgram)
@@ -133,11 +135,12 @@ public:
     }
 
     const int                          aBits    = getProgramBits(theTextures,
-                                     theAlphaMode,
-                                     theInteriorStyle,
-                                     theHasVertColor,
-                                     theEnableEnvMap,
-                                     theEnableMeshEdges);
+                                      theAlphaMode,
+                                      theInteriorStyle,
+                                      theHasVertColor,
+                                      theToUseVertexColorForBackFaces,
+                                      theEnableEnvMap,
+                                      theEnableMeshEdges);
     occ::handle<OpenGl_ShaderProgram>& aProgram = getStdProgram(aShadeModelOnFace, aBits);
     return bindProgramWithState(aProgram, aShadeModelOnFace);
   }
@@ -155,8 +158,13 @@ public:
       return bindProgramWithState(theCustomProgram, theShadingModel);
     }
 
-    int aBits =
-      getProgramBits(theTextures, theAlphaMode, Aspect_IS_SOLID, theHasVertColor, false, false);
+    int aBits = getProgramBits(theTextures,
+                               theAlphaMode,
+                               Aspect_IS_SOLID,
+                               theHasVertColor,
+                               true, // lines have no front/back face semantics
+                               false,
+                               false);
     if (theLineType != Aspect_TOL_SOLID)
     {
       aBits |= Graphic3d_ShaderFlags_StippleLine;
@@ -188,6 +196,7 @@ public:
                                      Graphic3d_AlphaMode_Opaque,
                                      Aspect_IS_SOLID,
                                      false,
+                                     true, // outline has no vertex-color back-face policy
                                      false,
                                      false);
     if (myOutlinePrograms.IsNull())
@@ -598,10 +607,11 @@ protected:
   //! Define program bits.
   int getProgramBits(const occ::handle<OpenGl_TextureSet>& theTextures,
                      Graphic3d_AlphaMode                   theAlphaMode,
-                     Aspect_InteriorStyle                  theInteriorStyle,
-                     bool                                  theHasVertColor,
-                     bool                                  theEnableEnvMap,
-                     bool                                  theEnableMeshEdges) const
+                      Aspect_InteriorStyle                  theInteriorStyle,
+                      bool                                  theHasVertColor,
+                      bool                                  theToUseVertexColorForBackFaces,
+                      bool                                  theEnableEnvMap,
+                      bool                                  theEnableMeshEdges) const
   {
     int aBits = 0;
     if (theAlphaMode == Graphic3d_AlphaMode_Mask || theAlphaMode == Graphic3d_AlphaMode_MaskBlend)
@@ -635,6 +645,10 @@ protected:
     if (theHasVertColor && theInteriorStyle != Aspect_IS_HIDDENLINE)
     {
       aBits |= Graphic3d_ShaderFlags_VertColor;
+      if (!theToUseVertexColorForBackFaces)
+      {
+        aBits |= Graphic3d_ShaderFlags_VertColorFrontOnly;
+      }
     }
 
     if (myOitState.ActiveMode() == Graphic3d_RTM_BLEND_OIT)

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.cxx
@@ -69,6 +69,7 @@ const char* OpenGl_ShaderProgram::PredefinedKeywords[] = {
   "occCommonMaterial",     // OpenGl_OCCT_COMMON_MATERIAL
   "occAlphaCutoff",        // OpenGl_OCCT_ALPHA_CUTOFF
   "occColor",              // OpenGl_OCCT_COLOR
+  "occBackColor",          // OpenGl_OCCT_BACK_COLOR
 
   "occOitOutput",      // OpenGl_OCCT_OIT_OUTPUT
   "occOitDepthFactor", // OpenGl_OCCT_OIT_DEPTH_FACTOR

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_ShaderProgram.hxx
@@ -65,6 +65,7 @@ enum OpenGl_StateVariable
   OpenGl_OCCT_COMMON_MATERIAL,
   OpenGl_OCCT_ALPHA_CUTOFF,
   OpenGl_OCCT_COLOR,
+  OpenGl_OCCT_BACK_COLOR,
 
   // Weighted, Blended Order-Independent Transparency rendering state
   OpenGl_OCCT_OIT_OUTPUT,

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Workspace.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Workspace.hxx
@@ -121,7 +121,15 @@ public:
   const NCollection_Vec4<float>& InteriorColor() const
   {
     return !myHighlightStyle.IsNull() ? myHighlightStyle->ColorRGBA()
-                                      : myAspectsSet->Aspect()->InteriorColorRGBA();
+                                       : myAspectsSet->Aspect()->InteriorColorRGBA();
+  }
+
+  //! Return back interior color taking into account highlight and distinguish flags.
+  const NCollection_Vec4<float>& BackInteriorColor() const
+  {
+    return !myHighlightStyle.IsNull() ? myHighlightStyle->ColorRGBA()
+           : myAspectsSet->Aspect()->Distinguish() ? myAspectsSet->Aspect()->BackInteriorColorRGBA()
+                                                   : myAspectsSet->Aspect()->InteriorColorRGBA();
   }
 
   //! Return text color taking into account highlight flag.

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_Workspace.hxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_Workspace.hxx
@@ -121,13 +121,13 @@ public:
   const NCollection_Vec4<float>& InteriorColor() const
   {
     return !myHighlightStyle.IsNull() ? myHighlightStyle->ColorRGBA()
-                                       : myAspectsSet->Aspect()->InteriorColorRGBA();
+                                      : myAspectsSet->Aspect()->InteriorColorRGBA();
   }
 
   //! Return back interior color taking into account highlight and distinguish flags.
   const NCollection_Vec4<float>& BackInteriorColor() const
   {
-    return !myHighlightStyle.IsNull() ? myHighlightStyle->ColorRGBA()
+    return !myHighlightStyle.IsNull()              ? myHighlightStyle->ColorRGBA()
            : myAspectsSet->Aspect()->Distinguish() ? myAspectsSet->Aspect()->BackInteriorColorRGBA()
                                                    : myAspectsSet->Aspect()->InteriorColorRGBA();
   }

--- a/src/Visualization/TKService/GTests/FILES.cmake
+++ b/src/Visualization/TKService/GTests/FILES.cmake
@@ -7,5 +7,6 @@ set(OCCT_TKService_GTests_FILES
   Graphic3d_Aspects_Test.cxx
   Graphic3d_BndBox_Test.cxx
   Graphic3d_Flipper_Test.cxx
+  Graphic3d_ShaderManager_Test.cxx
   Image_VideoRecorder_Test.cxx
 )

--- a/src/Visualization/TKService/GTests/Graphic3d_Aspects_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_Aspects_Test.cxx
@@ -32,6 +32,39 @@ TEST(Graphic3d_AspectsTest, ShadingModel_ExplicitUnlit)
   EXPECT_EQ(anAspect->ShadingModel(), Graphic3d_TypeOfShadingModel_Unlit);
 }
 
+// Test: vertex color is applied to back faces by default for backward compatibility.
+TEST(Graphic3d_AspectsTest, VertexColorForBackFaces_Default)
+{
+  occ::handle<Graphic3d_Aspects> anAspect = new Graphic3d_Aspects();
+  EXPECT_TRUE(anAspect->ToUseVertexColorForBackFaces());
+}
+
+// Test: vertex color back-face policy can be changed and participates in aspect equality.
+TEST(Graphic3d_AspectsTest, VertexColorForBackFaces_SetterAndEquality)
+{
+  occ::handle<Graphic3d_Aspects> anAspect1 = new Graphic3d_Aspects();
+  occ::handle<Graphic3d_Aspects> anAspect2 = new Graphic3d_Aspects();
+
+  EXPECT_TRUE(anAspect1->IsEqual(*anAspect2));
+
+  anAspect1->SetUseVertexColorForBackFaces(false);
+  EXPECT_FALSE(anAspect1->ToUseVertexColorForBackFaces());
+  EXPECT_FALSE(anAspect1->IsEqual(*anAspect2));
+
+  anAspect2->SetUseVertexColorForBackFaces(false);
+  EXPECT_TRUE(anAspect1->IsEqual(*anAspect2));
+}
+
+// Test: the flag is inherited by fill-area aspects used for shaded presentations.
+TEST(Graphic3d_AspectsTest, VertexColorForBackFaces_FillAreaAspect)
+{
+  occ::handle<Graphic3d_AspectFillArea3d> anAspect = new Graphic3d_AspectFillArea3d();
+  EXPECT_TRUE(anAspect->ToUseVertexColorForBackFaces());
+
+  anAspect->SetUseVertexColorForBackFaces(false);
+  EXPECT_FALSE(anAspect->ToUseVertexColorForBackFaces());
+}
+
 // Test: shading model is independent of material reflection properties.
 // Regression test: the removed optimization in OpenGl_Aspects implicitly forced UNLIT
 // when material had no reflection properties (all colors BLACK).

--- a/src/Visualization/TKService/GTests/Graphic3d_ShaderManager_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_ShaderManager_Test.cxx
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <Graphic3d_LightSet.hxx>
+#include <Graphic3d_ShaderManager.hxx>
+#include <Graphic3d_ShaderObject.hxx>
+#include <Graphic3d_ShaderProgram.hxx>
+
+namespace
+{
+class Graphic3d_ShaderManagerTestProxy : public Graphic3d_ShaderManager
+{
+public:
+  Graphic3d_ShaderManagerTestProxy()
+      : Graphic3d_ShaderManager(Aspect_GraphicsLibrary_OpenGL)
+  {
+    SetGapiVersion(3, 2);
+  }
+
+  occ::handle<Graphic3d_ShaderProgram> StdProgramUnlit(int theBits) const
+  {
+    return getStdProgramUnlit(theBits, false);
+  }
+
+  occ::handle<Graphic3d_ShaderProgram> StdProgramGouraud(
+    const occ::handle<Graphic3d_LightSet>& theLights,
+    int                                    theBits) const
+  {
+    return getStdProgramGouraud(theLights, theBits);
+  }
+
+  occ::handle<Graphic3d_ShaderProgram> StdProgramPhong(
+    const occ::handle<Graphic3d_LightSet>& theLights,
+    int                                    theBits) const
+  {
+    return getStdProgramPhong(theLights, theBits, false, false, 0);
+  }
+};
+
+bool hasShaderSource(const occ::handle<Graphic3d_ShaderProgram>& theProgram,
+                     Graphic3d_TypeOfShaderObject               theType,
+                     const TCollection_AsciiString&              theSnippet)
+{
+  for (NCollection_Sequence<occ::handle<Graphic3d_ShaderObject>>::Iterator anIter(
+         theProgram->ShaderObjects());
+       anIter.More();
+       anIter.Next())
+  {
+    const occ::handle<Graphic3d_ShaderObject>& aShader = anIter.Value();
+    if (!aShader.IsNull() && aShader->Type() == theType && aShader->Source().Search(theSnippet) > 0)
+    {
+      return true;
+    }
+  }
+  return false;
+}
+} // namespace
+
+TEST(Graphic3d_ShaderManagerTest, UnlitFrontOnlyVertexColor_UsesBackColor)
+{
+  Graphic3d_ShaderManagerTestProxy aManager;
+
+  const occ::handle<Graphic3d_ShaderProgram> aDefaultProgram =
+    aManager.StdProgramUnlit(Graphic3d_ShaderFlags_VertColor);
+  const occ::handle<Graphic3d_ShaderProgram> aFrontOnlyProgram =
+    aManager.StdProgramUnlit(Graphic3d_ShaderFlags_VertColor
+                             | Graphic3d_ShaderFlags_VertColorFrontOnly);
+
+  ASSERT_FALSE(aDefaultProgram.IsNull());
+  ASSERT_FALSE(aFrontOnlyProgram.IsNull());
+  EXPECT_NE(aDefaultProgram->GetId(), aFrontOnlyProgram->GetId());
+  EXPECT_TRUE(hasShaderSource(aFrontOnlyProgram,
+                              Graphic3d_TOS_FRAGMENT,
+                              "gl_FrontFacing ? VertColor : getBackColor()"));
+  EXPECT_TRUE(hasShaderSource(aFrontOnlyProgram, Graphic3d_TOS_FRAGMENT, "occBackColor"));
+}
+
+TEST(Graphic3d_ShaderManagerTest, GouraudFrontOnlyVertexColor_UsesSideAwareHelper)
+{
+  Graphic3d_ShaderManagerTestProxy        aManager;
+  occ::handle<Graphic3d_LightSet>         aLights = new Graphic3d_LightSet();
+  const occ::handle<Graphic3d_ShaderProgram> aProgram =
+    aManager.StdProgramGouraud(aLights,
+                               Graphic3d_ShaderFlags_VertColor
+                                 | Graphic3d_ShaderFlags_VertColorFrontOnly);
+
+  ASSERT_FALSE(aProgram.IsNull());
+  EXPECT_TRUE(hasShaderSource(aProgram,
+                              Graphic3d_TOS_VERTEX,
+                              "theIsFront ? occVertColor : vec4(1.0)"));
+  EXPECT_TRUE(hasShaderSource(aProgram,
+                              Graphic3d_TOS_VERTEX,
+                              "BackColor   = computeLighting (aNormal, aView, aPositionWorld, false)"));
+}
+
+TEST(Graphic3d_ShaderManagerTest, PhongFrontOnlyVertexColor_UsesSideAwareHelper)
+{
+  Graphic3d_ShaderManagerTestProxy        aManager;
+  occ::handle<Graphic3d_LightSet>         aLights = new Graphic3d_LightSet();
+  const occ::handle<Graphic3d_ShaderProgram> aProgram =
+    aManager.StdProgramPhong(aLights,
+                             Graphic3d_ShaderFlags_VertColor
+                               | Graphic3d_ShaderFlags_VertColorFrontOnly);
+
+  ASSERT_FALSE(aProgram.IsNull());
+  EXPECT_TRUE(hasShaderSource(aProgram,
+                              Graphic3d_TOS_FRAGMENT,
+                              "theIsFront ? VertColor : vec4(1.0)"));
+  EXPECT_TRUE(hasShaderSource(aProgram, Graphic3d_TOS_FRAGMENT, "getVertColor(theIsFront)"));
+}

--- a/src/Visualization/TKService/GTests/Graphic3d_ShaderManager_Test.cxx
+++ b/src/Visualization/TKService/GTests/Graphic3d_ShaderManager_Test.cxx
@@ -50,7 +50,7 @@ public:
 };
 
 bool hasShaderSource(const occ::handle<Graphic3d_ShaderProgram>& theProgram,
-                     Graphic3d_TypeOfShaderObject               theType,
+                     Graphic3d_TypeOfShaderObject                theType,
                      const TCollection_AsciiString&              theSnippet)
 {
   for (NCollection_Sequence<occ::handle<Graphic3d_ShaderObject>>::Iterator anIter(
@@ -74,9 +74,8 @@ TEST(Graphic3d_ShaderManagerTest, UnlitFrontOnlyVertexColor_UsesBackColor)
 
   const occ::handle<Graphic3d_ShaderProgram> aDefaultProgram =
     aManager.StdProgramUnlit(Graphic3d_ShaderFlags_VertColor);
-  const occ::handle<Graphic3d_ShaderProgram> aFrontOnlyProgram =
-    aManager.StdProgramUnlit(Graphic3d_ShaderFlags_VertColor
-                             | Graphic3d_ShaderFlags_VertColorFrontOnly);
+  const occ::handle<Graphic3d_ShaderProgram> aFrontOnlyProgram = aManager.StdProgramUnlit(
+    Graphic3d_ShaderFlags_VertColor | Graphic3d_ShaderFlags_VertColorFrontOnly);
 
   ASSERT_FALSE(aDefaultProgram.IsNull());
   ASSERT_FALSE(aFrontOnlyProgram.IsNull());
@@ -89,34 +88,31 @@ TEST(Graphic3d_ShaderManagerTest, UnlitFrontOnlyVertexColor_UsesBackColor)
 
 TEST(Graphic3d_ShaderManagerTest, GouraudFrontOnlyVertexColor_UsesSideAwareHelper)
 {
-  Graphic3d_ShaderManagerTestProxy        aManager;
-  occ::handle<Graphic3d_LightSet>         aLights = new Graphic3d_LightSet();
-  const occ::handle<Graphic3d_ShaderProgram> aProgram =
-    aManager.StdProgramGouraud(aLights,
-                               Graphic3d_ShaderFlags_VertColor
-                                 | Graphic3d_ShaderFlags_VertColorFrontOnly);
+  Graphic3d_ShaderManagerTestProxy           aManager;
+  occ::handle<Graphic3d_LightSet>            aLights  = new Graphic3d_LightSet();
+  const occ::handle<Graphic3d_ShaderProgram> aProgram = aManager.StdProgramGouraud(
+    aLights,
+    Graphic3d_ShaderFlags_VertColor | Graphic3d_ShaderFlags_VertColorFrontOnly);
 
   ASSERT_FALSE(aProgram.IsNull());
-  EXPECT_TRUE(hasShaderSource(aProgram,
-                              Graphic3d_TOS_VERTEX,
-                              "theIsFront ? occVertColor : vec4(1.0)"));
-  EXPECT_TRUE(hasShaderSource(aProgram,
-                              Graphic3d_TOS_VERTEX,
-                              "BackColor   = computeLighting (aNormal, aView, aPositionWorld, false)"));
+  EXPECT_TRUE(
+    hasShaderSource(aProgram, Graphic3d_TOS_VERTEX, "theIsFront ? occVertColor : vec4(1.0)"));
+  EXPECT_TRUE(
+    hasShaderSource(aProgram,
+                    Graphic3d_TOS_VERTEX,
+                    "BackColor   = computeLighting (aNormal, aView, aPositionWorld, false)"));
 }
 
 TEST(Graphic3d_ShaderManagerTest, PhongFrontOnlyVertexColor_UsesSideAwareHelper)
 {
-  Graphic3d_ShaderManagerTestProxy        aManager;
-  occ::handle<Graphic3d_LightSet>         aLights = new Graphic3d_LightSet();
-  const occ::handle<Graphic3d_ShaderProgram> aProgram =
-    aManager.StdProgramPhong(aLights,
-                             Graphic3d_ShaderFlags_VertColor
-                               | Graphic3d_ShaderFlags_VertColorFrontOnly);
+  Graphic3d_ShaderManagerTestProxy           aManager;
+  occ::handle<Graphic3d_LightSet>            aLights  = new Graphic3d_LightSet();
+  const occ::handle<Graphic3d_ShaderProgram> aProgram = aManager.StdProgramPhong(
+    aLights,
+    Graphic3d_ShaderFlags_VertColor | Graphic3d_ShaderFlags_VertColorFrontOnly);
 
   ASSERT_FALSE(aProgram.IsNull());
-  EXPECT_TRUE(hasShaderSource(aProgram,
-                              Graphic3d_TOS_FRAGMENT,
-                              "theIsFront ? VertColor : vec4(1.0)"));
+  EXPECT_TRUE(
+    hasShaderSource(aProgram, Graphic3d_TOS_FRAGMENT, "theIsFront ? VertColor : vec4(1.0)"));
   EXPECT_TRUE(hasShaderSource(aProgram, Graphic3d_TOS_FRAGMENT, "getVertColor(theIsFront)"));
 }

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.cxx
@@ -39,6 +39,7 @@ Graphic3d_Aspects::Graphic3d_Aspects()
       myTextAngle(0.0f),
       myToSkipFirstEdge(false),
       myToDistinguishMaterials(false),
+      myToUseVertexColorForBackFaces(true),
       myToDrawEdges(false),
       myToDrawSilhouette(false),
       myToMapTexture(false),
@@ -72,6 +73,7 @@ void Graphic3d_Aspects::DumpJson(Standard_OStream& theOStream, int theDepth) con
 
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToSkipFirstEdge)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToDistinguishMaterials)
+  OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToUseVertexColorForBackFaces)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToDrawEdges)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myToDrawSilhouette)
   OCCT_DUMP_FIELD_VALUE_NUMERICAL(theOStream, myFaceCulling)

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.hxx
@@ -157,10 +157,7 @@ public:
 
   //! Set whether per-vertex color should be applied to back-facing fragments.
   //! When disabled, back faces use back material/interior color without vertex color modulation.
-  void SetUseVertexColorForBackFaces(bool theToUse)
-  {
-    myToUseVertexColorForBackFaces = theToUse;
-  }
+  void SetUseVertexColorForBackFaces(bool theToUse) { myToUseVertexColorForBackFaces = theToUse; }
 
   //! Return shader program.
   const occ::handle<Graphic3d_ShaderProgram>& ShaderProgram() const { return myProgram; }
@@ -545,13 +542,13 @@ public:
            && myMarkerScale == theOther.myMarkerScale && myHatchStyle == theOther.myHatchStyle
            && myTextFont == theOther.myTextFont && myPolygonOffset == theOther.myPolygonOffset
            && myTextStyle == theOther.myTextStyle && myTextDisplayType == theOther.myTextDisplayType
-            && myTextFontAspect == theOther.myTextFontAspect && myTextAngle == theOther.myTextAngle
-            && myToSkipFirstEdge == theOther.myToSkipFirstEdge
-            && myToDistinguishMaterials == theOther.myToDistinguishMaterials
-            && myToUseVertexColorForBackFaces == theOther.myToUseVertexColorForBackFaces
-            && myToDrawEdges == theOther.myToDrawEdges
-            && myToDrawSilhouette == theOther.myToDrawSilhouette
-            && myToMapTexture == theOther.myToMapTexture
+           && myTextFontAspect == theOther.myTextFontAspect && myTextAngle == theOther.myTextAngle
+           && myToSkipFirstEdge == theOther.myToSkipFirstEdge
+           && myToDistinguishMaterials == theOther.myToDistinguishMaterials
+           && myToUseVertexColorForBackFaces == theOther.myToUseVertexColorForBackFaces
+           && myToDrawEdges == theOther.myToDrawEdges
+           && myToDrawSilhouette == theOther.myToDrawSilhouette
+           && myToMapTexture == theOther.myToMapTexture
            && myIsTextZoomable == theOther.myIsTextZoomable;
   }
 

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_Aspects.hxx
@@ -151,6 +151,17 @@ public:
   //! Forbids material distinction between front and back faces.
   void SetDistinguishOff() { myToDistinguishMaterials = false; }
 
+  //! Return true if per-vertex color should be applied to back-facing fragments.
+  //! True by default for backward compatibility.
+  bool ToUseVertexColorForBackFaces() const { return myToUseVertexColorForBackFaces; }
+
+  //! Set whether per-vertex color should be applied to back-facing fragments.
+  //! When disabled, back faces use back material/interior color without vertex color modulation.
+  void SetUseVertexColorForBackFaces(bool theToUse)
+  {
+    myToUseVertexColorForBackFaces = theToUse;
+  }
+
   //! Return shader program.
   const occ::handle<Graphic3d_ShaderProgram>& ShaderProgram() const { return myProgram; }
 
@@ -534,12 +545,13 @@ public:
            && myMarkerScale == theOther.myMarkerScale && myHatchStyle == theOther.myHatchStyle
            && myTextFont == theOther.myTextFont && myPolygonOffset == theOther.myPolygonOffset
            && myTextStyle == theOther.myTextStyle && myTextDisplayType == theOther.myTextDisplayType
-           && myTextFontAspect == theOther.myTextFontAspect && myTextAngle == theOther.myTextAngle
-           && myToSkipFirstEdge == theOther.myToSkipFirstEdge
-           && myToDistinguishMaterials == theOther.myToDistinguishMaterials
-           && myToDrawEdges == theOther.myToDrawEdges
-           && myToDrawSilhouette == theOther.myToDrawSilhouette
-           && myToMapTexture == theOther.myToMapTexture
+            && myTextFontAspect == theOther.myTextFontAspect && myTextAngle == theOther.myTextAngle
+            && myToSkipFirstEdge == theOther.myToSkipFirstEdge
+            && myToDistinguishMaterials == theOther.myToDistinguishMaterials
+            && myToUseVertexColorForBackFaces == theOther.myToUseVertexColorForBackFaces
+            && myToDrawEdges == theOther.myToDrawEdges
+            && myToDrawSilhouette == theOther.myToDrawSilhouette
+            && myToMapTexture == theOther.myToMapTexture
            && myIsTextZoomable == theOther.myIsTextZoomable;
   }
 
@@ -610,6 +622,7 @@ protected:
 
   bool myToSkipFirstEdge;
   bool myToDistinguishMaterials;
+  bool myToUseVertexColorForBackFaces;
   bool myToDrawEdges;
   bool myToDrawSilhouette;
   bool myToMapTexture;

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderFlags.hxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderFlags.hxx
@@ -43,8 +43,10 @@ enum Graphic3d_ShaderFlags
   Graphic3d_ShaderFlags_WriteOit =
     0x0800, //!< write coverage buffer for Blended Order-Independent Transparency
   Graphic3d_ShaderFlags_OitDepthPeeling = 0x1000, //!< handle Depth Peeling OIT
+  Graphic3d_ShaderFlags_VertColorFrontOnly =
+    0x2000, //!< apply per-vertex color only to front-facing fragments
   //
-  Graphic3d_ShaderFlags_NB      = 0x2000, //!< overall number of combinations
+  Graphic3d_ShaderFlags_NB      = 0x4000, //!< overall number of combinations
   Graphic3d_ShaderFlags_IsPoint = Graphic3d_ShaderFlags_PointSimple
                                   | Graphic3d_ShaderFlags_PointSprite
                                   | Graphic3d_ShaderFlags_PointSpriteA,

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -875,12 +875,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
   TCollection_AsciiString              aSrcVert, aSrcVertExtraMain, aSrcVertExtraFunc, aSrcGetAlpha,
     aSrcVertEndMain;
   TCollection_AsciiString aSrcFrag, aSrcFragExtraMain;
-  TCollection_AsciiString aSrcFragGetBaseColor =
-    EOL "vec4 getBaseColor(void) { return occColor; }";
+  TCollection_AsciiString aSrcFragGetBaseColor = EOL "vec4 getBaseColor(void) { return occColor; }";
   TCollection_AsciiString aSrcFragGetBackColor =
     EOL "vec4 getBackColor(void) { return occBackColor; }";
-  TCollection_AsciiString aSrcFragGetColor =
-    EOL "vec4 getColor(void) { return getBaseColor(); }";
+  TCollection_AsciiString aSrcFragGetColor = EOL "vec4 getColor(void) { return getBaseColor(); }";
   TCollection_AsciiString aSrcFragMainGetColor = EOL "  occSetFragColor (getFinalColor());";
   Graphic3d_ShaderObject::ShaderVariableList aUniforms, aStageInOuts;
 
@@ -897,9 +895,9 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
                                                               Graphic3d_TOS_FRAGMENT));
       if ((theBits & Graphic3d_ShaderFlags_PointSpriteA) != Graphic3d_ShaderFlags_PointSpriteA)
       {
-        aSrcFragGetBaseColor = EOL
-          "vec4 getBaseColor(void) { return occTexture2D(occSamplerPointSprite, " THE_VEC2_glPointCoord
-          "); }";
+        aSrcFragGetBaseColor =
+          EOL "vec4 getBaseColor(void) { return "
+              "occTexture2D(occSamplerPointSprite, " THE_VEC2_glPointCoord "); }";
       }
       else if ((theBits & Graphic3d_ShaderFlags_TextureRGB) != 0
                && (theBits & Graphic3d_ShaderFlags_VertColor) == 0)
@@ -971,9 +969,9 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
         aProgramSrc->SetTextureSetBits(Graphic3d_TextureSetBits_BaseColor);
         aSrcVertExtraMain += THE_VARY_TexCoord_Trsf;
 
-        aSrcFragGetBaseColor = EOL
-          "vec4 getBaseColor(void) { return occTexture2D(occSamplerBaseColor, TexCoord.st / "
-          "TexCoord.w); }";
+        aSrcFragGetBaseColor =
+          EOL "vec4 getBaseColor(void) { return occTexture2D(occSamplerBaseColor, TexCoord.st / "
+              "TexCoord.w); }";
         aSrcFragGetBackColor = EOL "vec4 getBackColor(void) { return getBaseColor(); }";
       }
     }
@@ -1087,10 +1085,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
              + THE_VERT_gl_Position + aSrcVertEndMain + EOL "}";
 
   TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits);
-  aSrcFragGetColor = aSrcFragGetBaseColor + aSrcFragGetBackColor + aSrcFragGetColor
-                     + ((theBits & Graphic3d_ShaderFlags_MeshEdges) != 0
-                          ? THE_FRAG_WIREFRAME_COLOR
-                          : EOL "#define getFinalColor getColor");
+  aSrcFragGetColor =
+    aSrcFragGetBaseColor + aSrcFragGetBackColor + aSrcFragGetColor
+    + ((theBits & Graphic3d_ShaderFlags_MeshEdges) != 0 ? THE_FRAG_WIREFRAME_COLOR
+                                                        : EOL "#define getFinalColor getColor");
 
   aSrcFrag = aSrcFragGetColor + aSrcGetAlpha
              + EOL "void main()" EOL "{" EOL "  if (occFragEarlyReturn()) { return; }"
@@ -1295,7 +1293,7 @@ TCollection_AsciiString Graphic3d_ShaderManager::stdComputeLighting(
                  "  vec3 aMatSpecular = occMaterial_Specular(theIsFront);" EOL
                  "  vec4 aColor = vec4(Ambient * aMatAmbient + Diffuse * aMatDiffuse.rgb + "
                  "Specular * aMatSpecular, aMatDiffuse.a);"
-            + (theHasVertColor ? EOL "  aColor *= getVertColor(theIsFront);" : "")
+           + (theHasVertColor ? EOL "  aColor *= getVertColor(theIsFront);" : "")
            + (theHasTexColor ? EOL
                 "#if defined(THE_HAS_TEXTURE_COLOR) && defined(FRAGMENT_SHADER)" EOL
                 "  aColor *= occTexture2D(occSamplerBaseColor, TexCoord.st / TexCoord.w);" EOL
@@ -1316,8 +1314,8 @@ TCollection_AsciiString Graphic3d_ShaderManager::stdComputeLighting(
            "                      in vec4 thePoint," EOL
            "                      in bool theIsFront)" EOL "{" EOL
            "  DirectLighting = vec3(0.0);" EOL
-            "  BaseColor           = occMaterialBaseColor(theIsFront, TexCoord.st / TexCoord.w)"
-            + (theHasVertColor ? " * getVertColor(theIsFront)" : "") + ";"
+           "  BaseColor           = occMaterialBaseColor(theIsFront, TexCoord.st / TexCoord.w)"
+           + (theHasVertColor ? " * getVertColor(theIsFront)" : "") + ";"
            + EOL
            "  Emission            = occMaterialEmission(theIsFront, TexCoord.st / TexCoord.w);" EOL
            "  Metallic            = occMaterialMetallic(theIsFront, TexCoord.st / TexCoord.w);" EOL
@@ -1380,7 +1378,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
       aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("sampler2D occSamplerBaseColor",
                                                               Graphic3d_TOS_VERTEX));
       aSrcVertColor = EOL "vec4 getVertColor(in bool theIsFront) { return occTexture2D "
-                           "(occSamplerBaseColor, occTexCoord.xy); }";
+                          "(occSamplerBaseColor, occTexCoord.xy); }";
     }
   }
   else

--- a/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
+++ b/src/Visualization/TKService/Graphic3d/Graphic3d_ShaderManager.cxx
@@ -875,7 +875,12 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
   TCollection_AsciiString              aSrcVert, aSrcVertExtraMain, aSrcVertExtraFunc, aSrcGetAlpha,
     aSrcVertEndMain;
   TCollection_AsciiString aSrcFrag, aSrcFragExtraMain;
-  TCollection_AsciiString aSrcFragGetColor     = EOL "vec4 getColor(void) { return occColor; }";
+  TCollection_AsciiString aSrcFragGetBaseColor =
+    EOL "vec4 getBaseColor(void) { return occColor; }";
+  TCollection_AsciiString aSrcFragGetBackColor =
+    EOL "vec4 getBackColor(void) { return occBackColor; }";
+  TCollection_AsciiString aSrcFragGetColor =
+    EOL "vec4 getColor(void) { return getBaseColor(); }";
   TCollection_AsciiString aSrcFragMainGetColor = EOL "  occSetFragColor (getFinalColor());";
   Graphic3d_ShaderObject::ShaderVariableList aUniforms, aStageInOuts;
 
@@ -892,8 +897,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
                                                               Graphic3d_TOS_FRAGMENT));
       if ((theBits & Graphic3d_ShaderFlags_PointSpriteA) != Graphic3d_ShaderFlags_PointSpriteA)
       {
-        aSrcFragGetColor = EOL
-          "vec4 getColor(void) { return occTexture2D(occSamplerPointSprite, " THE_VEC2_glPointCoord
+        aSrcFragGetBaseColor = EOL
+          "vec4 getBaseColor(void) { return occTexture2D(occSamplerPointSprite, " THE_VEC2_glPointCoord
           "); }";
       }
       else if ((theBits & Graphic3d_ShaderFlags_TextureRGB) != 0
@@ -907,7 +912,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
                                                  Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
         aSrcVertExtraMain +=
           EOL "  VertColor = occTexture2D (occSamplerBaseColor, occTexCoord.xy);";
-        aSrcFragGetColor = EOL "vec4 getColor(void) { return VertColor; }";
+        aSrcFragGetBaseColor = EOL "vec4 getBaseColor(void) { return VertColor; }";
       }
 
       aSrcGetAlpha = pointSpriteAlphaSrc(theBits);
@@ -928,7 +933,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
                                                  Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
         aSrcVertExtraMain +=
           EOL "  VertColor = occTexture2D (occSamplerBaseColor, occTexCoord.xy);";
-        aSrcFragGetColor = EOL "vec4 getColor(void) { return VertColor; }";
+        aSrcFragGetBaseColor = EOL "vec4 getBaseColor(void) { return VertColor; }";
       }
 
       aSrcFragMainGetColor =
@@ -957,16 +962,19 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
               "  aReflect.z += 1.0;" EOL "  TexCoord = vec4(aReflect.xy * inversesqrt (dot "
               "(aReflect, aReflect)) * 0.5 + vec2 (0.5), 0.0, 1.0);";
 
-        aSrcFragGetColor =
-          EOL "vec4 getColor(void) { return occTexture2D (occSamplerBaseColor, TexCoord.st); }";
+        aSrcFragGetBaseColor =
+          EOL "vec4 getBaseColor(void) { return occTexture2D (occSamplerBaseColor, TexCoord.st); }";
+        aSrcFragGetBackColor = EOL "vec4 getBackColor(void) { return getBaseColor(); }";
       }
       else
       {
         aProgramSrc->SetTextureSetBits(Graphic3d_TextureSetBits_BaseColor);
         aSrcVertExtraMain += THE_VARY_TexCoord_Trsf;
 
-        aSrcFragGetColor = EOL "vec4 getColor(void) { return occTexture2D(occSamplerBaseColor, "
-                               "TexCoord.st / TexCoord.w); }";
+        aSrcFragGetBaseColor = EOL
+          "vec4 getBaseColor(void) { return occTexture2D(occSamplerBaseColor, TexCoord.st / "
+          "TexCoord.w); }";
+        aSrcFragGetBackColor = EOL "vec4 getBackColor(void) { return getBaseColor(); }";
       }
     }
   }
@@ -976,7 +984,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
       Graphic3d_ShaderObject::ShaderVariable("vec4 VertColor",
                                              Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
     aSrcVertExtraMain += EOL "  VertColor = occVertColor;";
-    aSrcFragGetColor = EOL "vec4 getColor(void) { return VertColor; }";
+    aSrcFragGetColor = (theBits & Graphic3d_ShaderFlags_VertColorFrontOnly) != 0
+                         ? EOL "vec4 getColor(void) { return gl_FrontFacing ? VertColor : "
+                               "getBackColor(); }"
+                         : EOL "vec4 getColor(void) { return VertColor; }";
   }
 
   int aNbClipPlanes = 0;
@@ -1076,9 +1087,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramUnlit
              + THE_VERT_gl_Position + aSrcVertEndMain + EOL "}";
 
   TCollection_AsciiString aSrcGeom = prepareGeomMainSrc(aUniforms, aStageInOuts, theBits);
-  aSrcFragGetColor += (theBits & Graphic3d_ShaderFlags_MeshEdges) != 0 ? THE_FRAG_WIREFRAME_COLOR
-                                                                       : EOL
-                        "#define getFinalColor getColor";
+  aSrcFragGetColor = aSrcFragGetBaseColor + aSrcFragGetBackColor + aSrcFragGetColor
+                     + ((theBits & Graphic3d_ShaderFlags_MeshEdges) != 0
+                          ? THE_FRAG_WIREFRAME_COLOR
+                          : EOL "#define getFinalColor getColor");
 
   aSrcFrag = aSrcFragGetColor + aSrcGetAlpha
              + EOL "void main()" EOL "{" EOL "  if (occFragEarlyReturn()) { return; }"
@@ -1283,7 +1295,7 @@ TCollection_AsciiString Graphic3d_ShaderManager::stdComputeLighting(
                  "  vec3 aMatSpecular = occMaterial_Specular(theIsFront);" EOL
                  "  vec4 aColor = vec4(Ambient * aMatAmbient + Diffuse * aMatDiffuse.rgb + "
                  "Specular * aMatSpecular, aMatDiffuse.a);"
-           + (theHasVertColor ? EOL "  aColor *= getVertColor();" : "")
+            + (theHasVertColor ? EOL "  aColor *= getVertColor(theIsFront);" : "")
            + (theHasTexColor ? EOL
                 "#if defined(THE_HAS_TEXTURE_COLOR) && defined(FRAGMENT_SHADER)" EOL
                 "  aColor *= occTexture2D(occSamplerBaseColor, TexCoord.st / TexCoord.w);" EOL
@@ -1304,8 +1316,8 @@ TCollection_AsciiString Graphic3d_ShaderManager::stdComputeLighting(
            "                      in vec4 thePoint," EOL
            "                      in bool theIsFront)" EOL "{" EOL
            "  DirectLighting = vec3(0.0);" EOL
-           "  BaseColor           = occMaterialBaseColor(theIsFront, TexCoord.st / TexCoord.w)"
-           + (theHasVertColor ? " * getVertColor()" : "") + ";"
+            "  BaseColor           = occMaterialBaseColor(theIsFront, TexCoord.st / TexCoord.w)"
+            + (theHasVertColor ? " * getVertColor(theIsFront)" : "") + ";"
            + EOL
            "  Emission            = occMaterialEmission(theIsFront, TexCoord.st / TexCoord.w);" EOL
            "  Metallic            = occMaterialMetallic(theIsFront, TexCoord.st / TexCoord.w);" EOL
@@ -1367,8 +1379,8 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
       aProgramSrc->SetTextureSetBits(Graphic3d_TextureSetBits_BaseColor);
       aUniforms.Append(Graphic3d_ShaderObject::ShaderVariable("sampler2D occSamplerBaseColor",
                                                               Graphic3d_TOS_VERTEX));
-      aSrcVertColor = EOL
-        "vec4 getVertColor(void) { return occTexture2D (occSamplerBaseColor, occTexCoord.xy); }";
+      aSrcVertColor = EOL "vec4 getVertColor(in bool theIsFront) { return occTexture2D "
+                           "(occSamplerBaseColor, occTexCoord.xy); }";
     }
   }
   else
@@ -1393,7 +1405,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramGoura
 
   if ((theBits & Graphic3d_ShaderFlags_VertColor) != 0)
   {
-    aSrcVertColor = EOL "vec4 getVertColor(void) { return occVertColor; }";
+    aSrcVertColor = (theBits & Graphic3d_ShaderFlags_VertColorFrontOnly) != 0
+                      ? EOL "vec4 getVertColor(in bool theIsFront) { return theIsFront ? "
+                            "occVertColor : vec4(1.0); }"
+                      : EOL "vec4 getVertColor(in bool theIsFront) { return occVertColor; }";
   }
 
   int aNbClipPlanes = 0;
@@ -1559,7 +1574,7 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramPhong
                                                Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
 
       aSrcVertExtraMain += EOL "  VertColor = occTexture2D (occSamplerBaseColor, occTexCoord.xy);";
-      aSrcFragGetVertColor = EOL "vec4 getVertColor(void) { return VertColor; }";
+      aSrcFragGetVertColor = EOL "vec4 getVertColor(in bool theIsFront) { return VertColor; }";
     }
   }
   else
@@ -1603,7 +1618,10 @@ occ::handle<Graphic3d_ShaderProgram> Graphic3d_ShaderManager::getStdProgramPhong
       Graphic3d_ShaderObject::ShaderVariable("vec4 VertColor",
                                              Graphic3d_TOS_VERTEX | Graphic3d_TOS_FRAGMENT));
     aSrcVertExtraMain += EOL "  VertColor = occVertColor;";
-    aSrcFragGetVertColor = EOL "vec4 getVertColor(void) { return VertColor; }";
+    aSrcFragGetVertColor = (theBits & Graphic3d_ShaderFlags_VertColorFrontOnly) != 0
+                             ? EOL "vec4 getVertColor(in bool theIsFront) { return theIsFront ? "
+                                   "VertColor : vec4(1.0); }"
+                             : EOL "vec4 getVertColor(in bool theIsFront) { return VertColor; }";
   }
 
   int aNbClipPlanes = 0;

--- a/src/Visualization/TKService/Shaders/Shaders_Declarations_glsl.pxx
+++ b/src/Visualization/TKService/Shaders/Shaders_Declarations_glsl.pxx
@@ -274,6 +274,7 @@ static const char Shaders_Declarations_glsl[] =
   "#endif\n"
   "\n"
   "uniform               vec4      occColor;              //!< color value (in case of disabled lighting)\n"
+  "uniform               vec4      occBackColor;          //!< back color value (in case of disabled lighting)\n"
   "uniform THE_PREC_ENUM int       occDistinguishingMode; //!< Are front and back faces distinguished?\n"
   "uniform THE_PREC_ENUM int       occTextureEnable;      //!< Is texture enabled?\n"
   "uniform               vec4      occTexTrsf2d[2];       //!< 2D texture transformation parameters\n"

--- a/src/Visualization/TKV3d/Prs3d/Prs3d_ShadingAspect.hxx
+++ b/src/Visualization/TKV3d/Prs3d/Prs3d_ShadingAspect.hxx
@@ -66,6 +66,18 @@ public:
   Standard_EXPORT double Transparency(
     const Aspect_TypeOfFacingModel aModel = Aspect_TOFM_FRONT_SIDE) const;
 
+  //! Return true if per-vertex color should be applied to back-facing fragments.
+  bool ToUseVertexColorForBackFaces() const
+  {
+    return myAspect->ToUseVertexColorForBackFaces();
+  }
+
+  //! Set whether per-vertex color should be applied to back-facing fragments.
+  void SetUseVertexColorForBackFaces(bool theToUse)
+  {
+    myAspect->SetUseVertexColorForBackFaces(theToUse);
+  }
+
   //! Returns the polygons aspect properties.
   const occ::handle<Graphic3d_AspectFillArea3d>& Aspect() const { return myAspect; }
 

--- a/src/Visualization/TKV3d/Prs3d/Prs3d_ShadingAspect.hxx
+++ b/src/Visualization/TKV3d/Prs3d/Prs3d_ShadingAspect.hxx
@@ -67,10 +67,7 @@ public:
     const Aspect_TypeOfFacingModel aModel = Aspect_TOFM_FRONT_SIDE) const;
 
   //! Return true if per-vertex color should be applied to back-facing fragments.
-  bool ToUseVertexColorForBackFaces() const
-  {
-    return myAspect->ToUseVertexColorForBackFaces();
-  }
+  bool ToUseVertexColorForBackFaces() const { return myAspect->ToUseVertexColorForBackFaces(); }
 
   //! Set whether per-vertex color should be applied to back-facing fragments.
   void SetUseVertexColorForBackFaces(bool theToUse)

--- a/tests/opengl/data/shading/vert_color_back_faces
+++ b/tests/opengl/data/shading/vert_color_back_faces
@@ -22,23 +22,27 @@ set aSquare {
 vdrawparray p triangles {*}$aSquare
 vaspects p -color WHITE -backfaceColor BLUE -faceCulling doublesided -useVertexColorForBackFaces 1
 vviewparams -scale 3 -proj 0 0 1 -up 0 1 0 -at 0 0 0
+vfit
 
 if { [vreadpixel 200 200 rgb name] != "RED" } {
   puts "Error: front face should use vertex color"
 }
 
 vviewparams -scale 3 -proj 0 0 -1 -up 0 1 0 -at 0 0 0
+vfit
 if { [vreadpixel 200 200 rgb name] != "RED" } {
   puts "Error: back face should use vertex color by default"
 }
 
 vaspects p -useVertexColorForBackFaces 0
 vviewparams -scale 3 -proj 0 0 1 -up 0 1 0 -at 0 0 0
+vfit
 if { [vreadpixel 200 200 rgb name] != "RED" } {
   puts "Error: front face should keep vertex color when back-face vertex color is disabled"
 }
 
 vviewparams -scale 3 -proj 0 0 -1 -up 0 1 0 -at 0 0 0
+vfit
 if { [vreadpixel 200 200 rgb name] != "BLUE" } {
   puts "Error: back face should use uniform back color when back-face vertex color is disabled"
 }

--- a/tests/opengl/data/shading/vert_color_back_faces
+++ b/tests/opengl/data/shading/vert_color_back_faces
@@ -1,0 +1,53 @@
+puts "============"
+puts "Visualization - allow vertex colors only on front-facing fragments"
+puts "============"
+puts ""
+
+pload VISUALIZATION
+
+vclear
+vinit View1
+vbackground -color BLACK
+vrenderparams -shadingModel UNLIT
+
+set aSquare {
+  v -1 -1 0 n 0 0 1 c 1 0 0
+  v  1 -1 0 n 0 0 1 c 1 0 0
+  v  1  1 0 n 0 0 1 c 1 0 0
+  v -1 -1 0 n 0 0 1 c 1 0 0
+  v  1  1 0 n 0 0 1 c 1 0 0
+  v -1  1 0 n 0 0 1 c 1 0 0
+}
+
+vdrawparray p triangles {*}$aSquare
+vaspects p -color WHITE -backfaceColor BLUE -faceCulling doublesided -useVertexColorForBackFaces 1
+vviewparams -scale 3 -proj 0 0 1 -up 0 1 0 -at 0 0 0
+
+if { [vreadpixel 200 200 rgb name] != "RED" } {
+  puts "Error: front face should use vertex color"
+}
+
+vviewparams -scale 3 -proj 0 0 -1 -up 0 1 0 -at 0 0 0
+if { [vreadpixel 200 200 rgb name] != "RED" } {
+  puts "Error: back face should use vertex color by default"
+}
+
+vaspects p -useVertexColorForBackFaces 0
+vviewparams -scale 3 -proj 0 0 1 -up 0 1 0 -at 0 0 0
+if { [vreadpixel 200 200 rgb name] != "RED" } {
+  puts "Error: front face should keep vertex color when back-face vertex color is disabled"
+}
+
+vviewparams -scale 3 -proj 0 0 -1 -up 0 1 0 -at 0 0 0
+if { [vreadpixel 200 200 rgb name] != "BLUE" } {
+  puts "Error: back face should use uniform back color when back-face vertex color is disabled"
+}
+
+vdump ${imagedir}/${casename}_unlit.png
+
+vrenderparams -shadingModel PHONG
+set aPhongBackColor [vreadpixel 200 200 rgb]
+if { [lindex $aPhongBackColor 0] >= [lindex $aPhongBackColor 2] } {
+  puts "Error: PHONG back face should use back material color, not red vertex color"
+}
+vdump ${imagedir}/${casename}_phong.png


### PR DESCRIPTION
- Add aspect API controlling vertex color use on back faces
- Generate front-only vertex color shader variants for face programs
- Expose the option through ViewerTest and add DRAW/GTest coverage