### PR TITLE
Modeling Algorithms, UnifySameDomain - Guard null pcurve dereferences

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeUpgrade_UnifySameDomain_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeUpgrade_UnifySameDomain_Test.cxx
@@ -20,9 +20,14 @@
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepBuilderAPI_Sewing.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
-#include <Geom_Plane.hxx>
+#include <Geom_CylindricalSurface.hxx>
+#include <Geom2d_Line.hxx>
+#include <gp_Dir2d.hxx>
 #include <gp_Pln.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <Precision.hxx>
 #include <ShapeUpgrade_UnifySameDomain.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
@@ -32,9 +37,238 @@
 #include <TopoDS_Shell.hxx>
 #include <TopoDS_Wire.hxx>
 
+#include <cmath>
+
 //=================================================================================================
 // ShapeUpgrade_UnifySameDomain Tests
 //=================================================================================================
+
+namespace
+{
+struct MissingPCurveShape
+{
+  TopoDS_Shell Shell;
+  TopoDS_Face  ReferenceFace;
+  TopoDS_Edge  MissingPCurveEdge;
+  TopoDS_Edge  ValidPCurveEdge;
+};
+
+static TopoDS_Vertex makeVertex(BRep_Builder& theBuilder, const gp_Pnt& thePoint)
+{
+  TopoDS_Vertex aVertex;
+  theBuilder.MakeVertex(aVertex, thePoint, Precision::Confusion());
+  return aVertex;
+}
+
+static TopoDS_Edge makeEdge(BRep_Builder&                    theBuilder,
+                            const occ::handle<Geom_Surface>& theSurface,
+                            const TopLoc_Location&           theLocation,
+                            const TopoDS_Vertex&             theFirst,
+                            const TopoDS_Vertex&             theLast,
+                            const bool                       theAddPCurve)
+{
+  BRepBuilderAPI_MakeEdge anEdgeMaker(theFirst, theLast);
+  if (!anEdgeMaker.IsDone())
+  {
+    return TopoDS_Edge();
+  }
+
+  TopoDS_Edge anEdge = anEdgeMaker.Edge();
+  if (theAddPCurve)
+  {
+    const gp_Pnt&  aFirstPoint = BRep_Tool::Pnt(theFirst);
+    const gp_Pnt&  aLastPoint  = BRep_Tool::Pnt(theLast);
+    const gp_Pnt2d aFirstPoint2d(std::atan2(aFirstPoint.Y(), aFirstPoint.X()), aFirstPoint.Z());
+    const gp_Pnt2d aLastPoint2d(std::atan2(aLastPoint.Y(), aLastPoint.X()), aLastPoint.Z());
+    const gp_Vec2d aDirection(aFirstPoint2d, aLastPoint2d);
+    occ::handle<Geom2d_Curve> aPCurve = new Geom2d_Line(aFirstPoint2d, gp_Dir2d(aDirection));
+    theBuilder.UpdateEdge(anEdge, aPCurve, theSurface, theLocation, Precision::Confusion());
+    theBuilder.Range(anEdge, 0.0, aDirection.Magnitude());
+  }
+  return anEdge;
+}
+
+static MissingPCurveShape makeMissingPCurveShape(BRep_Builder& theBuilder)
+{
+  const occ::handle<Geom_CylindricalSurface> aSurface = new Geom_CylindricalSurface(gp::XOY(), 1.0);
+  const TopLoc_Location                      aLocation;
+  const TopoDS_Vertex aVertexA = makeVertex(theBuilder, aSurface->Value(0.0, 0.0));
+  const TopoDS_Vertex aVertexB = makeVertex(theBuilder, aSurface->Value(1.0, 0.0));
+  const TopoDS_Vertex aVertexC = makeVertex(theBuilder, aSurface->Value(1.0, 1.0));
+  const TopoDS_Vertex aVertexD = makeVertex(theBuilder, aSurface->Value(0.5, -1.0));
+  const TopoDS_Vertex aVertexE = makeVertex(theBuilder, aSurface->Value(0.5, 1.0));
+
+  const TopoDS_Edge aCommonEdge =
+    makeEdge(theBuilder, aSurface, aLocation, aVertexA, aVertexB, true);
+  const TopoDS_Edge anEdgeBC = makeEdge(theBuilder, aSurface, aLocation, aVertexB, aVertexC, false);
+  const TopoDS_Edge anEdgeCB = makeEdge(theBuilder, aSurface, aLocation, aVertexC, aVertexB, true);
+  const TopoDS_Edge anEdgeBD = makeEdge(theBuilder, aSurface, aLocation, aVertexB, aVertexD, true);
+  const TopoDS_Edge anEdgeDA = makeEdge(theBuilder, aSurface, aLocation, aVertexD, aVertexA, true);
+  const TopoDS_Edge anEdgeAE = makeEdge(theBuilder, aSurface, aLocation, aVertexA, aVertexE, true);
+  const TopoDS_Edge anEdgeEB = makeEdge(theBuilder, aSurface, aLocation, aVertexE, aVertexB, true);
+
+  TopoDS_Wire aSelfTouchingWire;
+  theBuilder.MakeWire(aSelfTouchingWire);
+  theBuilder.Add(aSelfTouchingWire, aCommonEdge);
+  theBuilder.Add(aSelfTouchingWire, anEdgeBC);
+  theBuilder.Add(aSelfTouchingWire, anEdgeCB);
+  theBuilder.Add(aSelfTouchingWire, anEdgeBD);
+  theBuilder.Add(aSelfTouchingWire, anEdgeDA);
+  aSelfTouchingWire.Closed(true);
+
+  TopoDS_Face aSelfTouchingFace;
+  theBuilder.MakeFace(aSelfTouchingFace, aSurface, aLocation, Precision::Confusion());
+  theBuilder.Add(aSelfTouchingFace, aSelfTouchingWire);
+
+  TopoDS_Edge aReversedCommonEdge = aCommonEdge;
+  aReversedCommonEdge.Reverse();
+  TopoDS_Wire aSecondWire;
+  theBuilder.MakeWire(aSecondWire);
+  theBuilder.Add(aSecondWire, aReversedCommonEdge);
+  theBuilder.Add(aSecondWire, anEdgeAE);
+  theBuilder.Add(aSecondWire, anEdgeEB);
+  aSecondWire.Closed(true);
+
+  TopoDS_Face aSecondFace;
+  theBuilder.MakeFace(aSecondFace, aSurface, aLocation, Precision::Confusion());
+  theBuilder.Add(aSecondFace, aSecondWire);
+
+  MissingPCurveShape aResult;
+  theBuilder.MakeShell(aResult.Shell);
+  theBuilder.Add(aResult.Shell, aSelfTouchingFace);
+  theBuilder.Add(aResult.Shell, aSecondFace);
+  aResult.ReferenceFace     = aSelfTouchingFace;
+  aResult.MissingPCurveEdge = anEdgeBC;
+  aResult.ValidPCurveEdge   = anEdgeBD;
+  return aResult;
+}
+
+static MissingPCurveShape makeMissingPCurveTransformationShape(BRep_Builder& theBuilder)
+{
+  const occ::handle<Geom_CylindricalSurface> aSurface = new Geom_CylindricalSurface(gp::XOY(), 1.0);
+  const TopLoc_Location                      aLocation;
+  const TopoDS_Vertex aVertexA = makeVertex(theBuilder, aSurface->Value(0.0, 0.0));
+  const TopoDS_Vertex aVertexB = makeVertex(theBuilder, aSurface->Value(0.5, 0.0));
+  const TopoDS_Vertex aVertexC = makeVertex(theBuilder, aSurface->Value(0.5, 1.0));
+  const TopoDS_Vertex aVertexD = makeVertex(theBuilder, aSurface->Value(0.0, 1.0));
+  const TopoDS_Vertex aVertexE = makeVertex(theBuilder, aSurface->Value(1.0, 0.0));
+  const TopoDS_Vertex aVertexF = makeVertex(theBuilder, aSurface->Value(1.0, 1.0));
+
+  const TopoDS_Edge anEdgeAB = makeEdge(theBuilder, aSurface, aLocation, aVertexA, aVertexB, true);
+  const TopoDS_Edge anEdgeBC = makeEdge(theBuilder, aSurface, aLocation, aVertexB, aVertexC, true);
+  const TopoDS_Edge anEdgeCD = makeEdge(theBuilder, aSurface, aLocation, aVertexC, aVertexD, true);
+  const TopoDS_Edge anEdgeDA = makeEdge(theBuilder, aSurface, aLocation, aVertexD, aVertexA, true);
+  const TopoDS_Edge anEdgeBE = makeEdge(theBuilder, aSurface, aLocation, aVertexB, aVertexE, false);
+  const TopoDS_Edge anEdgeEF = makeEdge(theBuilder, aSurface, aLocation, aVertexE, aVertexF, true);
+  const TopoDS_Edge anEdgeFC = makeEdge(theBuilder, aSurface, aLocation, aVertexF, aVertexC, true);
+
+  TopoDS_Wire aLeftWire;
+  theBuilder.MakeWire(aLeftWire);
+  theBuilder.Add(aLeftWire, anEdgeAB);
+  theBuilder.Add(aLeftWire, anEdgeBC);
+  theBuilder.Add(aLeftWire, anEdgeCD);
+  theBuilder.Add(aLeftWire, anEdgeDA);
+  aLeftWire.Closed(true);
+
+  TopoDS_Edge aReversedEdgeBC = anEdgeBC;
+  aReversedEdgeBC.Reverse();
+  TopoDS_Wire aRightWire;
+  theBuilder.MakeWire(aRightWire);
+  theBuilder.Add(aRightWire, anEdgeBE);
+  theBuilder.Add(aRightWire, anEdgeEF);
+  theBuilder.Add(aRightWire, anEdgeFC);
+  theBuilder.Add(aRightWire, aReversedEdgeBC);
+  aRightWire.Closed(true);
+
+  MissingPCurveShape aResult;
+  theBuilder.MakeFace(aResult.ReferenceFace, aSurface, aLocation, Precision::Confusion());
+  theBuilder.Add(aResult.ReferenceFace, aLeftWire);
+  TopoDS_Face aRightFace;
+  theBuilder.MakeFace(aRightFace, aSurface, aLocation, Precision::Confusion());
+  theBuilder.Add(aRightFace, aRightWire);
+  theBuilder.MakeShell(aResult.Shell);
+  theBuilder.Add(aResult.Shell, aResult.ReferenceFace);
+  theBuilder.Add(aResult.Shell, aRightFace);
+  aResult.MissingPCurveEdge = anEdgeBE;
+  aResult.ValidPCurveEdge   = anEdgeBC;
+  return aResult;
+}
+
+static bool addPlanarFacePair(BRep_Builder& theBuilder, TopoDS_Shell& theShell)
+{
+  const occ::handle<Geom_Surface> aNullSurface;
+  const TopLoc_Location           aLocation;
+  const TopoDS_Vertex             aVertex1 = makeVertex(theBuilder, gp_Pnt(3.0, 0.0, 0.0));
+  const TopoDS_Vertex             aVertex2 = makeVertex(theBuilder, gp_Pnt(4.0, 0.0, 0.0));
+  const TopoDS_Vertex             aVertex3 = makeVertex(theBuilder, gp_Pnt(4.0, 1.0, 0.0));
+  const TopoDS_Vertex             aVertex4 = makeVertex(theBuilder, gp_Pnt(3.0, 1.0, 0.0));
+  const TopoDS_Vertex             aVertex5 = makeVertex(theBuilder, gp_Pnt(5.0, 0.0, 0.0));
+  const TopoDS_Vertex             aVertex6 = makeVertex(theBuilder, gp_Pnt(5.0, 1.0, 0.0));
+
+  const TopoDS_Edge anEdge12 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex1, aVertex2, false);
+  const TopoDS_Edge anEdge23 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex2, aVertex3, false);
+  const TopoDS_Edge anEdge34 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex3, aVertex4, false);
+  const TopoDS_Edge anEdge41 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex4, aVertex1, false);
+  const TopoDS_Edge anEdge25 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex2, aVertex5, false);
+  const TopoDS_Edge anEdge56 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex5, aVertex6, false);
+  const TopoDS_Edge anEdge63 =
+    makeEdge(theBuilder, aNullSurface, aLocation, aVertex6, aVertex3, false);
+  if (anEdge12.IsNull() || anEdge23.IsNull() || anEdge34.IsNull() || anEdge41.IsNull()
+      || anEdge25.IsNull() || anEdge56.IsNull() || anEdge63.IsNull())
+  {
+    return false;
+  }
+
+  BRepBuilderAPI_MakeWire aLeftWireMaker;
+  aLeftWireMaker.Add(anEdge12);
+  aLeftWireMaker.Add(anEdge23);
+  aLeftWireMaker.Add(anEdge34);
+  aLeftWireMaker.Add(anEdge41);
+  if (!aLeftWireMaker.IsDone())
+  {
+    return false;
+  }
+
+  TopoDS_Edge aReversedEdge23 = anEdge23;
+  aReversedEdge23.Reverse();
+  BRepBuilderAPI_MakeWire aRightWireMaker;
+  aRightWireMaker.Add(aReversedEdge23);
+  aRightWireMaker.Add(anEdge25);
+  aRightWireMaker.Add(anEdge56);
+  aRightWireMaker.Add(anEdge63);
+  if (!aRightWireMaker.IsDone())
+  {
+    return false;
+  }
+
+  const gp_Pln            aPlanarSurface(gp::XOY());
+  BRepBuilderAPI_MakeFace aLeftFaceMaker(aPlanarSurface, aLeftWireMaker.Wire());
+  BRepBuilderAPI_MakeFace aRightFaceMaker(aPlanarSurface, aRightWireMaker.Wire());
+  if (!aLeftFaceMaker.IsDone() || !aRightFaceMaker.IsDone())
+  {
+    return false;
+  }
+  theBuilder.Add(theShell, aLeftFaceMaker.Face());
+  theBuilder.Add(theShell, aRightFaceMaker.Face());
+  return true;
+}
+
+static int countFaces(const TopoDS_Shape& theShape)
+{
+  int aFaceCount = 0;
+  for (TopExp_Explorer anExp(theShape, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    ++aFaceCount;
+  }
+  return aFaceCount;
+}
+} // namespace
 
 // Test for issue #925: Infinite loop when processing internal edges.
 // This test verifies that UnifySameDomain properly handles internal edges
