### PR TITLE
Fix CDF_Application-cached storage/retrieval driver reentrancy (SIGSEGV, #1393)

### DIFF
--- a/src/ApplicationFramework/TKCDF/CDF/CDF_Application.cxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_Application.cxx
@@ -32,6 +32,7 @@
 #include <Standard_NoSuchObject.hxx>
 #include <Standard_ProgramError.hxx>
 #include <UTL.hxx>
+#include <mutex>
 
 IMPLEMENT_STANDARD_RTTIEXT(CDF_Application, CDM_Application)
 
@@ -327,6 +328,8 @@ occ::handle<CDM_Document> CDF_Application::Retrieve(const occ::handle<CDM_MetaDa
     try
     {
       OCC_CATCH_SIGNALS
+      // theReader is shared across threads/calls for this format; Read() is not reentrant.
+      std::lock_guard<std::mutex> aDriverLock(theReader->Mutex());
       theReader->Read(aMetaData->FileName(), aDocument, this, theFilter, theRange);
     }
     catch (Standard_Failure const& anException)
@@ -451,6 +454,8 @@ void CDF_Application::Read(Standard_IStream&                     theIStream,
   try
   {
     OCC_CATCH_SIGNALS
+    // aReader is shared across threads/calls for this format; Read() is not reentrant.
+    std::lock_guard<std::mutex> aDriverLock(aReader->Mutex());
     aReader->Read(theIStream, dData, theDocument, this, theFilter, theRange);
   }
   catch (Standard_Failure const& anException)

--- a/src/ApplicationFramework/TKCDF/CDF/CDF_StoreList.cxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_StoreList.cxx
@@ -23,6 +23,7 @@
 #include <CDM_ReferenceIterator.hxx>
 #include <PCDM_StorageDriver.hxx>
 #include <TCollection_ExtendedString.hxx>
+#include <mutex>
 
 IMPLEMENT_STANDARD_RTTIEXT(CDF_StoreList, Standard_Transient)
 
@@ -126,6 +127,10 @@ PCDM_StoreStatus CDF_StoreList::Store(occ::handle<CDM_MetaData>&   aMetaData,
           }
           else
           {
+            // aDocumentStorageDriver is shared across threads/calls for this format;
+            // Write() is not reentrant.
+            std::lock_guard<std::mutex> aDriverLock(aDocumentStorageDriver->Mutex());
+
             // Reset the store-status.
             // It has sense in multi-threaded access to the storage driver - this way we reset the
             // status for each call.

--- a/src/ApplicationFramework/TKCDF/PCDM/PCDM_Reader.hxx
+++ b/src/ApplicationFramework/TKCDF/PCDM/PCDM_Reader.hxx
@@ -25,6 +25,7 @@
 #include <Standard_IStream.hxx>
 #include <Storage_Data.hxx>
 #include <Message_ProgressRange.hxx>
+#include <mutex>
 
 class CDM_Document;
 class TCollection_ExtendedString;
@@ -53,10 +54,16 @@ public:
 
   PCDM_ReaderStatus GetStatus() const;
 
+  //! Guards Read(), which is not reentrant on a shared driver instance.
+  std::mutex& Mutex() const { return myMutex; }
+
   DEFINE_STANDARD_RTTIEXT(PCDM_Reader, Standard_Transient)
 
 protected:
   PCDM_ReaderStatus myReaderStatus;
+
+private:
+  mutable std::mutex myMutex;
 };
 
 #include <PCDM_Reader.lxx>

--- a/src/ApplicationFramework/TKCDF/PCDM/PCDM_StorageDriver.hxx
+++ b/src/ApplicationFramework/TKCDF/PCDM/PCDM_StorageDriver.hxx
@@ -25,6 +25,7 @@
 #include <PCDM_Writer.hxx>
 #include <PCDM_Document.hxx>
 #include <NCollection_Sequence.hxx>
+#include <mutex>
 class PCDM_Document;
 class CDM_Document;
 
@@ -84,12 +85,16 @@ public:
 
   Standard_EXPORT void SetStoreStatus(const PCDM_StoreStatus theStoreStatus);
 
+  //! Guards Write(), which is not reentrant on a shared driver instance.
+  std::mutex& Mutex() const { return myMutex; }
+
   DEFINE_STANDARD_RTTIEXT(PCDM_StorageDriver, PCDM_Writer)
 
 private:
   TCollection_ExtendedString myFormat;
   bool                       myIsError;
   PCDM_StoreStatus           myStoreStatus;
+  mutable std::mutex         myMutex;
 };
 
 #endif // _PCDM_StorageDriver_HeaderFile


### PR DESCRIPTION
Fixes #1393.

`CDF_Application::WriterFromFormat`/`ReaderFromFormat` cache one storage/retrieval driver instance
per format and hand the same instance back to every subsequent `Store()`/`Retrieve()` call for
that format — including from different threads, different documents, concurrently.
`PCDM_StorageDriver`/`PCDM_Reader` subclasses (e.g. `BinLDrivers_DocumentStorageDriver`) are not
reentrant: `Write()`/`Read()` mutate instance-level scratch state with no synchronization, so two
threads calling `Write()` on the same cached instance corrupt it — reliably reproducible SIGSEGV,
see #1393 for the full trace and TSan evidence (136 race warnings → 0 with this patch).

`CDF_StoreList::Store` already carries a comment acknowledging multi-threaded access to the driver
("It has sense in multi-threaded access to the storage driver..."), but only the store-status was
ever actually made safe for concurrent use — every other member of the driver races freely.

## Fix

Adds a `mutable std::mutex` + `Mutex()` accessor to `PCDM_StorageDriver` and `PCDM_Reader`, so every
concrete format driver (`BinLDrivers`, `XmlLDrivers`, `BinXCAFDrivers`, `XmlXCAFDrivers`, `TObj`
variants, ...) inherits the guard for free — no changes needed in any subclass. The three places
`CDF_Application`/`CDF_StoreList` invoke a cached driver's `Write()`/`Read()` now hold that driver's
own mutex for the call: `CDF_StoreList::Store`, `CDF_Application::Retrieve`, `CDF_Application::Read`.

This targets the actual shared resource (the cached driver instance) rather than a broad lock
around unrelated code, and doesn't serialize unrelated formats against each other — a `"BinOcaf"`
save and an unrelated `"Xml"` save use different cached driver instances and different mutexes.

## Testing

- Reproducer (`occt_349_barrier.cpp`, N threads racing `TDocStd_Application::SaveAs()` on a shared
  application): SIGSEGV within the first few hundred rounds at just 2 threads on unpatched master;
  clean across repeated runs with this patch.
- ThreadSanitizer (minimal-module build: FoundationClasses+ModelingData+ModelingAlgorithms+
  DataExchange): 136 distinct race warnings + SIGSEGV (exit 139) on unpatched master → 0 races,
  clean exit, confirmed at both 8×25 and 10×200 thread/round configurations.
- Full reproducer, writeup, and TSan logs: https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/349-ocaf-driver-reentrancy
