### PR TITLE
Modeling - Improve Gordon surface construction for rational networks

### DIFF
--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
@@ -54,10 +54,10 @@ occ::handle<Geom_BSplineCurve> makeLinearBSpline(const gp_Pnt& theP1, const gp_P
 
 //! Helper: create a quadratic BSpline curve through 3 control points on [0,1].
 occ::handle<Geom_BSplineCurve> makeQuadraticBSpline(const gp_Pnt& theP1,
-                                                     const gp_Pnt& theP2,
-                                                     const gp_Pnt& theP3,
-                                                     const double  theFirstParameter = 0.0,
-                                                     const double  theLastParameter  = 1.0)
+                                                    const gp_Pnt& theP2,
+                                                    const gp_Pnt& theP3,
+                                                    const double  theFirstParameter = 0.0,
+                                                    const double  theLastParameter  = 1.0)
 {
   NCollection_Array1<gp_Pnt> aPoles(1, 3);
   aPoles(1) = theP1;
@@ -2512,10 +2512,8 @@ TEST(GeomFill_Gordon, ClosedBSplineProfilesWithInteriorGuides_ProducePeriodicSur
 TEST(GeomFill_Gordon, NetworkSurface_ClosedNetworkWithNonUnitUParameters_ProducesUPeriodicSurface)
 {
   NCollection_Array1<occ::handle<Geom_BSplineCurve>> aProfiles(1, 2);
-  aProfiles(1) =
-    makeQuadraticBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0), gp_Pnt(0, 0, 0), 2.0, 5.0);
-  aProfiles(2) =
-    makeQuadraticBSpline(gp_Pnt(0, 1, 0), gp_Pnt(1, 1, 1), gp_Pnt(0, 1, 0), 2.0, 5.0);
+  aProfiles(1) = makeQuadraticBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0), gp_Pnt(0, 0, 0), 2.0, 5.0);
+  aProfiles(2) = makeQuadraticBSpline(gp_Pnt(0, 1, 0), gp_Pnt(1, 1, 1), gp_Pnt(0, 1, 0), 2.0, 5.0);
 
   NCollection_Array1<double> aGuideParameters(1, 2);
   aGuideParameters(1) = 2.0;

