### PR TITLE
Modeling - Optimize BRepCheck_Face classification for faces with many holes

### DIFF
--- a/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Face.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Face.cxx
@@ -68,6 +68,10 @@ static bool IsInside(const TopoDS_Wire&             wir,
                      const BRepTopAdaptor_FClass2d& FClass2d,
                      const TopoDS_Face&             F);
 
+static bool ComputeWireUVBounds(const TopoDS_Face& theFace,
+                                const TopoDS_Wire& theWire,
+                                Bnd_Box2d&         theBox);
+
 static bool CheckThin(const TopoDS_Shape& w, const TopoDS_Shape& f);
 
 //=================================================================================================
@@ -348,64 +352,25 @@ BRepCheck_Status BRepCheck_Face::ClassifyWires(const bool Update)
   TopExp_Explorer                exp1, exp2;
   NCollection_List<TopoDS_Shape> theListOfShape;
 
-  // Precompute a 2D parametric bounding box for every wire, the same
-  // pattern IntersectWires() already uses above. IsInside() classifies a
-  // single representative point of wir2 against wir1's region, so if the
-  // two wires' boxes don't overlap, that point can't be inside wir1's
-  // region and the classification test can be skipped. The loop below is
-  // still a pair over every wire, but each pair now costs an O(1) box
-  // check instead of a real classification, which is what actually
-  // matters for a plate with many non-overlapping holes.
-  Geom2dAdaptor_Curve aBoxCurveAdapt;
-  double              aBoxFirst, aBoxLast;
+  const TopoDS_Face   aForwardFace = TopoDS::Face(myShape.Oriented(TopAbs_FORWARD));
   DataMapOfShapeBox2d aWireBoxMap;
-  for (exp1.Init(myShape.Oriented(TopAbs_FORWARD), TopAbs_WIRE); exp1.More(); exp1.Next())
+  // Precompute reliable UV bounds for cheap rejection of disjoint wire pairs.
+  for (exp1.Init(aForwardFace, TopAbs_WIRE); exp1.More(); exp1.Next())
   {
-    Bnd_Box2d aBoxW;
-    bool      isBoxReliable = true;
-    for (exp2.Init(exp1.Current(), TopAbs_EDGE); exp2.More(); exp2.Next())
+    const TopoDS_Wire& aWire = TopoDS::Wire(exp1.Current());
+    Bnd_Box2d          aBox;
+    if (ComputeWireUVBounds(aForwardFace, aWire, aBox))
     {
-      const TopoDS_Edge&        anEdge = TopoDS::Edge(exp2.Current());
-      occ::handle<Geom2d_Curve> aPCurve =
-        BRep_Tool::CurveOnSurface(anEdge, TopoDS::Face(myShape), aBoxFirst, aBoxLast);
-      if (aPCurve.IsNull())
-      {
-        continue;
-      }
-      aBoxCurveAdapt.Load(aPCurve);
-      double aF = aBoxFirst, aL = aBoxLast;
-      if (aBoxCurveAdapt.FirstParameter() > aF)
-      {
-        aF            = aBoxCurveAdapt.FirstParameter();
-        isBoxReliable = false;
-      }
-      if (aBoxCurveAdapt.LastParameter() < aL)
-      {
-        aL            = aBoxCurveAdapt.LastParameter();
-        isBoxReliable = false;
-      }
-      Bnd_Box2d aBoxE;
-      BndLib_Add2dCurve::Add(aBoxCurveAdapt, aF, aL, 0., aBoxE);
-      aBoxW.Add(aBoxE);
-    }
-    // IsInside() below picks its representative point using the edge's own
-    // (unclamped) parameter range, not the curve's own definition domain, so
-    // if any edge's trim range had to be clamped to build this box, the box
-    // may not actually contain the point IsInside() would evaluate. Skip the
-    // pre-filter for such a wire rather than risk a wrong answer.
-    if (isBoxReliable)
-    {
-      aWireBoxMap.Bind(exp1.Current(), aBoxW);
+      aWireBoxMap.Bind(aWire, aBox);
     }
   }
 
