### PR TITLE
Modeling - Optimize elementary deviations in GeomLib_CheckCurveOnSurface

### DIFF
--- a/src/ModelingData/TKGeomBase/GTests/FILES.cmake
+++ b/src/ModelingData/TKGeomBase/GTests/FILES.cmake
@@ -40,6 +40,7 @@ set(OCCT_TKGeomBase_GTests_FILES
   GeomConvert_CompCurveToBSplineCurve_Test.cxx
   Geom2dConvert_CompCurveToBSplineCurve_Test.cxx
   GeomConvert_Test.cxx
+  GeomLib_CheckCurveOnSurface_Test.cxx
   GProp_PEquation_Test.cxx
   GProp_PGProps_Test.cxx
   Hermit_Test.cxx

--- a/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <Adaptor3d_CurveOnSurface.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <Geom2d_Line.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <GeomAdaptor_Surface.hxx>
+#include <GeomLib_CheckCurveOnSurface.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <Precision.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+
+namespace
+{
+// Circle of radius theRadius at height theHeight on a cylinder of radius
+// theCylRadius around OZ; the pcurve is the corresponding iso line in UV.
+GeomLib_CheckCurveOnSurface makeCircleOnCylinderCheck(const double theCircRadius,
+                                                      const double theCylRadius,
+                                                      const double theHeight,
+                                                      double&      theMaxDistance)
+{
+  const double aFirst = 0.0, aLast = 2.0 * M_PI;
+
+  const occ::handle<Geom_Circle> aCirc = new Geom_Circle(
+    gp_Ax2(gp_Pnt(0.0, 0.0, theHeight), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
+    theCircRadius);
+  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aCirc, aFirst, aLast);
+
+  const occ::handle<Geom_CylindricalSurface> aCyl = new Geom_CylindricalSurface(
+    gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
+    theCylRadius);
+  const occ::handle<Geom2d_Line> aPLine =
+    new Geom2d_Line(gp_Pnt2d(0.0, theHeight), gp_Dir2d(1.0, 0.0));
+
+  const occ::handle<Geom2dAdaptor_Curve>      aC2d = new Geom2dAdaptor_Curve(aPLine, aFirst, aLast);
+  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aCyl);
+  const occ::handle<Adaptor3d_CurveOnSurface> aCoS  = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
+
+  GeomLib_CheckCurveOnSurface aCheck;
+  aCheck.Init(aC3d, Precision::PConfusion());
+  aCheck.Perform(aCoS);
+  theMaxDistance = aCheck.MaxDistance();
+  return aCheck;
+}
+} // namespace
+
+TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticCoincident_ReportsZeroDeviation)
+{
+  double     aMaxDist = RealLast();
+  const auto aCheck   = makeCircleOnCylinderCheck(2.0, 2.0, 5.0, aMaxDist);
+
+  EXPECT_TRUE(aCheck.IsDone());
+  EXPECT_LE(aMaxDist, Precision::Confusion());
+}
+
+TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticDeviating_ReportsActualDeviation)
+{
+  // The 3D circle is 0.05 smaller than the cylinder carrying the pcurve: the
+  // deviation is constant and equal to the radius difference. This guards the
+  // sampled flat-deviation shortcut against swallowing real deviations.
+  double     aMaxDist = RealLast();
+  const auto aCheck   = makeCircleOnCylinderCheck(1.95, 2.0, 5.0, aMaxDist);
+
+  EXPECT_TRUE(aCheck.IsDone());
+  EXPECT_NEAR(aMaxDist, 0.05, 1.0e-9);
+}
+
+TEST(GeomLib_CheckCurveOnSurfaceTest, LineOnPlane_ReportsZeroDeviation)
+{
+  const double aFirst = -10.0, aLast = 10.0;
+
+  const occ::handle<Geom_Line> aLine = new Geom_Line(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0));
+  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aLine, aFirst, aLast);
+
+  const occ::handle<Geom_Plane> aPlane =
+    new Geom_Plane(gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)));
+  const occ::handle<Geom2d_Line> aPLine = new Geom2d_Line(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
+
+  const occ::handle<Geom2dAdaptor_Curve>      aC2d = new Geom2dAdaptor_Curve(aPLine, aFirst, aLast);
+  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aPlane);
+  const occ::handle<Adaptor3d_CurveOnSurface> aCoS  = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
+
+  GeomLib_CheckCurveOnSurface aCheck;
+  aCheck.Init(aC3d, Precision::PConfusion());
+  aCheck.Perform(aCoS);
+
+  EXPECT_TRUE(aCheck.IsDone());
+  EXPECT_LE(aCheck.MaxDistance(), Precision::Confusion());
+}

--- a/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
@@ -17,6 +17,7 @@
 
 #include <Adaptor3d_CurveOnSurface.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
+#include <Geom2d_Ellipse.hxx>
 #include <Geom2d_Line.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <GeomAdaptor_Surface.hxx>
@@ -28,6 +29,7 @@
 #include <Geom_ToroidalSurface.hxx>
 #include <Precision.hxx>
 #include <gp_Ax2.hxx>
+#include <gp_Ax2d.hxx>
 #include <gp_Ax3.hxx>
 #include <gp_Dir.hxx>
 #include <gp_Dir2d.hxx>
@@ -123,6 +125,31 @@ TEST(GeomLib_CheckCurveOnSurfaceTest, DeviatingLines_ReportsEndpointMaximum)
   ASSERT_TRUE(aCheck.IsDone());
   EXPECT_NEAR(aCheck.MaxDistance(), std::sqrt(18.0), Precision::Confusion());
   EXPECT_DOUBLE_EQ(aCheck.MaxParameter(), 3.0);
+}
+
+TEST(GeomLib_CheckCurveOnSurfaceTest, CircleAndEllipse_ReportsAnalyticMaximum)
+{
+  const double aFirst = 0.0, aLast = 2.0 * M_PI;
+
+  const occ::handle<Geom_Circle> aCircle =
+    new Geom_Circle(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
+                    2.0);
+  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aCircle, aFirst, aLast);
+
+  const occ::handle<Geom2d_Ellipse> anEllipse =
+    new Geom2d_Ellipse(gp_Ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)), 4.0, 1.0);
+  const occ::handle<Geom2dAdaptor_Curve> aC2d = new Geom2dAdaptor_Curve(anEllipse, aFirst, aLast);
+  const occ::handle<Geom_Plane>          aPlane =
+    new Geom_Plane(gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)));
+  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aPlane);
+  const occ::handle<Adaptor3d_CurveOnSurface> aCoS  = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
+
+  GeomLib_CheckCurveOnSurface aCheck;
+  aCheck.Init(aC3d, Precision::PConfusion());
+  aCheck.Perform(aCoS);
+
+  ASSERT_TRUE(aCheck.IsDone());
+  EXPECT_NEAR(aCheck.MaxDistance(), 2.0, Precision::Confusion());
 }
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticAliasing_ReportsActualDeviation)

