### PR TITLE
OCAF - Fix data races in XCAFApp_Application::GetApplication and CDF_Directory

### DIFF
--- a/src/ApplicationFramework/TKCDF/CDF/CDF_Application.cxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_Application.cxx
@@ -472,6 +472,7 @@ void CDF_Application::Read(Standard_IStream&                     theIStream,
 occ::handle<PCDM_Reader> CDF_Application::ReaderFromFormat(
   const TCollection_ExtendedString& theFormat)
 {
+  std::lock_guard<std::mutex> aLock(myReadersWritersMutex);
   // check map of readers
   occ::handle<PCDM_RetrievalDriver> aReader;
   if (myReaders.FindFromKey(theFormat, aReader))
@@ -531,6 +532,7 @@ occ::handle<PCDM_Reader> CDF_Application::ReaderFromFormat(
 occ::handle<PCDM_StorageDriver> CDF_Application::WriterFromFormat(
   const TCollection_ExtendedString& theFormat)
 {
+  std::lock_guard<std::mutex> aLock(myReadersWritersMutex);
   // check map of writers
   occ::handle<PCDM_StorageDriver> aDriver;
   if (myWriters.FindFromKey(theFormat, aDriver))

--- a/src/ApplicationFramework/TKCDF/CDF/CDF_Application.hxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_Application.hxx
@@ -25,6 +25,7 @@
 #include <CDM_CanCloseStatus.hxx>
 #include <Standard_IStream.hxx>
 #include <NCollection_IndexedDataMap.hxx>
+#include <mutex>
 
 class Standard_GUID;
 class CDM_Document;
@@ -233,6 +234,7 @@ protected:
   NCollection_IndexedDataMap<TCollection_ExtendedString, occ::handle<PCDM_RetrievalDriver>>
                                                                                           myReaders;
   NCollection_IndexedDataMap<TCollection_ExtendedString, occ::handle<PCDM_StorageDriver>> myWriters;
+  mutable std::mutex myReadersWritersMutex;
 
 private:
   TCollection_ExtendedString myDefaultFolder;

--- a/src/ApplicationFramework/TKCDF/CDF/CDF_Directory.cxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_Directory.cxx
@@ -25,16 +25,23 @@ IMPLEMENT_STANDARD_RTTIEXT(CDF_Directory, Standard_Transient)
 
 CDF_Directory::CDF_Directory() = default;
 
+// myMutex-guarded; inlined instead of calling Contains() to avoid a recursive lock.
 void CDF_Directory::Add(const occ::handle<CDM_Document>& aDocument)
 {
-  if (!Contains(aDocument))
+  std::lock_guard<std::mutex> aLock(myMutex);
+  for (NCollection_List<occ::handle<CDM_Document>>::Iterator it(myDocuments); it.More(); it.Next())
   {
-    myDocuments.Append(aDocument);
+    if (aDocument == it.Value())
+    {
+      return;
+    }
   }
+  myDocuments.Append(aDocument);
 }
 
 void CDF_Directory::Remove(const occ::handle<CDM_Document>& aDocument)
 {
+  std::lock_guard<std::mutex> aLock(myMutex);
   for (NCollection_List<occ::handle<CDM_Document>>::Iterator it(myDocuments); it.More(); it.Next())
   {
     if (aDocument == it.Value())
@@ -47,6 +54,7 @@ void CDF_Directory::Remove(const occ::handle<CDM_Document>& aDocument)
 
 bool CDF_Directory::Contains(const occ::handle<CDM_Document>& aDocument) const
 {
+  std::lock_guard<std::mutex> aLock(myMutex);
   for (NCollection_List<occ::handle<CDM_Document>>::Iterator it(myDocuments); it.More(); it.Next())
   {
     if (aDocument == it.Value())
@@ -59,6 +67,7 @@ bool CDF_Directory::Contains(const occ::handle<CDM_Document>& aDocument) const
 
 int CDF_Directory::Length() const
 {
+  std::lock_guard<std::mutex> aLock(myMutex);
   return myDocuments.Extent();
 }
 
@@ -70,13 +79,15 @@ const NCollection_List<occ::handle<CDM_Document>>& CDF_Directory::List() const
 
 bool CDF_Directory::IsEmpty() const
 {
+  std::lock_guard<std::mutex> aLock(myMutex);
   return myDocuments.IsEmpty();
 }
 
 occ::handle<CDM_Document> CDF_Directory::Last()
 {
+  std::lock_guard<std::mutex> aLock(myMutex);
   Standard_NoSuchObject_Raise_if(
-    IsEmpty(),
+    myDocuments.IsEmpty(),
     "CDF_Directory::Last: the directory does not contain any document");
   return myDocuments.Last();
 }

--- a/src/ApplicationFramework/TKCDF/CDF/CDF_Directory.hxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_Directory.hxx
@@ -23,6 +23,7 @@
 #include <NCollection_List.hxx>
 #include <Standard_Transient.hxx>
 #include <Standard_Integer.hxx>
+#include <mutex>
 class CDM_Document;
 
 //! A directory is a collection of documents. There is only one instance
@@ -62,6 +63,7 @@ private:
   Standard_EXPORT const NCollection_List<occ::handle<CDM_Document>>& List() const;
 
   NCollection_List<occ::handle<CDM_Document>> myDocuments;
+  mutable std::mutex                          myMutex;
 };
 
 #endif // _CDF_Directory_HeaderFile

--- a/src/ApplicationFramework/TKLCAF/TDocStd/TDocStd_Application.cxx
+++ b/src/ApplicationFramework/TKLCAF/TDocStd/TDocStd_Application.cxx
@@ -59,6 +59,7 @@ bool TDocStd_Application::IsDriverLoaded() const
 
 occ::handle<Resource_Manager> TDocStd_Application::Resources()
 {
+  std::lock_guard<std::mutex> aLock(myResourcesMutex);
   if (myResources.IsNull())
   {
     myResources = new Resource_Manager(ResourcesName());
@@ -99,6 +100,7 @@ void TDocStd_Application::DefineFormat(const TCollection_AsciiString&           
   }
 
   // register drivers
+  std::lock_guard<std::mutex> aLock(myReadersWritersMutex);
   myReaders.Add(theFormat, theReader);
   myWriters.Add(theFormat, theWriter);
 }
@@ -109,6 +111,7 @@ void TDocStd_Application::ReadingFormats(NCollection_Sequence<TCollection_AsciiS
 {
   theFormats.Clear();
 
+  std::lock_guard<std::mutex> aLock(myReadersWritersMutex);
   NCollection_IndexedDataMap<TCollection_ExtendedString,
                              occ::handle<PCDM_RetrievalDriver>>::Iterator anIter(myReaders);
   for (; anIter.More(); anIter.Next())
@@ -127,6 +130,7 @@ void TDocStd_Application::WritingFormats(NCollection_Sequence<TCollection_AsciiS
 {
   theFormats.Clear();
 
+  std::lock_guard<std::mutex> aLock(myReadersWritersMutex);
   NCollection_IndexedDataMap<TCollection_ExtendedString, occ::handle<PCDM_StorageDriver>>::Iterator
     anIter(myWriters);
   for (; anIter.More(); anIter.Next())
@@ -502,7 +506,7 @@ PCDM_StoreStatus TDocStd_Application::SaveAs(const occ::handle<TDocStd_Document>
     theStatusMessage = TCollection_ExtendedString("TDocStd_Application::SaveAs"
                                                   ": No such directory ")
                        + directory;
-    aStatus = PCDM_SS_Failure;
+    aStatus          = PCDM_SS_Failure;
   }
   return aStatus;
 }

--- a/src/ApplicationFramework/TKLCAF/TDocStd/TDocStd_Application.cxx
+++ b/src/ApplicationFramework/TKLCAF/TDocStd/TDocStd_Application.cxx
@@ -506,7 +506,7 @@ PCDM_StoreStatus TDocStd_Application::SaveAs(const occ::handle<TDocStd_Document>
     theStatusMessage = TCollection_ExtendedString("TDocStd_Application::SaveAs"
                                                   ": No such directory ")
                        + directory;
-    aStatus          = PCDM_SS_Failure;
+    aStatus = PCDM_SS_Failure;
   }
   return aStatus;
 }

--- a/src/ApplicationFramework/TKLCAF/TDocStd/TDocStd_Application.hxx
+++ b/src/ApplicationFramework/TKLCAF/TDocStd/TDocStd_Application.hxx
@@ -28,6 +28,7 @@
 #include <PCDM_ReaderStatus.hxx>
 #include <PCDM_StoreStatus.hxx>
 #include <TDocStd_Document.hxx>
+#include <mutex>
 
 class Resource_Manager;
 class CDM_Document;
@@ -325,6 +326,7 @@ public:
 protected:
   occ::handle<Resource_Manager> myResources;
   bool                          myIsDriverLoaded;
+  mutable std::mutex            myResourcesMutex;
 };
 
 #endif // _TDocStd_Application_HeaderFile

--- a/src/DataExchange/TKXCAF/XCAFApp/XCAFApp_Application.cxx
+++ b/src/DataExchange/TKXCAF/XCAFApp/XCAFApp_Application.cxx
@@ -27,11 +27,9 @@ IMPLEMENT_STANDARD_RTTIEXT(XCAFApp_Application, TDocStd_Application)
 
 occ::handle<XCAFApp_Application> XCAFApp_Application::GetApplication()
 {
-  static occ::handle<XCAFApp_Application> locApp;
-  if (locApp.IsNull())
-  {
-    locApp = new XCAFApp_Application;
-  }
+  // Construct in the initializer: thread-safe exactly once (C++11 magic statics),
+  // unlike the previous separate IsNull()-guarded assignment.
+  static occ::handle<XCAFApp_Application> locApp = new XCAFApp_Application;
   return locApp;
 }
 

--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
@@ -153,6 +153,7 @@ Resource_Manager::Resource_Manager()
 //=================================================================================================
 
 Resource_Manager::Resource_Manager(const Resource_Manager& theOther)
+    : Standard_Transient()
 {
   std::lock_guard<std::recursive_mutex> aLock(theOther.myMutex);
   myName        = theOther.myName;

--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
@@ -152,6 +152,19 @@ Resource_Manager::Resource_Manager()
 
 //=================================================================================================
 
+Resource_Manager::Resource_Manager(const Resource_Manager& theOther)
+{
+  std::lock_guard<std::recursive_mutex> aLock(theOther.myMutex);
+  myName        = theOther.myName;
+  myRefMap      = theOther.myRefMap;
+  myUserMap     = theOther.myUserMap;
+  myExtStrMap   = theOther.myExtStrMap;
+  myVerbose     = theOther.myVerbose;
+  myInitialized = theOther.myInitialized;
+}
+
+//=================================================================================================
+
 void Resource_Manager::Load(
   const TCollection_AsciiString&                                         thePath,
   NCollection_DataMap<TCollection_AsciiString, TCollection_AsciiString>& aMap)
@@ -322,7 +335,8 @@ static int GetLine(OSD_File& aFile, TCollection_AsciiString& aLine)
 //=======================================================================
 bool Resource_Manager::Save() const
 {
-  TCollection_AsciiString anEnvVar("CSF_");
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               anEnvVar("CSF_");
   anEnvVar += myName;
   anEnvVar += "UserDefaults";
 
@@ -455,7 +469,8 @@ bool Resource_Manager::Save() const
 
 int Resource_Manager::Integer(const char* const aResourceName) const
 {
-  TCollection_AsciiString Result = Value(aResourceName);
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               Result = Value(aResourceName);
   if (!Result.IsIntegerValue())
   {
     TCollection_AsciiString n("Value of resource `");
@@ -473,7 +488,8 @@ int Resource_Manager::Integer(const char* const aResourceName) const
 
 double Resource_Manager::Real(const char* const aResourceName) const
 {
-  TCollection_AsciiString Result = Value(aResourceName);
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               Result = Value(aResourceName);
   if (!Result.IsRealValue())
   {
     TCollection_AsciiString n("Value of resource `");
@@ -491,7 +507,8 @@ double Resource_Manager::Real(const char* const aResourceName) const
 
 const char* Resource_Manager::Value(const char* const aResource) const
 {
-  TCollection_AsciiString Resource(aResource);
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               Resource(aResource);
   if (myUserMap.IsBound(Resource))
   {
     return myUserMap(Resource).ToCString();
@@ -510,7 +527,8 @@ const char* Resource_Manager::Value(const char* const aResource) const
 
 const char16_t* Resource_Manager::ExtValue(const char* const aResource)
 {
-  TCollection_AsciiString Resource(aResource);
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               Resource(aResource);
   if (myExtStrMap.IsBound(Resource))
   {
     return myExtStrMap(Resource).ToExtString();
@@ -532,6 +550,7 @@ const char16_t* Resource_Manager::ExtValue(const char* const aResource)
 //=======================================================================
 void Resource_Manager::SetResource(const char* const aResourceName, const int aValue)
 {
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
   SetResource(aResourceName, TCollection_AsciiString(aValue).ToCString());
 }
 
@@ -542,6 +561,7 @@ void Resource_Manager::SetResource(const char* const aResourceName, const int aV
 //=======================================================================
 void Resource_Manager::SetResource(const char* const aResourceName, const double aValue)
 {
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
   SetResource(aResourceName, TCollection_AsciiString(aValue).ToCString());
 }
 
@@ -552,10 +572,11 @@ void Resource_Manager::SetResource(const char* const aResourceName, const double
 //=======================================================================
 void Resource_Manager::SetResource(const char* const aResource, const char16_t* const aValue)
 {
-  Standard_PCharacter        pStr;
-  TCollection_AsciiString    Resource = aResource;
-  TCollection_ExtendedString ExtValue = aValue;
-  TCollection_AsciiString    FormatStr(ExtValue.Length() * 3 + 10, ' ');
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  Standard_PCharacter                   pStr;
+  TCollection_AsciiString               Resource = aResource;
+  TCollection_ExtendedString            ExtValue = aValue;
+  TCollection_AsciiString               FormatStr(ExtValue.Length() * 3 + 10, ' ');
 
   if (!myExtStrMap.Bind(Resource, ExtValue))
   {
@@ -577,8 +598,9 @@ void Resource_Manager::SetResource(const char* const aResource, const char16_t* 
 //=======================================================================
 void Resource_Manager::SetResource(const char* const aResource, const char* const aValue)
 {
-  TCollection_AsciiString Resource = aResource;
-  TCollection_AsciiString Value    = aValue;
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               Resource = aResource;
+  TCollection_AsciiString               Value    = aValue;
   if (!myUserMap.Bind(Resource, Value))
   {
     myUserMap(Resource) = Value;
@@ -589,7 +611,8 @@ void Resource_Manager::SetResource(const char* const aResource, const char* cons
 
 bool Resource_Manager::Find(const char* const aResource) const
 {
-  TCollection_AsciiString Resource(aResource);
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
+  TCollection_AsciiString               Resource(aResource);
   return myUserMap.IsBound(Resource) || myRefMap.IsBound(Resource);
 }
 
@@ -598,6 +621,7 @@ bool Resource_Manager::Find(const char* const aResource) const
 bool Resource_Manager::Find(const TCollection_AsciiString& theResource,
                             TCollection_AsciiString&       theValue) const
 {
+  std::lock_guard<std::recursive_mutex> aLock(myMutex);
   return myUserMap.Find(theResource, theValue) || myRefMap.Find(theResource, theValue);
 }
 

--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.hxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.hxx
@@ -28,6 +28,7 @@
 #include <Standard_CString.hxx>
 #include <Standard_Integer.hxx>
 #include <Standard_Real.hxx>
+#include <mutex>
 
 //! Defines a resource structure and its management methods.
 class Resource_Manager : public Standard_Transient
@@ -60,6 +61,10 @@ public:
                                    const TCollection_AsciiString& theDefaultsDirectory,
                                    const TCollection_AsciiString& theUserDefaultsDirectory,
                                    const bool                     theIsVerbose = false);
+
+  //! Copies the maps under theOther's lock; myMutex is not itself copyable and is
+  //! default-constructed.
+  Standard_EXPORT Resource_Manager(const Resource_Manager& theOther);
 
   //! Save the user resource structure in the specified file.
   //! Creates the file if it does not exist.
@@ -132,6 +137,7 @@ private:
   NCollection_DataMap<TCollection_AsciiString, TCollection_ExtendedString> myExtStrMap;
   bool                                                                     myVerbose;
   bool                                                                     myInitialized;
+  mutable std::recursive_mutex                                             myMutex;
 };
 
 #endif // _Resource_Manager_HeaderFile


### PR DESCRIPTION
## Summary

`XCAFApp_Application::GetApplication()`'s lazy singleton init races two threads' first concurrent
call: both can observe `locApp.IsNull()` and both construct a new `XCAFApp_Application`, racing to
assign the shared handle. ThreadSanitizer shows this is the most severe of several races on the
same shared singleton — it produces multiple concurrently-constructed `XCAFApp_Application`
instances, cascading into races across dozens of unrelated destructors (`TDF_LabelNode::Destroy`,
`CDM_Document::~CDM_Document`, `NCollection_BaseList::PClear`, ...) as the "losing" instances are
torn down while other threads are still constructing/using a same-generation object.

`CDF_Directory::Add`/`Remove`/`Contains` mutate/read `myDocuments` (a plain `NCollection_List`) with
zero synchronization. Every `CDF_Application` is normally a single process-wide instance shared by
every caller — that's the entire point of a `GetApplication()`-style accessor — so its one
`CDF_Directory` receives `Add()` from every document-creating call on every thread, racing on
`NCollection_BaseList::PAppend`.

Confirmed via a real crash (not just a theoretical race): a debug build with a temporary
`SIGSEGV`/`SIGBUS` handler resolves the crash to
`TDocStd_Application::NewDocument -> CDF_Application::Open` (which calls
`myDirectory->Add(aDocument)`), at a garbage-looking fault address consistent with linked-list
corruption from concurrent `PAppend` calls.

**Second commit, found during validation**: fixing `GetApplication()`'s race means every caller
now genuinely shares ONE `TDocStd_Application` instance (as intended) — which surfaced further
races on that *same* instance's other unsynchronized state, previously masked by threads sometimes
getting different (uncontended) instances of their own:

- `TDocStd_Application::Resources()` has the identical lazy-init race pattern as `GetApplication()`.
- `Resource_Manager`'s own maps (`myRefMap`/`myUserMap`/`myExtStrMap`) have no synchronization at
  all.
- `CDF_Application::myReaders`/`myWriters` (format-name → driver maps) are read/written from
  `DefineFormat`, `ReaderFromFormat`/`WriterFromFormat`, and `ReadingFormats`/`WritingFormats` with
  no locking.

## Fix

1. `XCAFApp_Application::GetApplication()`: fold construction into the static local's initializer.
   A function-local static's dynamic initializer is guaranteed thread-safe exactly once (C++11
   "magic statics", N2660), unlike the previous separate `IsNull()`-guarded assignment.
2. `CDF_Directory`: a private `mutable std::mutex myMutex` guards `Add`/`Remove`/`Contains`/
   `Length`/`IsEmpty`/`Last`. `Add()` inlines the containment scan instead of calling the public
   `Contains()`, to avoid a self-deadlock on the (non-recursive) mutex. `List()` — used only by the
   friend `CDF_DirectoryIterator` — is intentionally left unguarded; closing that gap would need a
   bigger API change (a snapshot copy) out of proportion to the races this PR fixes.
3. `TDocStd_Application::Resources()`: a mutex guards the lazy-init, same pattern as fix 1.
4. `Resource_Manager`: a `std::recursive_mutex` (recursive because `Integer()`/`Real()`/`ExtValue()`
   call `Value()` internally, and the `int`/`double` `SetResource()` overloads call the `char*`
   one) guards `Save`, `Integer`, `Real`, `Value`, `ExtValue`, all four `SetResource` overloads, and
   both `Find` overloads. `GetMap()` — a raw-reference escape hatch with no other callers in this
   area — is left unguarded, same rationale as `CDF_Directory::List()` above. The new mutex member
   makes the class non-copyable by default, breaking `ShapeProcess_Context.cxx`'s existing
   (pre-existing, unrelated) `new Resource_Manager(*sRC)` thread-safety workaround — added an
   explicit copy constructor that copies the maps under the source's lock and default-constructs a
   fresh mutex for the new instance.
5. `CDF_Application`: a mutex guards `myReaders`/`myWriters` across all their access points
   (`ReaderFromFormat`/`WriterFromFormat` in this file; `DefineFormat`/`ReadingFormats`/
   `WritingFormats` in `TDocStd_Application.cxx`, which directly touch these protected members).

## Testing

Minimal-module ThreadSanitizer build (`FoundationClasses`+`ModelingData`+`ModelingAlgorithms`+
`DataExchange`, `RelWithDebInfo`, `-fsanitize=thread`). A pure-C++ harness runs N threads, each
calling `XCAFApp_Application::GetApplication()->NewDocument(...)`.

- Before (commit 1's baseline): 8 threads × 200 iterations reports 234 distinct race warnings — the
  large majority in the `GetApplication()`/destructor-cascade class, the remainder directly on
  `CDF_Directory.cxx`/`NCollection_BaseList.cxx` (`PAppend`).
- After commit 1 alone: 9 warnings remain, all in `CDF_Directory::Add`/`NCollection_BaseList::
  PAppend`, all showing the *same* mutex held on both sides of the reported conflict — a pattern
  consistent with a TSan/allocator-recycling artifact, not a genuine unaddressed race (a control
  program with a trivially-correct `std::lock_guard` pattern under identical TSan flags reports no
  such warning). The `GetApplication()`-driven destructor cascade is gone entirely.
- Separately, repeated `swift test` runs against a downstream Swift wrapper
  (SecondMouseAU/OCCTSwift) surfaced the `Resource_Manager`/`myReaders`/`myWriters` races commit 2
  fixes: SIGTRAP in `Resource_Manager::SetResource` (via `TDocStd_Application::DefineFormat`) and
  SIGSEGV in `TDocStd_Application::ReadingFormats`, both reproducible before commit 2 and clean
  across 12 further runs after it.
- Zero regression on unrelated concurrent-shape-creation and independent-meshing scenarios (same
  scenarios exercised for #1387/#1388).

No behavior change for the documented semantics of any of the affected classes — this only closes
the underlying data races. A separate, deeper issue (concurrent Save/Store of the same format
shares one non-reentrant cached storage-driver instance, e.g. `BinLDrivers_DocumentStorageDriver`)
was also found during validation but is architecturally different (a shared worker object, not a
container needing a lock) and is being tracked separately rather than folded into this PR.

Fixes #1389.
