### PR TITLE
Modeling Algorithms - fix unbounded self-interference: O(1) tangent-zone point access + a checkpointed breaker

### DIFF
--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_CheckerSI.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_CheckerSI.cxx
@@ -30,6 +30,7 @@
 #include <BOPTools_AlgoTools.hxx>
 #include <BOPTools_Parallel.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
+#include <Intf_Interference.hxx>
 #include <IntTools_Context.hxx>
 #include <IntTools_FaceFace.hxx>
 #include <Standard_ErrorHandler.hxx>
@@ -81,7 +82,26 @@ public:
     {
       return;
     }
-    IntTools_FaceFace::Perform(myF, myF, myRunParallel);
+    // Let aPS's deadline interrupt the self-interference search itself, not
+    // just gate entry to it. Only when single-threaded: an exception from a
+    // worker thread of OSD_Parallel::For's parallel path would be unsafe.
+    if (!myRunParallel)
+    {
+      Intf_InterferenceBreakerScope aBreakerScope(&aPS);
+      try
+      {
+        IntTools_FaceFace::Perform(myF, myF, myRunParallel);
+      }
+      catch (Standard_Failure const&)
+      {
+        // Aborted by the breaker: leave IsDone() false, same as any other
+        // reason IntTools_FaceFace::Perform does not finish.
+      }
+    }
+    else
+    {
+      IntTools_FaceFace::Perform(myF, myF, myRunParallel);
+    }
   }
 
   //