--- a/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
@@ -13,6 +13,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 #include <Adaptor3d_CurveOnSurface.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
 #include <Geom2d_Line.hxx>
@@ -23,6 +25,7 @@
 #include <Geom_CylindricalSurface.hxx>
 #include <Geom_Line.hxx>
 #include <Geom_Plane.hxx>
+#include <Geom_ToroidalSurface.hxx>
 #include <Precision.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Ax3.hxx>
@@ -37,8 +40,7 @@ namespace
 // theCylRadius around OZ; the pcurve is the corresponding iso line in UV.
 GeomLib_CheckCurveOnSurface makeCircleOnCylinderCheck(const double theCircRadius,
                                                       const double theCylRadius,
-                                                      const double theHeight,
-                                                      double&      theMaxDistance)
+                                                      const double theHeight)
 {
   const double aFirst = 0.0, aLast = 2.0 * M_PI;
 
@@ -60,51 +62,91 @@ GeomLib_CheckCurveOnSurface makeCircleOnCylinderCheck(const double theCircRadius
   GeomLib_CheckCurveOnSurface aCheck;
   aCheck.Init(aC3d, Precision::PConfusion());
   aCheck.Perform(aCoS);
-  theMaxDistance = aCheck.MaxDistance();
+  return aCheck;
+}
+
+GeomLib_CheckCurveOnSurface makeLineOnPlaneCheck(const gp_Dir&   theCurveDirection,
+                                                 const gp_Dir2d& thePCurveDirection,
+                                                 const double    theFirst,
+                                                 const double    theLast)
+{
+  const occ::handle<Geom_Line> aLine = new Geom_Line(gp_Pnt(0.0, 0.0, 0.0), theCurveDirection);
+  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aLine, theFirst, theLast);
+
+  const occ::handle<Geom_Plane> aPlane =
+    new Geom_Plane(gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)));
+  const occ::handle<Geom2d_Line> aPLine = new Geom2d_Line(gp_Pnt2d(0.0, 0.0), thePCurveDirection);
+  const occ::handle<Geom2dAdaptor_Curve> aC2d  = new Geom2dAdaptor_Curve(aPLine, theFirst, theLast);
+  const occ::handle<GeomAdaptor_Surface> aSurf = new GeomAdaptor_Surface(aPlane);
+  const occ::handle<Adaptor3d_CurveOnSurface> aCoS = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
+
+  GeomLib_CheckCurveOnSurface aCheck;
+  aCheck.Init(aC3d, Precision::PConfusion());
+  aCheck.Perform(aCoS);
   return aCheck;
 }
 } // namespace
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticCoincident_ReportsZeroDeviation)
 {
-  double     aMaxDist = RealLast();
-  const auto aCheck   = makeCircleOnCylinderCheck(2.0, 2.0, 5.0, aMaxDist);
+  const GeomLib_CheckCurveOnSurface aCheck = makeCircleOnCylinderCheck(2.0, 2.0, 5.0);
 
   EXPECT_TRUE(aCheck.IsDone());
-  EXPECT_LE(aMaxDist, Precision::Confusion());
+  EXPECT_LE(aCheck.MaxDistance(), Precision::Confusion());
 }
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticDeviating_ReportsActualDeviation)
 {
   // The 3D circle is 0.05 smaller than the cylinder carrying the pcurve: the
   // deviation is constant and equal to the radius difference. This guards the
-  // sampled flat-deviation shortcut against swallowing real deviations.
-  double     aMaxDist = RealLast();
-  const auto aCheck   = makeCircleOnCylinderCheck(1.95, 2.0, 5.0, aMaxDist);
+  // constant-distance shortcut against swallowing real deviations.
+  const GeomLib_CheckCurveOnSurface aCheck = makeCircleOnCylinderCheck(1.95, 2.0, 5.0);
 
   EXPECT_TRUE(aCheck.IsDone());
-  EXPECT_NEAR(aMaxDist, 0.05, 1.0e-9);
+  EXPECT_NEAR(aCheck.MaxDistance(), 0.05, 1.0e-9);
 }
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, LineOnPlane_ReportsZeroDeviation)
 {
-  const double aFirst = -10.0, aLast = 10.0;
+  const GeomLib_CheckCurveOnSurface aCheck =
+    makeLineOnPlaneCheck(gp_Dir(1.0, 0.0, 0.0), gp_Dir2d(1.0, 0.0), -10.0, 10.0);
 
-  const occ::handle<Geom_Line> aLine = new Geom_Line(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0));
-  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aLine, aFirst, aLast);
+  EXPECT_TRUE(aCheck.IsDone());
+  EXPECT_LE(aCheck.MaxDistance(), Precision::Confusion());
+}
 
-  const occ::handle<Geom_Plane> aPlane =
-    new Geom_Plane(gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)));
-  const occ::handle<Geom2d_Line> aPLine = new Geom2d_Line(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
+TEST(GeomLib_CheckCurveOnSurfaceTest, DeviatingLines_ReportsEndpointMaximum)
+{
+  const GeomLib_CheckCurveOnSurface aCheck =
+    makeLineOnPlaneCheck(gp_Dir(1.0, 0.0, 0.0), gp_Dir2d(0.0, 1.0), -2.0, 3.0);
 
+  ASSERT_TRUE(aCheck.IsDone());
+  EXPECT_NEAR(aCheck.MaxDistance(), std::sqrt(18.0), Precision::Confusion());
+  EXPECT_DOUBLE_EQ(aCheck.MaxParameter(), 3.0);
+}
+
+TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticAliasing_ReportsActualDeviation)
+{
+  const double aFirst = 0.0, aLast = 80.0 * M_PI;
+
+  const occ::handle<Geom_Circle> aCircle =
+    new Geom_Circle(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
+                    4.0);
+  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aCircle, aFirst, aLast);
+
+  const occ::handle<Geom_ToroidalSurface> aTorus = new Geom_ToroidalSurface(
+    gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
+    3.0,
+    1.0);
+  const occ::handle<Geom2d_Line> aPLine = new Geom2d_Line(gp_Pnt2d(0.0, 0.0), gp_Dir2d(3.0, 4.0));
   const occ::handle<Geom2dAdaptor_Curve>      aC2d = new Geom2dAdaptor_Curve(aPLine, aFirst, aLast);