-  for (exp1.Init(myShape.Oriented(TopAbs_FORWARD), TopAbs_WIRE); exp1.More(); exp1.Next())
+  for (exp1.Init(aForwardFace, TopAbs_WIRE); exp1.More(); exp1.Next())
   {
 
     const TopoDS_Wire& wir1        = TopoDS::Wire(exp1.Current());
     TopoDS_Shape       aLocalShape = myShape.EmptyCopied();
     TopoDS_Face        newFace     = TopoDS::Face(aLocalShape);
-    //    TopoDS_Face newFace = TopoDS::Face(myShape.EmptyCopied());
 
     newFace.Orientation(TopAbs_FORWARD);
     B.Add(newFace, wir1);
@@ -420,39 +385,25 @@ BRepCheck_Status BRepCheck_Face::ClassifyWires(const bool Update)
       myMapImb.Bind(wir1.Reversed(), theListOfShape);
     }
 
-    Bnd_Box2d aBox1;
-    bool      hasBox1 =
-      aWireBoxMap.IsBound(exp1.Current()) && !(aBox1 = aWireBoxMap(exp1.Current())).IsVoid();
+    const Bnd_Box2d* aBox1 = aWireBoxMap.Seek(wir1);
 
-    for (exp2.Init(myShape.Oriented(TopAbs_FORWARD), TopAbs_WIRE); exp2.More(); exp2.Next())
+    for (exp2.Init(aForwardFace, TopAbs_WIRE); exp2.More(); exp2.Next())
     {
       const TopoDS_Wire& wir2 = TopoDS::Wire(exp2.Current());
-      if (!wir2.IsSame(wir1))
+      if (wir2.IsSame(wir1))
       {
-        bool      isWire2Inside;
-        Bnd_Box2d aBox2;
-        bool      hasBox2 = hasBox1 && aWireBoxMap.IsBound(exp2.Current())
-                       && !(aBox2 = aWireBoxMap(exp2.Current())).IsVoid();
-        if (hasBox2 && aBox1.IsOut(aBox2))
-        {
-          // wir2's point falls outside wir1's box, so it's outside wir1's
-          // finite bounded region. If WireBienOriente is false, that
-          // finite region is exactly what IsInside() tests for, so the
-          // point is out. If WireBienOriente is true, IsInside() tests
-          // for the infinite complement of that region instead, and a
-          // point outside the finite region is inside the complement, so
-          // IsInside() returns false there too. Either way the answer is
-          // false.
-          isWire2Inside = false;
-        }
-        else
-        {
-          isWire2Inside = IsInside(wir2, WireBienOriente, FClass2d, newFace);
-        }
-        if (isWire2Inside)
-        {
-          myMapImb(wir1).Append(wir2);
-        }
+        continue;
+      }
+
+      const Bnd_Box2d* aBox2 = aWireBoxMap.Seek(wir2);
+      // Wires with disjoint UV bounds cannot contain one another.
+      if (aBox1 != nullptr && aBox2 != nullptr && aBox1->IsOut(*aBox2))
+      {
+        continue;
+      }
+      if (IsInside(wir2, WireBienOriente, FClass2d, newFace))
+      {
+        myMapImb(wir1).Append(wir2);
       }
     }
   }
@@ -870,6 +821,49 @@ static bool Intersect(const TopoDS_Wire&         wir1,
     }
   }
   return false;
