### PR TITLE
Modeling - Make fillet solid reconstruction reentrant across threads

### DIFF
--- a/src/ModelingAlgorithms/TKBool/TopOpeBRep/TopOpeBRep_kpart.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRep/TopOpeBRep_kpart.cxx
@@ -38,7 +38,7 @@ extern bool TopOpeBRep_GetcontextNEWKP();
 
 // VP<STATIC_lastVPind> is the vp on which was computed the last CPI.
 // if no CPI is computed yet, <STATIC_lastVPind> = 0.
-static int STATIC_lastVPind;
+static thread_local int STATIC_lastVPind; // per-thread cross-call cache
 
 #define M_FORWARD(st) (st == TopAbs_FORWARD)
 #define M_REVERSED(st) (st == TopAbs_REVERSED)

--- a/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder.cxx
+++ b/src/ModelingAlgorithms/TKBool/TopOpeBRepBuild/TopOpeBRepBuild_Builder.cxx
@@ -70,7 +70,8 @@ Standard_EXPORT void debspf(const int i)
 }
 #endif
 
-static int STATIC_SOLIDINDEX = 0;
+// Per-thread: a SplitSolid/FillSolid state flag; sharing it races concurrent builds.
+static thread_local int STATIC_SOLIDINDEX = 0;
 
 //=================================================================================================
 

--- a/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_ConstRad.cxx
+++ b/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_ConstRad.cxx
@@ -138,13 +138,12 @@ bool BlendFunc_ConstRad::ComputeValues(const math_Vector& X,
                                        const bool         byParam,
                                        const double       Param)
 {
-  // static declaration to avoid systematic reallocation
-
-  static gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
-  static gp_Vec d1gui, d2gui, d3gui;
-  static gp_Pnt ptgui;
-  static double invnormtg, dinvnormtg;
-  double        T = Param, aux;
+  // Per-thread scratch, reused across calls via the t_OK / myX_OK guards below.
+  static thread_local gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
+  static thread_local gp_Vec d1gui, d2gui, d3gui;
+  static thread_local gp_Pnt ptgui;
+  static thread_local double invnormtg, dinvnormtg;
+  double                     T = Param, aux;
 
   // Case of implicite parameter
   if (!byParam)

--- a/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_EvolRad.cxx
+++ b/src/ModelingAlgorithms/TKFillet/BlendFunc/BlendFunc_EvolRad.cxx
@@ -196,13 +196,12 @@ bool BlendFunc_EvolRad::ComputeValues(const math_Vector& X,
                                       const bool         byParam,
                                       const double       Param)
 {
-  // static declaration to avoid systematic realloc
-
-  static gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
-  static gp_Vec d1gui, d2gui, d3gui;
-  static gp_Pnt ptgui;
-  static double invnormtg, dinvnormtg;
-  double        T = Param, aux;
+  // Per-thread scratch, reused across calls via the t_OK / myX_OK guards below.
+  static thread_local gp_Vec d3u1, d3v1, d3uuv1, d3uvv1, d3u2, d3v2, d3uuv2, d3uvv2;
+  static thread_local gp_Vec d1gui, d2gui, d3gui;
+  static thread_local gp_Pnt ptgui;
+  static thread_local double invnormtg, dinvnormtg;
+  double                     T = Param, aux;
 
   // Case of implicit parameter
   if (!byParam)

--- a/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
+++ b/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
@@ -641,7 +641,8 @@ bool ChFi3d_Builder::StoreData(occ::handle<ChFiDS_SurfData>&         Data,
                                const bool                            Reversed)
 {
   // Small control tools.
-  static occ::handle<GeomAdaptor_Curve> checkcurve;
+  // Per-thread reused scratch adaptor.
+  static thread_local occ::handle<GeomAdaptor_Curve> checkcurve;
   if (checkcurve.IsNull())
   {
     checkcurve = new GeomAdaptor_Curve();


### PR DESCRIPTION
## Problem

`BRepFilletAPI_MakeFillet` is not reentrant: two builds on **independent shapes** running on **separate threads** — the concurrency model OCCT documents as supported ("algorithms on different threads in different contexts") — corrupt each other and return a wrong-but-plausible solid that fails `BRepCheck`. Silent bad geometry: no crash, no thrown error.

The fillet reconstructs its result solid through the legacy `TopOpeBRepBuild` engine:

```
ChFi3d_Builder::Compute()
 → TopOpeBRepBuild_HBuilder::MergeSolid()
 → TopOpeBRepBuild_Builder::SplitSolid()   // writes STATIC_SOLIDINDEX
```

`STATIC_SOLIDINDEX` (`TopOpeBRepBuild_Builder.cxx`) is a file-scope `static` used as a **mode flag**: `SplitSolid` sets it to 1/2 to tell `FillSolid` which operand it is currently splitting, and `FillSolid` reads it back (`if (STATIC_SOLIDINDEX == 1)`) to pick the operand shape. Two concurrent reconstructions interleave the writes, so `FillSolid` reads the wrong value and mis-classifies faces — dropping material.

## Evidence (ThreadSanitizer + behaviour)

Isolated pure-C++ repro: fuse three prisms into a U-channel, fillet the seam, 8 threads. Built RelWithDebInfo + `-fsanitize=thread`, `MMGT_OPT=0`.

- **Stock master:** an 8-thread stress returns BRepCheck-invalid solids across several distinct wrong volumes (~15–20% of builds); the correct part is a single volume. TSan reports a data race on `STATIC_SOLIDINDEX` (write/write in `SplitSolid` from two threads), plus benign scratch races in the blend solver.
- **After this change:** 1600 concurrent fillet builds return correct geometry every time (0 invalid, single volume), and the fillet path is TSan-clean.

## Change

Converts the fillet-path shared statics to `static thread_local` — each thread keeps its own copy of the cross-call state, so single-thread behaviour is identical while independent instances on separate threads become reentrant:

| File | Variable | Kind |
|------|----------|------|
| `TopOpeBRepBuild_Builder.cxx` | `STATIC_SOLIDINDEX` | **Functional** — causes the corruption |
| `TopOpeBRep_kpart.cxx` | `STATIC_lastVPind` | Functional — same cross-call-cache pattern ("the vp on which was computed the last CPI") |
| `BlendFunc_ConstRad.cxx`, `BlendFunc_EvolRad.cxx` | `ComputeValues` scratch | Benign data race (no corruption, but TSan-flagged) |
| `ChFi3d_Builder_6.cxx` | `checkcurve` | Benign data race |

This is the same class of fix, in the same engine, as the earlier TKBool `thread_local` conversion (#1180, 19 globals across 8 files); `STATIC_SOLIDINDEX` and these were not covered by it.

Reported downstream as [SecondMouseAU/OCCTSwift#298](https://github.com/SecondMouseAU/OCCTSwift/issues/298).

Draft while I confirm CI; happy to split the benign scratch conversions into a separate change if you'd prefer the functional `STATIC_SOLIDINDEX` fix on its own.