### PR TITLE
Foundation Classes - Fix Resource_Manager::Debug and Storage_Schema current-data data races

### DIFF
--- a/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
+++ b/src/FoundationClasses/TKernel/Resource/Resource_Manager.cxx
@@ -31,6 +31,7 @@
 #include <NCollection_Array1.hxx>
 
 #include <algorithm>
+#include <atomic>
 #include <cerrno>
 
 IMPLEMENT_STANDARD_RTTIEXT(Resource_Manager, Standard_Transient)
@@ -51,7 +52,7 @@ static Resource_KindOfLine WhatKindOfLine(OSD_File&                aFile,
 
 static int GetLine(OSD_File& aFile, TCollection_AsciiString& aLine);
 
-static bool Debug;
+static std::atomic<bool> Debug(false);
 
 //=================================================================================================
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.cxx
@@ -318,7 +318,7 @@ void Storage_Schema::Write(const occ::handle<Storage_BaseDriver>& theDriver,
   occ::handle<Standard_Persistent>                              p;
   occ::handle<NCollection_HSequence<occ::handle<Storage_Root>>> plist;
   TCollection_AsciiString                                       errorContext("AddPersistent");
-  Storage_Schema::ISetCurrentData(aData);
+  myCurrentData = aData;
 
   occ::handle<Storage_InternalData> iData = aData->InternalData();
 
@@ -614,8 +614,8 @@ void Storage_Schema::BindType(const TCollection_AsciiString&       aTypeName,
 {
   if (!HasTypeBinding(aTypeName))
   {
-    occ::handle<Storage_InternalData>  iData = Storage_Schema::ICurrentData()->InternalData();
-    occ::handle<Storage_TypeData>      tData = Storage_Schema::ICurrentData()->TypeData();
+    occ::handle<Storage_InternalData>  iData = myCurrentData->InternalData();
+    occ::handle<Storage_TypeData>      tData = myCurrentData->TypeData();
     occ::handle<Storage_TypedCallBack> c     = new Storage_TypedCallBack(aTypeName, aCallBack);
 
     tData->AddType(aTypeName, iData->myTypeId);
@@ -633,7 +633,7 @@ occ::handle<Storage_CallBack> Storage_Schema::TypeBinding(
 
   if (HasTypeBinding(aTypeName))
   {
-    occ::handle<Storage_InternalData> iData = Storage_Schema::ICurrentData()->InternalData();
+    occ::handle<Storage_InternalData> iData = myCurrentData->InternalData();
 
     result = iData->myTypeBinding.Find(aTypeName)->CallBack();
   }
@@ -650,14 +650,13 @@ bool Storage_Schema::AddPersistent(const occ::handle<Standard_Persistent>& sp,
 
   if (!sp.IsNull())
   {
-    occ::handle<Storage_InternalData> iData = Storage_Schema::ICurrentData()->InternalData();
+    occ::handle<Storage_InternalData> iData = myCurrentData->InternalData();
 
     if (sp->_typenum == 0)
     {
-      int                            aTypenum;
-      static TCollection_AsciiString aTypeName;
-      aTypeName                           = tName;
-      occ::handle<Storage_TypeData> tData = Storage_Schema::ICurrentData()->TypeData();
+      int                           aTypenum;
+      TCollection_AsciiString       aTypeName(tName);
+      occ::handle<Storage_TypeData> tData = myCurrentData->TypeData();
 
       aTypenum = iData->myTypeBinding.Find(aTypeName)->Index();
 
@@ -679,7 +678,7 @@ bool Storage_Schema::PersistentToAdd(const occ::handle<Standard_Persistent>& sp)
 
   if (!sp.IsNull())
   {
-    occ::handle<Storage_InternalData> di = Storage_Schema::ICurrentData()->InternalData();
+    occ::handle<Storage_InternalData> di = myCurrentData->InternalData();
 
     if (sp->_typenum == 0 && sp->_refnum != -1)
     {
@@ -696,7 +695,7 @@ bool Storage_Schema::PersistentToAdd(const occ::handle<Standard_Persistent>& sp)
 
 void Storage_Schema::Clear() const
 {
-  Storage_Schema::ICurrentData().Nullify();
+  myCurrentData.Nullify();
 }
 
 #ifdef DATATYPE_MIGRATION
@@ -789,21 +788,6 @@ bool Storage_Schema::CheckTypeMigration(const TCollection_AsciiString& oldName,
   return aMigration;
 }
 #endif
-
-//=================================================================================================
-
-void Storage_Schema::ISetCurrentData(const occ::handle<Storage_Data>& dData)
-{
-  Storage_Schema::ICurrentData() = dData;
-}
-
-//=================================================================================================
-
-occ::handle<Storage_Data>& Storage_Schema::ICurrentData()
-{
-  static occ::handle<Storage_Data> _Storage_CData;
-  return _Storage_CData;
-}
 
 #define SLENGTH 80
 

--- a/src/FoundationClasses/TKernel/Storage/Storage_Schema.hxx
+++ b/src/FoundationClasses/TKernel/Storage/Storage_Schema.hxx
@@ -167,7 +167,7 @@ public:
 protected:
   bool HasTypeBinding(const TCollection_AsciiString& aTypeName) const
   {
-    return Storage_Schema::ICurrentData()->InternalData()->myTypeBinding.IsBound(aTypeName);
+    return myCurrentData->InternalData()->myTypeBinding.IsBound(aTypeName);
   }
 
   Standard_EXPORT void BindType(const TCollection_AsciiString&       aTypeName,
@@ -179,9 +179,8 @@ protected:
 private:
   Standard_EXPORT void Clear() const;
 
-  Standard_EXPORT static void ISetCurrentData(const occ::handle<Storage_Data>& dData);
-
-  Standard_EXPORT static occ::handle<Storage_Data>& ICurrentData();
+  //! Scratch state for the duration of one Write() call.
+  mutable occ::handle<Storage_Data> myCurrentData;
 
   NCollection_DataMap<TCollection_AsciiString, occ::handle<Storage_TypedCallBack>> myCallBack;
   bool                                                                             myCallBackState;


### PR DESCRIPTION
## Description

Fixes #1398.

`Resource_Manager::Resource_Manager(const char*, bool)` (`Resource_Manager.cxx:109`) writes a
file-scope `static bool Debug` on every construction with zero synchronization. Two
`Resource_Manager` instances constructed concurrently on different threads (e.g. two independent
`TDocStd_Application` instances each lazily building their own via `Resources()`/`DefineFormat()`)
race on this write. Fixed by making `Debug` a `std::atomic<bool>`: it is a plain process-wide
debug-logging flag, not per-instance intent, so an atomic is sufficient here.

`Storage_Schema::ICurrentData()` (`Storage_Schema.cxx:802`) is a function-local static
`Handle(Storage_Data)`, shared by every `Storage_Schema` in the process and mutated with no
synchronization anywhere. `Write()` sets it for the duration of one store, and *any*
`Storage_Schema` construction calls `Clear()` -> `ICurrentData().Nullify()` in its constructor,
including throwaway instances built only to read header info
(`PCDM_ReadWriter_1::ReadReferenceCounter`, `ReadReferences` and `ReadDocumentVersion`, all reached
unconditionally from a plain `TDocStd_Application::Open()` via `CDF_Application::Retrieve`). One
instance's construction can therefore null out a *different*, unrelated instance's in-flight
`Write()` on another thread, or race a concurrent load's own throwaway construction.

**Fixed by removing the global rather than guarding it**, per @gkv311's review below: the handle
becomes a `mutable Handle(Storage_Data) myCurrentData` field on `Storage_Schema`, so there is no
shared state left to synchronize. `Write()` assigns the field, `Clear()` nullifies its own, and
`HasTypeBinding()`/`BindType()`/`TypeBinding()`/`AddPersistent()`/`PersistentToAdd()` read it
through `*this`. The private statics `ICurrentData()` and `ISetCurrentData()` are removed.
`mutable` because all of those methods are `const`.

Nothing in the tree relies on the state being process-wide:

- Every `Storage_Schema` is constructed locally by its caller and used only there
  (`PCDM_StorageDriver::Write`, and `PCDM_ReadWriter_1` at three sites). None is cached or shared.
- `Storage_CallBack::Add`/`Write`/`Read` all take the driving schema as an argument, so the
  `BindType`/`AddPersistent`/`PersistentToAdd` calls made from per-type callbacks during a `Write()`
  run against that same instance.
- The other `Storage_Schema` users in the tree (`BinLDrivers`, `XmlMDF`, `StdLDrivers`) use only the
  statics `CheckTypeMigration()` and `ICreationDate()`, neither of which reads the current data.
- `ICurrentData()` and `ISetCurrentData()` were both `private` with no reference outside the class,
  so removing them is not an API change.

The same commit drops the `static` from `AddPersistent()`'s `TCollection_AsciiString aTypeName`, a
second unsynchronized process-wide object in the same class. It is assigned from the `tName`
argument and read two lines later, so `static` only ever saved an allocation, and it was previously
covered only incidentally by the mutex this revision removes.

Both races are invisible under the traditional single shared `XCAFApp_Application` /
`TDocStd_Application` usage pattern, because there `Resources()`'s own lazy-init mutex happens to
serialize `Resource_Manager`/`Storage_Schema` construction down to "runs once, ever, for the whole
process." They only become reachable once an application is constructed privately per caller or
thread (the pattern this project's own `TDocStd_Application` documentation recommends over the
`XCAFApp_Application::GetApplication()` singleton) and multiple independent instances are built
concurrently. See the linked issue for the full TSan writeup and a standalone reproducer.

No public API signature changes. The revision is a net reduction: 15 insertions, 31 deletions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

ThreadSanitizer (minimal-module build: FoundationClasses + ModelingData + ModelingAlgorithms +
DataExchange, `RelWithDebInfo`, `-fsanitize=thread -g`), each round building a brand-new private
`TDocStd_Application`, defining formats, populating and saving a document, closing it, then a
**separate** brand-new private application opening, verifying and closing it. No two threads ever
share an application or schema instance.

- Before the fix: 13 TSan race warnings (2x `Resource_Manager::Resource_Manager`, 11x
  `Storage_Schema::Storage_Schema`'s `Clear()` call) at 8 threads x 30 rounds, 0 functional
  failures.
- The mutex revision: 0 races across 4 runs (8x30, 8x50, 10x60, 8x40), 0 functional failures.
- This per-instance revision: 0 races across 8x50, 8x30 and 10x60, 0 save, load or verify failures.
  Re-run after the `aTypeName` change with the same result.

Also run against the wider concurrency suite that the downstream project maintains for this kernel
(10 scenarios covering the fixes from #1374, #1388, #1390, #1394 and #1397 plus this one): all
clean, no regression. Full downstream test suite (4666 tests) clean against a production build of
the patched kernel.

Reproducer and full writeup:
https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/374-resource-manager-storage-schema-race

## Checklist:

- [x] My code follows the code style of this project (`clang-format --dry-run --Werror` clean on
      every touched file)
- [x] My change requires a change to the documentation
  - [ ] I have updated the documentation accordingly (no user-facing documentation covers this
        internal-only change)