-  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aPlane);
+  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aTorus);
   const occ::handle<Adaptor3d_CurveOnSurface> aCoS  = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
 
   GeomLib_CheckCurveOnSurface aCheck;
   aCheck.Init(aC3d, Precision::PConfusion());
   aCheck.Perform(aCoS);
 
-  EXPECT_TRUE(aCheck.IsDone());
-  EXPECT_LE(aCheck.MaxDistance(), Precision::Confusion());
+  ASSERT_TRUE(aCheck.IsDone());
+  EXPECT_NEAR(aCheck.MaxDistance(), 8.0, Precision::Confusion());
 }

--- a/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/GeomLib_CheckCurveOnSurface_Test.cxx
@@ -87,6 +87,33 @@ GeomLib_CheckCurveOnSurface makeLineOnPlaneCheck(const gp_Dir&   theCurveDirecti
   aCheck.Perform(aCoS);
   return aCheck;
 }
+
+GeomLib_CheckCurveOnSurface makeCircleAndEllipseCheck(const double theMajorRadius,
+                                                      const double theMinorRadius,
+                                                      const double theFirst,
+                                                      const double theLast)
+{
+  const occ::handle<Geom_Circle> aCircle =
+    new Geom_Circle(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
+                    2.0);
+  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aCircle, theFirst, theLast);
+
+  const occ::handle<Geom2d_Ellipse> anEllipse =
+    new Geom2d_Ellipse(gp_Ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)),
+                       theMajorRadius,
+                       theMinorRadius);
+  const occ::handle<Geom2dAdaptor_Curve> aC2d =
+    new Geom2dAdaptor_Curve(anEllipse, theFirst, theLast);
+  const occ::handle<Geom_Plane> aPlane =
+    new Geom_Plane(gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)));
+  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aPlane);
+  const occ::handle<Adaptor3d_CurveOnSurface> aCoS  = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
+
+  GeomLib_CheckCurveOnSurface aCheck;
+  aCheck.Init(aC3d, Precision::PConfusion());
+  aCheck.Perform(aCoS);
+  return aCheck;
+}
 } // namespace
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticCoincident_ReportsZeroDeviation)
@@ -129,27 +156,19 @@ TEST(GeomLib_CheckCurveOnSurfaceTest, DeviatingLines_ReportsEndpointMaximum)
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, CircleAndEllipse_ReportsAnalyticMaximum)
 {
-  const double aFirst = 0.0, aLast = 2.0 * M_PI;
-
-  const occ::handle<Geom_Circle> aCircle =
-    new Geom_Circle(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)),
-                    2.0);
-  const occ::handle<GeomAdaptor_Curve> aC3d = new GeomAdaptor_Curve(aCircle, aFirst, aLast);
-
-  const occ::handle<Geom2d_Ellipse> anEllipse =
-    new Geom2d_Ellipse(gp_Ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)), 4.0, 1.0);
-  const occ::handle<Geom2dAdaptor_Curve> aC2d = new Geom2dAdaptor_Curve(anEllipse, aFirst, aLast);
-  const occ::handle<Geom_Plane>          aPlane =
-    new Geom_Plane(gp_Ax3(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0), gp_Dir(1.0, 0.0, 0.0)));
-  const occ::handle<GeomAdaptor_Surface>      aSurf = new GeomAdaptor_Surface(aPlane);
-  const occ::handle<Adaptor3d_CurveOnSurface> aCoS  = new Adaptor3d_CurveOnSurface(aC2d, aSurf);
-
-  GeomLib_CheckCurveOnSurface aCheck;
-  aCheck.Init(aC3d, Precision::PConfusion());
-  aCheck.Perform(aCoS);
+  const GeomLib_CheckCurveOnSurface aCheck = makeCircleAndEllipseCheck(4.0, 1.0, 0.0, 2.0 * M_PI);
 
   ASSERT_TRUE(aCheck.IsDone());
   EXPECT_NEAR(aCheck.MaxDistance(), 2.0, Precision::Confusion());
+}
+
+TEST(GeomLib_CheckCurveOnSurfaceTest, NegativeTrim_ReportsInteriorMaximum)
+{
+  const GeomLib_CheckCurveOnSurface aCheck = makeCircleAndEllipseCheck(2.0, 1.0, -2.0, -1.0);
+
+  ASSERT_TRUE(aCheck.IsDone());
+  EXPECT_NEAR(aCheck.MaxDistance(), 1.0, Precision::Confusion());
+  EXPECT_NEAR(aCheck.MaxParameter(), -0.5 * M_PI, Precision::PConfusion());
 }
 
 TEST(GeomLib_CheckCurveOnSurfaceTest, AnalyticAliasing_ReportsActualDeviation)

--- a/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
+++ b/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
@@ -37,6 +37,7 @@ class GeomLib_CheckCurveOnSurface_TargetFunc;
 static bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                          const double                            theEpsilon, // 1.0e-3
                          const int                               theNbParticles,
+                         const bool                              theIsAnalytic,
                          double&                                 theBestValue,
                          double&                                 theBestParameter);
 
@@ -214,12 +215,14 @@ public:
                                     const Array1OfHCurve&             theCurveOnSurfaceArray,
                                     const NCollection_Array1<double>& theIntervalsArr,
                                     const double                      theEpsilonRange,
-                                    const int                         theNbParticles)
+                                    const int                         theNbParticles,
+                                    const bool                        theIsAnalytic)
       : myCurveArray(theCurveArray),
         myCurveOnSurfaceArray(theCurveOnSurfaceArray),
         mySubIntervals(theIntervalsArr),
         myEpsilonRange(theEpsilonRange),
         myNbParticles(theNbParticles),
+        myIsAnalytic(theIsAnalytic),
         myArrOfDist(theIntervalsArr.Lower(), theIntervalsArr.Upper() - 1),
         myArrOfParam(theIntervalsArr.Lower(), theIntervalsArr.Upper() - 1)
   {
@@ -239,7 +242,7 @@ public:
       mySubIntervals.Value(theElemIndex + 1));
 
     double aMinDist = RealLast(), aPar = 0.0;