--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/FILES.cmake
@@ -24,6 +24,8 @@ set(OCCT_TKGeomAlgo_GTests_FILES
   IntCurveSurface_ThePolyhedronOfHInter_Test.cxx
   IntCurveSurface_ThePolygonOfHInter_Test.cxx
   Intf_Tool_Test.cxx
+  Intf_TangentZone_Test.cxx
+  Intf_Interference_Test.cxx
   IntPatch_Polyhedron_Test.cxx
   IntPatch_PolyhedronBVH_Test.cxx
   IntPolyh_Intersection_Test.cxx

--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/Intf_Interference_Test.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/Intf_Interference_Test.cxx
@@ -1,0 +1,135 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Intf_Interference.hxx>
+#include <Intf_SectionPoint.hxx>
+#include <Intf_TangentZone.hxx>
+#include <Message_ProgressIndicator.hxx>
+#include <Message_ProgressScope.hxx>
+#include <Standard_Failure.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+// Intf_Interference's constructor is protected; expose it for the test.
+class TestInterference : public Intf_Interference
+{
+public:
+  TestInterference()
+      : Intf_Interference(true)
+  {
+  }
+};
+
+// Always signals UserBreak(), regardless of Show()/position.
+class AlwaysBreakIndicator : public Message_ProgressIndicator
+{
+public:
+  bool UserBreak() override { return true; }
+
+  void Show(const Message_ProgressScope&, const bool) override {}
+  DEFINE_STANDARD_RTTI_INLINE(AlwaysBreakIndicator, Message_ProgressIndicator)
+};
+
+// Never signals UserBreak().
+class NeverBreakIndicator : public Message_ProgressIndicator
+{
+public:
+  bool UserBreak() override { return false; }
+
+  void Show(const Message_ProgressScope&, const bool) override {}
+  DEFINE_STANDARD_RTTI_INLINE(NeverBreakIndicator, Message_ProgressIndicator)
+};
+
+// theOffset keeps distinct calls geometrically disjoint, so they accumulate
+// as separate zones instead of merging into one.
+Intf_TangentZone MakeZoneOfSize(int theN, double theOffset)
+{
+  Intf_TangentZone aZone;
+  for (int i = 0; i < theN; ++i)
+  {
+    aZone.Append(Intf_SectionPoint(gp_Pnt(theOffset + i, 0.0, 0.0),
+                                   Intf_VERTEX,
+                                   1,
+                                   0,
+                                   0.0,
+                                   Intf_VERTEX,
+                                   1,
+                                   0,
+                                   0.0,
+                                   0.0));
+  }
+  return aZone;
+}
+
+// Enough zones that Insert()'s poll counter (every 256 calls) has a
+// realistic chance to fire within the test, without depending on timing.
+void SeedManyZones(TestInterference& theInterference, int theCount)
+{
+  for (int i = 0; i < theCount; ++i)
+  {
+    theInterference.Insert(MakeZoneOfSize(3, i * 10.0));
+  }
+}
+} // namespace
+
+// With no breaker set (the default), Insert() behaves exactly as before:
+// no exception, regardless of call volume.
+TEST(Intf_Interference, Insert_NoBreaker_DoesNotThrow)
+{
+  TestInterference anInterference;
+  EXPECT_NO_THROW(SeedManyZones(anInterference, 600));
+}
+
+// A breaker that never signals UserBreak() must not affect Insert().
+TEST(Intf_Interference, Insert_NonTrippingBreaker_DoesNotThrow)
+{
+  Handle(NeverBreakIndicator)   anIndicator = new NeverBreakIndicator;
+  Message_ProgressRange         aRange      = anIndicator->Start();
+  Message_ProgressScope         aScope(aRange, nullptr, 1);
+  Intf_InterferenceBreakerScope aGuard(&aScope);
+
+  TestInterference anInterference;
+  EXPECT_NO_THROW(SeedManyZones(anInterference, 600));
+}
+
+// A breaker that always signals UserBreak() must abort Insert() by
+// throwing Standard_Failure, within the polling grain (some multiple of
+// 256 calls), not run all 600 insertions to completion.
+TEST(Intf_Interference, Insert_TrippedBreaker_Throws)
+{
+  Handle(AlwaysBreakIndicator)  anIndicator = new AlwaysBreakIndicator;
+  Message_ProgressRange         aRange      = anIndicator->Start();
+  Message_ProgressScope         aScope(aRange, nullptr, 1);
+  Intf_InterferenceBreakerScope aGuard(&aScope);
+
+  TestInterference anInterference;
+  EXPECT_THROW(SeedManyZones(anInterference, 600), Standard_Failure);
+}
+
+// The breaker scope restores the previous (null) breaker on destruction,
+// so a later, unguarded Insert() call is unaffected.
+TEST(Intf_Interference, BreakerScope_RestoresPreviousOnDestruction)
+{
+  {
+    Handle(AlwaysBreakIndicator)  anIndicator = new AlwaysBreakIndicator;
+    Message_ProgressRange         aRange      = anIndicator->Start();
+    Message_ProgressScope         aScope(aRange, nullptr, 1);
+    Intf_InterferenceBreakerScope aGuard(&aScope);
+    // Guard is live and tripped here; not exercised further in this test.
+  }
+
+  TestInterference anInterference;
+  EXPECT_NO_THROW(SeedManyZones(anInterference, 600));
+}