--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
@@ -251,7 +251,7 @@ occ::handle<Geom_BSplineCurve> makePeriodicGuide(const double theX)
 }
 
 occ::handle<Geom_BSplineCurve> makeInterpolatedPeriodicProfile(const double theY,
-                                                                const int    theSeamShift)
+                                                               const int    theSeamShift)
 {
   constexpr int    THE_NB_POINTS = 8;
   constexpr double THE_PI        = 3.14159265358979323846;
@@ -352,7 +352,7 @@ void verifyPointOnSurface(const occ::handle<Geom_BSplineSurface>& theSurf,
   EXPECT_LT(aDist, theTol) << "Surface point at (" << theU << ", " << theV << ") = (" << aSurfPt.X()
                            << ", " << aSurfPt.Y() << ", " << aSurfPt.Z()
                            << ") differs from expected (" << theExpected.X() << ", "
-                            << theExpected.Y() << ", " << theExpected.Z() << ") by " << aDist;
+                           << theExpected.Y() << ", " << theExpected.Z() << ") by " << aDist;
 }
 
 using HeightFunction = double (*)(double, double);
@@ -379,11 +379,11 @@ struct AnalyticNetwork
   NCollection_Array1<occ::handle<Geom_Curve>> Profiles;
   NCollection_Array1<occ::handle<Geom_Curve>> Guides;
 
-  AnalyticNetwork(const size_t          theNbProfiles,
-                  const size_t          theNbGuides,
-                  HeightFunction        theHeight,
-                  const gp_XYZ&         theOrigin = gp_XYZ(0.0, 0.0, 0.0),
-                  const double          theScale  = 1.0)
+  AnalyticNetwork(const size_t   theNbProfiles,
+                  const size_t   theNbGuides,
+                  HeightFunction theHeight,
+                  const gp_XYZ&  theOrigin = gp_XYZ(0.0, 0.0, 0.0),
+                  const double   theScale  = 1.0)
       : Profiles(1, static_cast<int>(theNbProfiles)),
         Guides(1, static_cast<int>(theNbGuides))
   {
@@ -397,9 +397,9 @@ struct AnalyticNetwork
       for (size_t aGuideIdx = 0; aGuideIdx < theNbGuides; ++aGuideIdx)
       {
         const double aU = static_cast<double>(aGuideIdx) / static_cast<double>(theNbGuides - 1);
-        aPoints->SetValue(static_cast<int>(aGuideIdx) + 1,
-                          gp_Pnt(theOrigin
-                                 + gp_XYZ(theScale * aU, theScale * aV, theScale * theHeight(aU, aV))));
+        aPoints->SetValue(
+          static_cast<int>(aGuideIdx) + 1,
+          gp_Pnt(theOrigin + gp_XYZ(theScale * aU, theScale * aV, theScale * theHeight(aU, aV))));
         aParams->SetValue(static_cast<int>(aGuideIdx) + 1, aU);
       }
       GeomAPI_Interpolate anInterpolator(aPoints, aParams, false, Precision::Confusion());
@@ -417,9 +417,9 @@ struct AnalyticNetwork
       for (size_t aProfileIdx = 0; aProfileIdx < theNbProfiles; ++aProfileIdx)
       {
         const double aV = static_cast<double>(aProfileIdx) / static_cast<double>(theNbProfiles - 1);
-        aPoints->SetValue(static_cast<int>(aProfileIdx) + 1,
-                          gp_Pnt(theOrigin
-                                 + gp_XYZ(theScale * aU, theScale * aV, theScale * theHeight(aU, aV))));
+        aPoints->SetValue(
+          static_cast<int>(aProfileIdx) + 1,
+          gp_Pnt(theOrigin + gp_XYZ(theScale * aU, theScale * aV, theScale * theHeight(aU, aV))));
         aParams->SetValue(static_cast<int>(aProfileIdx) + 1, aV);
       }
       GeomAPI_Interpolate anInterpolator(aPoints, aParams, false, Precision::Confusion());
@@ -435,26 +435,29 @@ void verifyUniformNetworkInterpolation(const occ::handle<Geom_BSplineSurface>& t
 {
   ASSERT_FALSE(theSurface.IsNull());
   constexpr size_t THE_NB_SAMPLES = 32;
-  const double aUMin = theSurface->UKnot(1);
-  const double aUMax = theSurface->UKnot(theSurface->NbUKnots());
-  const double aVMin = theSurface->VKnot(1);
-  const double aVMax = theSurface->VKnot(theSurface->NbVKnots());
+  const double     aUMin          = theSurface->UKnot(1);
+  const double     aUMax          = theSurface->UKnot(theSurface->NbUKnots());
+  const double     aVMin          = theSurface->VKnot(1);
+  const double     aVMax          = theSurface->VKnot(theSurface->NbVKnots());
   for (size_t aProfileIdx = 0; aProfileIdx < theNetwork.Profiles.Size(); ++aProfileIdx)
   {
-    const double aV = aVMin + static_cast<double>(aProfileIdx)
-                                  / static_cast<double>(theNetwork.Profiles.Size() - 1) * (aVMax - aVMin);
+    const double aV = aVMin
+                      + static_cast<double>(aProfileIdx)
+                          / static_cast<double>(theNetwork.Profiles.Size() - 1) * (aVMax - aVMin);
     for (size_t aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
     {
       const double aParam = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
       const double aU     = aUMin + aParam * (aUMax - aUMin);
-      EXPECT_LE(theSurface->Value(aU, aV).Distance(theNetwork.Profiles.At(aProfileIdx)->Value(aParam)),
-                theTolerance);
+      EXPECT_LE(
+        theSurface->Value(aU, aV).Distance(theNetwork.Profiles.At(aProfileIdx)->Value(aParam)),
+        theTolerance);
     }
   }
   for (size_t aGuideIdx = 0; aGuideIdx < theNetwork.Guides.Size(); ++aGuideIdx)
   {
-    const double aU = aUMin + static_cast<double>(aGuideIdx)
-                                  / static_cast<double>(theNetwork.Guides.Size() - 1) * (aUMax - aUMin);
+    const double aU = aUMin
+                      + static_cast<double>(aGuideIdx)
+                          / static_cast<double>(theNetwork.Guides.Size() - 1) * (aUMax - aUMin);
     for (size_t aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
     {
       const double aParam = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
@@ -676,17 +679,17 @@ TEST(GeomFill_Gordon, NonAffineProfileReparametrization_PreservesProfilesAndGuid
 {
   NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
   aProfiles(1) = makeCubicInterpBSpline(gp_Pnt(0, 0, 0),
-                                         gp_Pnt(0.25, 0, 0.4),
-                                         gp_Pnt(0.75, 0, -0.3),
-                                         gp_Pnt(1, 0, 0));
+                                        gp_Pnt(0.25, 0, 0.4),
+                                        gp_Pnt(0.75, 0, -0.3),
+                                        gp_Pnt(1, 0, 0));
   aProfiles(2) = makeCubicInterpBSpline(gp_Pnt(0, 0.5, 0),
-                                         gp_Pnt(0.25, 0.5, 0.2),
-                                         gp_Pnt(0.75, 0.5, -0.5),
-                                         gp_Pnt(1, 0.5, 0));
+                                        gp_Pnt(0.25, 0.5, 0.2),
+                                        gp_Pnt(0.75, 0.5, -0.5),
+                                        gp_Pnt(1, 0.5, 0));
   aProfiles(3) = makeCubicInterpBSpline(gp_Pnt(0, 1, 0),
-                                         gp_Pnt(0.25, 1, 0.5),
-                                         gp_Pnt(0.75, 1, -0.2),
-                                         gp_Pnt(1, 1, 0));
+                                        gp_Pnt(0.25, 1, 0.5),
+                                        gp_Pnt(0.75, 1, -0.2),
+                                        gp_Pnt(1, 1, 0));
 
   occ::handle<NCollection_HArray1<gp_Pnt>> aGuidePoints = new NCollection_HArray1<gp_Pnt>(1, 3);
   aGuidePoints->SetValue(1, aProfiles(1)->Value(0.4));
@@ -713,14 +716,13 @@ TEST(GeomFill_Gordon, NonAffineProfileReparametrization_PreservesProfilesAndGuid
   const occ::handle<Geom_BSplineSurface>& aSurface = aGordon.Surface();
   EXPECT_LE(aGordon.Report().MaxProfileDeviation, Precision::Confusion());
   EXPECT_LE(aGordon.Report().MaxGuideDeviation, Precision::Confusion());
-  const double aMiddleProfileV =
-    0.5 * (aSurface->VKnot(1) + aSurface->VKnot(aSurface->NbVKnots()));
+  const double aMiddleProfileV = 0.5 * (aSurface->VKnot(1) + aSurface->VKnot(aSurface->NbVKnots()));
   constexpr int THE_NB_SAMPLES = 32;
   for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
   {
     const double aRatio = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
-    const double aU     = aSurface->UKnot(1)
-                       + aRatio * (aSurface->UKnot(aSurface->NbUKnots()) - aSurface->UKnot(1));
+    const double aU =
+      aSurface->UKnot(1) + aRatio * (aSurface->UKnot(aSurface->NbUKnots()) - aSurface->UKnot(1));
     const double aProfile1Param = aRatio <= 0.5 ? 0.8 * aRatio : 1.2 * aRatio - 0.2;
     const double aProfile3Param = aRatio <= 0.5 ? 1.2 * aRatio : 0.2 + 0.8 * aRatio;
 
@@ -737,8 +739,8 @@ TEST(GeomFill_Gordon, NonAffineProfileReparametrization_PreservesProfilesAndGuid
   for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
   {
     const double aRatio = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
-    const double aV     = aSurface->VKnot(1)
-                       + aRatio * (aSurface->VKnot(aSurface->NbVKnots()) - aSurface->VKnot(1));
+    const double aV =
+      aSurface->VKnot(1) + aRatio * (aSurface->VKnot(aSurface->NbVKnots()) - aSurface->VKnot(1));
     EXPECT_LE(aSurface->Value(aGuideU, aV).Distance(aGuides(2)->Value(aRatio)),
               Precision::Confusion());
   }
@@ -822,17 +824,17 @@ TEST(GeomFill_Gordon, InterpolatedPeriodicProfilesWithAlignedSeams_InterpolateWi
     occ::down_cast<Geom_BSplineCurve>(aProfiles(1));
   const occ::handle<Geom_BSplineCurve> aSecondProfile =
     occ::down_cast<Geom_BSplineCurve>(aProfiles(2));
-  const gp_Pnt aFirstSeam = aFirstProfile->Value(aFirstProfile->FirstParameter());
-  GeomAPI_ProjectPointOnCurve aSeamProjection(
-    gp_Pnt(aFirstSeam.X(), 1.0, aFirstSeam.Z()), aSecondProfile);
+  const gp_Pnt                aFirstSeam = aFirstProfile->Value(aFirstProfile->FirstParameter());
+  GeomAPI_ProjectPointOnCurve aSeamProjection(gp_Pnt(aFirstSeam.X(), 1.0, aFirstSeam.Z()),
+                                              aSecondProfile);
   ASSERT_GT(aSeamProjection.NbPoints(), 0);
   aSecondProfile->SetOrigin(aSeamProjection.LowerDistanceParameter(), Precision::Confusion());
   const double aFirstProfileMiddle =
     0.5 * (aFirstProfile->FirstParameter() + aFirstProfile->LastParameter());
   const double aSecondProfileMiddle =
     0.5 * (aSecondProfile->FirstParameter() + aSecondProfile->LastParameter());
-  const gp_Pnt aSecondSeam = aSecondProfile->Value(aSecondProfile->FirstParameter());
-  const gp_Pnt aFirstMiddle = aFirstProfile->Value(aFirstProfileMiddle);
+  const gp_Pnt aSecondSeam   = aSecondProfile->Value(aSecondProfile->FirstParameter());
+  const gp_Pnt aFirstMiddle  = aFirstProfile->Value(aFirstProfileMiddle);
   const gp_Pnt aSecondMiddle = aSecondProfile->Value(aSecondProfileMiddle);
   ASSERT_LE(aFirstSeam.Distance(gp_Pnt(aSecondSeam.X(), aFirstSeam.Y(), aSecondSeam.Z())),
             Precision::Confusion());
@@ -840,15 +842,12 @@ TEST(GeomFill_Gordon, InterpolatedPeriodicProfilesWithAlignedSeams_InterpolateWi
             Precision::Confusion());
 
   NCollection_Array1<occ::handle<Geom_Curve>> aGuides(1, 3);
-  aGuides(1) =
-    makeLinearBSpline(aFirstProfile->Value(aFirstProfile->FirstParameter()),
-                      aSecondProfile->Value(aSecondProfile->FirstParameter()));
-  aGuides(2) =
-    makeLinearBSpline(aFirstProfile->Value(aFirstProfileMiddle),
-                      aSecondProfile->Value(aSecondProfileMiddle));
-  aGuides(3) =
-    makeLinearBSpline(aFirstProfile->Value(aFirstProfile->FirstParameter()),
-                      aSecondProfile->Value(aSecondProfile->FirstParameter()));
+  aGuides(1) = makeLinearBSpline(aFirstProfile->Value(aFirstProfile->FirstParameter()),
+                                 aSecondProfile->Value(aSecondProfile->FirstParameter()));
+  aGuides(2) = makeLinearBSpline(aFirstProfile->Value(aFirstProfileMiddle),
+                                 aSecondProfile->Value(aSecondProfileMiddle));
+  aGuides(3) = makeLinearBSpline(aFirstProfile->Value(aFirstProfile->FirstParameter()),
+                                 aSecondProfile->Value(aSecondProfile->FirstParameter()));
 
   GeomFill_Gordon aGordon;
   aGordon.Init(aProfiles, aGuides, Precision::Confusion());
@@ -870,17 +869,17 @@ TEST(GeomFill_Gordon, InterpolatedPeriodicProfilesWithAlignedSeams_InterpolateWi
   for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
   {
     const double aRatio = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
-    const double aU = aSurface->UKnot(1)
-                      + aRatio * (aSurface->UKnot(aSurface->NbUKnots()) - aSurface->UKnot(1));
-    const double aFirstProfileParam = aFirstProfile->FirstParameter()
-                                      + aRatio * (aFirstProfile->LastParameter()
-                                                  - aFirstProfile->FirstParameter());
-    const double aSecondProfileParam = aSecondProfile->FirstParameter()
-                                       + aRatio * (aSecondProfile->LastParameter()
-                                                   - aSecondProfile->FirstParameter());
-    EXPECT_LE(aSurface->Value(aU, aSurface->VKnot(1))
-                .Distance(aFirstProfile->Value(aFirstProfileParam)),
-              Precision::Confusion());
+    const double aU =
+      aSurface->UKnot(1) + aRatio * (aSurface->UKnot(aSurface->NbUKnots()) - aSurface->UKnot(1));
+    const double aFirstProfileParam =
+      aFirstProfile->FirstParameter()
+      + aRatio * (aFirstProfile->LastParameter() - aFirstProfile->FirstParameter());
+    const double aSecondProfileParam =
+      aSecondProfile->FirstParameter()
+      + aRatio * (aSecondProfile->LastParameter() - aSecondProfile->FirstParameter());
+    EXPECT_LE(
+      aSurface->Value(aU, aSurface->VKnot(1)).Distance(aFirstProfile->Value(aFirstProfileParam)),
+      Precision::Confusion());
     EXPECT_LE(aSurface->Value(aU, aSurface->VKnot(aSurface->NbVKnots()))
                 .Distance(aSecondProfile->Value(aSecondProfileParam)),
               Precision::Confusion());
@@ -2068,10 +2067,8 @@ TEST(GeomFill_Gordon, PolynomialProfilesWithRationalGuidesProducesSurface)
   NCollection_Array1<occ::handle<Geom_Curve>> aGuides(1, 3);
   aGuides(1) =
     makeRationalQuadraticBSpline(gp_Pnt(0, 0, 0), gp_Pnt(0, 0.5, 0), gp_Pnt(0, 1, 0), 0.5);
-  aGuides(2) = makeRationalQuadraticBSpline(gp_Pnt(0.5, 0, 0),
-                                             gp_Pnt(0.5, 0.5, 0),
-                                             gp_Pnt(0.5, 1, 0),
-                                             0.5);
+  aGuides(2) =
+    makeRationalQuadraticBSpline(gp_Pnt(0.5, 0, 0), gp_Pnt(0.5, 0.5, 0), gp_Pnt(0.5, 1, 0), 0.5);
   aGuides(3) =
     makeRationalQuadraticBSpline(gp_Pnt(1, 0, 0), gp_Pnt(1, 0.5, 0), gp_Pnt(1, 1, 0), 0.5);
 
@@ -2113,21 +2110,21 @@ TEST(GeomFill_Gordon, ApproximateFallbackCanRecoverRationalDegreeOverflow)
   EXPECT_LE(aGordon.Report().MaxApproximationDeviation, 0.001);
   EXPECT_FALSE(aGordon.Surface().IsNull());
 
-  constexpr size_t THE_NB_QUALITY_SAMPLES = 48;
-  const occ::handle<Geom_BSplineSurface>& aSurface = aGordon.Surface();
-  const double aUMin = aSurface->UKnot(1);
-  const double aUMax = aSurface->UKnot(aSurface->NbUKnots());
-  const double aVMin = aSurface->VKnot(1);
-  const double aVMax = aSurface->VKnot(aSurface->NbVKnots());
-  double       aMaxDeviation = 0.0;
+  constexpr size_t                        THE_NB_QUALITY_SAMPLES = 48;
+  const occ::handle<Geom_BSplineSurface>& aSurface               = aGordon.Surface();
+  const double                            aUMin                  = aSurface->UKnot(1);
+  const double                            aUMax         = aSurface->UKnot(aSurface->NbUKnots());
+  const double                            aVMin         = aSurface->VKnot(1);
+  const double                            aVMax         = aSurface->VKnot(aSurface->NbVKnots());
+  double                                  aMaxDeviation = 0.0;
   for (size_t aUIdx = 0; aUIdx <= THE_NB_QUALITY_SAMPLES; ++aUIdx)
   {
     const double aUParam = static_cast<double>(aUIdx) / THE_NB_QUALITY_SAMPLES;
     const double aU      = aUMin + aUParam * (aUMax - aUMin);
     for (size_t aVIdx = 0; aVIdx <= THE_NB_QUALITY_SAMPLES; ++aVIdx)
     {
-      const double aVParam = static_cast<double>(aVIdx) / THE_NB_QUALITY_SAMPLES;
-      const double aV      = aVMin + aVParam * (aVMax - aVMin);
+      const double aVParam       = static_cast<double>(aVIdx) / THE_NB_QUALITY_SAMPLES;
+      const double aV            = aVMin + aVParam * (aVMax - aVMin);
       const gp_Pnt aProfilePoint = aProfiles.At(0)->Value(aUParam);
       const gp_Pnt aGuidePoint   = aGuides.At(0)->Value(aVParam);
       const gp_Pnt anExpectedPoint(aProfilePoint.X(), aGuidePoint.Y(), 0.0);

--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
@@ -19,6 +19,7 @@
 #include <Geom_Line.hxx>
 #include <Geom_TrimmedCurve.hxx>
 #include <GeomAPI_Interpolate.hxx>
+#include <GeomAPI_ProjectPointOnCurve.hxx>
 #include <GeomFill_Gordon.hxx>
 #include <GeomFill_NetworkSurface.hxx>
 #include <NCollection_Array1.hxx>
@@ -249,6 +250,26 @@ occ::handle<Geom_BSplineCurve> makePeriodicGuide(const double theX)
   return new Geom_BSplineCurve(aPoles, aKnots, aMults, 3, true);
 }
 
+occ::handle<Geom_BSplineCurve> makeInterpolatedPeriodicProfile(const double theY,
+                                                                const int    theSeamShift)
+{
+  constexpr int    THE_NB_POINTS = 8;
+  constexpr double THE_PI        = 3.14159265358979323846;
+
+  occ::handle<NCollection_HArray1<gp_Pnt>> aPoints =
+    new NCollection_HArray1<gp_Pnt>(1, THE_NB_POINTS);
+  for (int aPointIdx = 0; aPointIdx < THE_NB_POINTS; ++aPointIdx)
+  {
+    const double anAngle =
+      2.0 * THE_PI * static_cast<double>(aPointIdx + theSeamShift) / THE_NB_POINTS;
+    aPoints->SetValue(aPointIdx + 1, gp_Pnt(std::cos(anAngle), theY, std::sin(anAngle)));
+  }
+
+  GeomAPI_Interpolate anInterpolator(aPoints, true, Precision::Confusion());
+  anInterpolator.Perform();
+  return anInterpolator.Curve();
+}
+
 //! Helper: create a cubic BSpline through 4 interpolation points on [0,1].
 occ::handle<Geom_BSplineCurve> makeCubicInterpBSpline(const gp_Pnt& theP1,
                                                       const gp_Pnt& theP2,
@@ -331,7 +352,117 @@ void verifyPointOnSurface(const occ::handle<Geom_BSplineSurface>& theSurf,
   EXPECT_LT(aDist, theTol) << "Surface point at (" << theU << ", " << theV << ") = (" << aSurfPt.X()
                            << ", " << aSurfPt.Y() << ", " << aSurfPt.Z()
                            << ") differs from expected (" << theExpected.X() << ", "
-                           << theExpected.Y() << ", " << theExpected.Z() << ") by " << aDist;
+                            << theExpected.Y() << ", " << theExpected.Z() << ") by " << aDist;
+}
+
+using HeightFunction = double (*)(double, double);
+
+double wavyHeight(const double theU, const double theV)
+{
+  return 0.35 * std::sin(M_PI * theU) * (0.4 + theV)
+         + 0.12 * std::sin(2.0 * M_PI * theV) * (1.0 - theU);
+}
+
+double saddleHeight(const double theU, const double theV)
+{
+  return 0.6 * (theU - 0.5) * (theV - 0.5) + 0.15 * std::sin(M_PI * theU) * std::sin(M_PI * theV);
+}
+
+double rippleHeight(const double theU, const double theV)
+{
+  return 0.2 * std::sin(2.0 * M_PI * theU) * std::cos(M_PI * theV)
+         + 0.1 * std::sin(3.0 * M_PI * theV);
+}
+
+struct AnalyticNetwork
+{
+  NCollection_Array1<occ::handle<Geom_Curve>> Profiles;
+  NCollection_Array1<occ::handle<Geom_Curve>> Guides;
+
+  AnalyticNetwork(const size_t          theNbProfiles,
+                  const size_t          theNbGuides,
+                  HeightFunction        theHeight,
+                  const gp_XYZ&         theOrigin = gp_XYZ(0.0, 0.0, 0.0),
+                  const double          theScale  = 1.0)
+      : Profiles(1, static_cast<int>(theNbProfiles)),
+        Guides(1, static_cast<int>(theNbGuides))
+  {
+    for (size_t aProfileIdx = 0; aProfileIdx < theNbProfiles; ++aProfileIdx)
+    {
+      const double aV = static_cast<double>(aProfileIdx) / static_cast<double>(theNbProfiles - 1);
+      occ::handle<NCollection_HArray1<gp_Pnt>> aPoints =
+        new NCollection_HArray1<gp_Pnt>(1, static_cast<int>(theNbGuides));
+      occ::handle<NCollection_HArray1<double>> aParams =
+        new NCollection_HArray1<double>(1, static_cast<int>(theNbGuides));
+      for (size_t aGuideIdx = 0; aGuideIdx < theNbGuides; ++aGuideIdx)
+      {
+        const double aU = static_cast<double>(aGuideIdx) / static_cast<double>(theNbGuides - 1);
+        aPoints->SetValue(static_cast<int>(aGuideIdx) + 1,
+                          gp_Pnt(theOrigin
+                                 + gp_XYZ(theScale * aU, theScale * aV, theScale * theHeight(aU, aV))));
+        aParams->SetValue(static_cast<int>(aGuideIdx) + 1, aU);
+      }
+      GeomAPI_Interpolate anInterpolator(aPoints, aParams, false, Precision::Confusion());
+      anInterpolator.Perform();
+      Profiles.ChangeAt(aProfileIdx) = anInterpolator.Curve();
+    }
+
+    for (size_t aGuideIdx = 0; aGuideIdx < theNbGuides; ++aGuideIdx)
+    {
+      const double aU = static_cast<double>(aGuideIdx) / static_cast<double>(theNbGuides - 1);
+      occ::handle<NCollection_HArray1<gp_Pnt>> aPoints =
+        new NCollection_HArray1<gp_Pnt>(1, static_cast<int>(theNbProfiles));
+      occ::handle<NCollection_HArray1<double>> aParams =
+        new NCollection_HArray1<double>(1, static_cast<int>(theNbProfiles));
+      for (size_t aProfileIdx = 0; aProfileIdx < theNbProfiles; ++aProfileIdx)
+      {
+        const double aV = static_cast<double>(aProfileIdx) / static_cast<double>(theNbProfiles - 1);
+        aPoints->SetValue(static_cast<int>(aProfileIdx) + 1,
+                          gp_Pnt(theOrigin
+                                 + gp_XYZ(theScale * aU, theScale * aV, theScale * theHeight(aU, aV))));
+        aParams->SetValue(static_cast<int>(aProfileIdx) + 1, aV);
+      }
+      GeomAPI_Interpolate anInterpolator(aPoints, aParams, false, Precision::Confusion());
+      anInterpolator.Perform();
+      Guides.ChangeAt(aGuideIdx) = anInterpolator.Curve();
+    }
+  }
+};
+
+void verifyUniformNetworkInterpolation(const occ::handle<Geom_BSplineSurface>& theSurface,
+                                       const AnalyticNetwork&                  theNetwork,
+                                       const double                            theTolerance)
+{
+  ASSERT_FALSE(theSurface.IsNull());
+  constexpr size_t THE_NB_SAMPLES = 32;
+  const double aUMin = theSurface->UKnot(1);
+  const double aUMax = theSurface->UKnot(theSurface->NbUKnots());
+  const double aVMin = theSurface->VKnot(1);
+  const double aVMax = theSurface->VKnot(theSurface->NbVKnots());
+  for (size_t aProfileIdx = 0; aProfileIdx < theNetwork.Profiles.Size(); ++aProfileIdx)
+  {
+    const double aV = aVMin + static_cast<double>(aProfileIdx)
+                                  / static_cast<double>(theNetwork.Profiles.Size() - 1) * (aVMax - aVMin);
+    for (size_t aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
+    {
+      const double aParam = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
+      const double aU     = aUMin + aParam * (aUMax - aUMin);
+      EXPECT_LE(theSurface->Value(aU, aV).Distance(theNetwork.Profiles.At(aProfileIdx)->Value(aParam)),
+                theTolerance);
+    }
+  }
+  for (size_t aGuideIdx = 0; aGuideIdx < theNetwork.Guides.Size(); ++aGuideIdx)
+  {
+    const double aU = aUMin + static_cast<double>(aGuideIdx)
+                                  / static_cast<double>(theNetwork.Guides.Size() - 1) * (aUMax - aUMin);
+    for (size_t aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
+    {
+      const double aParam = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
+      const double aV     = aVMin + aParam * (aVMax - aVMin);
+      EXPECT_LE(theSurface->Value(aU, aV).Distance(theNetwork.Guides.At(aGuideIdx)->Value(aParam)),
+                theTolerance);
+    }
+  }
 }
 
 } // namespace
@@ -541,6 +672,78 @@ TEST(GeomFill_Gordon, CurvedBSplineNetwork_ProducesValidSurface)
   EXPECT_NEAR(aMidPt.Z(), 0.3, 1.0e-6) << "Surface should have Z-bump at center";
 }
 
+TEST(GeomFill_Gordon, NonAffineProfileReparametrization_PreservesProfilesAndGuideContinuity)
+{
+  NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
+  aProfiles(1) = makeCubicInterpBSpline(gp_Pnt(0, 0, 0),
+                                         gp_Pnt(0.25, 0, 0.4),
+                                         gp_Pnt(0.75, 0, -0.3),
+                                         gp_Pnt(1, 0, 0));
+  aProfiles(2) = makeCubicInterpBSpline(gp_Pnt(0, 0.5, 0),
+                                         gp_Pnt(0.25, 0.5, 0.2),
+                                         gp_Pnt(0.75, 0.5, -0.5),
+                                         gp_Pnt(1, 0.5, 0));
+  aProfiles(3) = makeCubicInterpBSpline(gp_Pnt(0, 1, 0),
+                                         gp_Pnt(0.25, 1, 0.5),
+                                         gp_Pnt(0.75, 1, -0.2),
+                                         gp_Pnt(1, 1, 0));
+
+  occ::handle<NCollection_HArray1<gp_Pnt>> aGuidePoints = new NCollection_HArray1<gp_Pnt>(1, 3);
+  aGuidePoints->SetValue(1, aProfiles(1)->Value(0.4));
+  aGuidePoints->SetValue(2, aProfiles(2)->Value(0.5));
+  aGuidePoints->SetValue(3, aProfiles(3)->Value(0.6));
+  occ::handle<NCollection_HArray1<double>> aGuideParams = new NCollection_HArray1<double>(1, 3);
+  aGuideParams->SetValue(1, 0.0);
+  aGuideParams->SetValue(2, 0.5);
+  aGuideParams->SetValue(3, 1.0);
+  GeomAPI_Interpolate anInterpolator(aGuidePoints, aGuideParams, false, Precision::Confusion());
+  anInterpolator.Perform();
+  ASSERT_TRUE(anInterpolator.IsDone());
+
+  NCollection_Array1<occ::handle<Geom_Curve>> aGuides(1, 3);
+  aGuides(1) = makeLinearBSpline(aProfiles(1)->Value(0.0), aProfiles(3)->Value(0.0));
+  aGuides(2) = anInterpolator.Curve();
+  aGuides(3) = makeLinearBSpline(aProfiles(1)->Value(1.0), aProfiles(3)->Value(1.0));
+
+  GeomFill_Gordon aGordon;
+  aGordon.Init(aProfiles, aGuides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  const occ::handle<Geom_BSplineSurface>& aSurface = aGordon.Surface();
+  EXPECT_LE(aGordon.Report().MaxProfileDeviation, Precision::Confusion());
+  EXPECT_LE(aGordon.Report().MaxGuideDeviation, Precision::Confusion());
+  const double aMiddleProfileV =
+    0.5 * (aSurface->VKnot(1) + aSurface->VKnot(aSurface->NbVKnots()));
+  constexpr int THE_NB_SAMPLES = 32;
+  for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
+  {
+    const double aRatio = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
+    const double aU     = aSurface->UKnot(1)
+                       + aRatio * (aSurface->UKnot(aSurface->NbUKnots()) - aSurface->UKnot(1));
+    const double aProfile1Param = aRatio <= 0.5 ? 0.8 * aRatio : 1.2 * aRatio - 0.2;
+    const double aProfile3Param = aRatio <= 0.5 ? 1.2 * aRatio : 0.2 + 0.8 * aRatio;
+
+    EXPECT_LE(aSurface->Value(aU, aSurface->VKnot(1)).Distance(aProfiles(1)->Value(aProfile1Param)),
+              Precision::Confusion());
+    EXPECT_LE(aSurface->Value(aU, aMiddleProfileV).Distance(aProfiles(2)->Value(aRatio)),
+              Precision::Confusion());
+    EXPECT_LE(aSurface->Value(aU, aSurface->VKnot(aSurface->NbVKnots()))
+                .Distance(aProfiles(3)->Value(aProfile3Param)),
+              Precision::Confusion());
+  }
+
+  const double aGuideU = 0.5 * (aSurface->UKnot(1) + aSurface->UKnot(aSurface->NbUKnots()));
+  for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
+  {
+    const double aRatio = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
+    const double aV     = aSurface->VKnot(1)
+                       + aRatio * (aSurface->VKnot(aSurface->NbVKnots()) - aSurface->VKnot(1));
+    EXPECT_LE(aSurface->Value(aGuideU, aV).Distance(aGuides(2)->Value(aRatio)),
+              Precision::Confusion());
+  }
+}
+
 TEST(GeomFill_Gordon, MixedCurveTypes_ProducesValidSurface)
 {
   NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 2);
@@ -609,6 +812,81 @@ TEST(GeomFill_Gordon, PeriodicBSplineGuides_AreExpandedBeforeConstruction)
   EXPECT_TRUE(aGordon.Surface()->IsVPeriodic());
 }
 
+TEST(GeomFill_Gordon, InterpolatedPeriodicProfilesWithAlignedSeams_InterpolateWithoutDeviation)
+{
+  NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 2);
+  aProfiles(1) = makeInterpolatedPeriodicProfile(0.0, 0);
+  aProfiles(2) = makeInterpolatedPeriodicProfile(1.0, 2);
+
+  const occ::handle<Geom_BSplineCurve> aFirstProfile =
+    occ::down_cast<Geom_BSplineCurve>(aProfiles(1));
+  const occ::handle<Geom_BSplineCurve> aSecondProfile =
+    occ::down_cast<Geom_BSplineCurve>(aProfiles(2));
+  const gp_Pnt aFirstSeam = aFirstProfile->Value(aFirstProfile->FirstParameter());
+  GeomAPI_ProjectPointOnCurve aSeamProjection(
+    gp_Pnt(aFirstSeam.X(), 1.0, aFirstSeam.Z()), aSecondProfile);
+  ASSERT_GT(aSeamProjection.NbPoints(), 0);
+  aSecondProfile->SetOrigin(aSeamProjection.LowerDistanceParameter(), Precision::Confusion());
+  const double aFirstProfileMiddle =
+    0.5 * (aFirstProfile->FirstParameter() + aFirstProfile->LastParameter());
+  const double aSecondProfileMiddle =
+    0.5 * (aSecondProfile->FirstParameter() + aSecondProfile->LastParameter());
+  const gp_Pnt aSecondSeam = aSecondProfile->Value(aSecondProfile->FirstParameter());
+  const gp_Pnt aFirstMiddle = aFirstProfile->Value(aFirstProfileMiddle);
+  const gp_Pnt aSecondMiddle = aSecondProfile->Value(aSecondProfileMiddle);
+  ASSERT_LE(aFirstSeam.Distance(gp_Pnt(aSecondSeam.X(), aFirstSeam.Y(), aSecondSeam.Z())),
+            Precision::Confusion());
+  ASSERT_LE(aFirstMiddle.Distance(gp_Pnt(aSecondMiddle.X(), aFirstMiddle.Y(), aSecondMiddle.Z())),
+            Precision::Confusion());
+
+  NCollection_Array1<occ::handle<Geom_Curve>> aGuides(1, 3);
+  aGuides(1) =
+    makeLinearBSpline(aFirstProfile->Value(aFirstProfile->FirstParameter()),
+                      aSecondProfile->Value(aSecondProfile->FirstParameter()));
+  aGuides(2) =
+    makeLinearBSpline(aFirstProfile->Value(aFirstProfileMiddle),
+                      aSecondProfile->Value(aSecondProfileMiddle));
+  aGuides(3) =
+    makeLinearBSpline(aFirstProfile->Value(aFirstProfile->FirstParameter()),
+                      aSecondProfile->Value(aSecondProfile->FirstParameter()));
+
+  GeomFill_Gordon aGordon;
+  aGordon.Init(aProfiles, aGuides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  const occ::handle<Geom_BSplineSurface>& aSurface = aGordon.Surface();
+  EXPECT_TRUE(aSurface->IsUPeriodic());
+  EXPECT_LE(aGordon.Report().MaxProfileDeviation, Precision::Confusion());
+  EXPECT_LE(aGordon.Report().MaxGuideDeviation, Precision::Confusion());
+
+  const double aMiddleV = 0.5 * (aSurface->VKnot(1) + aSurface->VKnot(aSurface->NbVKnots()));
+  const Geom_Surface::ResD1 aFirstSeamD1 = aSurface->EvalD1(aSurface->UKnot(1), aMiddleV);
+  const Geom_Surface::ResD1 aLastSeamD1 =
+    aSurface->EvalD1(aSurface->UKnot(aSurface->NbUKnots()), aMiddleV);
+  EXPECT_LE(aFirstSeamD1.D1U.Angle(aLastSeamD1.D1U), Precision::Angular());
+
+  constexpr int THE_NB_SAMPLES = 16;
+  for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
+  {
+    const double aRatio = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
+    const double aU = aSurface->UKnot(1)
+                      + aRatio * (aSurface->UKnot(aSurface->NbUKnots()) - aSurface->UKnot(1));
+    const double aFirstProfileParam = aFirstProfile->FirstParameter()
+                                      + aRatio * (aFirstProfile->LastParameter()
+                                                  - aFirstProfile->FirstParameter());
+    const double aSecondProfileParam = aSecondProfile->FirstParameter()
+                                       + aRatio * (aSecondProfile->LastParameter()
+                                                   - aSecondProfile->FirstParameter());
+    EXPECT_LE(aSurface->Value(aU, aSurface->VKnot(1))
+                .Distance(aFirstProfile->Value(aFirstProfileParam)),
+              Precision::Confusion());
+    EXPECT_LE(aSurface->Value(aU, aSurface->VKnot(aSurface->NbVKnots()))
+                .Distance(aSecondProfile->Value(aSecondProfileParam)),
+              Precision::Confusion());
+  }
+}
+
 TEST(GeomFill_Gordon, MultipleIntersections_SelectsMonotoneBranch)
 {
   NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
@@ -627,10 +905,17 @@ TEST(GeomFill_Gordon, MultipleIntersections_SelectsMonotoneBranch)
 
   ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
   ASSERT_FALSE(aGordon.Surface().IsNull());
+  EXPECT_LE(aGordon.Report().MaxProfileDeviation, 1.0e-5);
+  EXPECT_LE(aGordon.Report().MaxGuideDeviation, 1.0e-5);
   verifyPointOnSurface(aGordon.Surface(), 0.0, 0.0, gp_Pnt(0.0, 0.0, 0.0), 1.0e-3);
   verifyPointOnSurface(aGordon.Surface(), 1.0, 0.0, gp_Pnt(1.0, 0.0, 0.0), 1.0e-3);
   verifyPointOnSurface(aGordon.Surface(), 0.0, 1.0, gp_Pnt(0.0, 1.0, 0.0), 1.0e-3);
   verifyPointOnSurface(aGordon.Surface(), 1.0, 1.0, gp_Pnt(1.0, 1.0, 0.0), 1.0e-3);
+
+  const gp_Pnt aFirstCenter = aGordon.Surface()->Value(0.5, 0.5);
+  aGordon.Perform();
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_LE(aFirstCenter.Distance(aGordon.Surface()->Value(0.5, 0.5)), Precision::Confusion());
 }
 
 TEST(GeomFill_Gordon, FourByThreeGrid_NonUniformParams)
@@ -1769,6 +2054,36 @@ TEST(GeomFill_Gordon, RationalProfilesWithPolynomialGuidesProducesSurface)
   ASSERT_TRUE(aGordon.IsDone());
   EXPECT_FALSE(aGordon.IsApproximate());
   EXPECT_TRUE(aGordon.Surface()->IsURational() || aGordon.Surface()->IsVRational());
+  EXPECT_LE(aGordon.Report().MaxProfileDeviation, Precision::Confusion());
+  EXPECT_LE(aGordon.Report().MaxGuideDeviation, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, PolynomialProfilesWithRationalGuidesProducesSurface)
+{
+  NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
+  aProfiles(1) = makeLinearBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0));
+  aProfiles(2) = makeLinearBSpline(gp_Pnt(0, 0.5, 0), gp_Pnt(1, 0.5, 0));
+  aProfiles(3) = makeLinearBSpline(gp_Pnt(0, 1, 0), gp_Pnt(1, 1, 0));
+
+  NCollection_Array1<occ::handle<Geom_Curve>> aGuides(1, 3);
+  aGuides(1) =
+    makeRationalQuadraticBSpline(gp_Pnt(0, 0, 0), gp_Pnt(0, 0.5, 0), gp_Pnt(0, 1, 0), 0.5);
+  aGuides(2) = makeRationalQuadraticBSpline(gp_Pnt(0.5, 0, 0),
+                                             gp_Pnt(0.5, 0.5, 0),
+                                             gp_Pnt(0.5, 1, 0),
+                                             0.5);
+  aGuides(3) =
+    makeRationalQuadraticBSpline(gp_Pnt(1, 0, 0), gp_Pnt(1, 0.5, 0), gp_Pnt(1, 1, 0), 0.5);
+
+  GeomFill_Gordon aGordon;
+  aGordon.Init(aProfiles, aGuides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  EXPECT_TRUE(aGordon.Surface()->IsURational() || aGordon.Surface()->IsVRational());
+  EXPECT_LE(aGordon.Report().MaxProfileDeviation, Precision::Confusion());
+  EXPECT_LE(aGordon.Report().MaxGuideDeviation, Precision::Confusion());
 }
 
 TEST(GeomFill_Gordon, ApproximateFallbackCanRecoverRationalDegreeOverflow)
@@ -1795,8 +2110,32 @@ TEST(GeomFill_Gordon, ApproximateFallbackCanRecoverRationalDegreeOverflow)
   EXPECT_EQ(aGordon.Report().Status, GeomFill_Gordon::ResultStatus::Done);
   EXPECT_TRUE(aGordon.Report().IsApproximate);
   EXPECT_EQ(aGordon.Report().FailedStage, GeomFill_Gordon::BuildStage::NotStarted);
-  EXPECT_NEAR(aGordon.Report().MaxApproximationDeviation, 0.015625557595219788, 1.0e-12);
+  EXPECT_LE(aGordon.Report().MaxApproximationDeviation, 0.001);
   EXPECT_FALSE(aGordon.Surface().IsNull());
+
+  constexpr size_t THE_NB_QUALITY_SAMPLES = 48;
+  const occ::handle<Geom_BSplineSurface>& aSurface = aGordon.Surface();
+  const double aUMin = aSurface->UKnot(1);
+  const double aUMax = aSurface->UKnot(aSurface->NbUKnots());
+  const double aVMin = aSurface->VKnot(1);
+  const double aVMax = aSurface->VKnot(aSurface->NbVKnots());
+  double       aMaxDeviation = 0.0;
+  for (size_t aUIdx = 0; aUIdx <= THE_NB_QUALITY_SAMPLES; ++aUIdx)
+  {
+    const double aUParam = static_cast<double>(aUIdx) / THE_NB_QUALITY_SAMPLES;
+    const double aU      = aUMin + aUParam * (aUMax - aUMin);
+    for (size_t aVIdx = 0; aVIdx <= THE_NB_QUALITY_SAMPLES; ++aVIdx)
+    {
+      const double aVParam = static_cast<double>(aVIdx) / THE_NB_QUALITY_SAMPLES;
+      const double aV      = aVMin + aVParam * (aVMax - aVMin);
+      const gp_Pnt aProfilePoint = aProfiles.At(0)->Value(aUParam);
+      const gp_Pnt aGuidePoint   = aGuides.At(0)->Value(aVParam);
+      const gp_Pnt anExpectedPoint(aProfilePoint.X(), aGuidePoint.Y(), 0.0);
+      aMaxDeviation = std::max(aMaxDeviation, aSurface->Value(aU, aV).Distance(anExpectedPoint));
+    }
+  }
+  // An interior Gordon point combines the independently approximated profile and guide skins.
+  EXPECT_LE(aMaxDeviation, 0.002);
 }
 
 TEST(GeomFill_Gordon, ExactOnlyReportsRationalDegreeOverflow)
@@ -1826,7 +2165,7 @@ TEST(GeomFill_Gordon, ExactOnlyReportsRationalDegreeOverflow)
   EXPECT_FALSE(aGordon.Report().IsApproximate);
 }
 
-TEST(GeomFill_Gordon, ExactOnlyReportsRationalReparametrizationFailure)
+TEST(GeomFill_Gordon, ExactOnlyReparametrizesRationalCurves)
 {
   NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
   aProfiles(1) = makeRationalQuadraticLineBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0), 1.0, 0.45, 1.0);
@@ -1843,15 +2182,16 @@ TEST(GeomFill_Gordon, ExactOnlyReportsRationalReparametrizationFailure)
   aGordon.Init(aProfiles, aGuides, Precision::Confusion());
   aGordon.Perform();
 
-  EXPECT_FALSE(aGordon.IsDone());
+  EXPECT_TRUE(aGordon.IsDone());
   EXPECT_FALSE(aGordon.IsApproximate());
-  EXPECT_EQ(aGordon.Status(), GeomFill_Gordon::ResultStatus::RationalReparametrizationFailed);
-  EXPECT_EQ(aGordon.Report().Status,
-            GeomFill_Gordon::ResultStatus::RationalReparametrizationFailed);
-  EXPECT_EQ(aGordon.Report().FailedStage, GeomFill_Gordon::BuildStage::Reparametrization);
+  EXPECT_EQ(aGordon.Status(), GeomFill_Gordon::ResultStatus::Done);
+  EXPECT_EQ(aGordon.Report().Status, GeomFill_Gordon::ResultStatus::Done);
+  EXPECT_EQ(aGordon.Report().FailedStage, GeomFill_Gordon::BuildStage::NotStarted);
+  EXPECT_FALSE(aGordon.Report().IsApproximate);
+  EXPECT_NEAR(aGordon.Report().MaxReparametrizationDeviation, 0.0, 1.0e-12);
 }
 
-TEST(GeomFill_Gordon, ApproximateFallbackCanReparametrizeRationalCurves)
+TEST(GeomFill_Gordon, ApproximationModeUsesExactRationalReparametrizationWhenPossible)
 {
   NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
   aProfiles(1) = makeRationalQuadraticLineBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0), 1.0, 0.45, 1.0);
@@ -1870,14 +2210,14 @@ TEST(GeomFill_Gordon, ApproximateFallbackCanReparametrizeRationalCurves)
   aGordon.Perform();
 
   ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
-  EXPECT_TRUE(aGordon.IsApproximate());
+  EXPECT_FALSE(aGordon.IsApproximate());
   EXPECT_EQ(aGordon.Report().Status, GeomFill_Gordon::ResultStatus::Done);
-  EXPECT_TRUE(aGordon.Report().IsApproximate);
+  EXPECT_FALSE(aGordon.Report().IsApproximate);
   EXPECT_NEAR(aGordon.Report().MaxReparametrizationDeviation, 0.0, 1.0e-12);
   EXPECT_FALSE(aGordon.Surface().IsNull());
 }
 
-TEST(GeomFill_Gordon, ApproximateFallbackRepeatPerformKeepsReportStable)
+TEST(GeomFill_Gordon, ExactRationalReparametrizationRepeatPerformKeepsReportStable)
 {
   NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 3);
   aProfiles(1) = makeRationalQuadraticLineBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0), 1.0, 0.45, 1.0);
@@ -1896,10 +2236,10 @@ TEST(GeomFill_Gordon, ApproximateFallbackRepeatPerformKeepsReportStable)
 
   aGordon.Perform();
   ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
-  EXPECT_TRUE(aGordon.IsApproximate());
+  EXPECT_FALSE(aGordon.IsApproximate());
   EXPECT_EQ(aGordon.Report().Status, GeomFill_Gordon::ResultStatus::Done);
   EXPECT_EQ(aGordon.Report().FailedStage, GeomFill_Gordon::BuildStage::NotStarted);
-  EXPECT_TRUE(aGordon.Report().IsApproximate);
+  EXPECT_FALSE(aGordon.Report().IsApproximate);
   EXPECT_NEAR(aGordon.Report().MaxContactGap, 0.0, 1.0e-12);
   EXPECT_NEAR(aGordon.Report().MaxReparametrizationDeviation, 0.0, 1.0e-12);
   EXPECT_NEAR(aGordon.Report().MaxApproximationDeviation, 0.0, 1.0e-12);
@@ -1907,10 +2247,10 @@ TEST(GeomFill_Gordon, ApproximateFallbackRepeatPerformKeepsReportStable)
 
   aGordon.Perform();
   ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
-  EXPECT_TRUE(aGordon.IsApproximate());
+  EXPECT_FALSE(aGordon.IsApproximate());
   EXPECT_EQ(aGordon.Report().Status, GeomFill_Gordon::ResultStatus::Done);
   EXPECT_EQ(aGordon.Report().FailedStage, GeomFill_Gordon::BuildStage::NotStarted);
-  EXPECT_TRUE(aGordon.Report().IsApproximate);
+  EXPECT_FALSE(aGordon.Report().IsApproximate);
   EXPECT_NEAR(aGordon.Report().MaxContactGap, 0.0, 1.0e-12);
   EXPECT_NEAR(aGordon.Report().MaxReparametrizationDeviation, 0.0, 1.0e-12);
   EXPECT_NEAR(aGordon.Report().MaxApproximationDeviation, 0.0, 1.0e-12);
@@ -1957,4 +2297,154 @@ TEST(GeomFill_Gordon, NetworkSurface_VClosedNetwork_ProducesVPeriodicSurface)
   const occ::handle<Geom_BSplineSurface>& aSurf = aNetwork.Surface();
   ASSERT_FALSE(aSurf.IsNull());
   EXPECT_TRUE(aSurf->IsVPeriodic());
+}
+
+TEST(GeomFill_Gordon, DenseWavyFiveByFiveNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(5, 5, wavyHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, DenseSaddleSevenByFourNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(7, 4, saddleHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, DenseRippleFourBySevenNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(4, 7, rippleHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, DenseWavyEightByEightNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(8, 8, wavyHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, TranslatedScaledSixByFiveNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(6, 5, rippleHeight, gp_XYZ(1.0e5, -2.0e5, 3.0e5), 250.0);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, 1.0e-5);
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, 1.0e-5);
+}
+
+TEST(GeomFill_Gordon, SmallScaledFiveBySixNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(5, 6, saddleHeight, gp_XYZ(0.0, 0.0, 0.0), 0.01);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, DenseWavyNetwork_ParallelConstructionMatchesSerialQuality)
+{
+  const AnalyticNetwork aNetwork(6, 6, wavyHeight);
+  GeomFill_Gordon       aSerial;
+  aSerial.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aSerial.Perform();
+  ASSERT_TRUE(aSerial.IsDone()) << static_cast<int>(aSerial.Status());
+
+  GeomFill_Gordon aParallel;
+  aParallel.SetParallelMode(true);
+  aParallel.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aParallel.Perform();
+  ASSERT_TRUE(aParallel.IsDone()) << static_cast<int>(aParallel.Status());
+
+  verifyUniformNetworkInterpolation(aSerial.Surface(), aNetwork, Precision::Confusion());
+  verifyUniformNetworkInterpolation(aParallel.Surface(), aNetwork, Precision::Confusion());
+  constexpr size_t THE_NB_SAMPLES = 24;
+  for (size_t aUIdx = 0; aUIdx <= THE_NB_SAMPLES; ++aUIdx)
+  {
+    for (size_t aVIdx = 0; aVIdx <= THE_NB_SAMPLES; ++aVIdx)
+    {
+      const double aU = static_cast<double>(aUIdx) / THE_NB_SAMPLES;
+      const double aV = static_cast<double>(aVIdx) / THE_NB_SAMPLES;
+      EXPECT_LE(aSerial.Surface()->Value(aU, aV).Distance(aParallel.Surface()->Value(aU, aV)),
+                Precision::Confusion());
+    }
+  }
+}
+
+TEST(GeomFill_Gordon, DenseSaddleNetwork_RepeatedPerformMaintainsQuality)
+{
+  const AnalyticNetwork aNetwork(6, 5, saddleHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  const occ::handle<Geom_BSplineSurface> aFirstSurface = aGordon.Surface();
+
+  aGordon.Perform();
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+  constexpr size_t THE_NB_SAMPLES = 24;
+  for (size_t aUIdx = 0; aUIdx <= THE_NB_SAMPLES; ++aUIdx)
+  {
+    for (size_t aVIdx = 0; aVIdx <= THE_NB_SAMPLES; ++aVIdx)
+    {
+      const double aU = static_cast<double>(aUIdx) / THE_NB_SAMPLES;
+      const double aV = static_cast<double>(aVIdx) / THE_NB_SAMPLES;
+      EXPECT_LE(aFirstSurface->Value(aU, aV).Distance(aGordon.Surface()->Value(aU, aV)),
+                Precision::Confusion());
+    }
+  }
+}
+
+TEST(GeomFill_Gordon, DenseRippleNineByThreeNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(9, 3, rippleHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, DenseWavyThreeByNineNetwork_InterpolatesAllInputCurves)
+{
+  const AnalyticNetwork aNetwork(3, 9, wavyHeight);
+  GeomFill_Gordon       aGordon;
+  aGordon.Init(aNetwork.Profiles, aNetwork.Guides, Precision::Confusion());
+  aGordon.Perform();
+
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
 }

--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/GeomFill_Gordon_Test.cxx
@@ -12,8 +12,6 @@
 // commercial license or contractual agreement.
 
 #include <BSplCLib.hxx>
-#include <BRepBuilderAPI_MakeFace.hxx>
-#include <BRepTools.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_Line.hxx>
@@ -32,8 +30,6 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
-#include <filesystem>
-#include <string>
 
 namespace
 {
@@ -58,8 +54,10 @@ occ::handle<Geom_BSplineCurve> makeLinearBSpline(const gp_Pnt& theP1, const gp_P
 
 //! Helper: create a quadratic BSpline curve through 3 control points on [0,1].
 occ::handle<Geom_BSplineCurve> makeQuadraticBSpline(const gp_Pnt& theP1,
-                                                    const gp_Pnt& theP2,
-                                                    const gp_Pnt& theP3)
+                                                     const gp_Pnt& theP2,
+                                                     const gp_Pnt& theP3,
+                                                     const double  theFirstParameter = 0.0,
+                                                     const double  theLastParameter  = 1.0)
 {
   NCollection_Array1<gp_Pnt> aPoles(1, 3);
   aPoles(1) = theP1;
@@ -67,8 +65,8 @@ occ::handle<Geom_BSplineCurve> makeQuadraticBSpline(const gp_Pnt& theP1,
   aPoles(3) = theP3;
 
   NCollection_Array1<double> aKnots(1, 2);
-  aKnots(1) = 0.0;
-  aKnots(2) = 1.0;
+  aKnots(1) = theFirstParameter;
+  aKnots(2) = theLastParameter;
 
   NCollection_Array1<int> aMults(1, 2);
   aMults(1) = 3;
@@ -248,6 +246,37 @@ occ::handle<Geom_BSplineCurve> makePeriodicGuide(const double theX)
   aMults.Init(1);
 
   return new Geom_BSplineCurve(aPoles, aKnots, aMults, 3, true);
+}
+
+occ::handle<Geom_BSplineCurve> makeClosedBSplineProfile(const double theY,
+                                                        const double theXRadius,
+                                                        const double theZRadius)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 9);
+  aPoles(1) = gp_Pnt(theXRadius, theY, 0.0);
+  aPoles(2) = gp_Pnt(theXRadius, theY, 0.7 * theZRadius);
+  aPoles(3) = gp_Pnt(0.3 * theXRadius, theY, theZRadius);
+  aPoles(4) = gp_Pnt(-0.7 * theXRadius, theY, 0.8 * theZRadius);
+  aPoles(5) = gp_Pnt(-theXRadius, theY, 0.0);
+  aPoles(6) = gp_Pnt(-0.7 * theXRadius, theY, -0.8 * theZRadius);
+  aPoles(7) = gp_Pnt(0.3 * theXRadius, theY, -theZRadius);
+  aPoles(8) = gp_Pnt(theXRadius, theY, -0.7 * theZRadius);
+  aPoles(9) = gp_Pnt(theXRadius, theY, 0.0);
+
+  NCollection_Array1<double> aKnots(1, 7);
+  for (int aKnotIdx = 1; aKnotIdx <= 7; ++aKnotIdx)
+  {
+    aKnots(aKnotIdx) = static_cast<double>(aKnotIdx - 1) / 6.0;
+  }
+
+  NCollection_Array1<int> aMults(1, 7);
+  aMults(1) = 4;
+  aMults(7) = 4;
+  for (int aKnotIdx = 2; aKnotIdx < 7; ++aKnotIdx)
+  {
+    aMults(aKnotIdx) = 1;
+  }
+  return new Geom_BSplineCurve(aPoles, aKnots, aMults, 3, false);
 }
 
 occ::handle<Geom_BSplineCurve> makeInterpolatedPeriodicProfile(const double theY,
@@ -2444,4 +2473,77 @@ TEST(GeomFill_Gordon, DenseWavyThreeByNineNetwork_InterpolatesAllInputCurves)
   ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
   EXPECT_FALSE(aGordon.IsApproximate());
   verifyUniformNetworkInterpolation(aGordon.Surface(), aNetwork, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, ClosedBSplineProfilesWithInteriorGuides_ProducePeriodicSurface)
+{
+  NCollection_Array1<occ::handle<Geom_Curve>> aProfiles(1, 2);
+  aProfiles(1) = makeClosedBSplineProfile(0.0, 1.0, 1.0);
+  aProfiles(2) = makeClosedBSplineProfile(1.0, 1.15, 0.85);
+  ASSERT_FALSE(occ::down_cast<Geom_BSplineCurve>(aProfiles(1))->IsPeriodic());
+  ASSERT_LE(aProfiles(1)
+              ->Value(aProfiles(1)->FirstParameter())
+              .Distance(aProfiles(1)->Value(aProfiles(1)->LastParameter())),
+            Precision::Confusion());
+
+  NCollection_Array1<occ::handle<Geom_Curve>> aGuides(1, 4);
+  NCollection_Array1<double>                  aGuideParameters(1, 4);
+  aGuideParameters(1) = 0.12;
+  aGuideParameters(2) = 0.34;
+  aGuideParameters(3) = 0.59;
+  aGuideParameters(4) = 0.83;
+  for (int aGuideIdx = aGuides.Lower(); aGuideIdx <= aGuides.Upper(); ++aGuideIdx)
+  {
+    const double aParameter = aGuideParameters(aGuideIdx);
+    aGuides(aGuideIdx) =
+      makeLinearBSpline(aProfiles(1)->Value(aParameter), aProfiles(2)->Value(aParameter));
+  }
+
+  GeomFill_Gordon aGordon;
+  aGordon.Init(aProfiles, aGuides, Precision::Confusion());
+  aGordon.Perform();
+  ASSERT_TRUE(aGordon.IsDone()) << static_cast<int>(aGordon.Status());
+  EXPECT_FALSE(aGordon.IsApproximate());
+  EXPECT_TRUE(aGordon.Surface()->IsUPeriodic());
+  EXPECT_LE(aGordon.Report().MaxProfileDeviation, Precision::Confusion());
+  EXPECT_LE(aGordon.Report().MaxGuideDeviation, Precision::Confusion());
+}
+
+TEST(GeomFill_Gordon, NetworkSurface_ClosedNetworkWithNonUnitUParameters_ProducesUPeriodicSurface)
+{
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aProfiles(1, 2);
+  aProfiles(1) =
+    makeQuadraticBSpline(gp_Pnt(0, 0, 0), gp_Pnt(1, 0, 0), gp_Pnt(0, 0, 0), 2.0, 5.0);
+  aProfiles(2) =
+    makeQuadraticBSpline(gp_Pnt(0, 1, 0), gp_Pnt(1, 1, 1), gp_Pnt(0, 1, 0), 2.0, 5.0);
+
+  NCollection_Array1<double> aGuideParameters(1, 2);
+  aGuideParameters(1) = 2.0;
+  aGuideParameters(2) = 3.5;
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aGuides(1, 2);
+  for (int aGuideIdx = aGuides.Lower(); aGuideIdx <= aGuides.Upper(); ++aGuideIdx)
+  {
+    const double aParameter = aGuideParameters(aGuideIdx);
+    aGuides(aGuideIdx) =
+      makeLinearBSpline(aProfiles(1)->Value(aParameter), aProfiles(2)->Value(aParameter));
+  }
+
+  NCollection_Array1<double> aProfileParameters(1, 2);
+  aProfileParameters(1) = 0.0;
+  aProfileParameters(2) = 1.0;
+
+  GeomFill_NetworkSurface aNetwork;
+  aNetwork.Init(aProfiles,
+                aGuides,
+                aProfileParameters,
+                aGuideParameters,
+                makeIntersectionGrid(aProfiles, aGuideParameters),
+                makeUnitWeightGrid(aProfiles, aGuideParameters),
+                Precision::Confusion(),
+                true,
+                false);
+  aNetwork.Perform();
+
+  ASSERT_TRUE(aNetwork.IsDone()) << static_cast<int>(aNetwork.Status());
+  EXPECT_TRUE(aNetwork.Surface()->IsUPeriodic());
 }

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
@@ -167,9 +167,9 @@ NCollection_Array2<gp_Pnt> profileSampleGrid(
 {
   const NCollection_Array1<double> aUParams = unitParameters(theNbUSamples);
   NCollection_Array2<gp_Pnt>       aPoints(1,
-                                           static_cast<int>(theNbUSamples),
-                                           1,
-                                           static_cast<int>(theProfiles.Size()));
+                                     static_cast<int>(theNbUSamples),
+                                     1,
+                                     static_cast<int>(theProfiles.Size()));
   for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
   {
     const GeomGridEval_Curve         anEvaluator(theProfiles.At(aProfileIdx));
@@ -191,9 +191,9 @@ NCollection_Array2<gp_Pnt> guideSampleGrid(
 {
   const NCollection_Array1<double> aVParams = unitParameters(theNbVSamples);
   NCollection_Array2<gp_Pnt>       aPoints(1,
-                                           static_cast<int>(theGuides.Size()),
-                                           1,
-                                           static_cast<int>(theNbVSamples));
+                                     static_cast<int>(theGuides.Size()),
+                                     1,
+                                     static_cast<int>(theNbVSamples));
   for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
   {
     const GeomGridEval_Curve         anEvaluator(theGuides.At(aGuideIdx));
@@ -229,9 +229,9 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
     return nullptr;
   }
   NCollection_Array2<gp_Pnt>       aPoints(1,
-                                           static_cast<int>(aNbUSamples),
-                                           1,
-                                           static_cast<int>(aNbVSamples));
+                                     static_cast<int>(aNbUSamples),
+                                     1,
+                                     static_cast<int>(aNbVSamples));
   const NCollection_Array1<double> aUParams = unitParameters(aNbUSamples);
   const NCollection_Array1<double> aVParams = unitParameters(aNbVSamples);
   const GeomGridEval_Surface       aProfileEvaluator(aProfileSurface);
@@ -246,9 +246,9 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
   {
     for (size_t aVIdx = 0; aVIdx < aNbVSamples; ++aVIdx)
     {
-      const gp_XYZ aPoint            = aProfilePoints.At(aUIdx, aVIdx).XYZ()
-                                       + aGuidePoints.At(aUIdx, aVIdx).XYZ()
-                                       - aReferencePoints.At(aUIdx, aVIdx).XYZ();
+      const gp_XYZ aPoint = aProfilePoints.At(aUIdx, aVIdx).XYZ()
+                            + aGuidePoints.At(aUIdx, aVIdx).XYZ()
+                            - aReferencePoints.At(aUIdx, aVIdx).XYZ();
       aPoints.ChangeAt(aUIdx, aVIdx) = gp_Pnt(aPoint);
     }
   }
@@ -280,7 +280,7 @@ void setStatus(GeomFill_Gordon::BuildReport&       theReport,
 
 // Returns whether every profile closes geometrically at its parameter endpoints.
 bool areClosedCurves(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theCurves,
-                     const double                                               theTolerance)
+                     const double                                              theTolerance)
 {
   if (theCurves.IsEmpty())
   {
@@ -371,9 +371,9 @@ double maxCurveDeviation(const occ::handle<Geom_BSplineSurface>& theSurface,
   double                  aMaxDeviation = 0.0;
   const auto              evaluate      = [&](const double theParameter) {
     const double aU = theIsProfile ? surfaceParameter(theSurface, true, theParameter)
-                                   : surfaceParameter(theSurface, true, theFixedParameter);
+                                                     : surfaceParameter(theSurface, true, theFixedParameter);
     const double aV = theIsProfile ? surfaceParameter(theSurface, false, theFixedParameter)
-                                   : surfaceParameter(theSurface, false, theParameter);
+                                                     : surfaceParameter(theSurface, false, theParameter);
     aMaxDeviation =
       std::max(aMaxDeviation, anAdaptor.EvalD0(theParameter).Distance(theSurface->Value(aU, aV)));
   };
@@ -497,7 +497,7 @@ void GeomFill_Gordon::Perform()
     setStatus(myReport, ResultStatus::CompatibilityFailed, BuildStage::NetworkOrdering);
     return;
   }
-  myIsUClosed = myIsUClosed || areClosedCurves(myProfiles, myTolerance);
+  myIsUClosed                           = myIsUClosed || areClosedCurves(myProfiles, myTolerance);
   bool aHasApproximateReparametrization = false;
   if (!aNetwork.EqualizeIntersectionParameters(myApproximationMode
                                                  == ApproximationMode::AllowApproximateFallback,

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
@@ -14,12 +14,15 @@
 #include <GeomFill_Gordon.hxx>
 
 #include <BSplCLib.hxx>
+#include <BSplCLib_EvaluatorFunction.hxx>
 #include <GeomAbs_Shape.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <GeomAPI_ExtremaCurveCurve.hxx>
 #include <GeomAPI_PointsToBSplineSurface.hxx>
 #include <GeomConvert.hxx>
 #include <GeomFill_NetworkSurface.hxx>
+#include <GeomGridEval_Curve.hxx>
+#include <GeomGridEval_Surface.hxx>
 #include <GeomLib_Interpolate.hxx>
 #include <GeomLib_Tool.hxx>
 #include <NCollection_LinearVector.hxx>
@@ -30,6 +33,7 @@
 #include <StdFail_NotDone.hxx>
 #include <math_Matrix.hxx>
 #include <math_Vector.hxx>
+#include <gp_Vec.hxx>
 
 #include <algorithm>
 #include <atomic>
@@ -38,6 +42,10 @@
 
 namespace
 {
+
+//=================================================================================================
+
+// Returns whether at least one prepared curve uses rational weights.
 bool hasRationalCurve(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theCurves)
 {
   for (size_t aCurveIdx = 0; aCurveIdx < theCurves.Size(); ++aCurveIdx)
@@ -50,12 +58,18 @@ bool hasRationalCurve(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& 
   return false;
 }
 
+//=================================================================================================
+
+// Returns whether either prepared curve family uses rational weights.
 bool hasRationalCurve(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
                       const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides)
 {
   return hasRationalCurve(theProfiles) || hasRationalCurve(theGuides);
 }
 
+//=================================================================================================
+
+// Converts detailed network-construction statuses to the public Gordon status.
 GeomFill_Gordon::ResultStatus mapNetworkStatus(
   const GeomFill_NetworkSurface::ResultStatus theStatus)
 {
@@ -86,7 +100,9 @@ GeomFill_Gordon::ResultStatus mapNetworkStatus(
   return GeomFill_Gordon::ResultStatus::ConstructionFailed;
 }
 
-//! Returns true when a sampled fallback can still use a validated prepared network.
+//=================================================================================================
+
+// Returns true when a sampled fallback can still use a validated prepared network.
 bool canApproximateAfterExactFailure(const GeomFill_Gordon::ResultStatus theStatus)
 {
   return theStatus == GeomFill_Gordon::ResultStatus::CurveCompatibilityFailed
@@ -98,7 +114,7 @@ bool canApproximateAfterExactFailure(const GeomFill_Gordon::ResultStatus theStat
          || theStatus == GeomFill_Gordon::ResultStatus::ConstructionFailed;
 }
 
-//! Chooses a deterministic fallback grid density from the prepared network itself.
+// Chooses a deterministic fallback grid density from the prepared network itself.
 size_t fallbackSampleCount(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theCurves)
 {
   size_t aNbSamples = std::max<size_t>(theCurves.Size(), 2);
@@ -112,58 +128,87 @@ size_t fallbackSampleCount(const NCollection_Array1<occ::handle<Geom_BSplineCurv
   return std::max(aNbSamples, static_cast<size_t>(Geom_BSplineCurve::MaxDegree()) / 2);
 }
 
-//! Fits a non-exact B-spline surface through a point grid for approximate fallback.
+//=================================================================================================
+
+// Returns regularly spaced parameters in the unit interval.
+NCollection_Array1<double> unitParameters(const size_t theNbSamples)
+{
+  NCollection_Array1<double> aParameters(1, static_cast<int>(theNbSamples));
+  for (size_t aSampleIdx = 0; aSampleIdx < theNbSamples; ++aSampleIdx)
+  {
+    aParameters.ChangeAt(aSampleIdx) = static_cast<double>(aSampleIdx)
+                                        / static_cast<double>(theNbSamples - 1);
+  }
+  return aParameters;
+}
+
+//=================================================================================================
+
+// Fits a non-exact B-spline surface through a point grid for approximate fallback.
 occ::handle<Geom_BSplineSurface> approximateGrid(const NCollection_Array2<gp_Pnt>& thePoints,
-                                                 const double                      theTolerance)
+                                                  const double                      theTolerance)
 {
   GeomAPI_PointsToBSplineSurface anApprox;
-  anApprox.Init(thePoints, 1, 5, GeomAbs_C1, std::max(theTolerance, Precision::Confusion()));
+  anApprox.Init(thePoints,
+                Approx_IsoParametric,
+                1,
+                Geom_BSplineSurface::MaxDegree(),
+                GeomAbs_C1,
+                std::max(theTolerance, Precision::Confusion()));
   return anApprox.IsDone() ? anApprox.Surface() : nullptr;
 }
 
-//! Samples the prepared profiles as section curves of an approximate profile skin.
+//=================================================================================================
+
+// Samples the prepared profiles as section curves of an approximate profile skin.
 NCollection_Array2<gp_Pnt> profileSampleGrid(
   const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
   const size_t                                              theNbUSamples)
 {
+  const NCollection_Array1<double> aUParams = unitParameters(theNbUSamples);
   NCollection_Array2<gp_Pnt> aPoints(1,
-                                     static_cast<int>(theNbUSamples),
-                                     1,
+                                      static_cast<int>(theNbUSamples),
+                                      1,
                                      static_cast<int>(theProfiles.Size()));
   for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
   {
-    const GeomAdaptor_Curve aProfileAdaptor(theProfiles.At(aProfileIdx));
+    const GeomGridEval_Curve      anEvaluator(theProfiles.At(aProfileIdx));
+    const NCollection_Array1<gp_Pnt> aProfilePoints = anEvaluator.EvaluateGrid(aUParams);
     for (size_t aUIdx = 0; aUIdx < theNbUSamples; ++aUIdx)
     {
-      const double aU = static_cast<double>(aUIdx) / static_cast<double>(theNbUSamples - 1);
-      aPoints.ChangeAt(aUIdx, aProfileIdx) = aProfileAdaptor.EvalD0(aU);
+      aPoints.ChangeAt(aUIdx, aProfileIdx) = aProfilePoints.At(aUIdx);
     }
   }
   return aPoints;
 }
 
-//! Samples the prepared guides as section curves of an approximate guide skin.
+//=================================================================================================
+
+// Samples the prepared guides as section curves of an approximate guide skin.
 NCollection_Array2<gp_Pnt> guideSampleGrid(
   const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
   const size_t                                              theNbVSamples)
 {
+  const NCollection_Array1<double> aVParams = unitParameters(theNbVSamples);
   NCollection_Array2<gp_Pnt> aPoints(1,
-                                     static_cast<int>(theGuides.Size()),
+                                      static_cast<int>(theGuides.Size()),
                                      1,
                                      static_cast<int>(theNbVSamples));
   for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
   {
-    const GeomAdaptor_Curve aGuideAdaptor(theGuides.At(aGuideIdx));
+    const GeomGridEval_Curve      anEvaluator(theGuides.At(aGuideIdx));
+    const NCollection_Array1<gp_Pnt> aGuidePoints = anEvaluator.EvaluateGrid(aVParams);
     for (size_t aVIdx = 0; aVIdx < theNbVSamples; ++aVIdx)
     {
-      const double aV = static_cast<double>(aVIdx) / static_cast<double>(theNbVSamples - 1);
-      aPoints.ChangeAt(aGuideIdx, aVIdx) = aGuideAdaptor.EvalD0(aV);
+      aPoints.ChangeAt(aGuideIdx, aVIdx) = aGuidePoints.At(aVIdx);
     }
   }
   return aPoints;
 }
 
-//! Builds a sampled fallback from approximate profile, guide, and reference surfaces.
+//=================================================================================================
+
+// Builds a sampled fallback from approximate profile, guide, and reference surfaces.
 occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
   const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
   const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
@@ -185,29 +230,43 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
   }
 
   NCollection_Array2<gp_Pnt> aPoints(1,
-                                     static_cast<int>(aNbUSamples),
-                                     1,
-                                     static_cast<int>(aNbVSamples));
+                                      static_cast<int>(aNbUSamples),
+                                      1,
+                                      static_cast<int>(aNbVSamples));
+  const NCollection_Array1<double> aUParams = unitParameters(aNbUSamples);
+  const NCollection_Array1<double> aVParams = unitParameters(aNbVSamples);
+  const GeomGridEval_Surface       aProfileEvaluator(aProfileSurface);
+  const GeomGridEval_Surface       aGuideEvaluator(aGuideSurface);
+  const GeomGridEval_Surface       aReferenceEvaluator(aReferenceSurface);
+  const NCollection_Array2<gp_Pnt> aProfilePoints =
+    aProfileEvaluator.EvaluateGrid(aUParams, aVParams);
+  const NCollection_Array2<gp_Pnt> aGuidePoints = aGuideEvaluator.EvaluateGrid(aUParams, aVParams);
+  const NCollection_Array2<gp_Pnt> aReferencePoints =
+    aReferenceEvaluator.EvaluateGrid(aUParams, aVParams);
   for (size_t aUIdx = 0; aUIdx < aNbUSamples; ++aUIdx)
   {
-    const double aU = static_cast<double>(aUIdx) / static_cast<double>(aNbUSamples - 1);
     for (size_t aVIdx = 0; aVIdx < aNbVSamples; ++aVIdx)
     {
-      const double aV     = static_cast<double>(aVIdx) / static_cast<double>(aNbVSamples - 1);
-      const gp_XYZ aPoint = aProfileSurface->Value(aU, aV).XYZ()
-                            + aGuideSurface->Value(aU, aV).XYZ()
-                            - aReferenceSurface->Value(aU, aV).XYZ();
+      const gp_XYZ aPoint = aProfilePoints.At(aUIdx, aVIdx).XYZ()
+                             + aGuidePoints.At(aUIdx, aVIdx).XYZ()
+                             - aReferencePoints.At(aUIdx, aVIdx).XYZ();
       aPoints.ChangeAt(aUIdx, aVIdx) = gp_Pnt(aPoint);
     }
   }
   return approximateGrid(aPoints, theTolerance);
 }
 
+//=================================================================================================
+
+// Resets all report fields before starting a construction attempt.
 void resetReport(GeomFill_Gordon::BuildReport& theReport)
 {
   theReport = GeomFill_Gordon::BuildReport();
 }
 
+//=================================================================================================
+
+// Records the result status and its failing construction stage.
 void setStatus(GeomFill_Gordon::BuildReport&       theReport,
                const GeomFill_Gordon::ResultStatus theNewStatus,
                const GeomFill_Gordon::BuildStage   theStage)
@@ -218,6 +277,9 @@ void setStatus(GeomFill_Gordon::BuildReport&       theReport,
                             : theStage;
 }
 
+//=================================================================================================
+
+// Clones input curves because network preparation modifies its working copies.
 bool copyWorkingCurves(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theInput,
                        NCollection_Array1<occ::handle<Geom_BSplineCurve>>&       theWorking)
 {
@@ -246,17 +308,26 @@ bool copyWorkingCurves(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>&
   return true;
 }
 
+//=================================================================================================
+
+// Returns the first knot in the requested surface parameter direction.
 double surfaceStartParameter(const occ::handle<Geom_BSplineSurface>& theSurface, const bool theIsU)
 {
   return theIsU ? theSurface->UKnot(1) : theSurface->VKnot(1);
 }
 
+//=================================================================================================
+
+// Returns the last knot in the requested surface parameter direction.
 double surfaceEndParameter(const occ::handle<Geom_BSplineSurface>& theSurface, const bool theIsU)
 {
   return theIsU ? theSurface->UKnot(theSurface->NbUKnots())
                 : theSurface->VKnot(theSurface->NbVKnots());
 }
 
+//=================================================================================================
+
+// Maps a unit parameter to the knot range of the requested surface direction.
 double surfaceParameter(const occ::handle<Geom_BSplineSurface>& theSurface,
                         const bool                              theIsU,
                         const double                            theUnitParameter)
@@ -265,46 +336,79 @@ double surfaceParameter(const occ::handle<Geom_BSplineSurface>& theSurface,
   return aFirst + theUnitParameter * (surfaceEndParameter(theSurface, theIsU) - aFirst);
 }
 
-double maxProfileDeviation(const occ::handle<Geom_BSplineSurface>&                   theSurface,
-                           const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
-                           const math_Vector& theProfileParams)
+//=================================================================================================
+
+// Measures the maximum deviation of a curve from its corresponding surface isoparameter.
+double maxCurveDeviation(const occ::handle<Geom_BSplineSurface>& theSurface,
+                         const occ::handle<Geom_BSplineCurve>&  theCurve,
+                         const double                            theFixedParameter,
+                         const bool                              theIsProfile)
 {
-  constexpr int THE_NB_SAMPLES = 24;
-  double        aMaxDeviation  = 0.0;
-  for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
+  const GeomAdaptor_Curve anAdaptor(theCurve);
+  double                  aMaxDeviation = 0.0;
+  const auto evaluate = [&](const double theParameter) {
+    const double aU = theIsProfile ? surfaceParameter(theSurface, true, theParameter)
+                                   : surfaceParameter(theSurface, true, theFixedParameter);
+    const double aV = theIsProfile ? surfaceParameter(theSurface, false, theFixedParameter)
+                                   : surfaceParameter(theSurface, false, theParameter);
+    aMaxDeviation =
+      std::max(aMaxDeviation, anAdaptor.EvalD0(theParameter).Distance(theSurface->Value(aU, aV)));
+  };
+
+  const size_t aSamplesPerSpan = static_cast<size_t>(theCurve->Degree())
+                                 + static_cast<size_t>(theIsProfile ? theSurface->UDegree()
+                                                                     : theSurface->VDegree());
+  for (int aKnotIdx = 1; aKnotIdx < theCurve->NbKnots(); ++aKnotIdx)
   {
-    const GeomAdaptor_Curve aProfileAdaptor(theProfiles.At(aProfileIdx));
-    const double            aV =
-      surfaceParameter(theSurface, false, theProfileParams(static_cast<int>(aProfileIdx) + 1));
-    for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
+    const double aFirst = theCurve->Knot(aKnotIdx);
+    const double aLast  = theCurve->Knot(aKnotIdx + 1);
+    if (aLast - aFirst <= Precision::PConfusion())
     {
-      const double aParam = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
-      const double aU     = surfaceParameter(theSurface, true, aParam);
-      aMaxDeviation =
-        std::max(aMaxDeviation, aProfileAdaptor.EvalD0(aParam).Distance(theSurface->Value(aU, aV)));
+      continue;
+    }
+
+    // The sampled difference combines the curve and surface polynomial orders.
+    for (size_t aSampleIdx = 0; aSampleIdx <= aSamplesPerSpan; ++aSampleIdx)
+    {
+      const double aRatio = static_cast<double>(aSampleIdx) / aSamplesPerSpan;
+      evaluate(aFirst + aRatio * (aLast - aFirst));
     }
   }
   return aMaxDeviation;
 }
 
+//=================================================================================================
+
+// Returns the largest profile-to-surface deviation over all profile isoparameters.
+double maxProfileDeviation(const occ::handle<Geom_BSplineSurface>&                   theSurface,
+                           const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
+                           const math_Vector& theProfileParams)
+{
+  double aMaxDeviation = 0.0;
+  for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
+  {
+    const double aV =
+      surfaceParameter(theSurface, false, theProfileParams(static_cast<int>(aProfileIdx) + 1));
+    aMaxDeviation = std::max(aMaxDeviation,
+                             maxCurveDeviation(theSurface, theProfiles.At(aProfileIdx), aV, true));
+  }
+  return aMaxDeviation;
+}
+
+//=================================================================================================
+
+// Returns the largest guide-to-surface deviation over all guide isoparameters.
 double maxGuideDeviation(const occ::handle<Geom_BSplineSurface>&                   theSurface,
                          const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
                          const math_Vector&                                        theGuideParams)
 {
-  constexpr int THE_NB_SAMPLES = 24;
-  double        aMaxDeviation  = 0.0;
+  double aMaxDeviation = 0.0;
   for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
   {
-    const GeomAdaptor_Curve aGuideAdaptor(theGuides.At(aGuideIdx));
-    const double            aU =
+    const double aU =
       surfaceParameter(theSurface, true, theGuideParams(static_cast<int>(aGuideIdx) + 1));
-    for (int aSampleIdx = 0; aSampleIdx <= THE_NB_SAMPLES; ++aSampleIdx)
-    {
-      const double aParam = static_cast<double>(aSampleIdx) / THE_NB_SAMPLES;
-      const double aV     = surfaceParameter(theSurface, false, aParam);
-      aMaxDeviation =
-        std::max(aMaxDeviation, aGuideAdaptor.EvalD0(aParam).Distance(theSurface->Value(aU, aV)));
-    }
+    aMaxDeviation = std::max(aMaxDeviation,
+                             maxCurveDeviation(theSurface, theGuides.At(aGuideIdx), aU, false));
   }
   return aMaxDeviation;
 }
@@ -416,9 +520,9 @@ void GeomFill_Gordon::Perform()
         && canApproximateAfterExactFailure(anExactStatus))
     {
       mySurface = approximatePreparedNetwork(myProfiles,
-                                             myGuides,
-                                             aNetwork.IntersectionPoints(),
-                                             myTolerance);
+                                              myGuides,
+                                              aNetwork.IntersectionPoints(),
+                                              myTolerance);
       if (!mySurface.IsNull())
       {
         myReport.IsApproximate = true;
@@ -496,6 +600,8 @@ void GeomFill_Gordon::Init(const NCollection_Array1<occ::handle<Geom_Curve>>& th
   myGuideParams =
     NCollection_Array2<double>(1, static_cast<int>(aNbProf), 1, static_cast<int>(aNbGuid));
 }
+
+//=================================================================================================
 
 const occ::handle<Geom_BSplineSurface>& GeomFill_Gordon::Surface() const
 {

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
@@ -136,8 +136,8 @@ NCollection_Array1<double> unitParameters(const size_t theNbSamples)
   NCollection_Array1<double> aParameters(1, static_cast<int>(theNbSamples));
   for (size_t aSampleIdx = 0; aSampleIdx < theNbSamples; ++aSampleIdx)
   {
-    aParameters.ChangeAt(aSampleIdx) = static_cast<double>(aSampleIdx)
-                                        / static_cast<double>(theNbSamples - 1);
+    aParameters.ChangeAt(aSampleIdx) =
+      static_cast<double>(aSampleIdx) / static_cast<double>(theNbSamples - 1);
   }
   return aParameters;
 }
@@ -146,7 +146,7 @@ NCollection_Array1<double> unitParameters(const size_t theNbSamples)
 
 // Fits a non-exact B-spline surface through a point grid for approximate fallback.
 occ::handle<Geom_BSplineSurface> approximateGrid(const NCollection_Array2<gp_Pnt>& thePoints,
-                                                  const double                      theTolerance)
+                                                 const double                      theTolerance)
 {
   GeomAPI_PointsToBSplineSurface anApprox;
   anApprox.Init(thePoints,
@@ -166,13 +166,13 @@ NCollection_Array2<gp_Pnt> profileSampleGrid(
   const size_t                                              theNbUSamples)
 {
   const NCollection_Array1<double> aUParams = unitParameters(theNbUSamples);
-  NCollection_Array2<gp_Pnt> aPoints(1,
-                                      static_cast<int>(theNbUSamples),
-                                      1,
+  NCollection_Array2<gp_Pnt>       aPoints(1,
+                                     static_cast<int>(theNbUSamples),
+                                     1,
                                      static_cast<int>(theProfiles.Size()));
   for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
   {
-    const GeomGridEval_Curve      anEvaluator(theProfiles.At(aProfileIdx));
+    const GeomGridEval_Curve         anEvaluator(theProfiles.At(aProfileIdx));
     const NCollection_Array1<gp_Pnt> aProfilePoints = anEvaluator.EvaluateGrid(aUParams);
     for (size_t aUIdx = 0; aUIdx < theNbUSamples; ++aUIdx)
     {
@@ -190,13 +190,13 @@ NCollection_Array2<gp_Pnt> guideSampleGrid(
   const size_t                                              theNbVSamples)
 {
   const NCollection_Array1<double> aVParams = unitParameters(theNbVSamples);
-  NCollection_Array2<gp_Pnt> aPoints(1,
-                                      static_cast<int>(theGuides.Size()),
+  NCollection_Array2<gp_Pnt>       aPoints(1,
+                                     static_cast<int>(theGuides.Size()),
                                      1,
                                      static_cast<int>(theNbVSamples));
   for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
   {
-    const GeomGridEval_Curve      anEvaluator(theGuides.At(aGuideIdx));
+    const GeomGridEval_Curve         anEvaluator(theGuides.At(aGuideIdx));
     const NCollection_Array1<gp_Pnt> aGuidePoints = anEvaluator.EvaluateGrid(aVParams);
     for (size_t aVIdx = 0; aVIdx < theNbVSamples; ++aVIdx)
     {
@@ -229,10 +229,10 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
     return nullptr;
   }
 
-  NCollection_Array2<gp_Pnt> aPoints(1,
-                                      static_cast<int>(aNbUSamples),
-                                      1,
-                                      static_cast<int>(aNbVSamples));
+  NCollection_Array2<gp_Pnt>       aPoints(1,
+                                     static_cast<int>(aNbUSamples),
+                                     1,
+                                     static_cast<int>(aNbVSamples));
   const NCollection_Array1<double> aUParams = unitParameters(aNbUSamples);
   const NCollection_Array1<double> aVParams = unitParameters(aNbVSamples);
   const GeomGridEval_Surface       aProfileEvaluator(aProfileSurface);
@@ -248,8 +248,8 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
     for (size_t aVIdx = 0; aVIdx < aNbVSamples; ++aVIdx)
     {
       const gp_XYZ aPoint = aProfilePoints.At(aUIdx, aVIdx).XYZ()
-                             + aGuidePoints.At(aUIdx, aVIdx).XYZ()
-                             - aReferencePoints.At(aUIdx, aVIdx).XYZ();
+                            + aGuidePoints.At(aUIdx, aVIdx).XYZ()
+                            - aReferencePoints.At(aUIdx, aVIdx).XYZ();
       aPoints.ChangeAt(aUIdx, aVIdx) = gp_Pnt(aPoint);
     }
   }
@@ -340,24 +340,24 @@ double surfaceParameter(const occ::handle<Geom_BSplineSurface>& theSurface,
 
 // Measures the maximum deviation of a curve from its corresponding surface isoparameter.
 double maxCurveDeviation(const occ::handle<Geom_BSplineSurface>& theSurface,
-                         const occ::handle<Geom_BSplineCurve>&  theCurve,
+                         const occ::handle<Geom_BSplineCurve>&   theCurve,
                          const double                            theFixedParameter,
                          const bool                              theIsProfile)
 {
   const GeomAdaptor_Curve anAdaptor(theCurve);
   double                  aMaxDeviation = 0.0;
-  const auto evaluate = [&](const double theParameter) {
+  const auto              evaluate      = [&](const double theParameter) {
     const double aU = theIsProfile ? surfaceParameter(theSurface, true, theParameter)
-                                   : surfaceParameter(theSurface, true, theFixedParameter);
+                                                     : surfaceParameter(theSurface, true, theFixedParameter);
     const double aV = theIsProfile ? surfaceParameter(theSurface, false, theFixedParameter)
-                                   : surfaceParameter(theSurface, false, theParameter);
+                                                     : surfaceParameter(theSurface, false, theParameter);
     aMaxDeviation =
       std::max(aMaxDeviation, anAdaptor.EvalD0(theParameter).Distance(theSurface->Value(aU, aV)));
   };
 
-  const size_t aSamplesPerSpan = static_cast<size_t>(theCurve->Degree())
-                                 + static_cast<size_t>(theIsProfile ? theSurface->UDegree()
-                                                                     : theSurface->VDegree());
+  const size_t aSamplesPerSpan =
+    static_cast<size_t>(theCurve->Degree())
+    + static_cast<size_t>(theIsProfile ? theSurface->UDegree() : theSurface->VDegree());
   for (int aKnotIdx = 1; aKnotIdx < theCurve->NbKnots(); ++aKnotIdx)
   {
     const double aFirst = theCurve->Knot(aKnotIdx);
@@ -389,8 +389,8 @@ double maxProfileDeviation(const occ::handle<Geom_BSplineSurface>&              
   {
     const double aV =
       surfaceParameter(theSurface, false, theProfileParams(static_cast<int>(aProfileIdx) + 1));
-    aMaxDeviation = std::max(aMaxDeviation,
-                             maxCurveDeviation(theSurface, theProfiles.At(aProfileIdx), aV, true));
+    aMaxDeviation =
+      std::max(aMaxDeviation, maxCurveDeviation(theSurface, theProfiles.At(aProfileIdx), aV, true));
   }
   return aMaxDeviation;
 }
@@ -407,8 +407,8 @@ double maxGuideDeviation(const occ::handle<Geom_BSplineSurface>&                
   {
     const double aU =
       surfaceParameter(theSurface, true, theGuideParams(static_cast<int>(aGuideIdx) + 1));
-    aMaxDeviation = std::max(aMaxDeviation,
-                             maxCurveDeviation(theSurface, theGuides.At(aGuideIdx), aU, false));
+    aMaxDeviation =
+      std::max(aMaxDeviation, maxCurveDeviation(theSurface, theGuides.At(aGuideIdx), aU, false));
   }
   return aMaxDeviation;
 }
@@ -520,9 +520,9 @@ void GeomFill_Gordon::Perform()
         && canApproximateAfterExactFailure(anExactStatus))
     {
       mySurface = approximatePreparedNetwork(myProfiles,
-                                              myGuides,
-                                              aNetwork.IntersectionPoints(),
-                                              myTolerance);
+                                             myGuides,
+                                             aNetwork.IntersectionPoints(),
+                                             myTolerance);
       if (!mySurface.IsNull())
       {
         myReport.IsApproximate = true;

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_Gordon.cxx
@@ -167,9 +167,9 @@ NCollection_Array2<gp_Pnt> profileSampleGrid(
 {
   const NCollection_Array1<double> aUParams = unitParameters(theNbUSamples);
   NCollection_Array2<gp_Pnt>       aPoints(1,
-                                     static_cast<int>(theNbUSamples),
-                                     1,
-                                     static_cast<int>(theProfiles.Size()));
+                                           static_cast<int>(theNbUSamples),
+                                           1,
+                                           static_cast<int>(theProfiles.Size()));
   for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
   {
     const GeomGridEval_Curve         anEvaluator(theProfiles.At(aProfileIdx));
@@ -191,9 +191,9 @@ NCollection_Array2<gp_Pnt> guideSampleGrid(
 {
   const NCollection_Array1<double> aVParams = unitParameters(theNbVSamples);
   NCollection_Array2<gp_Pnt>       aPoints(1,
-                                     static_cast<int>(theGuides.Size()),
-                                     1,
-                                     static_cast<int>(theNbVSamples));
+                                           static_cast<int>(theGuides.Size()),
+                                           1,
+                                           static_cast<int>(theNbVSamples));
   for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
   {
     const GeomGridEval_Curve         anEvaluator(theGuides.At(aGuideIdx));
@@ -228,11 +228,10 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
   {
     return nullptr;
   }
-
   NCollection_Array2<gp_Pnt>       aPoints(1,
-                                     static_cast<int>(aNbUSamples),
-                                     1,
-                                     static_cast<int>(aNbVSamples));
+                                           static_cast<int>(aNbUSamples),
+                                           1,
+                                           static_cast<int>(aNbVSamples));
   const NCollection_Array1<double> aUParams = unitParameters(aNbUSamples);
   const NCollection_Array1<double> aVParams = unitParameters(aNbVSamples);
   const GeomGridEval_Surface       aProfileEvaluator(aProfileSurface);
@@ -247,9 +246,9 @@ occ::handle<Geom_BSplineSurface> approximatePreparedNetwork(
   {
     for (size_t aVIdx = 0; aVIdx < aNbVSamples; ++aVIdx)
     {
-      const gp_XYZ aPoint = aProfilePoints.At(aUIdx, aVIdx).XYZ()
-                            + aGuidePoints.At(aUIdx, aVIdx).XYZ()
-                            - aReferencePoints.At(aUIdx, aVIdx).XYZ();
+      const gp_XYZ aPoint            = aProfilePoints.At(aUIdx, aVIdx).XYZ()
+                                       + aGuidePoints.At(aUIdx, aVIdx).XYZ()
+                                       - aReferencePoints.At(aUIdx, aVIdx).XYZ();
       aPoints.ChangeAt(aUIdx, aVIdx) = gp_Pnt(aPoint);
     }
   }
@@ -275,6 +274,30 @@ void setStatus(GeomFill_Gordon::BuildReport&       theReport,
   theReport.FailedStage = theNewStatus == GeomFill_Gordon::ResultStatus::Done
                             ? GeomFill_Gordon::BuildStage::NotStarted
                             : theStage;
+}
+
+//=================================================================================================
+
+// Returns whether every profile closes geometrically at its parameter endpoints.
+bool areClosedCurves(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theCurves,
+                     const double                                               theTolerance)
+{
+  if (theCurves.IsEmpty())
+  {
+    return false;
+  }
+  const double aTolerance = std::max(theTolerance, Precision::Confusion());
+  for (size_t aCurveIdx = 0; aCurveIdx < theCurves.Size(); ++aCurveIdx)
+  {
+    const occ::handle<Geom_BSplineCurve>& aCurve = theCurves.At(aCurveIdx);
+    if (aCurve.IsNull()
+        || aCurve->Value(aCurve->FirstParameter()).Distance(aCurve->Value(aCurve->LastParameter()))
+             > aTolerance)
+    {
+      return false;
+    }
+  }
+  return true;
 }
 
 //=================================================================================================
@@ -348,9 +371,9 @@ double maxCurveDeviation(const occ::handle<Geom_BSplineSurface>& theSurface,
   double                  aMaxDeviation = 0.0;
   const auto              evaluate      = [&](const double theParameter) {
     const double aU = theIsProfile ? surfaceParameter(theSurface, true, theParameter)
-                                                     : surfaceParameter(theSurface, true, theFixedParameter);
+                                   : surfaceParameter(theSurface, true, theFixedParameter);
     const double aV = theIsProfile ? surfaceParameter(theSurface, false, theFixedParameter)
-                                                     : surfaceParameter(theSurface, false, theParameter);
+                                   : surfaceParameter(theSurface, false, theParameter);
     aMaxDeviation =
       std::max(aMaxDeviation, anAdaptor.EvalD0(theParameter).Distance(theSurface->Value(aU, aV)));
   };
@@ -469,13 +492,12 @@ void GeomFill_Gordon::Perform()
     setStatus(myReport, ResultStatus::OrderingFailed, BuildStage::NetworkOrdering);
     return;
   }
-
   if (!aNetwork.NormalizeIntersectionParameters(myIsUClosed, myIsVClosed))
   {
     setStatus(myReport, ResultStatus::CompatibilityFailed, BuildStage::NetworkOrdering);
     return;
   }
-
+  myIsUClosed = myIsUClosed || areClosedCurves(myProfiles, myTolerance);
   bool aHasApproximateReparametrization = false;
   if (!aNetwork.EqualizeIntersectionParameters(myApproximationMode
                                                  == ApproximationMode::AllowApproximateFallback,
@@ -494,6 +516,7 @@ void GeomFill_Gordon::Perform()
     setStatus(myReport, ResultStatus::CompatibilityFailed, BuildStage::Reparametrization);
     return;
   }
+  myIsUClosed = myIsUClosed || areClosedCurves(myProfiles, myTolerance);
 
   math_Matrix aProfileParamMatrix = GordonUtilities::toMatrix(myProfileParams);
   math_Matrix aGuideParamMatrix   = GordonUtilities::toMatrix(myGuideParams);

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GordonUtilities.pxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GordonUtilities.pxx
@@ -768,10 +768,70 @@ double orderedContactScore(const Contact& theContact,
                            const double   theGuideParam,
                            const double   theProfileTarget,
                            const double   theGuideTarget,
+                           const double   thePreviousProfileParam,
+                           const double   thePreviousGuideParam,
+                           const double   thePreviousProfileTarget,
+                           const double   thePreviousGuideTarget,
+                           const bool     theHasPreviousProfile,
+                           const bool     theHasPreviousGuide,
                            const double   theTolerance)
 {
-  return theContact.Gap / std::max(theTolerance, Precision::Confusion())
-         + std::abs(theProfileParam - theProfileTarget) + std::abs(theGuideParam - theGuideTarget);
+  double aScore = theContact.Gap / std::max(theTolerance, Precision::Confusion())
+                  + std::abs(theProfileParam - theProfileTarget)
+                  + std::abs(theGuideParam - theGuideTarget);
+  if (theHasPreviousProfile)
+  {
+    // Favor branches with a smooth advance along the current profile.
+    aScore += std::abs((theProfileParam - thePreviousProfileParam)
+                       - (theProfileTarget - thePreviousProfileTarget));
+  }
+  if (theHasPreviousGuide)
+  {
+    // Favor branches with a smooth advance along the current guide.
+    aScore += std::abs((theGuideParam - thePreviousGuideParam)
+                       - (theGuideTarget - thePreviousGuideTarget));
+  }
+  return aScore;
+}
+
+//! Returns the tangent mismatch between two parameters in the requested curve orientation.
+bool seamTangentMismatch(const occ::handle<Geom_BSplineCurve>& theCurve,
+                         const double                          theFirstParameter,
+                         const double                          theLastParameter,
+                         const bool                            theIsForward,
+                         const double                          theTolerance,
+                         double&                               theMismatch)
+{
+  const double aFirstRawParameter =
+    theIsForward ? theFirstParameter
+                 : theCurve->FirstParameter() + theCurve->LastParameter() - theFirstParameter;
+  const double aLastRawParameter =
+    theIsForward ? theLastParameter
+                 : theCurve->FirstParameter() + theCurve->LastParameter() - theLastParameter;
+  const Geom_Curve::ResD1 aFirstD1 = theCurve->EvalD1(aFirstRawParameter);
+  const Geom_Curve::ResD1 aLastD1  = theCurve->EvalD1(aLastRawParameter);
+  if (aFirstD1.Point.Distance(aLastD1.Point) > std::max(theTolerance, Precision::Confusion()))
+  {
+    return false;
+  }
+
+  gp_Vec aFirstTangent = aFirstD1.D1;
+  gp_Vec aLastTangent  = aLastD1.D1;
+  if (!theIsForward)
+  {
+    aFirstTangent.Reverse();
+    aLastTangent.Reverse();
+  }
+  const double aFirstMagnitude = aFirstTangent.Magnitude();
+  const double aLastMagnitude  = aLastTangent.Magnitude();
+  if (aFirstMagnitude <= gp::Resolution() || aLastMagnitude <= gp::Resolution())
+  {
+    return false;
+  }
+
+  theMismatch =
+    1.0 - std::clamp(aFirstTangent.Dot(aLastTangent) / (aFirstMagnitude * aLastMagnitude), -1.0, 1.0);
+  return true;
 }
 
 //! Selects one contact compatible with already selected row/column predecessors.
@@ -783,14 +843,21 @@ bool chooseOrderedContact(const ContactSet&                     theContacts,
                           const double                          theProfileTarget,
                           const double                          theGuideTarget,
                           const double                          thePreviousProfileParam,
-                          const double                          thePreviousGuideParam,
-                          const bool                            theHasPreviousProfile,
-                          const bool                            theHasPreviousGuide,
-                          const double                          theTolerance,
-                          Contact&                              theSelected)
+                           const double                          thePreviousGuideParam,
+                           const bool                            theHasPreviousProfile,
+                           const bool                            theHasPreviousGuide,
+                           const double                          thePreviousProfileTarget,
+                           const double                          thePreviousGuideTarget,
+                           const double                          theFirstProfileParam,
+                           const double                          theFirstGuideParam,
+                           const bool                            theIsProfileSeam,
+                           const bool                            theIsGuideSeam,
+                           const double                          theTolerance,
+                           Contact&                              theSelected)
 {
   const double aParamTol = parameterResolution(0.0, 1.0);
-  double       aBest     = RealLast();
+  double       aBestTangentMismatch = RealLast();
+  double       aBest                 = RealLast();
   for (size_t aCandidateIdx = 0; aCandidateIdx < theContacts.Candidates.Size(); ++aCandidateIdx)
   {
     const Contact& aCandidate = theContacts.Candidates.Value(aCandidateIdx);
@@ -804,13 +871,55 @@ bool chooseOrderedContact(const ContactSet&                     theContacts,
     }
 
     const double aScore = orderedContactScore(aCandidate,
-                                              aProfileParam,
-                                              aGuideParam,
-                                              theProfileTarget,
-                                              theGuideTarget,
-                                              theTolerance);
-    if (aScore < aBest)
+                                               aProfileParam,
+                                               aGuideParam,
+                                               theProfileTarget,
+                                               theGuideTarget,
+                                               thePreviousProfileParam,
+                                               thePreviousGuideParam,
+                                               thePreviousProfileTarget,
+                                               thePreviousGuideTarget,
+                                               theHasPreviousProfile,
+                                               theHasPreviousGuide,
+                                               theTolerance);
+    double aTangentMismatch = 0.0;
+    bool   hasTangentMatch  = false;
+    if (theIsProfileSeam)
     {
+      double aProfileMismatch = 0.0;
+      if (seamTangentMismatch(theProfile,
+                              theFirstProfileParam,
+                              aProfileParam,
+                              theProfileForward,
+                              theTolerance,
+                              aProfileMismatch))
+      {
+        aTangentMismatch += aProfileMismatch;
+        hasTangentMatch = true;
+      }
+    }
+    if (theIsGuideSeam)
+    {
+      double aGuideMismatch = 0.0;
+      if (seamTangentMismatch(theGuide,
+                              theFirstGuideParam,
+                              aGuideParam,
+                              theGuideForward,
+                              theTolerance,
+                              aGuideMismatch))
+      {
+        aTangentMismatch += aGuideMismatch;
+        hasTangentMatch = true;
+      }
+    }
+
+    if ((hasTangentMatch
+         && (aTangentMismatch < aBestTangentMismatch - Precision::Angular()
+             || (std::abs(aTangentMismatch - aBestTangentMismatch) <= Precision::Angular()
+                 && aScore < aBest)))
+        || (!hasTangentMatch && aBestTangentMismatch == RealLast() && aScore < aBest))
+    {
+      aBestTangentMismatch     = hasTangentMatch ? aTangentMismatch : RealLast();
       aBest                    = aScore;
       theSelected              = aCandidate;
       theSelected.ProfileParam = aProfileParam;
@@ -841,9 +950,10 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
   const NCollection_LinearVector<OrderedCurve> aGuideOrder =
     orderedCurves(columnMeans(aProfileParamMatrix));
 
-  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aProfiles(theProfiles.Lower(),
-                                                               theProfiles.Upper());
-  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aGuides(theGuides.Lower(), theGuides.Upper());
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aProfiles(1,
+                                                                static_cast<int>(theProfiles.Size()));
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aGuides(1,
+                                                              static_cast<int>(theGuides.Size()));
   NCollection_Array2<double>                         aProfileParams(theProfileParams.LowerRow(),
                                             theProfileParams.UpperRow(),
                                             theProfileParams.LowerCol(),
@@ -898,6 +1008,20 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
         aProfileIdx == 0
           ? 0.0
           : aGuideParamResult(static_cast<int>(aProfileIdx), static_cast<int>(aGuideIdx) + 1);
+      const double aPreviousProfileTarget = aGuideIdx < 2
+                                              ? 0.0
+                                              : static_cast<double>(aGuideIdx - 1)
+                                                  / (aGuideOrder.Size() - 1);
+      const double aPreviousGuideTarget = aProfileIdx < 2
+                                            ? 0.0
+                                            : static_cast<double>(aProfileIdx - 1)
+                                                / (aProfileOrder.Size() - 1);
+      const bool isProfileSeam = aGuideIdx + 1 == aGuideOrder.Size();
+      const bool isGuideSeam   = aProfileIdx + 1 == aProfileOrder.Size();
+      const double aFirstProfileParam =
+        isProfileSeam ? aProfileParamResult(static_cast<int>(aProfileIdx) + 1, 1) : 0.0;
+      const double aFirstGuideParam =
+        isGuideSeam ? aGuideParamResult(1, static_cast<int>(aGuideIdx) + 1) : 0.0;
 
       Contact aContact;
       if (!chooseOrderedContact(
@@ -909,10 +1033,16 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
             aProfileTarget,
             aGuideTarget,
             aPreviousProfileParam,
-            aPreviousGuideParam,
-            aGuideIdx != 0,
-            aProfileIdx != 0,
-            theTolerance,
+             aPreviousGuideParam,
+             aGuideIdx != 0,
+             aProfileIdx != 0,
+             aPreviousProfileTarget,
+             aPreviousGuideTarget,
+             aFirstProfileParam,
+             aFirstGuideParam,
+             isProfileSeam,
+             isGuideSeam,
+             theTolerance,
             aContact))
       {
         return false;
@@ -940,7 +1070,7 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
 }
 
 //! Monotone scalar map converting target parameters back to the source curve.
-class ScalarLaw
+class ScalarLaw : public BSplCLib_EvaluatorFunction
 {
 public:
   //! Stores a strictly increasing piecewise-linear parameter map.
@@ -997,10 +1127,174 @@ public:
     return mySource.Last();
   }
 
+  void Evaluate(const int     theDerivativeRequest,
+                const double* /*theStartEnd*/,
+                const double  theTargetParameter,
+                double&       theResult,
+                int&          theErrorCode) const override
+  {
+    theErrorCode = 0;
+    if (theDerivativeRequest == 0)
+    {
+      theResult = Value(theTargetParameter);
+      return;
+    }
+    if (theDerivativeRequest != 1)
+    {
+      theResult = 0.0;
+      return;
+    }
+
+    for (size_t aParamIdx = 1; aParamIdx < myTarget.Size(); ++aParamIdx)
+    {
+      if (theTargetParameter <= myTarget.Value(aParamIdx))
+      {
+        theResult = (mySource.Value(aParamIdx) - mySource.Value(aParamIdx - 1))
+                    / (myTarget.Value(aParamIdx) - myTarget.Value(aParamIdx - 1));
+        return;
+      }
+    }
+    theResult = (mySource.Last() - mySource.Value(mySource.Size() - 2))
+                / (myTarget.Last() - myTarget.Value(myTarget.Size() - 2));
+  }
+
 private:
   NCollection_LinearVector<double> mySource;
   NCollection_LinearVector<double> myTarget;
 };
+
+//! Reparametrizes a polynomial B-spline exactly using a piecewise-linear parameter law.
+bool reparametrizeExactly(const occ::handle<Geom_BSplineCurve>& theCurve,
+                          const math_Vector&                    theSourceParams,
+                          const math_Vector&                    theTargetParams,
+                          const int                             theNbConstraints,
+                          const ScalarLaw&                      theLaw,
+                          occ::handle<Geom_BSplineCurve>&       theResult)
+{
+  if (theNbConstraints < 2)
+  {
+    return false;
+  }
+
+  const int aDegree = theCurve->Degree();
+  NCollection_LinearVector<double> aNewKnotValues;
+  NCollection_LinearVector<int>    aNewKnotMults;
+  int aConstraintIdx = 1;
+  for (size_t aKnotIdx = 0; aKnotIdx < theCurve->Knots().Size(); ++aKnotIdx)
+  {
+    const double aSourceKnot = theCurve->Knots().At(aKnotIdx);
+    while (aConstraintIdx <= theNbConstraints
+           && theSourceParams(aConstraintIdx) < aSourceKnot - Precision::PConfusion())
+    {
+      aNewKnotValues.Append(theTargetParams(aConstraintIdx));
+      aNewKnotMults.Append(aDegree);
+      ++aConstraintIdx;
+    }
+
+    double aTargetKnot = theTargetParams(theNbConstraints);
+    for (int aParamIdx = 1; aParamIdx < theNbConstraints; ++aParamIdx)
+    {
+      if (aSourceKnot <= theSourceParams(aParamIdx + 1) + Precision::PConfusion())
+      {
+        const double aSourceFirst = theSourceParams(aParamIdx);
+        const double aSourceLast  = theSourceParams(aParamIdx + 1);
+        const double aTargetFirst = theTargetParams(aParamIdx);
+        const double aTargetLast  = theTargetParams(aParamIdx + 1);
+        aTargetKnot = aTargetFirst
+                      + (aSourceKnot - aSourceFirst) * (aTargetLast - aTargetFirst)
+                          / (aSourceLast - aSourceFirst);
+        break;
+      }
+    }
+
+    int aMultiplicity = theCurve->Multiplicities().At(aKnotIdx);
+    if (aConstraintIdx <= theNbConstraints
+        && std::abs(theSourceParams(aConstraintIdx) - aSourceKnot) <= Precision::PConfusion())
+    {
+      if (aConstraintIdx > 1 && aConstraintIdx < theNbConstraints)
+      {
+        aMultiplicity = std::max(aMultiplicity, aDegree);
+      }
+      ++aConstraintIdx;
+    }
+    aNewKnotValues.Append(aTargetKnot);
+    aNewKnotMults.Append(aMultiplicity);
+  }
+
+  NCollection_Array1<double> aNewKnots = toOneBasedArrayView(aNewKnotValues);
+  NCollection_Array1<int>    aNewMults = toOneBasedArrayView(aNewKnotMults);
+  const int aNbNewPoles = BSplCLib::NbPoles(aDegree, false, aNewMults);
+  NCollection_Array1<double> aSourceFlatKnots(1, theCurve->NbPoles() + aDegree + 1);
+  NCollection_Array1<double> aTargetFlatKnots(1, aNbNewPoles + aDegree + 1);
+  BSplCLib::KnotSequence(theCurve->Knots(), theCurve->Multiplicities(), aSourceFlatKnots);
+  BSplCLib::KnotSequence(aNewKnots, aNewMults, aTargetFlatKnots);
+
+  int aStatus = 0;
+  if (!theCurve->IsRational())
+  {
+    NCollection_Array1<gp_Pnt> aNewPoles(1, aNbNewPoles);
+    BSplCLib::FunctionReparameterise(theLaw,
+                                     aDegree,
+                                     aSourceFlatKnots,
+                                     theCurve->Poles(),
+                                     aTargetFlatKnots,
+                                     aDegree,
+                                     aNewPoles,
+                                     aStatus);
+    if (aStatus != 0)
+    {
+      return false;
+    }
+    theResult = new Geom_BSplineCurve(aNewPoles, aNewKnots, aNewMults, aDegree);
+    return !theResult.IsNull();
+  }
+
+  NCollection_Array1<double> aHomogeneousPoles(1, 4 * theCurve->NbPoles());
+  for (size_t aPoleIdx = 0; aPoleIdx < theCurve->Poles().Size(); ++aPoleIdx)
+  {
+    const gp_Pnt& aPole = theCurve->Poles().At(aPoleIdx);
+    const double  aWeight = theCurve->WeightsArray().At(aPoleIdx);
+    const size_t  aHomogeneousIdx = 4 * aPoleIdx;
+    aHomogeneousPoles.ChangeAt(aHomogeneousIdx)     = aPole.X() * aWeight;
+    aHomogeneousPoles.ChangeAt(aHomogeneousIdx + 1) = aPole.Y() * aWeight;
+    aHomogeneousPoles.ChangeAt(aHomogeneousIdx + 2) = aPole.Z() * aWeight;
+    aHomogeneousPoles.ChangeAt(aHomogeneousIdx + 3) = aWeight;
+  }
+
+  NCollection_Array1<double> aNewHomogeneousPoles(1, 4 * aNbNewPoles);
+  BSplCLib::FunctionReparameterise(theLaw,
+                                   aDegree,
+                                   aSourceFlatKnots,
+                                   4,
+                                   aHomogeneousPoles(1),
+                                   aTargetFlatKnots,
+                                   aDegree,
+                                   aNewHomogeneousPoles(1),
+                                   aStatus);
+  if (aStatus != 0)
+  {
+    return false;
+  }
+
+  NCollection_Array1<gp_Pnt> aNewPoles(1, aNbNewPoles);
+  NCollection_Array1<double> aNewWeights(1, aNbNewPoles);
+  for (size_t aPoleIdx = 0; aPoleIdx < aNewPoles.Size(); ++aPoleIdx)
+  {
+    const size_t aHomogeneousIdx = 4 * aPoleIdx;
+    const double aWeight = aNewHomogeneousPoles.At(aHomogeneousIdx + 3);
+    if (aWeight <= gp::Resolution())
+    {
+      return false;
+    }
+    aNewPoles.ChangeAt(aPoleIdx).SetCoord(aNewHomogeneousPoles.At(aHomogeneousIdx) / aWeight,
+                                           aNewHomogeneousPoles.At(aHomogeneousIdx + 1) / aWeight,
+                                           aNewHomogeneousPoles.At(aHomogeneousIdx + 2) / aWeight);
+    aNewWeights.ChangeAt(aPoleIdx) = aWeight;
+  }
+
+  theResult = new Geom_BSplineCurve(aNewPoles, aNewWeights, aNewKnots, aNewMults, aDegree);
+  return !theResult.IsNull();
+}
 
 //! Appends a monotone source/target pair.
 void pushConstraint(math_Vector& theSource,
@@ -1053,15 +1347,6 @@ bool rebuildCurve(occ::handle<Geom_BSplineCurve>& theCurve,
                   bool&                           theDidApproximate,
                   double&                         theMaxDeviation)
 {
-  if (theCurve->IsRational())
-  {
-    if (!theAllowApproximateRational)
-    {
-      return false;
-    }
-    theDidApproximate = true;
-  }
-
   math_Vector  aSource(1, theSourceParams.Length() + 2);
   math_Vector  aTarget(1, theTargetParams.Length() + 2);
   int          aNbConstraints = 0;
@@ -1106,6 +1391,30 @@ bool rebuildCurve(occ::handle<Geom_BSplineCurve>& theCurve,
   if (!aLaw.Init(aSource, aTarget, aNbConstraints))
   {
     return false;
+  }
+
+  occ::handle<Geom_BSplineCurve> anExactCurve;
+  math_Vector aExactSource(1, aNbConstraints);
+  math_Vector aExactTarget(1, aNbConstraints);
+  for (int aConstraintIdx = 1; aConstraintIdx <= aNbConstraints; ++aConstraintIdx)
+  {
+    aExactSource(aConstraintIdx) = aSource(aConstraintIdx);
+    aExactTarget(aConstraintIdx) = aTarget(aConstraintIdx);
+  }
+  if (reparametrizeExactly(
+        theCurve, aExactSource, aExactTarget, aNbConstraints, aLaw, anExactCurve))
+  {
+    theCurve = anExactCurve;
+    return true;
+  }
+
+  if (theCurve->IsRational())
+  {
+    if (!theAllowApproximateRational)
+    {
+      return false;
+    }
+    theDidApproximate = true;
   }
 
   const GeomAdaptor_Curve          aCurveAdaptor(theCurve);
@@ -1252,7 +1561,7 @@ NCollection_Array2<gp_Pnt> contactPointGrid(
     for (size_t aGuideIdx = 0; aGuideIdx < static_cast<size_t>(theProfileParams.RowLength());
          ++aGuideIdx)
     {
-      aPoints(static_cast<int>(aGuideIdx) + 1, static_cast<int>(aProfileIdx) + 1) =
+      aPoints.ChangeAt(aGuideIdx, aProfileIdx) =
         aProfileAdaptor.EvalD0(theProfileParams.At(aProfileIdx, aGuideIdx));
     }
   }
@@ -1297,7 +1606,7 @@ NCollection_Array2<double> contactWeightGrid(
     for (size_t aGuideIdx = 0; aGuideIdx < static_cast<size_t>(theProfileParams.RowLength());
          ++aGuideIdx)
     {
-      aWeights(static_cast<int>(aGuideIdx) + 1, static_cast<int>(aProfileIdx) + 1) =
+      aWeights.ChangeAt(aGuideIdx, aProfileIdx) =
         curveWeightAt(theProfiles.At(aProfileIdx), theProfileParams.At(aProfileIdx, aGuideIdx));
     }
   }

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GordonUtilities.pxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_GordonUtilities.pxx
@@ -788,8 +788,8 @@ double orderedContactScore(const Contact& theContact,
   if (theHasPreviousGuide)
   {
     // Favor branches with a smooth advance along the current guide.
-    aScore += std::abs((theGuideParam - thePreviousGuideParam)
-                       - (theGuideTarget - thePreviousGuideTarget));
+    aScore +=
+      std::abs((theGuideParam - thePreviousGuideParam) - (theGuideTarget - thePreviousGuideTarget));
   }
   return aScore;
 }
@@ -830,7 +830,8 @@ bool seamTangentMismatch(const occ::handle<Geom_BSplineCurve>& theCurve,
   }
 
   theMismatch =
-    1.0 - std::clamp(aFirstTangent.Dot(aLastTangent) / (aFirstMagnitude * aLastMagnitude), -1.0, 1.0);
+    1.0
+    - std::clamp(aFirstTangent.Dot(aLastTangent) / (aFirstMagnitude * aLastMagnitude), -1.0, 1.0);
   return true;
 }
 
@@ -843,21 +844,21 @@ bool chooseOrderedContact(const ContactSet&                     theContacts,
                           const double                          theProfileTarget,
                           const double                          theGuideTarget,
                           const double                          thePreviousProfileParam,
-                           const double                          thePreviousGuideParam,
-                           const bool                            theHasPreviousProfile,
-                           const bool                            theHasPreviousGuide,
-                           const double                          thePreviousProfileTarget,
-                           const double                          thePreviousGuideTarget,
-                           const double                          theFirstProfileParam,
-                           const double                          theFirstGuideParam,
-                           const bool                            theIsProfileSeam,
-                           const bool                            theIsGuideSeam,
-                           const double                          theTolerance,
-                           Contact&                              theSelected)
+                          const double                          thePreviousGuideParam,
+                          const bool                            theHasPreviousProfile,
+                          const bool                            theHasPreviousGuide,
+                          const double                          thePreviousProfileTarget,
+                          const double                          thePreviousGuideTarget,
+                          const double                          theFirstProfileParam,
+                          const double                          theFirstGuideParam,
+                          const bool                            theIsProfileSeam,
+                          const bool                            theIsGuideSeam,
+                          const double                          theTolerance,
+                          Contact&                              theSelected)
 {
-  const double aParamTol = parameterResolution(0.0, 1.0);
+  const double aParamTol            = parameterResolution(0.0, 1.0);
   double       aBestTangentMismatch = RealLast();
-  double       aBest                 = RealLast();
+  double       aBest                = RealLast();
   for (size_t aCandidateIdx = 0; aCandidateIdx < theContacts.Candidates.Size(); ++aCandidateIdx)
   {
     const Contact& aCandidate = theContacts.Candidates.Value(aCandidateIdx);
@@ -870,20 +871,20 @@ bool chooseOrderedContact(const ContactSet&                     theContacts,
       continue;
     }
 
-    const double aScore = orderedContactScore(aCandidate,
-                                               aProfileParam,
-                                               aGuideParam,
-                                               theProfileTarget,
-                                               theGuideTarget,
-                                               thePreviousProfileParam,
-                                               thePreviousGuideParam,
-                                               thePreviousProfileTarget,
-                                               thePreviousGuideTarget,
-                                               theHasPreviousProfile,
-                                               theHasPreviousGuide,
-                                               theTolerance);
-    double aTangentMismatch = 0.0;
-    bool   hasTangentMatch  = false;
+    const double aScore           = orderedContactScore(aCandidate,
+                                              aProfileParam,
+                                              aGuideParam,
+                                              theProfileTarget,
+                                              theGuideTarget,
+                                              thePreviousProfileParam,
+                                              thePreviousGuideParam,
+                                              thePreviousProfileTarget,
+                                              thePreviousGuideTarget,
+                                              theHasPreviousProfile,
+                                              theHasPreviousGuide,
+                                              theTolerance);
+    double       aTangentMismatch = 0.0;
+    bool         hasTangentMatch  = false;
     if (theIsProfileSeam)
     {
       double aProfileMismatch = 0.0;
@@ -950,10 +951,10 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
   const NCollection_LinearVector<OrderedCurve> aGuideOrder =
     orderedCurves(columnMeans(aProfileParamMatrix));
 
-  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aProfiles(1,
-                                                                static_cast<int>(theProfiles.Size()));
-  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aGuides(1,
-                                                              static_cast<int>(theGuides.Size()));
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aProfiles(
+    1,
+    static_cast<int>(theProfiles.Size()));
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aGuides(1, static_cast<int>(theGuides.Size()));
   NCollection_Array2<double>                         aProfileParams(theProfileParams.LowerRow(),
                                             theProfileParams.UpperRow(),
                                             theProfileParams.LowerCol(),
@@ -1008,16 +1009,12 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
         aProfileIdx == 0
           ? 0.0
           : aGuideParamResult(static_cast<int>(aProfileIdx), static_cast<int>(aGuideIdx) + 1);
-      const double aPreviousProfileTarget = aGuideIdx < 2
-                                              ? 0.0
-                                              : static_cast<double>(aGuideIdx - 1)
-                                                  / (aGuideOrder.Size() - 1);
-      const double aPreviousGuideTarget = aProfileIdx < 2
-                                            ? 0.0
-                                            : static_cast<double>(aProfileIdx - 1)
-                                                / (aProfileOrder.Size() - 1);
-      const bool isProfileSeam = aGuideIdx + 1 == aGuideOrder.Size();
-      const bool isGuideSeam   = aProfileIdx + 1 == aProfileOrder.Size();
+      const double aPreviousProfileTarget =
+        aGuideIdx < 2 ? 0.0 : static_cast<double>(aGuideIdx - 1) / (aGuideOrder.Size() - 1);
+      const double aPreviousGuideTarget =
+        aProfileIdx < 2 ? 0.0 : static_cast<double>(aProfileIdx - 1) / (aProfileOrder.Size() - 1);
+      const bool   isProfileSeam = aGuideIdx + 1 == aGuideOrder.Size();
+      const bool   isGuideSeam   = aProfileIdx + 1 == aProfileOrder.Size();
       const double aFirstProfileParam =
         isProfileSeam ? aProfileParamResult(static_cast<int>(aProfileIdx) + 1, 1) : 0.0;
       const double aFirstGuideParam =
@@ -1033,16 +1030,16 @@ bool reorderNetwork(NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfi
             aProfileTarget,
             aGuideTarget,
             aPreviousProfileParam,
-             aPreviousGuideParam,
-             aGuideIdx != 0,
-             aProfileIdx != 0,
-             aPreviousProfileTarget,
-             aPreviousGuideTarget,
-             aFirstProfileParam,
-             aFirstGuideParam,
-             isProfileSeam,
-             isGuideSeam,
-             theTolerance,
+            aPreviousGuideParam,
+            aGuideIdx != 0,
+            aProfileIdx != 0,
+            aPreviousProfileTarget,
+            aPreviousGuideTarget,
+            aFirstProfileParam,
+            aFirstGuideParam,
+            isProfileSeam,
+            isGuideSeam,
+            theTolerance,
             aContact))
       {
         return false;
@@ -1127,11 +1124,11 @@ public:
     return mySource.Last();
   }
 
-  void Evaluate(const int     theDerivativeRequest,
+  void Evaluate(const int theDerivativeRequest,
                 const double* /*theStartEnd*/,
-                const double  theTargetParameter,
-                double&       theResult,
-                int&          theErrorCode) const override
+                const double theTargetParameter,
+                double&      theResult,
+                int&         theErrorCode) const override
   {
     theErrorCode = 0;
     if (theDerivativeRequest == 0)
@@ -1176,10 +1173,10 @@ bool reparametrizeExactly(const occ::handle<Geom_BSplineCurve>& theCurve,
     return false;
   }
 
-  const int aDegree = theCurve->Degree();
+  const int                        aDegree = theCurve->Degree();
   NCollection_LinearVector<double> aNewKnotValues;
   NCollection_LinearVector<int>    aNewKnotMults;
-  int aConstraintIdx = 1;
+  int                              aConstraintIdx = 1;
   for (size_t aKnotIdx = 0; aKnotIdx < theCurve->Knots().Size(); ++aKnotIdx)
   {
     const double aSourceKnot = theCurve->Knots().At(aKnotIdx);
@@ -1200,7 +1197,7 @@ bool reparametrizeExactly(const occ::handle<Geom_BSplineCurve>& theCurve,
         const double aSourceLast  = theSourceParams(aParamIdx + 1);
         const double aTargetFirst = theTargetParams(aParamIdx);
         const double aTargetLast  = theTargetParams(aParamIdx + 1);
-        aTargetKnot = aTargetFirst
+        aTargetKnot               = aTargetFirst
                       + (aSourceKnot - aSourceFirst) * (aTargetLast - aTargetFirst)
                           / (aSourceLast - aSourceFirst);
         break;
@@ -1221,9 +1218,9 @@ bool reparametrizeExactly(const occ::handle<Geom_BSplineCurve>& theCurve,
     aNewKnotMults.Append(aMultiplicity);
   }
 
-  NCollection_Array1<double> aNewKnots = toOneBasedArrayView(aNewKnotValues);
-  NCollection_Array1<int>    aNewMults = toOneBasedArrayView(aNewKnotMults);
-  const int aNbNewPoles = BSplCLib::NbPoles(aDegree, false, aNewMults);
+  NCollection_Array1<double> aNewKnots   = toOneBasedArrayView(aNewKnotValues);
+  NCollection_Array1<int>    aNewMults   = toOneBasedArrayView(aNewKnotMults);
+  const int                  aNbNewPoles = BSplCLib::NbPoles(aDegree, false, aNewMults);
   NCollection_Array1<double> aSourceFlatKnots(1, theCurve->NbPoles() + aDegree + 1);
   NCollection_Array1<double> aTargetFlatKnots(1, aNbNewPoles + aDegree + 1);
   BSplCLib::KnotSequence(theCurve->Knots(), theCurve->Multiplicities(), aSourceFlatKnots);
@@ -1252,9 +1249,9 @@ bool reparametrizeExactly(const occ::handle<Geom_BSplineCurve>& theCurve,
   NCollection_Array1<double> aHomogeneousPoles(1, 4 * theCurve->NbPoles());
   for (size_t aPoleIdx = 0; aPoleIdx < theCurve->Poles().Size(); ++aPoleIdx)
   {
-    const gp_Pnt& aPole = theCurve->Poles().At(aPoleIdx);
-    const double  aWeight = theCurve->WeightsArray().At(aPoleIdx);
-    const size_t  aHomogeneousIdx = 4 * aPoleIdx;
+    const gp_Pnt& aPole                             = theCurve->Poles().At(aPoleIdx);
+    const double  aWeight                           = theCurve->WeightsArray().At(aPoleIdx);
+    const size_t  aHomogeneousIdx                   = 4 * aPoleIdx;
     aHomogeneousPoles.ChangeAt(aHomogeneousIdx)     = aPole.X() * aWeight;
     aHomogeneousPoles.ChangeAt(aHomogeneousIdx + 1) = aPole.Y() * aWeight;
     aHomogeneousPoles.ChangeAt(aHomogeneousIdx + 2) = aPole.Z() * aWeight;
@@ -1281,14 +1278,14 @@ bool reparametrizeExactly(const occ::handle<Geom_BSplineCurve>& theCurve,
   for (size_t aPoleIdx = 0; aPoleIdx < aNewPoles.Size(); ++aPoleIdx)
   {
     const size_t aHomogeneousIdx = 4 * aPoleIdx;
-    const double aWeight = aNewHomogeneousPoles.At(aHomogeneousIdx + 3);
+    const double aWeight         = aNewHomogeneousPoles.At(aHomogeneousIdx + 3);
     if (aWeight <= gp::Resolution())
     {
       return false;
     }
     aNewPoles.ChangeAt(aPoleIdx).SetCoord(aNewHomogeneousPoles.At(aHomogeneousIdx) / aWeight,
-                                           aNewHomogeneousPoles.At(aHomogeneousIdx + 1) / aWeight,
-                                           aNewHomogeneousPoles.At(aHomogeneousIdx + 2) / aWeight);
+                                          aNewHomogeneousPoles.At(aHomogeneousIdx + 1) / aWeight,
+                                          aNewHomogeneousPoles.At(aHomogeneousIdx + 2) / aWeight);
     aNewWeights.ChangeAt(aPoleIdx) = aWeight;
   }
 
@@ -1394,15 +1391,19 @@ bool rebuildCurve(occ::handle<Geom_BSplineCurve>& theCurve,
   }
 
   occ::handle<Geom_BSplineCurve> anExactCurve;
-  math_Vector aExactSource(1, aNbConstraints);
-  math_Vector aExactTarget(1, aNbConstraints);
+  math_Vector                    aExactSource(1, aNbConstraints);
+  math_Vector                    aExactTarget(1, aNbConstraints);
   for (int aConstraintIdx = 1; aConstraintIdx <= aNbConstraints; ++aConstraintIdx)
   {
     aExactSource(aConstraintIdx) = aSource(aConstraintIdx);
     aExactTarget(aConstraintIdx) = aTarget(aConstraintIdx);
   }
-  if (reparametrizeExactly(
-        theCurve, aExactSource, aExactTarget, aNbConstraints, aLaw, anExactCurve))
+  if (reparametrizeExactly(theCurve,
+                           aExactSource,
+                           aExactTarget,
+                           aNbConstraints,
+                           aLaw,
+                           anExactCurve))
   {
     theCurve = anExactCurve;
     return true;

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
@@ -24,6 +24,7 @@
 #include <Standard_ErrorHandler.hxx>
 #include <Standard_Failure.hxx>
 #include <StdFail_NotDone.hxx>
+#include <gp.hxx>
 #include <gp_Vec.hxx>
 
 #include <algorithm>
@@ -171,35 +172,35 @@ void makeInterpolationBasis(const NCollection_Array1<double>& theParameters,
                             NCollection_Array1<int>&          theMults,
                             NCollection_Array1<double>&       theFlatKnots)
 {
-  const int aNbParams = static_cast<int>(theParameters.Size());
-  theDegree           = std::min(3, aNbParams - 1);
+  const size_t aNbParams = theParameters.Size();
+  theDegree              = std::min(3, static_cast<int>(aNbParams) - 1);
 
-  const int aNbInternalKnots = aNbParams - theDegree - 1;
-  theKnots.Resize(1, aNbInternalKnots + 2, false);
-  theMults.Resize(1, aNbInternalKnots + 2, false);
+  const size_t aNbInternalKnots = aNbParams - static_cast<size_t>(theDegree) - 1;
+  theKnots.Resize(1, static_cast<int>(aNbInternalKnots + 2), false);
+  theMults.Resize(1, static_cast<int>(aNbInternalKnots + 2), false);
 
-  theKnots(1) = theParameters.At(0);
-  theMults(1) = theDegree + 1;
-  for (int aKnotIdx = 1; aKnotIdx <= aNbInternalKnots; ++aKnotIdx)
+  theKnots.ChangeAt(0) = theParameters.At(0);
+  theMults.ChangeAt(0) = theDegree + 1;
+  for (size_t aKnotIdx = 0; aKnotIdx < aNbInternalKnots; ++aKnotIdx)
   {
     double aSum = 0.0;
-    for (int aParamOffset = 1; aParamOffset <= theDegree; ++aParamOffset)
+    for (size_t aParamOffset = 1; aParamOffset <= static_cast<size_t>(theDegree); ++aParamOffset)
     {
-      aSum += theParameters.At(static_cast<size_t>(aKnotIdx + aParamOffset - 1));
+      aSum += theParameters.At(aKnotIdx + aParamOffset);
     }
-    theKnots(aKnotIdx + 1) = aSum / static_cast<double>(theDegree);
-    theMults(aKnotIdx + 1) = 1;
+    theKnots.ChangeAt(aKnotIdx + 1) = aSum / static_cast<double>(theDegree);
+    theMults.ChangeAt(aKnotIdx + 1) = 1;
   }
-  theKnots(theKnots.Upper()) = theParameters.At(theParameters.Size() - 1);
-  theMults(theMults.Upper()) = theDegree + 1;
+  theKnots.ChangeAt(theKnots.Size() - 1) = theParameters.At(theParameters.Size() - 1);
+  theMults.ChangeAt(theMults.Size() - 1) = theDegree + 1;
 
-  theFlatKnots.Resize(1, theDegree + aNbParams + 1, false);
-  int aFlatIdx = 1;
-  for (int aKnotIdx = theKnots.Lower(); aKnotIdx <= theKnots.Upper(); ++aKnotIdx)
+  theFlatKnots.Resize(1, theDegree + static_cast<int>(aNbParams) + 1, false);
+  size_t aFlatIdx = 0;
+  for (size_t aKnotIdx = 0; aKnotIdx < theKnots.Size(); ++aKnotIdx)
   {
-    for (int aMultIdx = 1; aMultIdx <= theMults(aKnotIdx); ++aMultIdx)
+    for (size_t aMultIdx = 0; aMultIdx < static_cast<size_t>(theMults.At(aKnotIdx)); ++aMultIdx)
     {
-      theFlatKnots(aFlatIdx++) = theKnots(aKnotIdx);
+      theFlatKnots.ChangeAt(aFlatIdx++) = theKnots.At(aKnotIdx);
     }
   }
 }
@@ -334,21 +335,22 @@ bool makeTripleProductBasis(const NCollection_Array1<double>& theKnots,
     return false;
   }
 
-  theProductKnots.Resize(theKnots.Lower(), theKnots.Upper(), false);
-  theProductMults.Resize(theMults.Lower(), theMults.Upper(), false);
+  theProductKnots.Resize(1, static_cast<int>(theKnots.Size()), false);
+  theProductMults.Resize(1, static_cast<int>(theMults.Size()), false);
   int aFlatLength = 0;
-  for (int aKnotIdx = theKnots.Lower(); aKnotIdx <= theKnots.Upper(); ++aKnotIdx)
+  for (size_t aKnotIdx = 0; aKnotIdx < theKnots.Size(); ++aKnotIdx)
   {
-    theProductKnots(aKnotIdx) = theKnots(aKnotIdx);
-    if (aKnotIdx == theKnots.Lower() || aKnotIdx == theKnots.Upper())
+    theProductKnots.ChangeAt(aKnotIdx) = theKnots.At(aKnotIdx);
+    if (aKnotIdx == 0 || aKnotIdx + 1 == theKnots.Size())
     {
-      theProductMults(aKnotIdx) = theProductDegree + 1;
+      theProductMults.ChangeAt(aKnotIdx) = theProductDegree + 1;
     }
     else
     {
-      theProductMults(aKnotIdx) = std::min(theProductDegree, 2 * theDegree + theMults(aKnotIdx));
+      theProductMults.ChangeAt(aKnotIdx) =
+        std::min(theProductDegree, 2 * theDegree + theMults.At(aKnotIdx));
     }
-    aFlatLength += theProductMults(aKnotIdx);
+    aFlatLength += theProductMults.At(aKnotIdx);
   }
 
   theProductFlatKnots.Resize(1, aFlatLength, false);
@@ -396,21 +398,20 @@ occ::handle<Geom_BSplineSurface> makeProfileSkin(
   const NCollection_Array1<int>&                            theVMults,
   const NCollection_Array1<double>&                         theVFlatKnots)
 {
-  const occ::handle<Geom_BSplineCurve>& aBaseProfile = theProfiles(theProfiles.Lower());
+  const occ::handle<Geom_BSplineCurve>& aBaseProfile = theProfiles.At(0);
   NCollection_Array2<gp_Pnt>            aPoles(1, aBaseProfile->NbPoles(), 1, theProfiles.Length());
   NCollection_Array2<double> aWeights(1, aBaseProfile->NbPoles(), 1, theProfiles.Length());
   NCollection_Array1<gp_Pnt> aColumn(1, theProfiles.Length());
   NCollection_Array1<double> aColumnWeights(1, theProfiles.Length());
-  NCollection_Array1<int>    aContactOrders(theProfileParameters.Lower(),
-                                         theProfileParameters.Upper());
+  NCollection_Array1<int> aContactOrders(1, static_cast<int>(theProfileParameters.Size()));
   aContactOrders.Init(0);
 
   for (int aUPoleIdx = 1; aUPoleIdx <= aBaseProfile->NbPoles(); ++aUPoleIdx)
   {
-    for (int aProfileIdx = 1; aProfileIdx <= theProfiles.Length(); ++aProfileIdx)
+    for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
     {
-      aColumn(aProfileIdx)        = theProfiles(aProfileIdx)->Pole(aUPoleIdx);
-      aColumnWeights(aProfileIdx) = poleWeight(theProfiles(aProfileIdx), aUPoleIdx);
+      aColumn.ChangeAt(aProfileIdx) = theProfiles.At(aProfileIdx)->Pole(aUPoleIdx);
+      aColumnWeights.ChangeAt(aProfileIdx) = poleWeight(theProfiles.At(aProfileIdx), aUPoleIdx);
     }
     if (!interpolatePoles(theVDegree,
                           theVFlatKnots,
@@ -421,10 +422,10 @@ occ::handle<Geom_BSplineSurface> makeProfileSkin(
     {
       return nullptr;
     }
-    for (int aVIdx = 1; aVIdx <= theProfiles.Length(); ++aVIdx)
+    for (size_t aVIdx = 0; aVIdx < theProfiles.Size(); ++aVIdx)
     {
-      aPoles(aUPoleIdx, aVIdx)   = aColumn(aVIdx);
-      aWeights(aUPoleIdx, aVIdx) = aColumnWeights(aVIdx);
+      aPoles.ChangeAt(static_cast<size_t>(aUPoleIdx - 1), aVIdx)   = aColumn.At(aVIdx);
+      aWeights.ChangeAt(static_cast<size_t>(aUPoleIdx - 1), aVIdx) = aColumnWeights.At(aVIdx);
     }
   }
 
@@ -446,20 +447,20 @@ occ::handle<Geom_BSplineSurface> makeGuideSkin(
   const NCollection_Array1<int>&                            theUMults,
   const NCollection_Array1<double>&                         theUFlatKnots)
 {
-  const occ::handle<Geom_BSplineCurve>& aBaseGuide = theGuides(theGuides.Lower());
+  const occ::handle<Geom_BSplineCurve>& aBaseGuide = theGuides.At(0);
   NCollection_Array2<gp_Pnt>            aPoles(1, theGuides.Length(), 1, aBaseGuide->NbPoles());
   NCollection_Array2<double>            aWeights(1, theGuides.Length(), 1, aBaseGuide->NbPoles());
   NCollection_Array1<gp_Pnt>            aRow(1, theGuides.Length());
   NCollection_Array1<double>            aRowWeights(1, theGuides.Length());
-  NCollection_Array1<int> aContactOrders(theGuideParameters.Lower(), theGuideParameters.Upper());
+  NCollection_Array1<int> aContactOrders(1, static_cast<int>(theGuideParameters.Size()));
   aContactOrders.Init(0);
 
   for (int aVPoleIdx = 1; aVPoleIdx <= aBaseGuide->NbPoles(); ++aVPoleIdx)
   {
-    for (int aGuideIdx = 1; aGuideIdx <= theGuides.Length(); ++aGuideIdx)
+    for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
     {
-      aRow(aGuideIdx)        = theGuides(aGuideIdx)->Pole(aVPoleIdx);
-      aRowWeights(aGuideIdx) = poleWeight(theGuides(aGuideIdx), aVPoleIdx);
+      aRow.ChangeAt(aGuideIdx) = theGuides.At(aGuideIdx)->Pole(aVPoleIdx);
+      aRowWeights.ChangeAt(aGuideIdx) = poleWeight(theGuides.At(aGuideIdx), aVPoleIdx);
     }
     if (!interpolatePoles(theUDegree,
                           theUFlatKnots,
@@ -470,10 +471,10 @@ occ::handle<Geom_BSplineSurface> makeGuideSkin(
     {
       return nullptr;
     }
-    for (int aUIdx = 1; aUIdx <= theGuides.Length(); ++aUIdx)
+    for (size_t aUIdx = 0; aUIdx < theGuides.Size(); ++aUIdx)
     {
-      aPoles(aUIdx, aVPoleIdx)   = aRow(aUIdx);
-      aWeights(aUIdx, aVPoleIdx) = aRowWeights(aUIdx);
+      aPoles.ChangeAt(aUIdx, static_cast<size_t>(aVPoleIdx - 1))   = aRow.At(aUIdx);
+      aWeights.ChangeAt(aUIdx, static_cast<size_t>(aVPoleIdx - 1)) = aRowWeights.At(aUIdx);
     }
   }
 
@@ -508,14 +509,14 @@ void collectKnots(const int                            theDegree,
                   const NCollection_Array1<int>&       theMults,
                   NCollection_LinearVector<KnotEntry>& theEntries)
 {
-  for (int aKnotIdx = theKnots.Lower(); aKnotIdx <= theKnots.Upper(); ++aKnotIdx)
+  for (size_t aKnotIdx = 0; aKnotIdx < theKnots.Size(); ++aKnotIdx)
   {
-    const double aKnot      = normalizedKnot(theStart, theEnd, theKnots(aKnotIdx));
+    const double aKnot      = normalizedKnot(theStart, theEnd, theKnots.At(aKnotIdx));
     const bool   isBoundary = aKnot == theStart || aKnot == theEnd;
     const int    aMaxMult   = isBoundary ? theDegree + 1 : theDegree;
     KnotEntry    anEntry;
     anEntry.Parameter    = aKnot;
-    anEntry.Multiplicity = std::min(theMults(aKnotIdx), aMaxMult);
+    anEntry.Multiplicity = std::min(theMults.At(aKnotIdx), aMaxMult);
     theEntries.Append(anEntry);
   }
 }
@@ -914,6 +915,20 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
   // The reference surface starts from the same contact grid validated during preparation.
   NCollection_Array2<gp_Pnt> aReferencePoles(theIntersectionPoints);
   NCollection_Array2<double> aReferenceWeights(theIntersectionWeights);
+  const bool isReferencePolynomial = hasRationalCurve(theProfiles) != hasRationalCurve(theGuides);
+  if (isReferencePolynomial)
+  {
+    aReferenceWeights.Init(1.0);
+  }
+  else
+  {
+    for (size_t aPoleIdx = 0; aPoleIdx < aReferencePoles.Size(); ++aPoleIdx)
+    {
+      const double aWeight = aReferenceWeights.NCollection_Array1<double>::At(aPoleIdx);
+      aReferencePoles.NCollection_Array1<gp_Pnt>::ChangeAt(aPoleIdx) =
+        gp_Pnt(aReferencePoles.NCollection_Array1<gp_Pnt>::At(aPoleIdx).XYZ() * aWeight);
+    }
+  }
 
   int anInversionProblem = 0;
   BSplSLib::Interpolate(anUBasis.Degree,
@@ -929,6 +944,20 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
   {
     theStatus = GeomFill_NetworkSurface::ResultStatus::ReferenceSurfaceFailed;
     return nullptr;
+  }
+  if (!isReferencePolynomial)
+  {
+    for (size_t aPoleIdx = 0; aPoleIdx < aReferencePoles.Size(); ++aPoleIdx)
+    {
+      const double aWeight = aReferenceWeights.NCollection_Array1<double>::At(aPoleIdx);
+      if (aWeight <= gp::Resolution())
+      {
+        theStatus = GeomFill_NetworkSurface::ResultStatus::ReferenceSurfaceFailed;
+        return nullptr;
+      }
+      aReferencePoles.NCollection_Array1<gp_Pnt>::ChangeAt(aPoleIdx) =
+        gp_Pnt(aReferencePoles.NCollection_Array1<gp_Pnt>::At(aPoleIdx).XYZ() / aWeight);
+    }
   }
 
   occ::handle<Geom_BSplineSurface> aReferenceSurface = new Geom_BSplineSurface(aReferencePoles,

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
@@ -16,6 +16,7 @@
 #include <BSplCLib.hxx>
 #include <BSplSLib.hxx>
 #include <BSplSLib_EvaluatorFunction.hxx>
+#include <GeomAPI_Interpolate.hxx>
 #include <GeomFill_Profiler.hxx>
 #include <NCollection_Array2.hxx>
 #include <NCollection_HArray1.hxx>
@@ -871,6 +872,129 @@ bool isReadyToBuild(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& th
          && checkWeights(theIntersectionWeights);
 }
 
+// Creates a seam guide through the start points of all closed profiles.
+occ::handle<Geom_BSplineCurve> makeProfileSeamGuide(
+  const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
+  const NCollection_Array1<double>&                         theProfileParameters)
+{
+  occ::handle<NCollection_HArray1<gp_Pnt>> aPoints =
+    new NCollection_HArray1<gp_Pnt>(1, theProfiles.Length());
+  occ::handle<NCollection_HArray1<double>> aParameters =
+    new NCollection_HArray1<double>(1, theProfileParameters.Length());
+  for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
+  {
+    const occ::handle<Geom_BSplineCurve>& aProfile = theProfiles.At(aProfileIdx);
+    aPoints->SetValue(static_cast<int>(aProfileIdx) + 1,
+                      aProfile->Value(aProfile->FirstParameter()));
+    aParameters->SetValue(static_cast<int>(aProfileIdx) + 1, theProfileParameters.At(aProfileIdx));
+  }
+
+  GeomAPI_Interpolate anInterpolator(aPoints, aParameters, false, Precision::Confusion());
+  anInterpolator.Perform();
+  return anInterpolator.IsDone() ? anInterpolator.Curve() : nullptr;
+}
+
+// Completes a closed U-direction interpolation basis at both profile endpoints.
+bool completeClosedGuideSeam(
+  const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
+  const NCollection_Array1<double>&                         theProfileParameters,
+  const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
+  const NCollection_Array1<double>&                         theGuideParameters,
+  const NCollection_Array2<gp_Pnt>&                         theIntersectionPoints,
+  const NCollection_Array2<double>&                         theIntersectionWeights,
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>>&       theClosedGuides,
+  NCollection_Array1<double>&                               theClosedGuideParameters,
+  NCollection_Array2<gp_Pnt>&                               theClosedIntersectionPoints,
+  NCollection_Array2<double>&                               theClosedIntersectionWeights)
+{
+  const double aProfileStart = theProfiles.At(0)->FirstParameter();
+  const double aProfileEnd   = theProfiles.At(0)->LastParameter();
+  const bool needsStartSeam =
+    theGuideParameters.First() > aProfileStart + Precision::PConfusion();
+  const bool needsEndSeam = theGuideParameters.Last() < aProfileEnd - Precision::PConfusion();
+  if (!needsStartSeam && !needsEndSeam)
+  {
+    return true;
+  }
+
+  occ::handle<Geom_BSplineCurve> aSeamGuide;
+  if (needsStartSeam)
+  {
+    aSeamGuide = makeProfileSeamGuide(theProfiles, theProfileParameters);
+    if (aSeamGuide.IsNull())
+    {
+      return false;
+    }
+  }
+
+  const size_t aGuideOffset = needsStartSeam ? 1 : 0;
+  const size_t aNbGuides = theGuides.Size() + aGuideOffset + (needsEndSeam ? 1 : 0);
+  theClosedGuides = NCollection_Array1<occ::handle<Geom_BSplineCurve>>(1,
+                                                                          static_cast<int>(aNbGuides));
+  theClosedGuideParameters = NCollection_Array1<double>(1, static_cast<int>(aNbGuides));
+  if (needsStartSeam)
+  {
+    theClosedGuides.ChangeAt(0)          = aSeamGuide;
+    theClosedGuideParameters.ChangeAt(0) = aProfileStart;
+  }
+  for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
+  {
+    theClosedGuides.ChangeAt(aGuideIdx + aGuideOffset) = theGuides.At(aGuideIdx);
+    theClosedGuideParameters.ChangeAt(aGuideIdx + aGuideOffset) = theGuideParameters.At(aGuideIdx);
+  }
+  if (needsEndSeam)
+  {
+    theClosedGuides.ChangeAt(aNbGuides - 1) = needsStartSeam ? aSeamGuide : theGuides.At(0);
+    theClosedGuideParameters.ChangeAt(aNbGuides - 1) = aProfileEnd;
+  }
+
+  theClosedIntersectionPoints = NCollection_Array2<gp_Pnt>(1,
+                                                            static_cast<int>(aNbGuides),
+                                                            1,
+                                                            theIntersectionPoints.NbColumns());
+  theClosedIntersectionWeights = NCollection_Array2<double>(1,
+                                                             static_cast<int>(aNbGuides),
+                                                             1,
+                                                             theIntersectionWeights.NbColumns());
+  if (needsStartSeam)
+  {
+    for (size_t aProfileIdx = 0;
+         aProfileIdx < static_cast<size_t>(theIntersectionPoints.NbColumns());
+         ++aProfileIdx)
+    {
+      theClosedIntersectionPoints.ChangeAt(0, aProfileIdx) =
+        theProfiles.At(aProfileIdx)->Value(theProfiles.At(aProfileIdx)->FirstParameter());
+      theClosedIntersectionWeights.ChangeAt(0, aProfileIdx) = poleWeight(theProfiles.At(aProfileIdx), 1);
+    }
+  }
+  for (size_t aGuideIdx = 0; aGuideIdx < static_cast<size_t>(theIntersectionPoints.NbRows());
+       ++aGuideIdx)
+  {
+    for (size_t aProfileIdx = 0;
+         aProfileIdx < static_cast<size_t>(theIntersectionPoints.NbColumns());
+         ++aProfileIdx)
+    {
+      theClosedIntersectionPoints.ChangeAt(aGuideIdx + aGuideOffset, aProfileIdx) =
+        theIntersectionPoints.At(aGuideIdx, aProfileIdx);
+      theClosedIntersectionWeights.ChangeAt(aGuideIdx + aGuideOffset, aProfileIdx) =
+        theIntersectionWeights.At(aGuideIdx, aProfileIdx);
+    }
+  }
+  if (needsEndSeam)
+  {
+    for (size_t aProfileIdx = 0;
+         aProfileIdx < static_cast<size_t>(theIntersectionPoints.NbColumns());
+         ++aProfileIdx)
+    {
+      theClosedIntersectionPoints.ChangeAt(aNbGuides - 1, aProfileIdx) =
+        theClosedIntersectionPoints.At(0, aProfileIdx);
+      theClosedIntersectionWeights.ChangeAt(aNbGuides - 1, aProfileIdx) =
+        theClosedIntersectionWeights.At(0, aProfileIdx);
+    }
+  }
+  return true;
+}
+
 occ::handle<Geom_BSplineSurface> makeNetworkSurface(
   const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
   const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
@@ -878,12 +1002,50 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
   const NCollection_Array1<double>&                         theGuideParameters,
   const NCollection_Array2<gp_Pnt>&                         theIntersectionPoints,
   const NCollection_Array2<double>&                         theIntersectionWeights,
+  const bool                                                theIsUClosed,
   GeomFill_NetworkSurface::ResultStatus&                    theStatus)
 {
   theStatus = GeomFill_NetworkSurface::ResultStatus::ConstructionFailed;
 
+  NCollection_Array1<occ::handle<Geom_BSplineCurve>> aClosedGuides;
+  NCollection_Array1<double>                         aClosedGuideParameters;
+  NCollection_Array2<gp_Pnt>                         aClosedIntersectionPoints;
+  NCollection_Array2<double>                         aClosedIntersectionWeights;
+  const bool shouldCompleteUSeam =
+    theIsUClosed
+    && (theGuideParameters.First() > theProfiles.At(0)->FirstParameter() + Precision::PConfusion()
+        || theGuideParameters.Last() < theProfiles.At(0)->LastParameter() - Precision::PConfusion());
+  if (shouldCompleteUSeam
+      && !completeClosedGuideSeam(theProfiles,
+                                  theProfileParameters,
+                                  theGuides,
+                                  theGuideParameters,
+                                  theIntersectionPoints,
+                                  theIntersectionWeights,
+                                  aClosedGuides,
+                                  aClosedGuideParameters,
+                                  aClosedIntersectionPoints,
+                                  aClosedIntersectionWeights))
+  {
+    theStatus = GeomFill_NetworkSurface::ResultStatus::SkinningFailed;
+    return nullptr;
+  }
+  if (shouldCompleteUSeam && !prepareCurveFamily(aClosedGuides))
+  {
+    theStatus = GeomFill_NetworkSurface::ResultStatus::CurveCompatibilityFailed;
+    return nullptr;
+  }
+  const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& aGuides =
+    shouldCompleteUSeam ? aClosedGuides : theGuides;
+  const NCollection_Array1<double>& aGuideParameters =
+    shouldCompleteUSeam ? aClosedGuideParameters : theGuideParameters;
+  const NCollection_Array2<gp_Pnt>& aIntersectionPoints =
+    shouldCompleteUSeam ? aClosedIntersectionPoints : theIntersectionPoints;
+  const NCollection_Array2<double>& aIntersectionWeights =
+    shouldCompleteUSeam ? aClosedIntersectionWeights : theIntersectionWeights;
+
   SkinningBasis anUBasis;
-  anUBasis.Init(theGuideParameters);
+  anUBasis.Init(aGuideParameters);
 
   SkinningBasis aVBasis;
   aVBasis.Init(theProfileParameters);
@@ -900,8 +1062,8 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
     return nullptr;
   }
 
-  occ::handle<Geom_BSplineSurface> aGuideSurface = makeGuideSkin(theGuides,
-                                                                 theGuideParameters,
+  occ::handle<Geom_BSplineSurface> aGuideSurface = makeGuideSkin(aGuides,
+                                                                 aGuideParameters,
                                                                  anUBasis.Degree,
                                                                  anUBasis.Knots,
                                                                  anUBasis.Mults,
@@ -913,9 +1075,9 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
   }
 
   // The reference surface starts from the same contact grid validated during preparation.
-  NCollection_Array2<gp_Pnt> aReferencePoles(theIntersectionPoints);
-  NCollection_Array2<double> aReferenceWeights(theIntersectionWeights);
-  const bool isReferencePolynomial = hasRationalCurve(theProfiles) != hasRationalCurve(theGuides);
+  NCollection_Array2<gp_Pnt> aReferencePoles(aIntersectionPoints);
+  NCollection_Array2<double> aReferenceWeights(aIntersectionWeights);
+  const bool isReferencePolynomial = hasRationalCurve(theProfiles) != hasRationalCurve(aGuides);
   if (isReferencePolynomial)
   {
     aReferenceWeights.Init(1.0);
@@ -935,7 +1097,7 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
                         aVBasis.Degree,
                         anUBasis.FlatKnots,
                         aVBasis.FlatKnots,
-                        theGuideParameters,
+                        aGuideParameters,
                         theProfileParameters,
                         aReferencePoles,
                         aReferenceWeights,
@@ -1064,12 +1226,13 @@ void GeomFill_NetworkSurface::Perform()
 
     ResultStatus aSurfaceStatus = ResultStatus::ConstructionFailed;
     mySurface                   = makeNetworkSurface(myProfiles,
-                                   myGuides,
-                                   myProfileParameters,
-                                   myGuideParameters,
-                                   myIntersectionPoints,
-                                   myIntersectionWeights,
-                                   aSurfaceStatus);
+                                                     myGuides,
+                                                     myProfileParameters,
+                                                     myGuideParameters,
+                                                     myIntersectionPoints,
+                                                     myIntersectionWeights,
+                                                     myIsUClosed,
+                                                     aSurfaceStatus);
     if (mySurface.IsNull())
     {
       myStatus = aSurfaceStatus;

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
@@ -403,14 +403,14 @@ occ::handle<Geom_BSplineSurface> makeProfileSkin(
   NCollection_Array2<double> aWeights(1, aBaseProfile->NbPoles(), 1, theProfiles.Length());
   NCollection_Array1<gp_Pnt> aColumn(1, theProfiles.Length());
   NCollection_Array1<double> aColumnWeights(1, theProfiles.Length());
-  NCollection_Array1<int> aContactOrders(1, static_cast<int>(theProfileParameters.Size()));
+  NCollection_Array1<int>    aContactOrders(1, static_cast<int>(theProfileParameters.Size()));
   aContactOrders.Init(0);
 
   for (int aUPoleIdx = 1; aUPoleIdx <= aBaseProfile->NbPoles(); ++aUPoleIdx)
   {
     for (size_t aProfileIdx = 0; aProfileIdx < theProfiles.Size(); ++aProfileIdx)
     {
-      aColumn.ChangeAt(aProfileIdx) = theProfiles.At(aProfileIdx)->Pole(aUPoleIdx);
+      aColumn.ChangeAt(aProfileIdx)        = theProfiles.At(aProfileIdx)->Pole(aUPoleIdx);
       aColumnWeights.ChangeAt(aProfileIdx) = poleWeight(theProfiles.At(aProfileIdx), aUPoleIdx);
     }
     if (!interpolatePoles(theVDegree,
@@ -459,7 +459,7 @@ occ::handle<Geom_BSplineSurface> makeGuideSkin(
   {
     for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
     {
-      aRow.ChangeAt(aGuideIdx) = theGuides.At(aGuideIdx)->Pole(aVPoleIdx);
+      aRow.ChangeAt(aGuideIdx)        = theGuides.At(aGuideIdx)->Pole(aVPoleIdx);
       aRowWeights.ChangeAt(aGuideIdx) = poleWeight(theGuides.At(aGuideIdx), aVPoleIdx);
     }
     if (!interpolatePoles(theUDegree,

--- a/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GeomFill/GeomFill_NetworkSurface.cxx
@@ -895,23 +895,21 @@ occ::handle<Geom_BSplineCurve> makeProfileSeamGuide(
 }
 
 // Completes a closed U-direction interpolation basis at both profile endpoints.
-bool completeClosedGuideSeam(
-  const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
-  const NCollection_Array1<double>&                         theProfileParameters,
-  const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
-  const NCollection_Array1<double>&                         theGuideParameters,
-  const NCollection_Array2<gp_Pnt>&                         theIntersectionPoints,
-  const NCollection_Array2<double>&                         theIntersectionWeights,
-  NCollection_Array1<occ::handle<Geom_BSplineCurve>>&       theClosedGuides,
-  NCollection_Array1<double>&                               theClosedGuideParameters,
-  NCollection_Array2<gp_Pnt>&                               theClosedIntersectionPoints,
-  NCollection_Array2<double>&                               theClosedIntersectionWeights)
+bool completeClosedGuideSeam(const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theProfiles,
+                             const NCollection_Array1<double>& theProfileParameters,
+                             const NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theGuides,
+                             const NCollection_Array1<double>& theGuideParameters,
+                             const NCollection_Array2<gp_Pnt>& theIntersectionPoints,
+                             const NCollection_Array2<double>& theIntersectionWeights,
+                             NCollection_Array1<occ::handle<Geom_BSplineCurve>>& theClosedGuides,
+                             NCollection_Array1<double>& theClosedGuideParameters,
+                             NCollection_Array2<gp_Pnt>& theClosedIntersectionPoints,
+                             NCollection_Array2<double>& theClosedIntersectionWeights)
 {
   const double aProfileStart = theProfiles.At(0)->FirstParameter();
   const double aProfileEnd   = theProfiles.At(0)->LastParameter();
-  const bool needsStartSeam =
-    theGuideParameters.First() > aProfileStart + Precision::PConfusion();
-  const bool needsEndSeam = theGuideParameters.Last() < aProfileEnd - Precision::PConfusion();
+  const bool needsStartSeam  = theGuideParameters.First() > aProfileStart + Precision::PConfusion();
+  const bool needsEndSeam    = theGuideParameters.Last() < aProfileEnd - Precision::PConfusion();
   if (!needsStartSeam && !needsEndSeam)
   {
     return true;
@@ -928,9 +926,9 @@ bool completeClosedGuideSeam(
   }
 
   const size_t aGuideOffset = needsStartSeam ? 1 : 0;
-  const size_t aNbGuides = theGuides.Size() + aGuideOffset + (needsEndSeam ? 1 : 0);
-  theClosedGuides = NCollection_Array1<occ::handle<Geom_BSplineCurve>>(1,
-                                                                          static_cast<int>(aNbGuides));
+  const size_t aNbGuides    = theGuides.Size() + aGuideOffset + (needsEndSeam ? 1 : 0);
+  theClosedGuides =
+    NCollection_Array1<occ::handle<Geom_BSplineCurve>>(1, static_cast<int>(aNbGuides));
   theClosedGuideParameters = NCollection_Array1<double>(1, static_cast<int>(aNbGuides));
   if (needsStartSeam)
   {
@@ -939,7 +937,7 @@ bool completeClosedGuideSeam(
   }
   for (size_t aGuideIdx = 0; aGuideIdx < theGuides.Size(); ++aGuideIdx)
   {
-    theClosedGuides.ChangeAt(aGuideIdx + aGuideOffset) = theGuides.At(aGuideIdx);
+    theClosedGuides.ChangeAt(aGuideIdx + aGuideOffset)          = theGuides.At(aGuideIdx);
     theClosedGuideParameters.ChangeAt(aGuideIdx + aGuideOffset) = theGuideParameters.At(aGuideIdx);
   }
   if (needsEndSeam)
@@ -948,14 +946,14 @@ bool completeClosedGuideSeam(
     theClosedGuideParameters.ChangeAt(aNbGuides - 1) = aProfileEnd;
   }
 
-  theClosedIntersectionPoints = NCollection_Array2<gp_Pnt>(1,
+  theClosedIntersectionPoints  = NCollection_Array2<gp_Pnt>(1,
+                                                           static_cast<int>(aNbGuides),
+                                                           1,
+                                                           theIntersectionPoints.NbColumns());
+  theClosedIntersectionWeights = NCollection_Array2<double>(1,
                                                             static_cast<int>(aNbGuides),
                                                             1,
-                                                            theIntersectionPoints.NbColumns());
-  theClosedIntersectionWeights = NCollection_Array2<double>(1,
-                                                             static_cast<int>(aNbGuides),
-                                                             1,
-                                                             theIntersectionWeights.NbColumns());
+                                                            theIntersectionWeights.NbColumns());
   if (needsStartSeam)
   {
     for (size_t aProfileIdx = 0;
@@ -964,7 +962,8 @@ bool completeClosedGuideSeam(
     {
       theClosedIntersectionPoints.ChangeAt(0, aProfileIdx) =
         theProfiles.At(aProfileIdx)->Value(theProfiles.At(aProfileIdx)->FirstParameter());
-      theClosedIntersectionWeights.ChangeAt(0, aProfileIdx) = poleWeight(theProfiles.At(aProfileIdx), 1);
+      theClosedIntersectionWeights.ChangeAt(0, aProfileIdx) =
+        poleWeight(theProfiles.At(aProfileIdx), 1);
     }
   }
   for (size_t aGuideIdx = 0; aGuideIdx < static_cast<size_t>(theIntersectionPoints.NbRows());
@@ -1011,10 +1010,11 @@ occ::handle<Geom_BSplineSurface> makeNetworkSurface(
   NCollection_Array1<double>                         aClosedGuideParameters;
   NCollection_Array2<gp_Pnt>                         aClosedIntersectionPoints;
   NCollection_Array2<double>                         aClosedIntersectionWeights;
-  const bool shouldCompleteUSeam =
+  const bool                                         shouldCompleteUSeam =
     theIsUClosed
     && (theGuideParameters.First() > theProfiles.At(0)->FirstParameter() + Precision::PConfusion()
-        || theGuideParameters.Last() < theProfiles.At(0)->LastParameter() - Precision::PConfusion());
+        || theGuideParameters.Last()
+             < theProfiles.At(0)->LastParameter() - Precision::PConfusion());
   if (shouldCompleteUSeam
       && !completeClosedGuideSeam(theProfiles,
                                   theProfileParameters,
@@ -1226,13 +1226,13 @@ void GeomFill_NetworkSurface::Perform()
 
     ResultStatus aSurfaceStatus = ResultStatus::ConstructionFailed;
     mySurface                   = makeNetworkSurface(myProfiles,
-                                                     myGuides,
-                                                     myProfileParameters,
-                                                     myGuideParameters,
-                                                     myIntersectionPoints,
-                                                     myIntersectionWeights,
-                                                     myIsUClosed,
-                                                     aSurfaceStatus);
+                                   myGuides,
+                                   myProfileParameters,
+                                   myGuideParameters,
+                                   myIntersectionPoints,
+                                   myIntersectionWeights,
+                                   myIsUClosed,
+                                   aSurfaceStatus);
     if (mySurface.IsNull())
     {
       myStatus = aSurfaceStatus;


### PR DESCRIPTION
- Reparametrize rational B-spline curves exactly when possible and preserve homogeneous reference-surface weights.
- Improve closed-network contact selection and curve-to-surface deviation validation.
- Use grid evaluators for approximate fallback construction.
- Add regression tests for rational, periodic, and dense curve networks.