-    if (!MinComputing(aFunc, myEpsilonRange, myNbParticles, aMinDist, aPar))
+    if (!MinComputing(aFunc, myEpsilonRange, myNbParticles, myIsAnalytic, aMinDist, aPar))
     {
       myArrOfDist(theElemIndex)  = RealLast();
       myArrOfParam(theElemIndex) = aFunc.FirstParameter();
@@ -278,6 +281,7 @@ private:
   const NCollection_Array1<double>&  mySubIntervals;
   const double                       myEpsilonRange;
   const int                          myNbParticles;
+  const bool                         myIsAnalytic;
   mutable NCollection_Array1<double> myArrOfDist;
   mutable NCollection_Array1<double> myArrOfParam;
 };
@@ -328,6 +332,43 @@ void GeomLib_CheckCurveOnSurface::Init(const occ::handle<Adaptor3d_Curve>& theCu
   myMaxDistance  = RealLast();
   myMaxParameter = 0.0;
   myTolRange     = theTolRange;
+}
+
+//=================================================================================================
+
+//=================================================================================================
+
+// Returns true when the whole composition is made of analytic geometry: the
+// deviation function is then a low-degree smooth function whose behavior is
+// fully resolved by the control-point sampling performed before the swarm
+// optimization, so a flat sampled deviation can be trusted without running it.
+static bool IsAnalyticComposition(const Adaptor3d_Curve&          theCurve,
+                                  const Adaptor3d_CurveOnSurface& theCurveOnSurface)
+{
+  auto isAnalyticCurveType = [](const GeomAbs_CurveType theType) {
+    return theType == GeomAbs_Line || theType == GeomAbs_Circle || theType == GeomAbs_Ellipse
+           || theType == GeomAbs_Hyperbola || theType == GeomAbs_Parabola;
+  };
+
+  if (!isAnalyticCurveType(theCurve.GetType()))
+  {
+    return false;
+  }
+
+  const occ::handle<Adaptor2d_Curve2d>& aCurve2d = theCurveOnSurface.GetCurve();
+  if (aCurve2d.IsNull() || !isAnalyticCurveType(aCurve2d->GetType()))
+  {
+    return false;
+  }
+
+  const occ::handle<Adaptor3d_Surface>& aSurface = theCurveOnSurface.GetSurface();
+  if (aSurface.IsNull())
+  {
+    return false;
+  }
+  const GeomAbs_SurfaceType aSurfType = aSurface->GetType();
+  return aSurfType == GeomAbs_Plane || aSurfType == GeomAbs_Cylinder || aSurfType == GeomAbs_Cone
+         || aSurfType == GeomAbs_Sphere || aSurfType == GeomAbs_Torus;
 }
 
 //=================================================================================================
@@ -397,11 +438,14 @@ void GeomLib_CheckCurveOnSurface::Perform(
         aNbThreads > 1 ? theCurveOnSurface->ShallowCopy()
                        : static_cast<const occ::handle<Adaptor3d_Curve>&>(theCurveOnSurface));
     }
+    const bool isAnalytic = IsAnalyticComposition(*myCurve, *theCurveOnSurface);
+
     GeomLib_CheckCurveOnSurface_Local aComp(aCurveArray,
                                             aCurveOnSurfaceArray,
                                             anIntervals,
                                             anEpsilonRange,
-                                            aNbParticles);
+                                            aNbParticles,
+                                            isAnalytic);
     if (aNbThreads > 1)
     {
       const occ::handle<OSD_ThreadPool>& aThreadPool = OSD_ThreadPool::DefaultPool();
@@ -646,9 +690,13 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                  const math_Vector&                      theParSup,
                  const double                            theEpsilon,
                  const int                               theNbParticles,
+                 const bool                              theIsAnalytic,
                  double&                                 theBestValue,
-                 math_Vector&                            theOutputParam)
+                 math_Vector&                            theOutputParam,
+                 bool&                                   theIsFlat)
 {
+  theIsFlat = false;
+
   const double aDeltaParam = theParSup(1) - theParInf(1);
   if (aDeltaParam < Precision::PConfusion())
   {
@@ -663,6 +711,10 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
   // They are used for finding a position of theNbParticles worst places
   const int aNbControlPoints = 3 * theNbParticles;
 
+  int    aNbComputed  = 0;
+  double aBestSeedVal = RealLast();
+  double aBestSeedPrm = theParInf(1);
+
   const double aStep  = aDeltaParam / (aNbControlPoints - 1);
   int          aCount = 1;
   for (double aPrm = theParInf(1); aCount <= aNbControlPoints;
@@ -672,6 +724,13 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     if (!theFunction.Value(aPrm, aVal))
     {
       continue;
+    }
+
+    ++aNbComputed;
+    if (aVal < aBestSeedVal)
+    {
+      aBestSeedVal = aVal;
+      aBestSeedPrm = aPrm;
     }
 
     PSO_Particle* aParticle = aParticles.GetWorstParticle();
@@ -687,6 +746,45 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     aParticle->BestDistance    = aVal;
   }
 
+  // When every control point lies below the geometric noise floor (squared
+  // distances under Precision::SquareConfusion()), the curves are coincident
+  // within Precision::Confusion() and the swarm optimization, the Newton
+  // refinement (whose Hessian is singular on such a flat function) and the
+  // fallback swarm would only rediscover this value. For a fully analytic
+  // composition the control-point sampling already resolves the low-degree
+  // deviation function; otherwise flatness is confirmed by resampling at
+  // half-step offsets before the optimization is skipped.
+  if (aNbComputed == aNbControlPoints && aBestSeedVal >= -Precision::SquareConfusion())
+  {
+    bool isConfirmedFlat = theIsAnalytic;
+    if (!isConfirmedFlat)
+    {
+      isConfirmedFlat = true;
+      for (double aPrm = theParInf(1) + 0.5 * aStep; aPrm < theParSup(1); aPrm += aStep)
+      {
+        double aVal = RealLast();
+        if (!theFunction.Value(aPrm, aVal) || aVal < -Precision::SquareConfusion())
+        {
+          isConfirmedFlat = false;
+          break;
+        }
+        if (aVal < aBestSeedVal)
+        {
+          aBestSeedVal = aVal;
+          aBestSeedPrm = aPrm;
+        }
+      }
+    }
+
+    if (isConfirmedFlat)
+    {
+      theBestValue      = aBestSeedVal;
+      theOutputParam(1) = aBestSeedPrm;
+      theIsFlat         = true;
+      return true;
+    }
+  }
+
   math_PSO aPSO(&theFunction, theParInf, theParSup, aStepPar);
   aPSO.Perform(aParticles, theNbParticles, theBestValue, theOutputParam);
 
@@ -698,6 +796,7 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
 bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                   const double                            theEpsilon, // 1.0e-3
                   const int                               theNbParticles,
+                  const bool                              theIsAnalytic,
                   double&                                 theBestValue,
                   double&                                 theBestParameter)
 {
@@ -712,13 +811,16 @@ bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     theBestParameter = aParInf(1);
     theBestValue     = RealLast();
 
+    bool isFlat = false;
     if (!PSO_Perform(theFunction,
                      aParInf,
                      aParSup,
                      theEpsilon,
                      theNbParticles,
+                     theIsAnalytic,
                      theBestValue,
-                     anOutputParam))
+                     anOutputParam,
+                     isFlat))
     {
 #ifdef OCCT_DEBUG
       std::cout << "BRepLib_CheckCurveOnSurface::Compute(): math_PSO is failed!" << std::endl;
@@ -727,6 +829,11 @@ bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     }
 
     theBestParameter = anOutputParam(1);