--- a/src/ModelingAlgorithms/TKGeomAlgo/GTests/Intf_TangentZone_Test.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/GTests/Intf_TangentZone_Test.cxx
@@ -1,0 +1,89 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Intf_SectionPoint.hxx>
+#include <Intf_TangentZone.hxx>
+#include <NCollection_Array1.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+Intf_SectionPoint MakePoint(double theX)
+{
+  return Intf_SectionPoint(gp_Pnt(theX, 0.0, 0.0),
+                           Intf_VERTEX,
+                           1,
+                           0,
+                           0.0,
+                           Intf_VERTEX,
+                           1,
+                           0,
+                           0.0,
+                           0.0);
+}
+} // namespace
+
+// Points() must return the same points, in the same order, as GetPoint(Index).
+TEST(Intf_TangentZone, Points_MatchesGetPoint)
+{
+  Intf_TangentZone aZone;
+  for (int i = 0; i < 5; ++i)
+  {
+    aZone.Append(MakePoint(static_cast<double>(i)));
+  }
+
+  const NCollection_Array1<Intf_SectionPoint>& aPts = aZone.Points();
+  ASSERT_EQ(aPts.Length(), aZone.NumberOfPoints());
+  for (int i = 1; i <= aZone.NumberOfPoints(); ++i)
+  {
+    EXPECT_TRUE(aPts(i).IsEqual(aZone.GetPoint(i))) << "index " << i;
+  }
+}
+
+// The cache must reflect Append() done after the first Points() call.
+TEST(Intf_TangentZone, Points_InvalidatedByAppend)
+{
+  Intf_TangentZone aZone;
+  aZone.Append(MakePoint(0.0));
+  EXPECT_EQ(aZone.Points().Length(), 1);
+
+  aZone.Append(MakePoint(1.0));
+  const NCollection_Array1<Intf_SectionPoint>& aPts = aZone.Points();
+  ASSERT_EQ(aPts.Length(), 2);
+  EXPECT_TRUE(aPts(2).IsEqual(aZone.GetPoint(2)));
+}
+
+// The cache must reflect InsertBefore() done after the first Points() call.
+TEST(Intf_TangentZone, Points_InvalidatedByInsertBefore)
+{
+  Intf_TangentZone aZone;
+  aZone.Append(MakePoint(0.0));
+  aZone.Append(MakePoint(2.0));
+  EXPECT_EQ(aZone.Points().Length(), 2);
+
+  aZone.InsertBefore(2, MakePoint(1.0));
+  const NCollection_Array1<Intf_SectionPoint>& aPts = aZone.Points();
+  ASSERT_EQ(aPts.Length(), 3);
+  for (int i = 1; i <= 3; ++i)
+  {
+    EXPECT_TRUE(aPts(i).IsEqual(aZone.GetPoint(i))) << "index " << i;
+  }
+}
+
+// An empty zone has an empty (not stale) Points() array.
+TEST(Intf_TangentZone, Points_EmptyZone)
+{
+  Intf_TangentZone aZone;
+  EXPECT_EQ(aZone.Points().Length(), 0);
+}

--- a/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_Interference.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_Interference.cxx
@@ -18,6 +18,8 @@
 #include <Intf_SectionLine.hxx>
 #include <Intf_SectionPoint.hxx>
 #include <Intf_TangentZone.hxx>
+#include <Message_ProgressScope.hxx>
+#include <Standard_Failure.hxx>
 
 //=======================================================================
 // function : Intf_Interference
@@ -27,6 +29,20 @@ Intf_Interference::Intf_Interference(const bool Self)
     : SelfIntf(Self),
       Tolerance(0.0)
 {
+}
+
+//=================================================================================================
+
+namespace
+{
+// thread_local: safe by construction even if a future caller runs this on
+// a worker thread of its own.
+thread_local const Message_ProgressScope* t_intfBreaker = nullptr;
+} // namespace
+
+void Intf_Interference::SetBreaker(const Message_ProgressScope* theScope)
+{
+  t_intfBreaker = theScope;
 }
 
 //=======================================================================