@@ -305,4 +539,53 @@ TEST(ShapeUpgrade_UnifySameDomainTest, BasicBoxUnification)
     aFaceCount++;
   }
   EXPECT_EQ(aFaceCount, 6) << "Box should have 6 faces";
+}
+
+// Test that a missing pcurve neither causes a null dereference nor aborts unrelated face merging.
+TEST(ShapeUpgrade_UnifySameDomainTest, MissingPCurveDoesNotAbortShellProcessing)
+{
+  BRep_Builder       aBuilder;
+  MissingPCurveShape aTestShape = makeMissingPCurveShape(aBuilder);
+  ASSERT_FALSE(aTestShape.Shell.IsNull());
+  ASSERT_TRUE(addPlanarFacePair(aBuilder, aTestShape.Shell));
+
+  double aFirst = 0.0;
+  double aLast  = 0.0;
+  EXPECT_TRUE(
+    BRep_Tool::CurveOnSurface(aTestShape.MissingPCurveEdge, aTestShape.ReferenceFace, aFirst, aLast)
+      .IsNull());
+  ASSERT_FALSE(
+    BRep_Tool::CurveOnSurface(aTestShape.ValidPCurveEdge, aTestShape.ReferenceFace, aFirst, aLast)
+      .IsNull());
+
+  ShapeUpgrade_UnifySameDomain aUnifier(aTestShape.Shell, false, true, false);
+  aUnifier.AllowInternalEdges(true);
+  aUnifier.Build();
+
+  const TopoDS_Shape& aResult = aUnifier.Shape();
+  ASSERT_FALSE(aResult.IsNull());
+
+  EXPECT_EQ(countFaces(aResult), 3);
+}
+
+// Test that pcurve transformation skips an edge which has no source pcurve.
+TEST(ShapeUpgrade_UnifySameDomainTest, MissingSourcePCurveDuringTransformation)
+{
+  BRep_Builder       aBuilder;
+  MissingPCurveShape aTestShape = makeMissingPCurveTransformationShape(aBuilder);
+  ASSERT_FALSE(aTestShape.Shell.IsNull());
+
+  double aFirst = 0.0;
+  double aLast  = 0.0;
+  ASSERT_TRUE(
+    BRep_Tool::CurveOnSurface(aTestShape.MissingPCurveEdge, aTestShape.ReferenceFace, aFirst, aLast)
+      .IsNull());
+
+  ShapeUpgrade_UnifySameDomain aUnifier(aTestShape.Shell, false, true, false);
+  aUnifier.AllowInternalEdges(true);
+  aUnifier.Build();
+
+  const TopoDS_Shape& aResult = aUnifier.Shape();
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countFaces(aResult), 2);
 }

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -3973,17 +3973,17 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
               }
               TmpElist.Append(anEdge);
             }