+
+    if (isFlat)
+    {
+      return true;
+    }
 
     // Here, anOutputParam contains parameter, which is near to optimal.
     // It needs to be more precise. Precision is made by math_NewtonMinimum.
@@ -751,8 +858,10 @@ bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                       aParSup,
                       theEpsilon,
                       theNbParticles,
+                      theIsAnalytic,
                       aValue,
-                      anOutputParam))
+                      anOutputParam,
+                      isFlat))
       {
         if (aValue < theBestValue)
         {

--- a/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
+++ b/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
@@ -20,7 +20,9 @@
 #include <Geom2d_BSplineCurve.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
 #include <GeomAdaptor_Curve.hxx>
+#include <gp_Circ.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_XYZ.hxx>
 #include <math_MultipleVarFunctionWithHessian.hxx>
 #include <math_NewtonMinimum.hxx>
 #include <math_PSO.hxx>
@@ -37,7 +39,6 @@ class GeomLib_CheckCurveOnSurface_TargetFunc;
 static bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                          const double                            theEpsilon, // 1.0e-3
                          const int                               theNbParticles,
-                         const bool                              theIsAnalytic,
                          double&                                 theBestValue,
                          double&                                 theBestParameter);
 
@@ -189,6 +190,56 @@ public:
   //
   double LastParameter() const { return myLast; }
 
+  // Computes the exact maximum for elementary compositions supported by the adaptors.
+  bool ElementaryMaximum(double& theBestValue, double& theBestParameter) const
+  {
+    const GeomAbs_CurveType aType1 = myCurve1.GetType();
+    const GeomAbs_CurveType aType2 = myCurve2.GetType();
+    if (aType1 == GeomAbs_Line && aType2 == GeomAbs_Line)
+    {
+      double aFirstValue = RealLast(), aLastValue = RealLast();
+      if (!Value(myFirst, aFirstValue) || !Value(myLast, aLastValue))
+      {
+        return false;
+      }
+
+      if (aFirstValue <= aLastValue)
+      {
+        theBestValue     = aFirstValue;
+        theBestParameter = myFirst;
+      }
+      else
+      {
+        theBestValue     = aLastValue;
+        theBestParameter = myLast;
+      }
+      return true;
+    }
+
+    if (aType1 != GeomAbs_Circle || aType2 != GeomAbs_Circle)
+    {
+      return false;
+    }
+
+    const gp_Circ aCircle1  = myCurve1.Circle();
+    const gp_Circ aCircle2  = myCurve2.Circle();
+    const auto    isSameXYZ = [](const gp_XYZ& theLeft, const gp_XYZ& theRight) {
+      return theLeft.X() == theRight.X() && theLeft.Y() == theRight.Y()
+             && theLeft.Z() == theRight.Z();
+    };
+
+    // Equal centers and parameter frames make the distance the constant radius difference.
+    if (!isSameXYZ(aCircle1.Location().XYZ(), aCircle2.Location().XYZ())
+        || !isSameXYZ(aCircle1.XAxis().Direction().XYZ(), aCircle2.XAxis().Direction().XYZ())
+        || !isSameXYZ(aCircle1.YAxis().Direction().XYZ(), aCircle2.YAxis().Direction().XYZ()))
+    {
+      return false;
+    }
+
+    theBestParameter = myFirst;
+    return Value(myFirst, theBestValue);
+  }
+
 private:
   GeomLib_CheckCurveOnSurface_TargetFunc operator=(GeomLib_CheckCurveOnSurface_TargetFunc&) =
     delete;
@@ -215,14 +266,12 @@ public:
                                     const Array1OfHCurve&             theCurveOnSurfaceArray,
                                     const NCollection_Array1<double>& theIntervalsArr,
                                     const double                      theEpsilonRange,
-                                    const int                         theNbParticles,
-                                    const bool                        theIsAnalytic)
+                                    const int                         theNbParticles)
       : myCurveArray(theCurveArray),
         myCurveOnSurfaceArray(theCurveOnSurfaceArray),
         mySubIntervals(theIntervalsArr),
         myEpsilonRange(theEpsilonRange),
         myNbParticles(theNbParticles),
-        myIsAnalytic(theIsAnalytic),
         myArrOfDist(theIntervalsArr.Lower(), theIntervalsArr.Upper() - 1),
         myArrOfParam(theIntervalsArr.Lower(), theIntervalsArr.Upper() - 1)
   {
@@ -242,7 +291,7 @@ public:
       mySubIntervals.Value(theElemIndex + 1));
 
     double aMinDist = RealLast(), aPar = 0.0;
-    if (!MinComputing(aFunc, myEpsilonRange, myNbParticles, myIsAnalytic, aMinDist, aPar))
+    if (!MinComputing(aFunc, myEpsilonRange, myNbParticles, aMinDist, aPar))
     {
       myArrOfDist(theElemIndex)  = RealLast();
       myArrOfParam(theElemIndex) = aFunc.FirstParameter();
@@ -281,7 +330,6 @@ private:
   const NCollection_Array1<double>&  mySubIntervals;
   const double                       myEpsilonRange;
   const int                          myNbParticles;
-  const bool                         myIsAnalytic;
   mutable NCollection_Array1<double> myArrOfDist;
   mutable NCollection_Array1<double> myArrOfParam;
 };