@@ -49,6 +65,14 @@ void Intf_Interference::SelfInterference(const bool Self)
 
 bool Intf_Interference::Insert(const Intf_TangentZone& LaZone)
 {
+  // Poll every 256 calls: this function can run tens of thousands of times
+  // on a degenerate surface, so polling every call would add its own tax.
+  static thread_local int t_pollCounter = 0;
+  if (t_intfBreaker != nullptr && (++t_pollCounter & 0xFF) == 0 && t_intfBreaker->UserBreak())
+  {
+    throw Standard_Failure("Intf_Interference::Insert: aborted by breaker");
+  }
+
   if (myTZones.Length() <= 0)
   {
     return false;
@@ -63,13 +87,20 @@ bool Intf_Interference::Insert(const Intf_TangentZone& LaZone)
   int  npcz     = -1;                      // Number of points in the current zone
   int  nplz     = LaZone.NumberOfPoints(); // in the new zone
 
+  // GetPoint(Index) is O(n) per call (NCollection_Sequence has no O(1)
+  // indexed access), so calling it inside the nested loop below made every
+  // comparison pay that cost again. Points() caches a random-access array
+  // per zone instead: same comparisons, same result, O(1) lookup.
+  const NCollection_Array1<Intf_SectionPoint>& laZonePts = LaZone.Points();
+
   // Loop on TangentZone :
   for (int Iz = 1; Iz <= myTZones.Length(); Iz++)
   {
 
     // Loop on edges of the TangentZone :
-    npcz = myTZones(Iz).NumberOfPoints();
-    int Ipz0, Ipz1, Ipz2;
+    npcz                                                    = myTZones(Iz).NumberOfPoints();
+    const NCollection_Array1<Intf_SectionPoint>& curZonePts = myTZones(Iz).Points();
+    int                                          Ipz0, Ipz1, Ipz2;
     for (Ipz1 = 1; Ipz1 <= npcz; Ipz1++)
     {
       Ipz0 = Ipz1 - 1;
@@ -86,9 +117,9 @@ bool Intf_Interference::Insert(const Intf_TangentZone& LaZone)
       {
         Ilz2 = (Ilz1 % nplz) + 1;
 
-        if ((myTZones(Iz).GetPoint(Ipz1)).IsEqual(LaZone.GetPoint(Ilz1)))
+        if (curZonePts(Ipz1).IsEqual(laZonePts(Ilz1)))
         {
-          if ((myTZones(Iz).GetPoint(Ipz0)).IsEqual(LaZone.GetPoint(Ilz2)))
+          if (curZonePts(Ipz0).IsEqual(laZonePts(Ilz2)))
           {
             lzin = Iz;
             lunp = Ipz0;
@@ -98,7 +129,7 @@ bool Intf_Interference::Insert(const Intf_TangentZone& LaZone)
             same = false;
             break;
           }
-          else if ((myTZones(Iz).GetPoint(Ipz2)).IsEqual(LaZone.GetPoint(Ilz2)))
+          else if (curZonePts(Ipz2).IsEqual(laZonePts(Ilz2)))
           {
             lzin = Iz;
             lunp = Ipz1;
@@ -132,7 +163,7 @@ bool Intf_Interference::Insert(const Intf_TangentZone& LaZone)
   {
     for (Ilc = lotl + 1; (((Ilc - 1) % nplz) + 1) != lunl; Ilc++)
     {
-      myTZones(lzin).InsertBefore(lotp, LaZone.GetPoint(((Ilc - 1) % nplz) + 1));
+      myTZones(lzin).InsertBefore(lotp, laZonePts(((Ilc - 1) % nplz) + 1));
       if (!same)
       {
         lotp++;
@@ -145,7 +176,7 @@ bool Intf_Interference::Insert(const Intf_TangentZone& LaZone)
     bool loop = false;
     for (Ilc = lunl;; Ilc++)
     {
-      myTZones(lzin).InsertBefore(lunp, LaZone.GetPoint((((Ilc - 1) % nplz) + 1)));
+      myTZones(lzin).InsertBefore(lunp, laZonePts((((Ilc - 1) % nplz) + 1)));
       lunp++;
       if (loop && (((Ilc - 1) % nplz) + 1) == lunl)
       {
@@ -324,4 +355,19 @@ void Intf_Interference::Dump() const
   {
     myTZones(t).Dump(2);
   }
+}
+
+//=================================================================================================
+
+Intf_InterferenceBreakerScope::Intf_InterferenceBreakerScope(const Message_ProgressScope* theScope)
+{
+  myPrev = t_intfBreaker;
+  Intf_Interference::SetBreaker(theScope);
+}
+
+//=================================================================================================
+
+Intf_InterferenceBreakerScope::~Intf_InterferenceBreakerScope()
+{
+  Intf_Interference::SetBreaker(myPrev);
 }

--- a/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_Interference.hxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_Interference.hxx
@@ -29,6 +29,7 @@
 class Intf_SectionPoint;
 class Intf_SectionLine;
 class Intf_TangentZone;
+class Message_ProgressScope;
 
 //! Describes the Interference computation result
 //! between polygon2d or polygon3d or polyhedron
@@ -72,7 +73,17 @@ public:
   //! Inserts a new zone of tangence in the current list of
   //! tangent zones of the interference and returns True
   //! when done.
+  //!
+  //! Periodically polls the breaker set by SetBreaker, if any, and throws
+  //! Standard_Failure to abort early if it signals UserBreak. No breaker
+  //! set (the default) is zero-overhead.
   Standard_EXPORT bool Insert(const Intf_TangentZone& TheZone);
+
+  //! Sets (or clears, with nullptr) the thread-local breaker Insert()
+  //! polls. theScope must outlive the Insert() calls it is set for; use
+  //! Intf_InterferenceBreakerScope for exception-safe scoping. Only safe
+  //! for callers that guarantee single-threaded execution.
+  Standard_EXPORT static void SetBreaker(const Message_ProgressScope* theScope);
 
   //! Insert a new segment of intersection in the current list of
   //! polylines of intersection of the interference.
@@ -98,5 +109,21 @@ protected:
 };
 
 #include <Intf_Interference.lxx>
+
+//! RAII scope for Intf_Interference::SetBreaker: restores the previous
+//! breaker (typically null) on destruction, including when unwound by the
+//! abort exception it enabled.
+class Intf_InterferenceBreakerScope
+{
+public:
+  Standard_EXPORT Intf_InterferenceBreakerScope(const Message_ProgressScope* theScope);
+  Standard_EXPORT ~Intf_InterferenceBreakerScope();
+
+private:
+  Intf_InterferenceBreakerScope(const Intf_InterferenceBreakerScope&)            = delete;
+  Intf_InterferenceBreakerScope& operator=(const Intf_InterferenceBreakerScope&) = delete;
+
+  const Message_ProgressScope* myPrev;
+};
 
 #endif // _Intf_Interference_HeaderFile

--- a/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_TangentZone.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_TangentZone.cxx
@@ -36,6 +36,7 @@ Intf_TangentZone::Intf_TangentZone()
 
 void Intf_TangentZone::Append(const Intf_SectionPoint& Pi)
 {
+  myPtsCacheValid = false;
   Result.Append(Pi);
   if (ParamOnFirstMin > Pi.ParamOnFirst())
   {
@@ -174,6 +175,7 @@ void Intf_TangentZone::PolygonInsert(const Intf_SectionPoint& Pi)
 
 void Intf_TangentZone::InsertAfter(const int Index, const Intf_SectionPoint& Pi)
 {
+  myPtsCacheValid = false;
   Result.InsertAfter(Index, Pi);
   if (ParamOnFirstMin > Pi.ParamOnFirst())
   {
@@ -198,6 +200,7 @@ void Intf_TangentZone::InsertAfter(const int Index, const Intf_SectionPoint& Pi)
 
 void Intf_TangentZone::InsertBefore(const int Index, const Intf_SectionPoint& Pi)
 {
+  myPtsCacheValid = false;
   Result.InsertBefore(Index, Pi);
   if (ParamOnFirstMin > Pi.ParamOnFirst())
   {
@@ -226,6 +229,28 @@ void Intf_TangentZone::InsertBefore(const int Index, const Intf_SectionPoint& Pi
 const Intf_SectionPoint& Intf_TangentZone::GetPoint(const int Index) const
 {
   return Result(Index);
+}
+
+//=================================================================================================
+
+const NCollection_Array1<Intf_SectionPoint>& Intf_TangentZone::Points() const
+{
+  if (!myPtsCacheValid)
+  {
+    const int aNb = Result.Length();
+    if (aNb > 0)
+    {
+      myPtsCache.Resize(1, aNb, false);
+      int i = 1;
+      for (NCollection_Sequence<Intf_SectionPoint>::Iterator anIt(Result); anIt.More();
+           anIt.Next(), ++i)
+      {
+        myPtsCache.SetValue(i, anIt.Value());
+      }
+    }
+    myPtsCacheValid = true;
+  }
+  return myPtsCache;
 }
 
 //=================================================================================================

--- a/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_TangentZone.hxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/Intf/Intf_TangentZone.hxx
@@ -22,6 +22,7 @@
 #include <Standard_Handle.hxx>
 
 #include <Intf_SectionPoint.hxx>
+#include <NCollection_Array1.hxx>
 #include <NCollection_Sequence.hxx>
 #include <Standard_Boolean.hxx>
 class Intf_SectionPoint;
@@ -39,6 +40,12 @@ public:
   //! Gives the SectionPoint of address <Index> in the
   //! TangentZone.
   Standard_EXPORT const Intf_SectionPoint& GetPoint(const int Index) const;
+
+  //! All points (1-based), for callers that touch every point of a large
+  //! TangentZone. Builds and caches a true random-access array in one
+  //! linear pass; the cache is invalidated by any mutation. Faster than
+  //! looping GetPoint(Index), which is O(n) per call.
+  Standard_EXPORT const NCollection_Array1<Intf_SectionPoint>& Points() const;
 
   //! Compares two TangentZones.
   Standard_EXPORT bool IsEqual(const Intf_TangentZone& Other) const;
@@ -101,6 +108,10 @@ private:
   double                                  ParamOnFirstMax;
   double                                  ParamOnSecondMin;
   double                                  ParamOnSecondMax;
+
+  // Points() cache, invalidated by any mutation.
+  mutable NCollection_Array1<Intf_SectionPoint> myPtsCache;
+  mutable bool                                  myPtsCacheValid = false;
 };
 
 #include <Intf_TangentZone.lxx>


### PR DESCRIPTION
## Summary

Fixes #1385: `BOPAlgo_ArgumentAnalyzer`'s self-interference check (`SelfInterMode()`) can run effectively unbounded on a degenerate self-intersecting surface.

1. `Intf_Interference::Insert` called `Intf_TangentZone::GetPoint(Index)` repeatedly inside a nested comparison loop. `GetPoint` is O(n) per call (the backing `NCollection_Sequence` has no O(1) indexed access), so every comparison paid that cost again -- measured ~80% of runtime in `NCollection_BaseSequence::Find` on the artifact in #1385. `Intf_TangentZone::Points()` now caches a true random-access array per zone (invalidated on any mutation): same comparisons, same result, O(1) lookup.

2. The self-interference phase never polled its cooperative progress indicator below `BOPAlgo_CheckerSI::CheckFaceSelfIntersection`, so a caller's timeout could only fire between whole-face checks, not within one -- 619s CPU against a 30s deadline on the artifact in #1385, never returning. `Intf_Interference::SetBreaker` (RAII-scoped via `Intf_InterferenceBreakerScope`) lets `Insert()` poll every 256 calls and abort by throwing `Standard_Failure`. Wired up in `BOPAlgo_CheckerSI`'s self-intersect functor, **only when execution is guaranteed single-threaded** -- an exception thrown from a worker thread of `OSD_Parallel::For`'s parallel path would be unsafe (`std::terminate`).

## Verification

On the artifact linked in #1385: with both fixes, a 0.5s deadline returns in 0.547s and a 30s deadline returns in 30.1s (vs. 619s+/never on stock), with correct `HasFaulty()` results throughout (the 0.5s case correctly reports "not yet determined" rather than a false negative, since the breaker trips before any fault is recorded).

Locally (minimal-module `RelWithDebInfo` build, `FoundationClasses`+`ModelingData`+`ModelingAlgorithms` only):
- New GTests (`Intf_TangentZone_Test.cxx`, `Intf_Interference_Test.cxx`): 8/8 pass.
- Related existing suites (`Intf_*`, `IntPatch_*`, `IntTools_*`, `BOPAlgo_*`, `BRepAlgoAPI_*`): 76/76 pass.
- Full `OpenCascadeGTest`: 7241/7249 pass. The 8 failures are all `BRepMesh_DiscretAlgoFactoryTest` (mesh discretization plugin self-registration), an artifact of this being a minimal-module local build -- unrelated to this change and not touched by it.

## Test plan

- [x] `clang-format --style=file` applied to all changed files.
- [x] New GTests added and passing locally.
- [x] No regression on related existing GTests.
- [x] CI (opening as draft to check style/build/test results first, per CONTRIBUTING.md).