### PR TITLE
Modeling Algorithms - use the adaptor's NbPoles() in BRepGProp_EdgeTool::IntegrationOrder

### DIFF
--- a/src/ModelingAlgorithms/TKTopAlgo/BRepGProp/BRepGProp_EdgeTool.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepGProp/BRepGProp_EdgeTool.cxx
@@ -42,19 +42,11 @@ int BRepGProp_EdgeTool::IntegrationOrder(const BRepAdaptor_Curve& BAC)
     case GeomAbs_Parabola:
       return 5;
 
-    case GeomAbs_BezierCurve: {
-      const GeomAdaptor_Curve&       GAC = BAC.Curve();
-      const occ::handle<Geom_Curve>& GC  = GAC.Curve();
-      occ::handle<Geom_BezierCurve>  GBZC(occ::down_cast<Geom_BezierCurve>(GC));
-      int                            n = 2 * (GBZC->NbPoles()) - 1;
-      return n;
-    }
-    break;
+    case GeomAbs_BezierCurve:
     case GeomAbs_BSplineCurve: {
-      const GeomAdaptor_Curve&       GAC = BAC.Curve();
-      const occ::handle<Geom_Curve>& GC  = GAC.Curve();
-      occ::handle<Geom_BSplineCurve> GBSC(occ::down_cast<Geom_BSplineCurve>(GC));
-      int                            n = 2 * (GBSC->NbPoles()) - 1;
+      // Use the adaptor's own NbPoles(), which handles the curve-on-surface case;
+      // Curve() is null there and down-casting it segfaults.
+      int n = 2 * BAC.NbPoles() - 1;
       return n;
     }
     break;

--- a/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepGProp_Test.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepGProp_Test.cxx
@@ -17,22 +17,32 @@
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
 #include <BRepPrimAPI_MakeSphere.hxx>
+#include <BRep_Builder.hxx>
 #include <GCPnts_AbscissaPoint.hxx>
+#include <Geom2d_BSplineCurve.hxx>
 #include <Geom_BSplineCurve.hxx>
+#include <Geom_Plane.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 #include <GProp_GProps.hxx>
 #include <GProp_PrincipalProps.hxx>
 #include <NCollection_Array1.hxx>
 #include <Precision.hxx>
 #include <Standard_Handle.hxx>
+#include <TColgp_Array1OfPnt2d.hxx>
+#include <TColStd_Array1OfInteger.hxx>
+#include <TColStd_Array1OfReal.hxx>
 #include <TopExp_Explorer.hxx>
+#include <TopLoc_Location.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Edge.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Shape.hxx>
 
 #include <gtest/gtest.h>
+
+#include <cmath>
 
 TEST(BRepGPropTest, LinearProperties_EdgeLength)
 {
@@ -194,4 +204,50 @@ TEST(BRepGPropTest, OCC8797_BSplineLengthConsistencyAbscissaVsLinearProperties)
 
   // Both methods must agree within 0.1 %
   EXPECT_NEAR(aLengthAbscissa, aLengthGProp, aLengthGProp * 1e-3);
+}
+
+// Regression: a degenerate edge whose ONLY representation is a Bezier/BSpline-type
+// curve-on-surface pcurve (no 3D curve) used to SIGSEGV inside
+// BRepGProp_EdgeTool::IntegrationOrder, which read the pole count via BAC.Curve().Curve()
+// (null when there is no 3D curve) instead of the adaptor's own NbPoles(). This is the
+// shape BRepBuilderAPI_Sewing produces reconciling near-coincident vertices between two
+// faces that do not share an edge outright.
+TEST(BRepGPropTest, LinearProperties_DegenerateEdgeWithBSplinePCurveNoCrash)
+{
+  occ::handle<Geom_Plane> aPlane = new Geom_Plane(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0));
+
+  TColgp_Array1OfPnt2d aPoles(1, 4);
+  aPoles.SetValue(1, gp_Pnt2d(0.0, 0.0));
+  aPoles.SetValue(2, gp_Pnt2d(0.1, 0.05));
+  aPoles.SetValue(3, gp_Pnt2d(0.2, -0.05));
+  aPoles.SetValue(4, gp_Pnt2d(0.3, 0.0));
+
+  TColStd_Array1OfReal aKnots(1, 2);
+  aKnots.SetValue(1, 0.0);
+  aKnots.SetValue(2, 1.0);
+
+  TColStd_Array1OfInteger aMults(1, 2);
+  aMults.SetValue(1, 4);
+  aMults.SetValue(2, 4);
+
+  occ::handle<Geom2d_BSplineCurve> aPCurve = new Geom2d_BSplineCurve(aPoles, aKnots, aMults, 3);
+
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  aBuilder.UpdateEdge(anEdge, aPCurve, aPlane, TopLoc_Location(), Precision::Confusion());
+  aBuilder.Range(anEdge,
+                 aPlane,
+                 TopLoc_Location(),
+                 aPCurve->FirstParameter(),
+                 aPCurve->LastParameter());
+  aBuilder.Degenerated(anEdge, true);
+
+  GProp_GProps aProps;
+  BRepGProp::LinearProperties(anEdge, aProps);
+
+  // Reaching this point at all is the regression check: IntegrationOrder used to SIGSEGV
+  // before returning.
+  EXPECT_TRUE(std::isfinite(aProps.Mass()));
+  EXPECT_GE(aProps.Mass(), 0.0);
 }

