### PR TITLE
Shape Healing - Guard null context in periodic face healing

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
@@ -6,6 +6,7 @@ set(OCCT_TKShHealing_GTests_FILES
   ShapeAnalysis_Edge_Test.cxx
   ShapeBuild_ReShape_Test.cxx
   ShapeConstruct_ProjectCurveOnSurface_Test.cxx
+  ShapeFix_Face_Test.cxx
   ShapeFix_Shape_Test.cxx
   ShapeUpgrade_FaceDivide_Test.cxx
   ShapeUpgrade_UnifySameDomain_Test.cxx

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_Face_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_Face_Test.cxx
@@ -47,7 +47,7 @@ TopoDS_Face MakeFaceOnPeriodicConicalSingleWire(occ::handle<Geom_ConicalSurface>
     aPts->SetValue(i, theCone->Value(anU, aV));
   }
 
-  GeomAPI_Interpolate anInterp(aPts, Standard_True, 1e-6);
+  GeomAPI_Interpolate anInterp(aPts, true, 1e-6);
   anInterp.Perform();
   if (!anInterp.IsDone())
   {
@@ -67,7 +67,7 @@ TopoDS_Face MakeFaceOnPeriodicConicalSingleWire(occ::handle<Geom_ConicalSurface>
     return TopoDS_Face();
   }
 
-  BRepBuilderAPI_MakeFace aMakeFace(theCone, aMakeWire.Wire(), Standard_True);
+  BRepBuilderAPI_MakeFace aMakeFace(theCone, aMakeWire.Wire(), true);
   return aMakeFace.IsDone() ? aMakeFace.Face() : TopoDS_Face();
 }
 } // namespace

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_Face_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_Face_Test.cxx
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepLib_MakeWire.hxx>
+#include <Geom_ConicalSurface.hxx>
+#include <GeomAPI_Interpolate.hxx>
+#include <gp_Ax3.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+#include <NCollection_HArray1.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeFix_Face.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// A closed edge belting a cone's full period (8 points sampled off the cone surface).
+TopoDS_Face MakeFaceOnPeriodicConicalSingleWire(occ::handle<Geom_ConicalSurface>& theCone)
+{
+  gp_Ax3 anAxis(gp_Pnt(0.0, 4.0, -9.1), gp_Dir(0.0, 0.09, -1.0));
+  theCone = new Geom_ConicalSurface(anAxis, 0.35, 0.0);
+
+  const int                                anN  = 8;
+  const double                             aV   = 0.5;
+  occ::handle<NCollection_HArray1<gp_Pnt>> aPts = new NCollection_HArray1<gp_Pnt>(1, anN);
+  for (int i = 1; i <= anN; i++)
+  {
+    const double anU = 2.0 * M_PI * (i - 1) / anN;
+    aPts->SetValue(i, theCone->Value(anU, aV));
+  }
+
+  GeomAPI_Interpolate anInterp(aPts, Standard_True, 1e-6);
+  anInterp.Perform();
+  if (!anInterp.IsDone())
+  {
+    return TopoDS_Face();
+  }
+
+  BRepBuilderAPI_MakeEdge aMakeEdge(anInterp.Curve());
+  if (!aMakeEdge.IsDone())
+  {
+    return TopoDS_Face();
+  }
+
+  BRepLib_MakeWire aMakeWire;
+  aMakeWire.Add(aMakeEdge.Edge());
+  if (!aMakeWire.IsDone() || !aMakeWire.Wire().Closed())
+  {
+    return TopoDS_Face();
+  }
+
+  BRepBuilderAPI_MakeFace aMakeFace(theCone, aMakeWire.Wire(), Standard_True);
+  return aMakeFace.IsDone() ? aMakeFace.Face() : TopoDS_Face();
+}
+} // namespace
+
+// No SetContext() call (the ordinary usage) -- used to SIGSEGV in FixPeriodicDegenerated().
+TEST(ShapeFix_FaceTest, NoCrashOnPeriodicConicalSingleWire)
+{
+  occ::handle<Geom_ConicalSurface> aCone;
+  TopoDS_Face                      aFace = MakeFaceOnPeriodicConicalSingleWire(aCone);
+  ASSERT_FALSE(aFace.IsNull());
+
+  ShapeFix_Face aFixer(aFace);
+  aFixer.Perform();
+
+  EXPECT_FALSE(aFixer.Face().IsNull());
+}
+
+// With a context supplied, the same input heals to a genuinely valid face.
+TEST(ShapeFix_FaceTest, ValidFaceOnPeriodicConicalSingleWireWithContext)
+{
+  occ::handle<Geom_ConicalSurface> aCone;
+  TopoDS_Face                      aFace = MakeFaceOnPeriodicConicalSingleWire(aCone);
+  ASSERT_FALSE(aFace.IsNull());
+
+  ShapeFix_Face aFixer(aFace);
+  aFixer.SetContext(new ShapeBuild_ReShape);
+  aFixer.Perform();
+
+  const TopoDS_Face& aFixed = aFixer.Face();
+  ASSERT_FALSE(aFixed.IsNull());
+  EXPECT_TRUE(BRepCheck_Analyzer(aFixed).IsValid());
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
@@ -3253,7 +3253,6 @@ bool ShapeFix_Face::FixPeriodicDegenerated()
 
   // Adjust the resulting state of the healing tool
   myResult = aNewFace;
-  // #317: guard null Context(), as every other Replace() call site in this file does
   if (!Context().IsNull())
   {
     Context()->Replace(myFace, myResult);

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_Face.cxx
@@ -3253,7 +3253,11 @@ bool ShapeFix_Face::FixPeriodicDegenerated()
 
   // Adjust the resulting state of the healing tool
   myResult = aNewFace;
-  Context()->Replace(myFace, myResult);
+  // #317: guard null Context(), as every other Replace() call site in this file does
+  if (!Context().IsNull())
+  {
+    Context()->Replace(myFace, myResult);
+  }
 
   return true;
 }


### PR DESCRIPTION
Fixes #1378.

### Problem

`ShapeFix_Face::Perform()` SIGSEGVs healing a face whose sole boundary wire is a single closed edge
belting the full 2π period of a `Geom_ConicalSurface` (positioned so the apex sits outside the
wire's V range) — the exact case `FixPeriodicDegenerated()` exists to patch in a degenerate apex
edge for. Only the plain, most common usage crashes: `ShapeFix_Face fixer(face); fixer.Perform();`,
with no explicit `SetContext()` call.

### Root cause

`FixPeriodicDegenerated()` builds the degenerate apex edge/wire, assembles a new face from the
original wire plus the apex wire, and finalizes:

```cpp
myResult = aNewFace;
Context()->Replace(myFace, myResult);
```

Every *other* `Context()->Replace` call site in this file — eleven of them — guards against a null
`Context()` first (either a plain `if (!Context().IsNull())`, or a lazy `SetContext(new
ShapeBuild_ReShape)` when null). `FixPeriodicDegenerated` even checks `Context().IsNull()` at the
*top* of the function before calling `Context()->Apply()` — but the check is missing at the
*bottom*. `Context()` returns `ShapeFix_Root::myContext`, left null by the base constructor and set
only by an explicit `SetContext()` call — which the ordinary construction `ShapeFix_Face
fixer(face); fixer.Perform();` never makes. Any caller healing a lone periodic-conical wire this way
null-derefs.

### Fix

The same guard used at every other call site in the file — only replace in the context if there is
one to replace in.

### Reproducer / test

```cpp
TColgp_Array1OfPnt pts(1, 8);
const double r = 0.14;
for (int i = 1; i <= 8; i++) {
    double a = 2.0 * M_PI * (i - 1) / 8;
    pts.SetValue(i, gp_Pnt(r * cos(a), 4.0 + r * sin(a), -9.6));
}
Handle(TColgp_HArray1OfPnt) hpts = new TColgp_HArray1OfPnt(1, pts.Length());
for (int i = pts.Lower(); i <= pts.Upper(); i++) hpts->SetValue(i, pts.Value(i));

GeomAPI_Interpolate interp(hpts, Standard_True, 1e-6);
interp.Perform();

BRepBuilderAPI_MakeEdge me(interp.Curve());
BRepLib_MakeWire mw;
mw.Add(me.Edge());

gp_Ax3 axis(gp_Pnt(0.0, 4.0, -9.1), gp_Dir(0.0, 0.09, -1.0));
Handle(Geom_ConicalSurface) cone = new Geom_ConicalSurface(axis, 0.35, 0.0);
BRepBuilderAPI_MakeFace mf(cone, mw.Wire(), Standard_True);

ShapeFix_Face fixer(mf.Face());  // crashes on master
fixer.Perform();
```

Crashes on current master; fixed here. Added GTest
`ShapeFix_FaceTest.NoCrashOnPeriodicConicalSingleWire`.

### Validation

Diagnosed with a custom `backtrace_symbols_fd` `SIGSEGV` handler (`lldb`/core dumps unavailable in
the diagnosing sandbox), pinpointing the crash to `ShapeFix_Face::FixPeriodicDegenerated`; an `-O0`
single-TU override-link (compiling just the patched `.cxx` and linking it before the archive)
confirmed every statement in the function up to the final `Context()->Replace` completes normally,
and that call is specifically where it faults. Both the minimal 8-point synthetic reproducer above
and a 10-point closed curve fit through real mesh-derived rivet-rim points (the case this was
originally surfaced from) crash 100% of the time on stock `V8_0_0_p1` and survive with this patch,
returning a valid healed face (`BRepCheck_Analyzer::IsValid() == true`).

Reported downstream and isolated at SecondMouseAU/OCCTSwift#317.
