### PR TITLE
Shape Healing - Handle empty wire sequences in ShapeAnalysis_FreeBounds

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
@@ -4,6 +4,7 @@ set(OCCT_TKShHealing_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 set(OCCT_TKShHealing_GTests_FILES
   ShapeAnalysis_CanonicalRecognition_Test.cxx
   ShapeAnalysis_Edge_Test.cxx
+  ShapeAnalysis_FreeBounds_Test.cxx
   ShapeBuild_ReShape_Test.cxx
   ShapeConstruct_ProjectCurveOnSurface_Test.cxx
   ShapeFix_Shape_Test.cxx

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeAnalysis_FreeBounds_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeAnalysis_FreeBounds_Test.cxx
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
+#include <BRep_Builder.hxx>
+#include <ShapeAnalysis_FreeBounds.hxx>
+#include <TopAbs_ShapeEnum.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Pnt.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+static TopoDS_Face MakeSquareFace(const gp_Pnt& theA,
+                                  const gp_Pnt& theB,
+                                  const gp_Pnt& theC,
+                                  const gp_Pnt& theD)
+{
+  BRepBuilderAPI_MakeWire aMakeWire;
+  aMakeWire.Add(BRepBuilderAPI_MakeEdge(theA, theB).Edge());
+  aMakeWire.Add(BRepBuilderAPI_MakeEdge(theB, theC).Edge());
+  aMakeWire.Add(BRepBuilderAPI_MakeEdge(theC, theD).Edge());
+  aMakeWire.Add(BRepBuilderAPI_MakeEdge(theD, theA).Edge());
+  return BRepBuilderAPI_MakeFace(aMakeWire.Wire()).Face();
+}
+} // namespace
+
+// Baseline: a single closed face alone does not trigger the bug (see below).
+TEST(ShapeAnalysis_FreeBoundsTest, SingleFaceNoCrash)
+{
+  const TopoDS_Face aFace = MakeSquareFace(gp_Pnt(0.0, 0.0, 0.0),
+                                           gp_Pnt(1.0, 0.0, 0.0),
+                                           gp_Pnt(1.0, 1.0, 0.0),
+                                           gp_Pnt(0.0, 1.0, 0.0));
+
+  ShapeAnalysis_FreeBounds aFreeBounds(aFace, 0.01, true, true);
+  const TopoDS_Compound&   aClosed = aFreeBounds.GetClosedWires();
+  const TopoDS_Compound&   anOpen  = aFreeBounds.GetOpenWires();
+  (void)aClosed;
+  (void)anOpen;
+}
+
+// Regression: two disjoint closed faces used to crash SplitWires (see PR description).
+TEST(ShapeAnalysis_FreeBoundsTest, TwoDisjointFacesNoCrash)
+{
+  const TopoDS_Face aFaceA = MakeSquareFace(gp_Pnt(0.0, 0.0, 0.0),
+                                            gp_Pnt(1.0, 0.0, 0.0),
+                                            gp_Pnt(1.0, 1.0, 0.0),
+                                            gp_Pnt(0.0, 1.0, 0.0));
+  const TopoDS_Face aFaceB = MakeSquareFace(gp_Pnt(5.0, 5.0, 0.0),
+                                            gp_Pnt(6.0, 5.0, 0.0),
+                                            gp_Pnt(6.0, 6.0, 0.0),
+                                            gp_Pnt(5.0, 6.0, 0.0));
+
+  BRep_Builder    aBuilder;
+  TopoDS_Compound aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, aFaceA);
+  aBuilder.Add(aCompound, aFaceB);
+
+  ShapeAnalysis_FreeBounds aFreeBounds(aCompound, 0.01, true, true);
+  const TopoDS_Compound&   aClosed = aFreeBounds.GetClosedWires();
+  const TopoDS_Compound&   anOpen  = aFreeBounds.GetOpenWires();
+
+  int aNbClosed = 0;
+  for (TopExp_Explorer anExp(aClosed, TopAbs_WIRE); anExp.More(); anExp.Next())
+  {
+    ++aNbClosed;
+  }
+  int aNbOpen = 0;
+  for (TopExp_Explorer anExp(anOpen, TopAbs_WIRE); anExp.More(); anExp.Next())
+  {
+    ++aNbOpen;
+  }
+
+  EXPECT_EQ(aNbClosed, 2);
+  EXPECT_EQ(aNbOpen, 0);
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeAnalysis/ShapeAnalysis_FreeBounds.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeAnalysis/ShapeAnalysis_FreeBounds.cxx
@@ -207,6 +207,7 @@ static void connectWiresToWiresImpl(
 {
   if (iwires.IsNull() || !iwires->Length())
   {
+    owires = new NCollection_HSequence<TopoDS_Shape>; // was left null, later crashed Append
     return;
   }
   occ::handle<NCollection_HArray1<TopoDS_Shape>> arrwires =


### PR DESCRIPTION
Fixes #1376.

### Problem

`ShapeAnalysis_FreeBounds`'s constructor (which runs `SplitWires()` internally) crashes with an
uncatchable SIGSEGV on some shapes containing multiple free-boundary components. Minimally
reproducible with just two disjoint planar faces in one compound — no shared or even nearby
geometry needed. Not a data-volume threshold: a shape with 150+ free-boundary loops can be fine
while a much smaller one crashes, depending only on whether any single component happens to close
with nothing left over.

### Root cause

`ShapeAnalysis_FreeBounds::SplitWire` (the per-wire helper) finds each wire's closed sub-loops,
then hands whatever edges weren't consumed to `ConnectEdgesToWires` to chain into the "open"
result:

```cpp
for (i = 1; i <= nbedges; i++)
  if (statuses.Value(i) != 2)
    edges->Append(sewd->Edge(i));
open = ShapeAnalysis_FreeBounds::ConnectEdgesToWires(edges, toler, shared);
```

When every edge of the wire was consumed into a closed loop, `edges` is a valid but **empty**
sequence. The call chain `ConnectEdgesToWires` → `ConnectWiresToWires` (3-arg) →
`ConnectWiresToWires` (4-arg, with a local `occ::handle<...> owires;`) → `connectWiresToWiresImpl`
starts with:

```cpp
if (iwires.IsNull() || !iwires->Length())
{
  return;
}
```

For empty input this returns **without ever assigning `owires`** — every caller in the file starts
from a freshly-defaulted (null) handle, so the null propagates back through `ConnectEdgesToWires`'s
return value into `SplitWire`'s `open` output parameter, into
`ShapeAnalysis_FreeBounds::SplitWires`'s per-wire loop:

```cpp
SplitWire(TopoDS::Wire(wires->Value(i)), toler, shared, tmpclosed, tmpopen);
closed->Append(tmpclosed);
open->Append(tmpopen);          // tmpopen is null here
```

`NCollection_HSequence::Append(const opencascade::handle<T>&)` dereferences the null handle
(`theOther->ChangeSequence()`) to obtain a reference, which is then passed into
`NCollection_Sequence::Append(NCollection_Sequence&)`, whose first statement reads
`theSeq.IsEmpty()` (== `theSeq.mySize`) through that invalid reference — SIGSEGV.

### Fix

The one-line contract restoration `connectWiresToWiresImpl`'s own non-empty path already follows a
few lines down (`owires = new NCollection_HSequence<TopoDS_Shape>;` before populating it): "no
wires to connect" should produce a valid **empty** result, not an untouched (and, for every caller
in this file, null-defaulted) out-parameter.

### Reproducer / test

```cpp
BRepBuilderAPI_MakeWire mw1;
mw1.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(0,0,0), gp_Pnt(1,0,0)).Edge());
mw1.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(1,0,0), gp_Pnt(1,1,0)).Edge());
mw1.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(1,1,0), gp_Pnt(0,1,0)).Edge());
mw1.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(0,1,0), gp_Pnt(0,0,0)).Edge());
TopoDS_Face faceA = BRepBuilderAPI_MakeFace(mw1.Wire()).Face();

BRepBuilderAPI_MakeWire mw2;                                    // far away, no shared geometry
mw2.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(5,5,0), gp_Pnt(6,5,0)).Edge());
mw2.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(6,5,0), gp_Pnt(6,6,0)).Edge());
mw2.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(6,6,0), gp_Pnt(5,6,0)).Edge());
mw2.Add(BRepBuilderAPI_MakeEdge(gp_Pnt(5,6,0), gp_Pnt(5,5,0)).Edge());
TopoDS_Face faceB = BRepBuilderAPI_MakeFace(mw2.Wire()).Face();

BRep_Builder B; TopoDS_Compound comp; B.MakeCompound(comp);
B.Add(comp, faceA); B.Add(comp, faceB);

ShapeAnalysis_FreeBounds safb(comp, 0.01, true, true);  // crashes on master
```

Crashes on current master; fixed here. Added GTest
`ShapeAnalysis_FreeBoundsTest.TwoDisjointFacesNoCrash` (plus a single-face baseline).

### Validation

Isolated with AddressSanitizer (an ASan-instrumented macOS-arm64 build of `ModelingAlgorithms` +
`ModelingData` + `FoundationClasses`, `RelWithDebInfo`, `MMGT_OPT=0` at runtime so allocations route
through malloc/free): the two-disjoint-face repro crashes 100% of the time on stock master with an
identical signature at both `-O2` and `-O0` (same function, same `NCollection_Sequence::Append`
call, same `0xfffffffffffffff8` fault address), and returns the correct `2 closed, 0 open` after
this patch. On a real-world 150-face analytic-BRep fixture (sewn with `BRepBuilderAPI_Sewing`):
`tol=0.05` gives `152 closed / 0 open` byte-identical before and after this patch (confirming no
behavior change on the working path); `tol=0.10` crashes on stock master and returns
`144 closed / 0 open` after.

Reported downstream and isolated at SecondMouseAU/OCCTSwift#310.