--- a/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepGProp_Test.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepGProp_Test.cxx
@@ -30,9 +30,6 @@
 #include <NCollection_Array1.hxx>
 #include <Precision.hxx>
 #include <Standard_Handle.hxx>
-#include <TColgp_Array1OfPnt2d.hxx>
-#include <TColStd_Array1OfInteger.hxx>
-#include <TColStd_Array1OfReal.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopLoc_Location.hxx>
 #include <TopoDS.hxx>
@@ -216,17 +213,17 @@ TEST(BRepGPropTest, LinearProperties_DegenerateEdgeWithBSplinePCurveNoCrash)
 {
   occ::handle<Geom_Plane> aPlane = new Geom_Plane(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0));
 
-  TColgp_Array1OfPnt2d aPoles(1, 4);
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 4);
   aPoles.SetValue(1, gp_Pnt2d(0.0, 0.0));
   aPoles.SetValue(2, gp_Pnt2d(0.1, 0.05));
   aPoles.SetValue(3, gp_Pnt2d(0.2, -0.05));
   aPoles.SetValue(4, gp_Pnt2d(0.3, 0.0));
 
-  TColStd_Array1OfReal aKnots(1, 2);
+  NCollection_Array1<double> aKnots(1, 2);
   aKnots.SetValue(1, 0.0);
   aKnots.SetValue(2, 1.0);
 
-  TColStd_Array1OfInteger aMults(1, 2);
+  NCollection_Array1<int> aMults(1, 2);
   aMults.SetValue(1, 4);
   aMults.SetValue(2, 4);
 


### PR DESCRIPTION
Fixes #1381.

### Problem

`BRepGProp::LinearProperties()` (and anything built on `BRepGProp_Cinert`) SIGSEGVs computing the
integration order for an edge whose only curve geometry is a Bezier- or BSpline-type
curve-on-surface (pcurve) — an edge with no 3D curve, the common case for a degenerate edge
`BRepBuilderAPI_Sewing` produces reconciling near-coincident vertices between two faces that don't
share an edge outright.

### Root cause

`IntegrationOrder` branches on `BAC.GetType()`, which correctly reports the curve-on-surface
pcurve's type via `GeomAdaptor_TransformedCurve::GetType()`'s override:

```cpp
return myConSurf.IsNull() ? myCurve.GetType() : myConSurf->GetType();
```

but then read the pole count via a completely different, non-virtual path — `BAC.Curve().Curve()`,
down-cast to `Geom_BezierCurve`/`Geom_BSplineCurve`. `BAC.Curve()` returns the base
`GeomAdaptor_Curve` sub-object, which holds the 3D-curve representation only: it is never `Load()`ed
when the edge has no 3D curve, so the handle is null, the down-cast returns null, and `->NbPoles()`
dereferences it.

### Fix

`GeomAdaptor_TransformedCurve` already has a correctly-dispatching `NbPoles()` override right next
to `GetType()` in the same header:

```cpp
int NbPoles() const override
{
  return myConSurf.IsNull() ? myCurve.NbPoles() : myConSurf->NbPoles();
}
```

Calling `BAC.NbPoles()` instead of manually re-deriving the pole count from `BAC.Curve()` fixes the
crash and matches the accessor `GetType()` one line above it already uses — no cast, no null check
needed, and no behaviour change for an edge that does have a 3D curve (`myConSurf.IsNull()` there,
so `NbPoles()` resolves to the same `myCurve.NbPoles()` the removed code reached by hand).

### Reproducer / test

```cpp
Handle(Geom_Plane) plane = new Geom_Plane(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1));

TColgp_Array1OfPnt2d poles(1, 4);
poles.SetValue(1, gp_Pnt2d(0.0, 0.0));
poles.SetValue(2, gp_Pnt2d(0.1, 0.05));
poles.SetValue(3, gp_Pnt2d(0.2, -0.05));
poles.SetValue(4, gp_Pnt2d(0.3, 0.0));

TColStd_Array1OfReal knots(1, 2);
knots.SetValue(1, 0.0);
knots.SetValue(2, 1.0);

TColStd_Array1OfInteger mults(1, 2);
mults.SetValue(1, 4);
mults.SetValue(2, 4);

Handle(Geom2d_BSplineCurve) pcurve = new Geom2d_BSplineCurve(poles, knots, mults, 3);

BRep_Builder builder;
TopoDS_Edge edge;
builder.MakeEdge(edge);
builder.UpdateEdge(edge, pcurve, plane, TopLoc_Location(), Precision::Confusion());
builder.Range(edge, plane, TopLoc_Location(), pcurve->FirstParameter(), pcurve->LastParameter());
builder.Degenerated(edge, true);

GProp_GProps props;
BRepGProp::LinearProperties(edge, props);  // crashes on master
```

Added as `BRepGPropTest.LinearProperties_DegenerateEdgeWithBSplinePCurveNoCrash` in the existing
`BRepGProp_Test.cxx`.
