### PR TITLE
Modeling - Boolean section stuck in infinite loop

### DIFF
--- a/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve.cxx
@@ -1223,8 +1223,19 @@ void Geom_BSplineCurve::PeriodicNormalization(double& theParameter) const
     return;
   }
 
-  const double aFirst  = myFlatKnots.Value(myDeg + 1);
-  const double aLast   = myFlatKnots.Value(myFlatKnots.Upper() - myDeg);
+  const double aFirst = myFlatKnots.Value(myDeg + 1);
+  const double aLast  = myFlatKnots.Value(myFlatKnots.Upper() - myDeg);
+
+  // If the parameter is already within the valid range, no adjustment is needed.
+  // Note: Strictly speaking, the parameter should be within [aFirst, aLast), since for
+  // periodic curves first and last parameters represent the same point.
+  // However, we allow the case theParameter == aLast to be valid as well just because
+  // there is already a lot of code that relies on this particular behavior.
+  if (theParameter >= aFirst && theParameter <= aLast)
+  {
+    return;
+  }
+
   const double aPeriod = aLast - aFirst;
 
   // Shift by the exact number of full periods in one step - O(1) regardless of distance.

--- a/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve.cxx
@@ -1216,21 +1216,34 @@ void Geom_BSplineCurve::updateKnots()
 
 //=================================================================================================
 
-void Geom_BSplineCurve::PeriodicNormalization(double& Parameter) const
+void Geom_BSplineCurve::PeriodicNormalization(double& theParameter) const
 {
-  double Period;
-
-  if (myPeriodic)
+  if (!myPeriodic)
   {
-    Period = myFlatKnots.Value(myFlatKnots.Upper() - myDeg) - myFlatKnots.Value(myDeg + 1);
-    while (Parameter > myFlatKnots.Value(myFlatKnots.Upper() - myDeg))
-    {
-      Parameter -= Period;
-    }
-    while (Parameter < myFlatKnots.Value(myDeg + 1))
-    {
-      Parameter += Period;
-    }
+    return;
+  }
+
+  const double aFirst  = myFlatKnots.Value(myDeg + 1);
+  const double aLast   = myFlatKnots.Value(myFlatKnots.Upper() - myDeg);
+  const double aPeriod = aLast - aFirst;
+
+  // Shift by the exact number of full periods in one step — O(1) regardless of distance.
+  const double aNbPeriods = std::floor((theParameter - aFirst) / aPeriod);
+  if (aNbPeriods != 0.0)
+  {
+    theParameter -= aNbPeriods * aPeriod;
+  }
+
+  // One-step correction for floating-point residual overshoot after the bulk shift.
+  if (theParameter > aLast)
+  {
+    const double aNewParam = theParameter - aPeriod;
+    theParameter = aNewParam == theParameter ? std::nextafter(aNewParam, aFirst) : aNewParam;
+  }
+  else if (theParameter < aFirst)
+  {
+    const double aNewParam = theParameter + aPeriod;
+    theParameter = aNewParam == theParameter ? std::nextafter(aNewParam, aLast) : aNewParam;
   }
 }
 

--- a/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve.cxx
@@ -1227,7 +1227,7 @@ void Geom_BSplineCurve::PeriodicNormalization(double& theParameter) const
   const double aLast   = myFlatKnots.Value(myFlatKnots.Upper() - myDeg);
   const double aPeriod = aLast - aFirst;
 
-  // Shift by the exact number of full periods in one step — O(1) regardless of distance.
+  // Shift by the exact number of full periods in one step - O(1) regardless of distance.
   const double aNbPeriods = std::floor((theParameter - aFirst) / aPeriod);
   if (aNbPeriods != 0.0)
   {


### PR DESCRIPTION
Method Geom_BSplineCurve::PeriodicNormalization() is rewritten - it now has algorithmic complexity O(1) instead of O(N) and protected against rounding error for large numbers.
Closes https://github.com/Open-Cascade-SAS/OCCT/issues/1288