### PR TITLE
Fix CDM_Application::myMetaDataLookUpTable/CDM_MetaData reentrancy races (#1396)

### DIFF
--- a/src/ApplicationFramework/TKCDF/CDF/CDF_Application.cxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_Application.cxx
@@ -41,7 +41,7 @@ CDF_Application::CDF_Application()
     : myRetrievableStatus(PCDM_RS_OK)
 {
   myDirectory      = new CDF_Directory();
-  myMetaDataDriver = new CDF_FWOSDriver(MetaDataLookUpTable());
+  myMetaDataDriver = new CDF_FWOSDriver(MetaDataLookUpTable(), MetaDataLookUpTableMutex());
 }
 
 //=================================================================================================

--- a/src/ApplicationFramework/TKCDF/CDF/CDF_FWOSDriver.cxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_FWOSDriver.cxx
@@ -43,8 +43,10 @@ static void PutSlash(TCollection_ExtendedString& anXSTRING)
 //=================================================================================================
 
 CDF_FWOSDriver::CDF_FWOSDriver(
-  NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable)
-    : myLookUpTable(&theLookUpTable)
+  NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+  std::mutex&                                                                 theMutex)
+    : myLookUpTable(&theLookUpTable),
+      myMutex(&theMutex)
 {
 }
 
@@ -102,7 +104,7 @@ occ::handle<CDM_MetaData> CDF_FWOSDriver::MetaData(const TCollection_ExtendedStr
                                                    const TCollection_ExtendedString& /*aVersion*/)
 {
   TCollection_ExtendedString p = Concatenate(aFolder, aName);
-  return CDM_MetaData::LookUp(*myLookUpTable, aFolder, aName, p, p, UTL::IsReadOnly(p));
+  return CDM_MetaData::LookUp(*myLookUpTable, *myMutex, aFolder, aName, p, p, UTL::IsReadOnly(p));
 }
 
 //=================================================================================================
@@ -112,6 +114,7 @@ occ::handle<CDM_MetaData> CDF_FWOSDriver::CreateMetaData(
   const TCollection_ExtendedString& aFileName)
 {
   return CDM_MetaData::LookUp(*myLookUpTable,
+                              *myMutex,
                               aDocument->RequestedFolder(),
                               aDocument->RequestedName(),
                               Concatenate(aDocument->RequestedFolder(), aDocument->RequestedName()),

--- a/src/ApplicationFramework/TKCDF/CDF/CDF_FWOSDriver.hxx
+++ b/src/ApplicationFramework/TKCDF/CDF/CDF_FWOSDriver.hxx
@@ -22,6 +22,7 @@
 #include <CDF_MetaDataDriver.hxx>
 #include <TCollection_ExtendedString.hxx>
 #include <NCollection_DataMap.hxx>
+#include <mutex>
 
 class TCollection_ExtendedString;
 class CDM_MetaData;
@@ -33,9 +34,11 @@ class CDF_FWOSDriver : public CDF_MetaDataDriver
 public:
   //! Initializes the MetaDatadriver connected to specified look-up table.
   //! Note that the created driver will keep reference to the table,
-  //! thus it must have life time longer than this object.
+  //! thus it must have life time longer than this object. theMutex must
+  //! guard theLookUpTable (CDM_Application::MetaDataLookUpTableMutex()).
   Standard_EXPORT CDF_FWOSDriver(
-    NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable);
+    NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+    std::mutex&                                                                 theMutex);
 
   //! indicate whether a file exists corresponding to the folder and the name
   Standard_EXPORT bool Find(const TCollection_ExtendedString& aFolder,
@@ -75,6 +78,7 @@ private:
 
 private:
   NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>* myLookUpTable;
+  std::mutex*                                                                 myMutex;
 };
 
 #endif // _CDF_FWOSDriver_HeaderFile

--- a/src/ApplicationFramework/TKCDF/CDM/CDM_Application.hxx
+++ b/src/ApplicationFramework/TKCDF/CDM/CDM_Application.hxx
@@ -24,6 +24,7 @@
 #include <TCollection_ExtendedString.hxx>
 #include <NCollection_DataMap.hxx>
 #include <Message_ProgressRange.hxx>
+#include <mutex>
 
 class CDM_MetaData;
 class CDM_Document;
@@ -66,6 +67,9 @@ public:
                                               occ::handle<CDM_MetaData>>&
     MetaDataLookUpTable();
 
+  //! Guards MetaDataLookUpTable(), shared across threads/calls.
+  std::mutex& MetaDataLookUpTableMutex() const { return myMetaDataLookUpTableMutex; }
+
   //! Dumps the content of me into the stream
   Standard_EXPORT void DumpJson(Standard_OStream& theOStream, int theDepth = -1) const;
 
@@ -95,6 +99,7 @@ private:
 
   occ::handle<Message_Messenger>                                             myMessenger;
   NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>> myMetaDataLookUpTable;
+  mutable std::mutex myMetaDataLookUpTableMutex;
 };
 
 #endif // _CDM_Application_HeaderFile