+}
+
+//=================================================================================================
+
+static bool ComputeWireUVBounds(const TopoDS_Face& theFace,
+                                const TopoDS_Wire& theWire,
+                                Bnd_Box2d&         theBox)
+{
+  if (!BRep_Tool::IsClosed(theWire))
+  {
+    return false;
+  }
+
+  Bnd_Box2d aBox;
+  for (TopExp_Explorer anExp(theWire, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    double                          aFirst, aLast;
+    const TopoDS_Edge&              anEdge = TopoDS::Edge(anExp.Current());
+    const occ::handle<Geom2d_Curve> aPCurve =
+      BRep_Tool::CurveOnSurface(anEdge, theFace, aFirst, aLast);
+    if (aPCurve.IsNull())
+    {
+      return false;
+    }
+
+    const Geom2dAdaptor_Curve aCurveAdaptor(aPCurve);
+    // IsInside() uses the original edge range, so a clamped box cannot safely reject the wire.
+    if (Precision::IsInfinite(aFirst) || Precision::IsInfinite(aLast)
+        || aFirst < aCurveAdaptor.FirstParameter() || aLast > aCurveAdaptor.LastParameter())
+    {
+      return false;
+    }
+
+    BndLib_Add2dCurve::Add(aCurveAdaptor, aFirst, aLast, Precision::PConfusion(), aBox);
+  }
+  if (aBox.IsVoid() || aBox.IsOpenXmin() || aBox.IsOpenXmax() || aBox.IsOpenYmin()
+      || aBox.IsOpenYmax())
+  {
+    return false;
+  }
+
+  theBox = aBox;
+  return true;
 }
 
 //=================================================================================================

--- a/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Face.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepCheck/BRepCheck_Face.cxx
@@ -347,6 +347,58 @@ BRepCheck_Status BRepCheck_Face::ClassifyWires(const bool Update)
   BRep_Builder                   B;
   TopExp_Explorer                exp1, exp2;
   NCollection_List<TopoDS_Shape> theListOfShape;
+
+  // Precompute a 2D parametric bounding box for every wire, the same
+  // pattern IntersectWires() already uses above. IsInside() classifies a
+  // single representative point of wir2 against wir1's region, so if the
+  // two wires' boxes don't overlap, that point can't be inside wir1's
+  // region and the classification test can be skipped. The loop below is
+  // still a pair over every wire, but each pair now costs an O(1) box
+  // check instead of a real classification, which is what actually
+  // matters for a plate with many non-overlapping holes.
+  Geom2dAdaptor_Curve aBoxCurveAdapt;
+  double              aBoxFirst, aBoxLast;
+  DataMapOfShapeBox2d aWireBoxMap;
+  for (exp1.Init(myShape.Oriented(TopAbs_FORWARD), TopAbs_WIRE); exp1.More(); exp1.Next())
+  {
+    Bnd_Box2d aBoxW;
+    bool      isBoxReliable = true;
+    for (exp2.Init(exp1.Current(), TopAbs_EDGE); exp2.More(); exp2.Next())
+    {
+      const TopoDS_Edge&        anEdge = TopoDS::Edge(exp2.Current());
+      occ::handle<Geom2d_Curve> aPCurve =
+        BRep_Tool::CurveOnSurface(anEdge, TopoDS::Face(myShape), aBoxFirst, aBoxLast);
+      if (aPCurve.IsNull())
+      {
+        continue;
+      }
+      aBoxCurveAdapt.Load(aPCurve);
+      double aF = aBoxFirst, aL = aBoxLast;
+      if (aBoxCurveAdapt.FirstParameter() > aF)
+      {
+        aF            = aBoxCurveAdapt.FirstParameter();
+        isBoxReliable = false;
+      }
+      if (aBoxCurveAdapt.LastParameter() < aL)
+      {
+        aL            = aBoxCurveAdapt.LastParameter();
+        isBoxReliable = false;
+      }
+      Bnd_Box2d aBoxE;
+      BndLib_Add2dCurve::Add(aBoxCurveAdapt, aF, aL, 0., aBoxE);
+      aBoxW.Add(aBoxE);
+    }
+    // IsInside() below picks its representative point using the edge's own
+    // (unclamped) parameter range, not the curve's own definition domain, so
+    // if any edge's trim range had to be clamped to build this box, the box
+    // may not actually contain the point IsInside() would evaluate. Skip the
+    // pre-filter for such a wire rather than risk a wrong answer.
+    if (isBoxReliable)
+    {
+      aWireBoxMap.Bind(exp1.Current(), aBoxW);
+    }
+  }
+
   for (exp1.Init(myShape.Oriented(TopAbs_FORWARD), TopAbs_WIRE); exp1.More(); exp1.Next())
   {
 
@@ -368,13 +420,36 @@ BRepCheck_Status BRepCheck_Face::ClassifyWires(const bool Update)
       myMapImb.Bind(wir1.Reversed(), theListOfShape);
     }
 
+    Bnd_Box2d aBox1;
+    bool      hasBox1 =
+      aWireBoxMap.IsBound(exp1.Current()) && !(aBox1 = aWireBoxMap(exp1.Current())).IsVoid();
+
     for (exp2.Init(myShape.Oriented(TopAbs_FORWARD), TopAbs_WIRE); exp2.More(); exp2.Next())
     {
       const TopoDS_Wire& wir2 = TopoDS::Wire(exp2.Current());
       if (!wir2.IsSame(wir1))
       {
-
-        if (IsInside(wir2, WireBienOriente, FClass2d, newFace))
+        bool      isWire2Inside;
+        Bnd_Box2d aBox2;
+        bool      hasBox2 = hasBox1 && aWireBoxMap.IsBound(exp2.Current())
+                       && !(aBox2 = aWireBoxMap(exp2.Current())).IsVoid();
+        if (hasBox2 && aBox1.IsOut(aBox2))
+        {
+          // wir2's point falls outside wir1's box, so it's outside wir1's
+          // finite bounded region. If WireBienOriente is false, that
+          // finite region is exactly what IsInside() tests for, so the
+          // point is out. If WireBienOriente is true, IsInside() tests
+          // for the infinite complement of that region instead, and a
+          // point outside the finite region is inside the complement, so
+          // IsInside() returns false there too. Either way the answer is
+          // false.
+          isWire2Inside = false;
+        }
+        else
+        {
+          isWire2Inside = IsInside(wir2, WireBienOriente, FClass2d, newFace);
+        }
+        if (isWire2Inside)
         {
           myMapImb(wir1).Append(wir2);
         }

--- a/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepCheck_Face_Test.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepCheck_Face_Test.cxx
@@ -1,0 +1,199 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepCheck_Face.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom_Line.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Ax2d.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <Precision.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+
+TopoDS_Wire makeRectangle(const double theXMin,
+                          const double theYMin,
+                          const double theXMax,
+                          const double theYMax)
+{
+  const gp_Pnt aP1(theXMin, theYMin, 0.0);
+  const gp_Pnt aP2(theXMax, theYMin, 0.0);
+  const gp_Pnt aP3(theXMax, theYMax, 0.0);
+  const gp_Pnt aP4(theXMin, theYMax, 0.0);
+
+  BRepBuilderAPI_MakeEdge anEdgeBuilders[4] = {BRepBuilderAPI_MakeEdge(aP1, aP2),
+                                               BRepBuilderAPI_MakeEdge(aP2, aP3),
+                                               BRepBuilderAPI_MakeEdge(aP3, aP4),
+                                               BRepBuilderAPI_MakeEdge(aP4, aP1)};
+  BRepBuilderAPI_MakeWire aWireBuilder;
+  for (BRepBuilderAPI_MakeEdge& anEdgeBuilder : anEdgeBuilders)
+  {
+    if (!anEdgeBuilder.IsDone())
+    {
+      return TopoDS_Wire();
+    }
+    aWireBuilder.Add(anEdgeBuilder.Edge());
+  }
+  return aWireBuilder.IsDone() ? aWireBuilder.Wire() : TopoDS_Wire();
+}
+
+TopoDS_Face makePlanarFace()
+{
+  const TopoDS_Wire anOuterWire = makeRectangle(0.0, 0.0, 100.0, 100.0);
+  if (anOuterWire.IsNull())
+  {
+    return TopoDS_Face();
+  }
+
+  BRepBuilderAPI_MakeFace aFaceBuilder(gp_Pln(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)),
+                                       anOuterWire,
+                                       true);
+  return aFaceBuilder.IsDone() ? aFaceBuilder.Face() : TopoDS_Face();
+}
+
+bool addCircularHole(TopoDS_Face& theFace, const gp_Pnt& theCenter, const double theRadius)
+{
+  BRepBuilderAPI_MakeEdge anEdgeBuilder(
+    gp_Circ(gp_Ax2(theCenter, gp_Dir(0.0, 0.0, 1.0)), theRadius));
+  if (!anEdgeBuilder.IsDone())
+  {
+    return false;
+  }
+
+  BRepBuilderAPI_MakeWire aWireBuilder(anEdgeBuilder.Edge());
+  if (!aWireBuilder.IsDone())
+  {
+    return false;
+  }
+
+  TopoDS_Wire aHole = aWireBuilder.Wire();
+  aHole.Reverse();
+  BRep_Builder().Add(theFace, aHole);
+  return true;
+}
+
+BRepCheck_Status classifyWires(const TopoDS_Face& theFace)
+{
+  BRepCheck_Face aChecker(theFace);
+  return aChecker.ClassifyWires();
+}
+
+} // namespace
+
+//=================================================================================================
+
+TEST(BRepCheck_FaceTest, ClassifyWires_DisjointHolesAreValid)
+{
+  TopoDS_Face aFace = makePlanarFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  for (int aRow = 0; aRow < 5; ++aRow)
+  {
+    for (int aColumn = 0; aColumn < 8; ++aColumn)
+    {
+      const gp_Pnt aCenter(10.0 + 11.0 * aColumn, 10.0 + 11.0 * aRow, 0.0);
+      ASSERT_TRUE(addCircularHole(aFace, aCenter, 2.0));
+    }
+  }
+
+  EXPECT_EQ(classifyWires(aFace), BRepCheck_NoError);
+  EXPECT_TRUE(BRepCheck_Analyzer(aFace).IsValid());
+}
+
+//=================================================================================================
+
+TEST(BRepCheck_FaceTest, ClassifyWires_OffsetPCurve)
+{
+  TopoDS_Face aFace = makePlanarFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  const gp_Pnt2d             aCenter2d(50.0, 50.0);
+  occ::handle<Geom2d_Circle> aBasis =
+    new Geom2d_Circle(gp_Ax2d(aCenter2d, gp_Dir2d(1.0, 0.0)), 4.0);
+  occ::handle<Geom2d_OffsetCurve> anOffset = new Geom2d_OffsetCurve(aBasis, 1.0);
+  const double                    aRadius  = anOffset->Value(0.0).Distance(aCenter2d);
+
+  BRepBuilderAPI_MakeEdge anEdgeBuilder(
+    gp_Circ(gp_Ax2(gp_Pnt(50.0, 50.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), aRadius));
+  ASSERT_TRUE(anEdgeBuilder.IsDone());
+
+  TopoDS_Edge anEdge = anEdgeBuilder.Edge();
+  BRep_Builder().UpdateEdge(anEdge, anOffset, aFace, Precision::Confusion());
+  BRepBuilderAPI_MakeWire aWireBuilder(anEdge);
+  ASSERT_TRUE(aWireBuilder.IsDone());
+
+  TopoDS_Wire aHole = aWireBuilder.Wire();
+  aHole.Reverse();
+  BRep_Builder().Add(aFace, aHole);
+
+  EXPECT_EQ(classifyWires(aFace), BRepCheck_NoError);
+}
+
+//=================================================================================================
+
+TEST(BRepCheck_FaceTest, ClassifyWires_OpenWireFallbackIsOrientationIndependent)
+{
+  TopoDS_Face aFace = makePlanarFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  BRepBuilderAPI_MakeEdge anEdgeBuilder(gp_Pnt(120.0, 10.0, 0.0), gp_Pnt(130.0, 10.0, 0.0));
+  ASSERT_TRUE(anEdgeBuilder.IsDone());
+  BRepBuilderAPI_MakeWire aWireBuilder(anEdgeBuilder.Edge());
+  ASSERT_TRUE(aWireBuilder.IsDone());
+  BRep_Builder().Add(aFace, aWireBuilder.Wire());
+
+  const BRepCheck_Status aForwardStatus = classifyWires(aFace);
+  const TopoDS_Face      aReversedFace  = TopoDS::Face(aFace.Reversed());
+  EXPECT_EQ(aForwardStatus, BRepCheck_NoError);
+  EXPECT_EQ(classifyWires(aReversedFace), aForwardStatus);
+}
+
+//=================================================================================================
+
+TEST(BRepCheck_FaceTest, ClassifyWires_UnboundedWireFallbackIsOrientationIndependent)
+{
+  TopoDS_Face aFace = makePlanarFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  const occ::handle<Geom_Line> aLine =
+    new Geom_Line(gp_Lin(gp_Pnt(0.0, 120.0, 0.0), gp_Dir(1.0, 0.0, 0.0)));
+  BRepBuilderAPI_MakeEdge anEdgeBuilder(aLine);
+  ASSERT_TRUE(anEdgeBuilder.IsDone());
+  BRepBuilderAPI_MakeWire aWireBuilder(anEdgeBuilder.Edge());
+  ASSERT_TRUE(aWireBuilder.IsDone());
+  BRep_Builder().Add(aFace, aWireBuilder.Wire());
+
+  const BRepCheck_Status aForwardStatus = classifyWires(aFace);
+  const TopoDS_Face      aReversedFace  = TopoDS::Face(aFace.Reversed());
+  EXPECT_EQ(aForwardStatus, BRepCheck_NoError);
+  EXPECT_EQ(classifyWires(aReversedFace), aForwardStatus);
+}

--- a/src/ModelingAlgorithms/TKTopAlgo/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKTopAlgo/GTests/FILES.cmake
@@ -7,6 +7,7 @@ set(OCCT_TKTopAlgo_GTests_FILES
   BRepBuilderAPI_MakeFace_Test.cxx
   BRepBuilderAPI_MakeWire_Test.cxx
   BRepBuilderAPI_Transform_Test.cxx
+  BRepCheck_Face_Test.cxx
   BRepClass3d_SolidClassifier_Test.cxx
   BRepExtrema_DistShapeShape_Test.cxx
   BRepGProp_Test.cxx

--- a/src/ModelingData/TKGeomBase/GeomLib/GeomLib_Tool.cxx
+++ b/src/ModelingData/TKGeomBase/GeomLib/GeomLib_Tool.cxx
@@ -20,6 +20,12 @@
 #include <Extrema_ExtPC2d.hxx>
 #include <Extrema_ExtPS.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_Hyperbola.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Parabola.hxx>
+#include <Geom_TrimmedCurve.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <GeomAdaptor_Surface.hxx>
 #include <math_PSO.hxx>
@@ -46,6 +52,70 @@ bool GeomLib_Tool::Parameter(const occ::handle<Geom_Curve>& Curve,
   //
   U           = 0.;
   double aTol = MaxDist * MaxDist;
+
+  // Analytic curve types already have an O(1) closed-form parameter
+  // computation in ElCLib, so use that instead of the iterative
+  // Extrema_ExtPC search below when the curve (or its basis curve, if
+  // trimmed) is a Line, Circle, Ellipse, Hyperbola or Parabola. The
+  // closed-form result is only kept if it lands within the curve's own
+  // range, accounting for periodicity. A trimmed arc whose true closest
+  // point falls outside the trimmed portion still goes through the
+  // generic search below.
+  {
+    occ::handle<Geom_Curve> aBasisCurve = Curve;
+    while (aBasisCurve->IsKind(STANDARD_TYPE(Geom_TrimmedCurve)))
+    {
+      aBasisCurve = occ::down_cast<Geom_TrimmedCurve>(aBasisCurve)->BasisCurve();
+    }
+
+    bool   hasFastU = true;
+    double aFastU   = 0.0;
+    if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Line)))
+    {
+      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Line>(aBasisCurve)->Lin(), Point);
+    }
+    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Circle)))
+    {
+      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Circle>(aBasisCurve)->Circ(), Point);
+    }
+    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Ellipse)))
+    {
+      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Ellipse>(aBasisCurve)->Elips(), Point);
+    }
+    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Hyperbola)))
+    {
+      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Hyperbola>(aBasisCurve)->Hypr(), Point);
+    }
+    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Parabola)))
+    {
+      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Parabola>(aBasisCurve)->Parab(), Point);
+    }
+    else
+    {
+      hasFastU = false;
+    }
+
+    if (hasFastU)
+    {
+      if (Curve->IsPeriodic())
+      {
+        aFastU = ElCLib::InPeriod(aFastU,
+                                  Curve->FirstParameter(),
+                                  Curve->FirstParameter() + Curve->Period());
+      }
+      if (aFastU >= Curve->FirstParameter() - PARTOLERANCE
+          && aFastU <= Curve->LastParameter() + PARTOLERANCE)
+      {
+        const gp_Pnt aFastP = Curve->Value(aFastU);
+        if (aFastP.SquareDistance(Point) <= aTol)
+        {
+          U = aFastU;
+          return true;
+        }
+        return false;
+      }
+    }
+  }
   //
   GeomAdaptor_Curve aGAC(Curve);
   Extrema_ExtPC     extrema(Point, aGAC);

