### PR TITLE
RWMesh - Fix lossy encoding of non-ASCII node names in glTF export

### DIFF
--- a/src/DataExchange/TKRWMesh/RWMesh/RWMesh.cxx
+++ b/src/DataExchange/TKRWMesh/RWMesh/RWMesh.cxx
@@ -21,11 +21,10 @@ namespace
 {
 static TCollection_AsciiString ExtendedToUtf8(const TCollection_ExtendedString& theStr)
 {
-  NCollection_UtfString<char> utf8(
-    reinterpret_cast<const char16_t*>(theStr.ToExtString()));
+  NCollection_UtfString<char> utf8(reinterpret_cast<const char16_t*>(theStr.ToExtString()));
   return TCollection_AsciiString(utf8.ToCString());
 }
-}
+} // namespace
 
 //=================================================================================================
 

--- a/src/DataExchange/TKRWMesh/RWMesh/RWMesh.cxx
+++ b/src/DataExchange/TKRWMesh/RWMesh/RWMesh.cxx
@@ -13,8 +13,19 @@
 
 #include <RWMesh.hxx>
 
+#include <NCollection_UtfString.hxx>
 #include <TDataStd_Name.hxx>
 #include <TDF_Tool.hxx>
+
+namespace
+{
+static TCollection_AsciiString ExtendedToUtf8(const TCollection_ExtendedString& theStr)
+{
+  NCollection_UtfString<char> utf8(
+    reinterpret_cast<const char16_t*>(theStr.ToExtString()));
+  return TCollection_AsciiString(utf8.ToCString());
+}
+}
 
 //=================================================================================================
 
@@ -22,7 +33,7 @@ TCollection_AsciiString RWMesh::ReadNameAttribute(const TDF_Label& theLabel)
 {
   occ::handle<TDataStd_Name> aNodeName;
   return theLabel.FindAttribute(TDataStd_Name::GetID(), aNodeName)
-           ? TCollection_AsciiString(aNodeName->Get())
+           ? ExtendedToUtf8(aNodeName->Get())
            : TCollection_AsciiString();
 }
 
@@ -40,25 +51,25 @@ TCollection_AsciiString RWMesh::FormatName(RWMesh_NameFormat theFormat,
     case RWMesh_NameFormat_Product: {
       occ::handle<TDataStd_Name> aRefNodeName;
       return theRefLabel.FindAttribute(TDataStd_Name::GetID(), aRefNodeName)
-               ? TCollection_AsciiString(aRefNodeName->Get())
+               ? ExtendedToUtf8(aRefNodeName->Get())
                : TCollection_AsciiString();
     }
     case RWMesh_NameFormat_Instance: {
       occ::handle<TDataStd_Name> aNodeName;
       return theLabel.FindAttribute(TDataStd_Name::GetID(), aNodeName)
-               ? TCollection_AsciiString(aNodeName->Get())
+               ? ExtendedToUtf8(aNodeName->Get())
                : TCollection_AsciiString();
     }
     case RWMesh_NameFormat_InstanceOrProduct: {
       occ::handle<TDataStd_Name> aNodeName;
       if (theLabel.FindAttribute(TDataStd_Name::GetID(), aNodeName) && !aNodeName->Get().IsEmpty())
       {
-        return TCollection_AsciiString(aNodeName->Get());
+        return ExtendedToUtf8(aNodeName->Get());
       }
 
       occ::handle<TDataStd_Name> aRefNodeName;
       return theRefLabel.FindAttribute(TDataStd_Name::GetID(), aRefNodeName)
-               ? TCollection_AsciiString(aRefNodeName->Get())
+               ? ExtendedToUtf8(aRefNodeName->Get())
                : TCollection_AsciiString();
     }
     case RWMesh_NameFormat_ProductOrInstance: {
@@ -66,12 +77,12 @@ TCollection_AsciiString RWMesh::FormatName(RWMesh_NameFormat theFormat,
       if (theRefLabel.FindAttribute(TDataStd_Name::GetID(), aRefNodeName)
           && !aRefNodeName->Get().IsEmpty())
       {
-        return TCollection_AsciiString(aRefNodeName->Get());
+        return ExtendedToUtf8(aRefNodeName->Get());
       }
 
       occ::handle<TDataStd_Name> aNodeName;
       return theLabel.FindAttribute(TDataStd_Name::GetID(), aNodeName)
-               ? TCollection_AsciiString(aNodeName->Get())
+               ? ExtendedToUtf8(aNodeName->Get())
                : TCollection_AsciiString();
     }
     case RWMesh_NameFormat_ProductAndInstance: {


### PR DESCRIPTION
`RWMesh::ReadNameAttribute` and `RWMesh::FormatName` convert node names from `TCollection_ExtendedString` (UTF-16) to `TCollection_AsciiString`. Lossy for non-ASCII characters, which are replaced with a substitution byte rather than being encoded correctly.

The PR just adds the small static helper `ExtendedToUtf8` that converts via `NCollection_UtfString<char>`, and all call sites in `ReadNameAttribute` and `FormatName` are updated to use this helper.

Verified with a STEP file containing French part names (`Pièce`, `Première`, `butée`) which previously produced `\ufffd` replacement characters in the glTF JSON chunk. Node names now survive conversion.