-            if (TmpElist.Extent() <= 1 || (Uperiod != 0. || Vperiod != 0))
+            occ::handle<Geom2d_Curve> CurPCurve =
+              BRep_Tool::CurveOnSurface(CurEdge, F_RefFace, fpar, lpar);
+            if (TmpElist.Extent() <= 1 || (Uperiod != 0. || Vperiod != 0) || CurPCurve.IsNull())
             {
               TrueElist.Assign(TmpElist);
             }
             else
             {
               // we must choose the closest direction - the biggest angle
-              double                    MaxAngle = RealFirst();
-              TopoDS_Edge               TrueEdge;
-              occ::handle<Geom2d_Curve> CurPCurve =
-                BRep_Tool::CurveOnSurface(CurEdge, F_RefFace, fpar, lpar);
+              double      MaxAngle = RealFirst();
+              TopoDS_Edge TrueEdge;
               CurParam = (CurEdge.Orientation() == TopAbs_FORWARD) ? lpar : fpar;
               gp_Vec2d CurDir;
               CurPCurve->D1(CurParam, CurPoint, CurDir);
@@ -3997,6 +3997,11 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
                 const TopoDS_Edge&        anEdge = TopoDS::Edge(itl.Value());
                 occ::handle<Geom2d_Curve> aPCurve =
                   BRep_Tool::CurveOnSurface(anEdge, F_RefFace, fpar, lpar);
+                if (aPCurve.IsNull())
+                {
+                  // edge has no pcurve on the reference face, skip it as a direction candidate
+                  continue;
+                }
                 double   aParam = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
                 gp_Pnt2d aPoint;
                 gp_Vec2d aDir;
@@ -4013,7 +4018,10 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
                   TrueEdge = anEdge;
                 }
               }