--- a/src/ModelingData/TKGeomBase/GeomLib/GeomLib_Tool.cxx
+++ b/src/ModelingData/TKGeomBase/GeomLib/GeomLib_Tool.cxx
@@ -20,12 +20,6 @@
 #include <Extrema_ExtPC2d.hxx>
 #include <Extrema_ExtPS.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
-#include <Geom_Circle.hxx>
-#include <Geom_Ellipse.hxx>
-#include <Geom_Hyperbola.hxx>
-#include <Geom_Line.hxx>
-#include <Geom_Parabola.hxx>
-#include <Geom_TrimmedCurve.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <GeomAdaptor_Surface.hxx>
 #include <math_PSO.hxx>
@@ -52,70 +46,6 @@ bool GeomLib_Tool::Parameter(const occ::handle<Geom_Curve>& Curve,
   //
   U           = 0.;
   double aTol = MaxDist * MaxDist;
-
-  // Analytic curve types already have an O(1) closed-form parameter
-  // computation in ElCLib, so use that instead of the iterative
-  // Extrema_ExtPC search below when the curve (or its basis curve, if
-  // trimmed) is a Line, Circle, Ellipse, Hyperbola or Parabola. The
-  // closed-form result is only kept if it lands within the curve's own
-  // range, accounting for periodicity. A trimmed arc whose true closest
-  // point falls outside the trimmed portion still goes through the
-  // generic search below.
-  {
-    occ::handle<Geom_Curve> aBasisCurve = Curve;
-    while (aBasisCurve->IsKind(STANDARD_TYPE(Geom_TrimmedCurve)))
-    {
-      aBasisCurve = occ::down_cast<Geom_TrimmedCurve>(aBasisCurve)->BasisCurve();
-    }
-
-    bool   hasFastU = true;
-    double aFastU   = 0.0;
-    if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Line)))
-    {
-      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Line>(aBasisCurve)->Lin(), Point);
-    }
-    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Circle)))
-    {
-      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Circle>(aBasisCurve)->Circ(), Point);
-    }
-    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Ellipse)))
-    {
-      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Ellipse>(aBasisCurve)->Elips(), Point);
-    }
-    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Hyperbola)))
-    {
-      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Hyperbola>(aBasisCurve)->Hypr(), Point);
-    }
-    else if (aBasisCurve->IsKind(STANDARD_TYPE(Geom_Parabola)))
-    {
-      aFastU = ElCLib::Parameter(occ::down_cast<Geom_Parabola>(aBasisCurve)->Parab(), Point);
-    }
-    else
-    {
-      hasFastU = false;
-    }
-
-    if (hasFastU)
-    {
-      if (Curve->IsPeriodic())
-      {
-        aFastU = ElCLib::InPeriod(aFastU,
-                                  Curve->FirstParameter(),
-                                  Curve->FirstParameter() + Curve->Period());
-      }
-      if (aFastU >= Curve->FirstParameter() - PARTOLERANCE
-          && aFastU <= Curve->LastParameter() + PARTOLERANCE)
-      {
-        const gp_Pnt aFastP = Curve->Value(aFastU);
-        if (aFastP.SquareDistance(Point) <= aTol)
-        {
-          U = aFastU;
-          return true;
-        }
-        return false;
-      }
-    }
-  }
   //
   GeomAdaptor_Curve aGAC(Curve);
   Extrema_ExtPC     extrema(Point, aGAC);