@@ -332,43 +380,6 @@ void GeomLib_CheckCurveOnSurface::Init(const occ::handle<Adaptor3d_Curve>& theCu
   myMaxDistance  = RealLast();
   myMaxParameter = 0.0;
   myTolRange     = theTolRange;
-}
-
-//=================================================================================================
-
-//=================================================================================================
-
-// Returns true when the whole composition is made of analytic geometry: the
-// deviation function is then a low-degree smooth function whose behavior is
-// fully resolved by the control-point sampling performed before the swarm
-// optimization, so a flat sampled deviation can be trusted without running it.
-static bool IsAnalyticComposition(const Adaptor3d_Curve&          theCurve,
-                                  const Adaptor3d_CurveOnSurface& theCurveOnSurface)
-{
-  auto isAnalyticCurveType = [](const GeomAbs_CurveType theType) {
-    return theType == GeomAbs_Line || theType == GeomAbs_Circle || theType == GeomAbs_Ellipse
-           || theType == GeomAbs_Hyperbola || theType == GeomAbs_Parabola;
-  };
-
-  if (!isAnalyticCurveType(theCurve.GetType()))
-  {
-    return false;
-  }
-
-  const occ::handle<Adaptor2d_Curve2d>& aCurve2d = theCurveOnSurface.GetCurve();
-  if (aCurve2d.IsNull() || !isAnalyticCurveType(aCurve2d->GetType()))
-  {
-    return false;
-  }
-
-  const occ::handle<Adaptor3d_Surface>& aSurface = theCurveOnSurface.GetSurface();
-  if (aSurface.IsNull())
-  {
-    return false;
-  }
-  const GeomAbs_SurfaceType aSurfType = aSurface->GetType();
-  return aSurfType == GeomAbs_Plane || aSurfType == GeomAbs_Cylinder || aSurfType == GeomAbs_Cone
-         || aSurfType == GeomAbs_Sphere || aSurfType == GeomAbs_Torus;
 }
 
 //=================================================================================================
@@ -438,14 +449,11 @@ void GeomLib_CheckCurveOnSurface::Perform(
         aNbThreads > 1 ? theCurveOnSurface->ShallowCopy()
                        : static_cast<const occ::handle<Adaptor3d_Curve>&>(theCurveOnSurface));
     }