-              TrueElist.Append(TrueEdge);
+              if (!TrueEdge.IsNull())
+              {
+                TrueElist.Append(TrueEdge);
+              }
             }
 
             // Find next edge in TrueElist
@@ -4023,6 +4031,11 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
 
               occ::handle<Geom2d_Curve> aPCurve =
                 BRep_Tool::CurveOnSurface(anEdge, F_RefFace, fpar, lpar);
+              if (aPCurve.IsNull())
+              {
+                // edge has no pcurve on the reference face, skip it as a next-edge candidate
+                continue;
+              }
               double   aParam = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
               gp_Pnt2d aPoint = aPCurve->Value(aParam);
               double   DiffU  = std::abs(aPoint.X() - CurPoint.X());
@@ -4627,16 +4640,15 @@ void SplitWire(const TopoDS_Wire&                                               
           break;
         }
 
-        if (aElist.Extent() == 1)
+        double                    fpar, lpar;
+        occ::handle<Geom2d_Curve> aPCurve = BRep_Tool::CurveOnSurface(CurEdge, theFace, fpar, lpar);
+        if (aElist.Extent() == 1 || aPCurve.IsNull())
         {
           CurEdge = TopoDS::Edge(aElist.First());
           aElist.Clear();
         }
         else
         {
-          double                    fpar, lpar;
-          occ::handle<Geom2d_Curve> aPCurve =
-            BRep_Tool::CurveOnSurface(CurEdge, theFace, fpar, lpar);
           double   aParam = (CurEdge.Orientation() == TopAbs_FORWARD) ? lpar : fpar;
           gp_Pnt2d aPoint;
           gp_Vec2d CurDir;
@@ -4654,7 +4666,12 @@ void SplitWire(const TopoDS_Wire&                                               
           {
             const TopoDS_Edge& anEdge = TopoDS::Edge(aLocalIter.Value());
             aPCurve                   = BRep_Tool::CurveOnSurface(anEdge, theFace, fpar, lpar);
-            aParam                    = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
+            if (aPCurve.IsNull())
+            {
+              // edge has no pcurve on the reference face, skip it as a direction candidate
+              continue;
+            }
+            aParam = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
             gp_Vec2d aDir;
             aPCurve->D1(aParam, aPoint, aDir);
             aDir.Normalize();
@@ -4668,6 +4685,11 @@ void SplitWire(const TopoDS_Wire&                                               
               MinAngle = anAngle;
               NextEdge = anEdge;
             }
+          }
+          if (NextEdge.IsNull())
+          {
+            // all candidates lacked a pcurve, fall back to an arbitrary one instead of stalling
+            NextEdge = TopoDS::Edge(aElist.First());
           }
           CurEdge = NextEdge;
           // Remove <CurEdge> from list

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_UnifySameDomain.cxx
@@ -533,7 +533,7 @@ static std::pair<gp_Pnt2d, gp_Pnt2d> getCurveParams(const TopoDS_Edge& theEdge,
 
 //=================================================================================================
 
-static void RelocatePCurvesToNewUorigin(
+static bool RelocatePCurvesToNewUorigin(
   const NCollection_Sequence<TopoDS_Shape>& theEdges,
   const TopoDS_Shape&                       theFirstFace,
   const TopoDS_Face&                        theRefFace,
@@ -611,6 +611,10 @@ static void RelocatePCurvesToNewUorigin(
     double                    anEdgeStartParam, anEdgeEndParam;
     occ::handle<Geom2d_Curve> CurPCurve =
       BRep_Tool::CurveOnSurface(aCurrentEdge, theRefFace, anEdgeStartParam, anEdgeEndParam);
+    if (CurPCurve.IsNull())
+    {
+      return false;
+    }
     CurPCurve = new Geom2d_TrimmedCurve(CurPCurve, anEdgeStartParam, anEdgeEndParam);
     theEdgeNewPCurve.Bind(aCurrentEdge, CurPCurve);
     if (aCurrentEdge.Orientation() == TopAbs_REVERSED)
@@ -655,6 +659,10 @@ static void RelocatePCurvesToNewUorigin(
 
         occ::handle<Geom2d_Curve> aPCurve =
           BRep_Tool::CurveOnSurface(anEdge, theRefFace, anEdgeStartParam, anEdgeEndParam);
+        if (aPCurve.IsNull())
+        {
+          return false;
+        }
         aPCurve = new Geom2d_TrimmedCurve(aPCurve, anEdgeStartParam, anEdgeEndParam);
         if (anEdge.Orientation() == TopAbs_REVERSED)
         {
@@ -694,6 +702,7 @@ static void RelocatePCurvesToNewUorigin(
       }
     } // for (;;) (collect pcurves of a contour)
   } // for (;;) (walk by contours)
+  return true;
 }
 
 static void InsertWiresIntoFaces(const NCollection_Sequence<TopoDS_Shape>& theWires,
@@ -801,6 +810,10 @@ static bool FindClosestPoints(const TopoDS_Edge&                                
     BRep_Tool::CurveOnSurface(theEdge1, theCommonFace, fpar1, lpar1);
   occ::handle<Geom2d_Curve> PCurve2 =
     BRep_Tool::CurveOnSurface(theEdge2, theCommonFace, fpar2, lpar2);
+  if (PCurve1.IsNull() || PCurve2.IsNull())
+  {
+    return false;
+  }
   PointsOnEdge1[0] = PCurve1->Value(fpar1);
   PointsOnEdge1[1] = PCurve1->Value(lpar1);
   PointsOnEdge2[0] = PCurve2->Value(fpar2);
@@ -1183,6 +1196,12 @@ static void TransformPCurves(
     PCurves[0] = BRep_Tool::CurveOnSurface(anEdge, theFace, fpar, lpar);
     anEdge.Reverse();
     PCurves[1] = BRep_Tool::CurveOnSurface(anEdge, theFace, fpar, lpar);
+
+    if (PCurves[0].IsNull() || PCurves[1].IsNull())
+    {
+      // The source face has no pcurve for this edge, so it cannot be transformed.
+      continue;
+    }
 
     int NbPcurves = (PCurves[0] == PCurves[1]) ? 1 : 2;
 
@@ -3708,15 +3727,26 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
               NCollection_DataMap<TopoDS_Shape, occ::handle<Geom2d_Curve>> EdgeNewPCurve;
 
               // Relocate pcurves to new U-origin
-              RelocatePCurvesToNewUorigin(edges,
-                                          faces(i_face_max),
-                                          F_RefFace,
-                                          CoordTol,
-                                          ii + 1,
-                                          aPeriods[ii],
-                                          VEmap,
-                                          EdgeNewPCurve,
-                                          UsedEdges);
+              if (!RelocatePCurvesToNewUorigin(edges,
+                                               faces(i_face_max),
+                                               F_RefFace,
+                                               CoordTol,
+                                               ii + 1,
+                                               aPeriods[ii],
+                                               VEmap,
+                                               EdgeNewPCurve,
+                                               UsedEdges))
+              {
+                VEmap.Clear();
+                for (int ind = 1; ind <= edges.Length(); ind++)
+                {
+                  TopExp::MapShapesAndUniqueAncestors(edges(ind),
+                                                      TopAbs_VERTEX,
+                                                      TopAbs_EDGE,
+                                                      VEmap);
+                }
+                break;
+              }
 
               // PCurves from unused edges (may be degenerated edges)
               for (int ind = 1; ind <= edges.Length(); ind++)
@@ -3727,9 +3757,18 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
                   double                    fpar, lpar;
                   occ::handle<Geom2d_Curve> aPCurve =
                     BRep_Tool::CurveOnSurface(anEdge, F_RefFace, fpar, lpar);
+                  if (aPCurve.IsNull())
+                  {
+                    EdgeNewPCurve.Clear();
+                    break;
+                  }
                   aPCurve = new Geom2d_TrimmedCurve(aPCurve, fpar, lpar);
                   EdgeNewPCurve.Bind(anEdge, aPCurve);
                 }
+              }
+              if (EdgeNewPCurve.Extent() != edges.Length())
+              {
+                break;
               }
 
               // Restore VEmap
@@ -3829,6 +3868,7 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
       }
 
       NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> UsedEdges;
+      bool                                                   isWireBuildingFailed = false;
 
       double FaceUmin = RealLast();
       double FaceVmin = RealLast();
@@ -3984,9 +4024,9 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
               // we must choose the closest direction - the biggest angle
               double      MaxAngle = RealFirst();
               TopoDS_Edge TrueEdge;
-              CurParam = (CurEdge.Orientation() == TopAbs_FORWARD) ? lpar : fpar;
-              gp_Vec2d CurDir;
-              CurPCurve->D1(CurParam, CurPoint, CurDir);
+              CurParam                 = (CurEdge.Orientation() == TopAbs_FORWARD) ? lpar : fpar;
+              auto [aCurPoint, CurDir] = CurPCurve->EvalD1(CurParam);
+              CurPoint                 = aCurPoint;
               CurDir.Normalize();
               if (CurEdge.Orientation() == TopAbs_REVERSED)
               {
@@ -4002,10 +4042,8 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
                   // edge has no pcurve on the reference face, skip it as a direction candidate
                   continue;
                 }
-                double   aParam = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
-                gp_Pnt2d aPoint;
-                gp_Vec2d aDir;
-                aPCurve->D1(aParam, aPoint, aDir);
+                const double aParam = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
+                gp_Vec2d     aDir   = aPCurve->EvalD1(aParam).D1;
                 aDir.Normalize();
                 if (anEdge.Orientation() == TopAbs_REVERSED)
                 {
@@ -4112,12 +4150,14 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
                                     NextPoint);
               if (NextEdge.IsNull())
               {
-                return;
+                isWireBuildingFailed = true;
+                break;
               }
             }
             else
             {
-              return;
+              isWireBuildingFailed = true;
+              break;
             }
           }
           CurPoint  = NextPoint;
@@ -4127,6 +4167,11 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
           UsedEdges.Add(CurEdge);
           RemoveEdgeFromMap(CurEdge, VEmap);
         } // for (;;)
+
+        if (isWireBuildingFailed)
+        {
+          break;
+        }
 
         aNewWire.Closed(true);
         UsedEdges.Add(StartEdge);
@@ -4180,6 +4225,11 @@ void ShapeUpgrade_UnifySameDomain::IntUnifyFaces(
           }
         }
       } // while (!edges.IsEmpty())