### PR DESCRIPTION
`ClassifyWires()` currently checks every pair of a face's wires against each
other. For a plate with thousands of non-overlapping holes, that nested loop
dominates `BRepCheck_Analyzer`'s runtime, and each check was going through a
full point classification plus an iterative curve-parameter search.

This PR has been split into two commits to make it easier to review. The two
fixes that together make validating a face with many hole wires about 8x
faster:

1. 1176043c771ed6842964712bb7ee389b82bb5e68 `GeomLib_Tool::Parameter()` now uses ElCLib's closed-form
   parameter computation for analytic curve types (Line, Circle, Ellipse,
   Hyperbola, Parabola) instead of always running the iterative Extrema_ExtPC
   search. `BRepCheck_Face::ClassifyWires` calls this once per wire edge to build
   a pcurve, so it adds up fast on a face with a lot of circular holes.

2. b06b9c9dc2f7fa5d2063acf98b2269d12df91348 `BRepCheck_Face::ClassifyWires()` now precomputes a 2D bounding
   box per wire and skips the exact point-classification test whenever two
   wires' boxes don't overlap, since a point outside a wire's box can't be
   inside its finite bounded region. This is the same pre-filter pattern
   `IntersectWires()` already uses above it in the same file.

Verified against current master with a [standalone test file](https://github.com/user-attachments/files/30158374/verify_perf_fix.cpp).
Timing at 500/1000/2000 holes: 0.57s/2.26s/9.21s before, down to
0.077s/0.29s/1.11s with both fixes applied. It's about 8x faster at 2000
holes.

CLA ID is 1145.