--- a/src/ApplicationFramework/TKCDF/CDM/CDM_Document.cxx
+++ b/src/ApplicationFramework/TKCDF/CDM/CDM_Document.cxx
@@ -28,6 +28,7 @@
 #include <Standard_DomainError.hxx>
 #include <Standard_Dump.hxx>
 #include <Standard_Failure.hxx>
+#include <mutex>
 #include <Standard_NoSuchObject.hxx>
 #include <Standard_NullObject.hxx>
 #include <Standard_Type.hxx>
@@ -479,6 +480,8 @@ void CDM_Document::SetMetaData(const occ::handle<CDM_MetaData>& aMetaData)
     aMetaData->SetDocument(this);
 
     // Update the document referencing this MetaData:
+    // MetaDataLookUpTable() is shared across threads/calls; guard the iteration.
+    std::lock_guard<std::mutex> aLookUpTableLock(Application()->MetaDataLookUpTableMutex());
     NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>::Iterator it(
       Application()->MetaDataLookUpTable());
     for (; it.More(); it.Next())

--- a/src/ApplicationFramework/TKCDF/CDM/CDM_MetaData.cxx
+++ b/src/ApplicationFramework/TKCDF/CDM/CDM_MetaData.cxx
@@ -66,27 +66,32 @@ CDM_MetaData::CDM_MetaData(const TCollection_ExtendedString& aFolder,
 
 bool CDM_MetaData::IsRetrieved() const
 {
+  std::lock_guard<std::mutex> aLock(myDocumentMutex);
   return myIsRetrieved;
 }
 
 occ::handle<CDM_Document> CDM_MetaData::Document() const
 {
+  std::lock_guard<std::mutex> aLock(myDocumentMutex);
   return myDocument;
 }
 
 void CDM_MetaData::SetDocument(const occ::handle<CDM_Document>& aDocument)
 {
+  std::lock_guard<std::mutex> aLock(myDocumentMutex);
   myIsRetrieved = true;
   myDocument    = aDocument.operator->();
 }
 
 void CDM_MetaData::UnsetDocument()
 {
+  std::lock_guard<std::mutex> aLock(myDocumentMutex);
   myIsRetrieved = false;
 }
 
 occ::handle<CDM_MetaData> CDM_MetaData::LookUp(
   NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+  std::mutex&                                                                 theMutex,
   const TCollection_ExtendedString&                                           aFolder,
   const TCollection_ExtendedString&                                           aName,
   const TCollection_ExtendedString&                                           aPath,
@@ -96,6 +101,8 @@ occ::handle<CDM_MetaData> CDM_MetaData::LookUp(
   occ::handle<CDM_MetaData>  theMetaData;
   TCollection_ExtendedString aConventionalPath = aPath;
   aConventionalPath.ChangeAll('\\', '/');
+
+  std::lock_guard<std::mutex> aLock(theMutex);
   if (!theLookUpTable.IsBound(aConventionalPath))
   {
     theMetaData = new CDM_MetaData(aFolder, aName, aPath, aFileName, ReadOnly);
@@ -111,6 +118,7 @@ occ::handle<CDM_MetaData> CDM_MetaData::LookUp(
 
 occ::handle<CDM_MetaData> CDM_MetaData::LookUp(
   NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+  std::mutex&                                                                 theMutex,
   const TCollection_ExtendedString&                                           aFolder,
   const TCollection_ExtendedString&                                           aName,
   const TCollection_ExtendedString&                                           aPath,
@@ -121,6 +129,8 @@ occ::handle<CDM_MetaData> CDM_MetaData::LookUp(
   occ::handle<CDM_MetaData>  theMetaData;
   TCollection_ExtendedString aConventionalPath = aPath;
   aConventionalPath.ChangeAll('\\', '/');
+
+  std::lock_guard<std::mutex> aLock(theMutex);
   if (!theLookUpTable.IsBound(aConventionalPath))
   {
     theMetaData = new CDM_MetaData(aFolder, aName, aPath, aVersion, aFileName, ReadOnly);

--- a/src/ApplicationFramework/TKCDF/CDM/CDM_MetaData.hxx
+++ b/src/ApplicationFramework/TKCDF/CDM/CDM_MetaData.hxx
@@ -99,7 +99,8 @@ public:
     //! associates database information to a document which
     //! has been stored. The name of the document is now the
     //! name which has beenused to store the data.
-    Standard_EXPORT void      CDM_Document::SetMetaData(const occ::handle<CDM_MetaData>& aMetaData);
+    Standard_EXPORT void
+                              CDM_Document::SetMetaData(const occ::handle<CDM_MetaData>& aMetaData);
   friend Standard_EXPORT void CDM_Application::SetDocumentVersion(
     const occ::handle<CDM_Document>& aDocument,
     const occ::handle<CDM_MetaData>& aMetaData) const;

--- a/src/ApplicationFramework/TKCDF/CDM/CDM_MetaData.hxx
+++ b/src/ApplicationFramework/TKCDF/CDM/CDM_MetaData.hxx
@@ -28,22 +28,27 @@
 #include <CDM_Application.hxx>
 #include <Standard_OStream.hxx>
 #include <NCollection_DataMap.hxx>
+#include <mutex>
 class CDM_MetaData;
 
 class CDM_MetaData : public Standard_Transient
 {
 
 public:
+  //! theMutex must guard theLookUpTable (CDM_Application::MetaDataLookUpTableMutex()).
   Standard_EXPORT static occ::handle<CDM_MetaData> LookUp(
     NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+    std::mutex&                                                                 theMutex,
     const TCollection_ExtendedString&                                           aFolder,
     const TCollection_ExtendedString&                                           aName,
     const TCollection_ExtendedString&                                           aPath,
     const TCollection_ExtendedString&                                           aFileName,
     const bool                                                                  ReadOnly);
 
+  //! theMutex must guard theLookUpTable (CDM_Application::MetaDataLookUpTableMutex()).
   Standard_EXPORT static occ::handle<CDM_MetaData> LookUp(
     NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+    std::mutex&                                                                 theMutex,
     const TCollection_ExtendedString&                                           aFolder,
     const TCollection_ExtendedString&                                           aName,
     const TCollection_ExtendedString&                                           aPath,
@@ -94,8 +99,7 @@ public:
     //! associates database information to a document which
     //! has been stored. The name of the document is now the
     //! name which has beenused to store the data.
-    Standard_EXPORT void
-                              CDM_Document::SetMetaData(const occ::handle<CDM_MetaData>& aMetaData);
+    Standard_EXPORT void      CDM_Document::SetMetaData(const occ::handle<CDM_MetaData>& aMetaData);
   friend Standard_EXPORT void CDM_Application::SetDocumentVersion(
     const occ::handle<CDM_Document>& aDocument,
     const occ::handle<CDM_MetaData>& aMetaData) const;
@@ -131,6 +135,7 @@ private:
   TCollection_ExtendedString myPath;
   int                        myDocumentVersion;
   bool                       myIsReadOnly;
+  mutable std::mutex         myDocumentMutex; //!< guards myIsRetrieved/myDocument
 };
 
 #endif // _CDM_MetaData_HeaderFile

--- a/src/ApplicationFramework/TKCDF/PCDM/PCDM_ReferenceIterator.cxx
+++ b/src/ApplicationFramework/TKCDF/PCDM/PCDM_ReferenceIterator.cxx
@@ -45,12 +45,13 @@ void PCDM_ReferenceIterator::LoadReferences(const occ::handle<CDM_Document>&    
 {
   for (Init(aMetaData); More(); Next())
   {
-    aDocument->CreateReference(
-      MetaData(anApplication->MetaDataLookUpTable(), UseStorageConfiguration),
-      ReferenceIdentifier(),
-      anApplication,
-      DocumentVersion(),
-      UseStorageConfiguration);
+    aDocument->CreateReference(MetaData(anApplication->MetaDataLookUpTable(),
+                                        anApplication->MetaDataLookUpTableMutex(),
+                                        UseStorageConfiguration),
+                               ReferenceIdentifier(),
+                               anApplication,
+                               DocumentVersion(),
+                               UseStorageConfiguration);
   }
 }
 
@@ -83,6 +84,7 @@ void PCDM_ReferenceIterator::Next()
 
 occ::handle<CDM_MetaData> PCDM_ReferenceIterator::MetaData(
   NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+  std::mutex&                                                                 theMutex,
   const bool) const
 {
 
@@ -131,6 +133,7 @@ occ::handle<CDM_MetaData> PCDM_ReferenceIterator::MetaData(
 #endif // _WIN32
 
   return CDM_MetaData::LookUp(theLookUpTable,
+                              theMutex,
                               theFolder,
                               theName,
                               theFile,

--- a/src/ApplicationFramework/TKCDF/PCDM/PCDM_ReferenceIterator.hxx
+++ b/src/ApplicationFramework/TKCDF/PCDM/PCDM_ReferenceIterator.hxx
@@ -24,6 +24,7 @@
 #include <NCollection_Sequence.hxx>
 #include <TCollection_ExtendedString.hxx>
 #include <NCollection_DataMap.hxx>
+#include <mutex>
 
 class Message_Messenger;
 class CDM_Document;
@@ -53,6 +54,7 @@ private:
 
   Standard_EXPORT virtual occ::handle<CDM_MetaData> MetaData(
     NCollection_DataMap<TCollection_ExtendedString, occ::handle<CDM_MetaData>>& theLookUpTable,
+    std::mutex&                                                                 theMutex,
     const bool UseStorageConfiguration) const;
 
   Standard_EXPORT virtual int ReferenceIdentifier() const;

--- a/src/ApplicationFramework/TKXmlL/XmlLDrivers/XmlLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKXmlL/XmlLDrivers/XmlLDrivers_DocumentRetrievalDriver.cxx
@@ -288,7 +288,7 @@ void XmlLDrivers_DocumentRetrievalDriver::ReadFromDomDocument(
       TCollection_ExtendedString aMsg = TCollection_ExtendedString("error: wrong file version: ")
                                         + aDocVerStr + " while current is "
                                         + TDocStd_Document::CurrentStorageFormatVersion();
-      myReaderStatus                  = PCDM_RS_NoVersion;
+      myReaderStatus = PCDM_RS_NoVersion;
       if (!aMsgDriver.IsNull())
       {
         aMsgDriver->Send(aMsg.ToExtString(), Message_Fail);

--- a/src/ApplicationFramework/TKXmlL/XmlLDrivers/XmlLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKXmlL/XmlLDrivers/XmlLDrivers_DocumentRetrievalDriver.cxx
@@ -288,7 +288,7 @@ void XmlLDrivers_DocumentRetrievalDriver::ReadFromDomDocument(
       TCollection_ExtendedString aMsg = TCollection_ExtendedString("error: wrong file version: ")
                                         + aDocVerStr + " while current is "
                                         + TDocStd_Document::CurrentStorageFormatVersion();
-      myReaderStatus = PCDM_RS_NoVersion;
+      myReaderStatus                  = PCDM_RS_NoVersion;
       if (!aMsgDriver.IsNull())
       {
         aMsgDriver->Send(aMsg.ToExtString(), Message_Fail);
@@ -443,6 +443,7 @@ void XmlLDrivers_DocumentRetrievalDriver::ReadFromDomDocument(
 
               occ::handle<CDM_MetaData> aMetaData =
                 CDM_MetaData::LookUp(theApplication->MetaDataLookUpTable(),
+                                     theApplication->MetaDataLookUpTableMutex(),
                                      theFolder,
                                      theName,
                                      aPath,


### PR DESCRIPTION
Fixes #1396.

`CDM_Application::myMetaDataLookUpTable` is shared process-wide (one `CDM_Application`/
`CDF_Application` instance per process, per the singleton pattern fixed in #1389/#1390) with zero
synchronization on its map accesses or on the individual `CDM_MetaData` objects it hands out. See
#1396 for the full trace and TSan evidence (1 confirmed race + SIGABRT → 0 races with this patch).

## Fix

1. `CDM_Application` gets a `mutable std::mutex myMetaDataLookUpTableMutex` +
   `MetaDataLookUpTableMutex()` accessor, threaded through every access point:
   `CDM_MetaData::LookUp()`'s two overloads (now take the mutex as an explicit parameter alongside
   the map, since they're `static` and operate on a caller-supplied table+mutex pair),
   `CDF_FWOSDriver`'s constructor/call sites, `XmlLDrivers_DocumentRetrievalDriver::
   ReadFromDomDocument`, and `PCDM_ReferenceIterator::MetaData`. `CDM_Document::SetMetaData()`'s
   full-table iteration is now guarded for its duration.
2. `CDM_MetaData` gets its own private `mutable std::mutex myDocumentMutex` guarding
   `myIsRetrieved`/`myDocument`, since `SetDocument`/`UnsetDocument`/`IsRetrieved`/`Document` are
   called on one shared `CDM_MetaData` instance from whichever thread looked it up and,
   independently, from another thread's document destructor.

## Testing

- ThreadSanitizer (minimal-module build: FoundationClasses+ModelingData+ModelingAlgorithms+
  DataExchange): 1 confirmed race + SIGABRT (exit 134) on unpatched master → 0 races, clean exit,
  across repeated runs (8×25, 10×60, 3×8×40 thread/round configurations).
- Full reproducer, writeup, and TSan logs:
  https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/353-cdm-metadata-lookup-table