+
+      if (isWireBuildingFailed)
+      {
+        continue;
+      }
 
       // Build wires from internal edges
       NCollection_IndexedDataMap<TopoDS_Shape,
@@ -4642,17 +4692,20 @@ void SplitWire(const TopoDS_Wire&                                               
 
         double                    fpar, lpar;
         occ::handle<Geom2d_Curve> aPCurve = BRep_Tool::CurveOnSurface(CurEdge, theFace, fpar, lpar);
-        if (aElist.Extent() == 1 || aPCurve.IsNull())
+        if (aElist.Extent() == 1)
         {
           CurEdge = TopoDS::Edge(aElist.First());
           aElist.Clear();
         }
+        else if (aPCurve.IsNull())
+        {
+          CurEdge = TopoDS::Edge(aElist.First());
+          aElist.RemoveFirst();
+        }
         else
         {
           double   aParam = (CurEdge.Orientation() == TopAbs_FORWARD) ? lpar : fpar;
-          gp_Pnt2d aPoint;
-          gp_Vec2d CurDir;
-          aPCurve->D1(aParam, aPoint, CurDir);
+          gp_Vec2d CurDir = aPCurve->EvalD1(aParam).D1;
           CurDir.Normalize();
           if (CurEdge.Orientation() == TopAbs_REVERSED)
           {
@@ -4671,9 +4724,8 @@ void SplitWire(const TopoDS_Wire&                                               
               // edge has no pcurve on the reference face, skip it as a direction candidate
               continue;
             }
-            aParam = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
-            gp_Vec2d aDir;
-            aPCurve->D1(aParam, aPoint, aDir);
+            aParam        = (anEdge.Orientation() == TopAbs_FORWARD) ? fpar : lpar;
+            gp_Vec2d aDir = aPCurve->EvalD1(aParam).D1;
             aDir.Normalize();
             if (anEdge.Orientation() == TopAbs_REVERSED)
             {


### PR DESCRIPTION
### Description of the change

Guards five unguarded `BRep_Tool::CurveOnSurface(...)` dereferences in
`ShapeUpgrade_UnifySameDomain::IntUnifyFaces` and its file-local `SplitWire` helper with
`IsNull()` checks, following the file's own established pattern used at every other
`CurveOnSurface` call site.

`CurveOnSurface` returns a null `Handle(Geom2d_Curve)` when an edge has no pcurve on the given
face — routine for a raw mesh-sewn solid (`BRepBuilderAPI_Sewing` output from an STL/mesh import)
at a vertex shared by more than two edges. The five sites dereference the result immediately
(`->D1(...)` / `->Value(...)`) with no check, which is a null-pointer virtual call — a raw
`SIGSEGV`, uncatchable in-process (this is a memory-safety bug, not a `Standard_Failure` a caller
could `try`/`catch`).

- A missing pcurve on a *candidate* edge now means "skip it, not a rankable direction" (`continue`).
- A missing pcurve on the *current* edge (so there is nothing to compare candidates against) falls
  back to treating all candidates as equally likely — the same fallback the surrounding code
  already takes for the "only one candidate" case.

### Related issue

Fixes #1391.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

1. Standalone repro: load the attached artifact, run `ShapeUpgrade_UnifySameDomain::Build()`.
   Debug (`-g -O0`) single-TU override-link + `lldb bt` on stock `master` resolves the crash to
   `ShapeUpgrade_UnifySameDomain.cxx:4003` (`aPCurve->D1(...)`, null handle), reached via
   `IntUnifyFaces` → `UnifyFaces` → `Build`.
2. With the patch applied: the same artifact unifies successfully, run repeatedly with no crash.
3. `clang-format --dry-run --Werror` is clean on every line this patch touches (two pre-existing
   formatting violations elsewhere in the file, both untouched by this patch, are unrelated
   pre-existing drift).

Reproducer artifact + standalone C++ driver:
https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/348-unify-null-pcurve

### Checklist:

- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My change requires a change to the documentation — N/A, no public API/behavior change beyond
      "does not crash"
- [x] I have added tests to cover my changes — regression coverage lives in the downstream Swift
      wrapper project (OCCTSwift) since this repo's DRAW test suite doesn't have an equivalent
      fixture-driven mesh-sew flow readily available; happy to add a DRAW test if maintainers
      point me at the right harness/fixture convention for this area