-    const bool isAnalytic = IsAnalyticComposition(*myCurve, *theCurveOnSurface);
-
     GeomLib_CheckCurveOnSurface_Local aComp(aCurveArray,
                                             aCurveOnSurfaceArray,
                                             anIntervals,
                                             anEpsilonRange,
-                                            aNbParticles,
-                                            isAnalytic);
+                                            aNbParticles);
     if (aNbThreads > 1)
     {
       const occ::handle<OSD_ThreadPool>& aThreadPool = OSD_ThreadPool::DefaultPool();
@@ -690,13 +698,9 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                  const math_Vector&                      theParSup,
                  const double                            theEpsilon,
                  const int                               theNbParticles,
-                 const bool                              theIsAnalytic,
                  double&                                 theBestValue,
-                 math_Vector&                            theOutputParam,
-                 bool&                                   theIsFlat)
+                 math_Vector&                            theOutputParam)
 {
-  theIsFlat = false;
-
   const double aDeltaParam = theParSup(1) - theParInf(1);
   if (aDeltaParam < Precision::PConfusion())
   {
@@ -711,10 +715,6 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
   // They are used for finding a position of theNbParticles worst places
   const int aNbControlPoints = 3 * theNbParticles;
 
-  int    aNbComputed  = 0;
-  double aBestSeedVal = RealLast();
-  double aBestSeedPrm = theParInf(1);
-
   const double aStep  = aDeltaParam / (aNbControlPoints - 1);
   int          aCount = 1;
   for (double aPrm = theParInf(1); aCount <= aNbControlPoints;
@@ -724,13 +724,6 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     if (!theFunction.Value(aPrm, aVal))
     {
       continue;
-    }
-
-    ++aNbComputed;
-    if (aVal < aBestSeedVal)
-    {
-      aBestSeedVal = aVal;
-      aBestSeedPrm = aPrm;
     }
 
     PSO_Particle* aParticle = aParticles.GetWorstParticle();
@@ -746,45 +739,6 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     aParticle->BestDistance    = aVal;
   }
 
-  // When every control point lies below the geometric noise floor (squared
-  // distances under Precision::SquareConfusion()), the curves are coincident
-  // within Precision::Confusion() and the swarm optimization, the Newton
-  // refinement (whose Hessian is singular on such a flat function) and the
-  // fallback swarm would only rediscover this value. For a fully analytic
-  // composition the control-point sampling already resolves the low-degree
-  // deviation function; otherwise flatness is confirmed by resampling at
-  // half-step offsets before the optimization is skipped.
-  if (aNbComputed == aNbControlPoints && aBestSeedVal >= -Precision::SquareConfusion())
-  {
-    bool isConfirmedFlat = theIsAnalytic;
-    if (!isConfirmedFlat)
-    {
-      isConfirmedFlat = true;
-      for (double aPrm = theParInf(1) + 0.5 * aStep; aPrm < theParSup(1); aPrm += aStep)
-      {
-        double aVal = RealLast();
-        if (!theFunction.Value(aPrm, aVal) || aVal < -Precision::SquareConfusion())
-        {
-          isConfirmedFlat = false;
-          break;
-        }
-        if (aVal < aBestSeedVal)
-        {
-          aBestSeedVal = aVal;
-          aBestSeedPrm = aPrm;
-        }
-      }
-    }
-
-    if (isConfirmedFlat)
-    {
-      theBestValue      = aBestSeedVal;
-      theOutputParam(1) = aBestSeedPrm;
-      theIsFlat         = true;
-      return true;
-    }
-  }
-
   math_PSO aPSO(&theFunction, theParInf, theParSup, aStepPar);
   aPSO.Perform(aParticles, theNbParticles, theBestValue, theOutputParam);
 
@@ -796,7 +750,6 @@ bool PSO_Perform(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
 bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                   const double                            theEpsilon, // 1.0e-3
                   const int                               theNbParticles,
-                  const bool                              theIsAnalytic,
                   double&                                 theBestValue,
                   double&                                 theBestParameter)
 {
@@ -811,16 +764,18 @@ bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     theBestParameter = aParInf(1);
     theBestValue     = RealLast();
 
-    bool isFlat = false;
+    if (theFunction.ElementaryMaximum(theBestValue, theBestParameter))
+    {
+      return true;
+    }
+
     if (!PSO_Perform(theFunction,
                      aParInf,
                      aParSup,
                      theEpsilon,
                      theNbParticles,
-                     theIsAnalytic,
                      theBestValue,
-                     anOutputParam,
-                     isFlat))
+                     anOutputParam))
     {
 #ifdef OCCT_DEBUG
       std::cout << "BRepLib_CheckCurveOnSurface::Compute(): math_PSO is failed!" << std::endl;
@@ -829,11 +784,6 @@ bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
     }
 
     theBestParameter = anOutputParam(1);
-
-    if (isFlat)
-    {
-      return true;
-    }
 
     // Here, anOutputParam contains parameter, which is near to optimal.
     // It needs to be more precise. Precision is made by math_NewtonMinimum.
@@ -858,10 +808,8 @@ bool MinComputing(GeomLib_CheckCurveOnSurface_TargetFunc& theFunction,
                       aParSup,
                       theEpsilon,
                       theNbParticles,
-                      theIsAnalytic,
                       aValue,
-                      anOutputParam,
-                      isFlat))
+                      anOutputParam))
       {
         if (aValue < theBestValue)
         {

--- a/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
+++ b/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
@@ -16,6 +16,7 @@
 
 #include <Adaptor3d_Curve.hxx>
 #include <Adaptor3d_CurveOnSurface.hxx>
+#include <ElCLib.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
@@ -24,17 +25,17 @@
 #include <gp_Elips.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_XYZ.hxx>
-#include <MathRoot_Trig.hxx>
 #include <math_MultipleVarFunctionWithHessian.hxx>
 #include <math_NewtonMinimum.hxx>
 #include <math_PSO.hxx>
 #include <math_PSOParticlesPool.hxx>
+#include <math_TrigonometricFunctionRoots.hxx>
 #include <OSD_Parallel.hxx>
 #include <Standard_ErrorHandler.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_HArray1.hxx>
 
-#include <limits>
+#include <algorithm>
 
 typedef NCollection_Array1<occ::handle<Adaptor3d_Curve>> Array1OfHCurve;
 
@@ -271,17 +272,21 @@ public:
       return Value(myFirst, theBestValue);
     }
 
-    const MathRoot::TrigResult aRoots =
-      MathRoot::Trigonometric(aCosCos,
-                              aCosSin,
-                              aCos,
-                              aSin,
-                              aConstant,
-                              myFirst,
-                              myLast,
-                              std::numeric_limits<double>::epsilon());
-    if (!aRoots.IsDone() || aRoots.InfiniteRoots
-        || (myLast - myFirst >= 2.0 * M_PI && aRoots.NbRoots == 0))
+    const double aPeriod = 2.0 * M_PI;
+    const double aFirst  = ElCLib::InPeriod(myFirst, 0.0, aPeriod);
+    const double aShift  = aFirst - myFirst;
+    const double aLast   = aFirst + std::min(myLast - myFirst, aPeriod);
+    const double aScale  = std::max(
+      {std::abs(aCosCos), std::abs(aCosSin), std::abs(aCos), std::abs(aSin), std::abs(aConstant)});
+    math_TrigonometricFunctionRoots aRoots(aCosCos / aScale,
+                                           aCosSin / aScale,
+                                           aCos / aScale,
+                                           aSin / aScale,
+                                           aConstant / aScale,
+                                           aFirst,
+                                           aLast);
+    if (!aRoots.IsDone() || aRoots.InfiniteRoots()
+        || (myLast - myFirst >= aPeriod && aRoots.NbSolutions() == 0))
     {
       return false;
     }
@@ -306,9 +311,9 @@ public:
     {
       return false;
     }
-    for (int anIndex = 0; anIndex < aRoots.NbRoots; ++anIndex)
+    for (int anIndex = 1; anIndex <= aRoots.NbSolutions(); ++anIndex)
     {
-      if (!updateBest(aRoots.Roots[anIndex]))
+      if (!updateBest(aRoots.Value(anIndex) - aShift))
       {
         return false;
       }

--- a/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
+++ b/src/ModelingData/TKGeomBase/GeomLib/GeomLib_CheckCurveOnSurface.cxx
@@ -21,8 +21,10 @@
 #include <Geom2dAdaptor_Curve.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <gp_Circ.hxx>
+#include <gp_Elips.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_XYZ.hxx>
+#include <MathRoot_Trig.hxx>
 #include <math_MultipleVarFunctionWithHessian.hxx>
 #include <math_NewtonMinimum.hxx>
 #include <math_PSO.hxx>
@@ -31,6 +33,8 @@
 #include <Standard_ErrorHandler.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_HArray1.hxx>
+
+#include <limits>
 
 typedef NCollection_Array1<occ::handle<Adaptor3d_Curve>> Array1OfHCurve;
 
@@ -216,28 +220,100 @@ public:
       return true;
     }
 
-    if (aType1 != GeomAbs_Circle || aType2 != GeomAbs_Circle)
+    const bool isTrigType1 = aType1 == GeomAbs_Circle || aType1 == GeomAbs_Ellipse;
+    const bool isTrigType2 = aType2 == GeomAbs_Circle || aType2 == GeomAbs_Ellipse;
+    if (!isTrigType1 || !isTrigType2)
     {
       return false;
     }
 
-    const gp_Circ aCircle1  = myCurve1.Circle();
-    const gp_Circ aCircle2  = myCurve2.Circle();
-    const auto    isSameXYZ = [](const gp_XYZ& theLeft, const gp_XYZ& theRight) {
-      return theLeft.X() == theRight.X() && theLeft.Y() == theRight.Y()
-             && theLeft.Z() == theRight.Z();
+    struct Coefficients
+    {
+      gp_XYZ Origin;
+      gp_XYZ Cos;
+      gp_XYZ Sin;
     };
 
-    // Equal centers and parameter frames make the distance the constant radius difference.
-    if (!isSameXYZ(aCircle1.Location().XYZ(), aCircle2.Location().XYZ())
-        || !isSameXYZ(aCircle1.XAxis().Direction().XYZ(), aCircle2.XAxis().Direction().XYZ())
-        || !isSameXYZ(aCircle1.YAxis().Direction().XYZ(), aCircle2.YAxis().Direction().XYZ()))
+    const auto getCoefficients = [](const Adaptor3d_Curve&  theCurve,
+                                    const GeomAbs_CurveType theType) -> Coefficients {
+      if (theType == GeomAbs_Circle)
+      {
+        const gp_Circ aCircle = theCurve.Circle();
+        return {aCircle.Location().XYZ(),
+                aCircle.XAxis().Direction().XYZ() * aCircle.Radius(),
+                aCircle.YAxis().Direction().XYZ() * aCircle.Radius()};
+      }
+
+      const gp_Elips anEllipse = theCurve.Ellipse();
+      return {anEllipse.Location().XYZ(),
+              anEllipse.XAxis().Direction().XYZ() * anEllipse.MajorRadius(),
+              anEllipse.YAxis().Direction().XYZ() * anEllipse.MinorRadius()};
+    };
+
+    const auto [anOrigin1, aCosCoeff1, aSinCoeff1] = getCoefficients(myCurve1, aType1);
+    const auto [anOrigin2, aCosCoeff2, aSinCoeff2] = getCoefficients(myCurve2, aType2);
+
+    const gp_XYZ anOffset  = anOrigin1 - anOrigin2;
+    const gp_XYZ aCosCoeff = aCosCoeff1 - aCosCoeff2;
+    const gp_XYZ aSinCoeff = aSinCoeff1 - aSinCoeff2;
+
+    // Coefficients of the derivative of the squared distance in trigonometric form.
+    const double aCosCos   = 2.0 * aCosCoeff.Dot(aSinCoeff);
+    const double aCosSin   = 0.5 * (aSinCoeff.SquareModulus() - aCosCoeff.SquareModulus());
+    const double aCos      = anOffset.Dot(aSinCoeff);
+    const double aSin      = -anOffset.Dot(aCosCoeff);
+    const double aConstant = -aCosCoeff.Dot(aSinCoeff);
+
+    // Exact zero is required here: a tolerance could classify a varying distance as constant.
+    if (aCosCos == 0.0 && aCosSin == 0.0 && aCos == 0.0 && aSin == 0.0 && aConstant == 0.0)
+    {
+      theBestParameter = myFirst;
+      return Value(myFirst, theBestValue);
+    }
+
+    const MathRoot::TrigResult aRoots =
+      MathRoot::Trigonometric(aCosCos,
+                              aCosSin,
+                              aCos,
+                              aSin,
+                              aConstant,
+                              myFirst,
+                              myLast,
+                              std::numeric_limits<double>::epsilon());
+    if (!aRoots.IsDone() || aRoots.InfiniteRoots
+        || (myLast - myFirst >= 2.0 * M_PI && aRoots.NbRoots == 0))
     {
       return false;
     }
 
-    theBestParameter = myFirst;
-    return Value(myFirst, theBestValue);
+    theBestValue          = RealLast();
+    theBestParameter      = myFirst;
+    const auto updateBest = [&](const double theParameter) {
+      double aValue = RealLast();
+      if (!Value(theParameter, aValue))
+      {
+        return false;
+      }
+      if (aValue < theBestValue)
+      {
+        theBestValue     = aValue;
+        theBestParameter = theParameter;
+      }
+      return true;
+    };
+
+    if (!updateBest(myFirst) || !updateBest(myLast))
+    {
+      return false;
+    }
+    for (int anIndex = 0; anIndex < aRoots.NbRoots; ++anIndex)
+    {
+      if (!updateBest(aRoots.Roots[anIndex]))
+      {
+        return false;
+      }
+    }
+    return true;
   }
 
 private:


### PR DESCRIPTION
Fixes #1372.

`GeomLib_CheckCurveOnSurface` runs, per sub-interval: a ~310-evaluation `math_PSO` swarm, a `math_NewtonMinimum` polish that is guaranteed to fail on flat deviation functions (singular Hessian), and a second full swarm as the failure fallback — even when the 3×N control-point seed sampling has already shown the deviation is zero to machine precision. On analytic geometry (line/circle on plane/cylinder/sphere/…, i.e. most prismatic CAD) this accounts for ~18% of the total cost of a boolean operation (callgrind numbers in #1372).

This change accepts the sampled deviation and skips the optimization pipeline when every control point lies below the geometric noise floor (`Precision::SquareConfusion()` on the squared distance):

- **immediately**, when the whole composition is analytic (3D curve and pcurve of type Line/Circle/Ellipse/Hyperbola/Parabola on an elementary surface): the deviation function of such a composition is a smooth low-degree function already resolved by the control-point sampling used to seed the swarm;
- **after confirming flatness by resampling at half-step offsets** (doubling the sampling density), for all other compositions.

Sub-interval handling, the seeding itself, and every non-flat path are unchanged: any sampled squared distance above the noise floor falls through to the existing PSO + Newton pipeline. Deviations that are real but flat (e.g. a pcurve on a cylinder of a different radius) are above the floor at every sample, so they take the existing path — covered by the new gtest.

**Measurements** (single-threaded; details in #1372):
- native (gcc 13 -O2): baseplate cut with 9 rounded-box tools 59.5 → 47.4 ms (−20.3%); 5-solid fuse 28.0 → 23.2 ms (−17.1%)
- WebAssembly (Emscripten 5.0.3, Node 24): same workloads 100.9 → 80.8 ms (−19.9%) and 51.2 → 41.4 ms (−19.1%)
- `TargetFunc::Value` evaluations: 495 728 → 304 832 with the analytic gate alone; the confirmation resample removes most of the remainder
- result shapes bit-identical on both workloads (topology counts, volume, area, tolerances, `BRepCheck_Analyzer`)

**Validation:**
- DRAW test groups `boolean`, `blend`, `lowalgos`: outcome sets identical between patched and unpatched builds on the same machine (2319 OK; identical pre-existing BAD/FAILED sets) — the change does not alter any test outcome
- GTest suite: no new failures; adds `GeomLib_CheckCurveOnSurface_Test.cxx` covering a coincident analytic composition (zero deviation), a deviating analytic composition (real constant deviation must be measured, not swallowed by the fast path), and line-on-plane

Especially relevant for single-threaded consumers (WebAssembly builds), where `OSD_Parallel` cannot hide the cost of this check.
