### PR TITLE
Shape Healing - create a ReShape context when none is set in ShapeFix_ComposeShell and ShapeUpgrade_WireDivide

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
@@ -7,8 +7,10 @@ set(OCCT_TKShHealing_GTests_FILES
   ShapeAnalysis_FreeBounds_Test.cxx
   ShapeBuild_ReShape_Test.cxx
   ShapeConstruct_ProjectCurveOnSurface_Test.cxx
+  ShapeFix_ComposeShell_Test.cxx
   ShapeFix_Face_Test.cxx
   ShapeFix_Shape_Test.cxx
   ShapeUpgrade_FaceDivide_Test.cxx
   ShapeUpgrade_UnifySameDomain_Test.cxx
+  ShapeUpgrade_WireDivide_Test.cxx
 )

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_ComposeShell_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_ComposeShell_Test.cxx
@@ -1,0 +1,108 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRep_Tool.hxx>
+#include <Geom_Plane.hxx>
+#include <Geom_Surface.hxx>
+#include <NCollection_HArray2.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeExtend_CompositeSurface.hxx>
+#include <ShapeFix_ComposeShell.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopoDS_Face.hxx>
+#include <gp_Pln.hxx>
+
+namespace
+{
+TopoDS_Face squareFace()
+{
+  BRepBuilderAPI_MakePolygon aPoly;
+  aPoly.Add(gp_Pnt(0, 0, 0));
+  aPoly.Add(gp_Pnt(10, 0, 0));
+  aPoly.Add(gp_Pnt(10, 10, 0));
+  aPoly.Add(gp_Pnt(0, 10, 0));
+  aPoly.Close();
+  occ::handle<Geom_Plane> aPln = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+  BRepBuilderAPI_MakeFace aMakeFace(aPln, aPoly.Wire(), true);
+  return aMakeFace.IsDone() ? aMakeFace.Face() : TopoDS_Face();
+}
+} // namespace
+
+// Test for issue #1409: ShapeFix_ComposeShell crashes with null context.
+TEST(ShapeFix_ComposeShellTest, Perform_WithoutContext_DoesNotCrash)
+{
+  const TopoDS_Face aFace = squareFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  occ::handle<Geom_Surface>                                   aSurf = BRep_Tool::Surface(aFace);
+  occ::handle<NCollection_HArray2<occ::handle<Geom_Surface>>> aGrid =
+    new NCollection_HArray2<occ::handle<Geom_Surface>>(1, 1, 1, 1);
+  aGrid->SetValue(1, 1, aSurf);
+  occ::handle<ShapeExtend_CompositeSurface> aCompSurf = new ShapeExtend_CompositeSurface(aGrid);
+
+  occ::handle<ShapeFix_ComposeShell> aShell = new ShapeFix_ComposeShell();
+  aShell->Init(aCompSurf, TopLoc_Location(), aFace, 1.e-7);
+  EXPECT_NO_THROW(aShell->Perform());
+  EXPECT_FALSE(aShell->Result().IsNull());
+}
+
+// Test for issue #1409: ShapeFix_ComposeShell::SplitEdges() crashes with null context.
+TEST(ShapeFix_ComposeShellTest, SplitEdges_WithoutContext_DoesNotCrash)
+{
+  const TopoDS_Face aFace = squareFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  occ::handle<Geom_Surface>                                   aSurf = BRep_Tool::Surface(aFace);
+  occ::handle<NCollection_HArray2<occ::handle<Geom_Surface>>> aGrid =
+    new NCollection_HArray2<occ::handle<Geom_Surface>>(1, 1, 1, 1);
+  aGrid->SetValue(1, 1, aSurf);
+  occ::handle<ShapeExtend_CompositeSurface> aCompSurf = new ShapeExtend_CompositeSurface(aGrid);
+
+  occ::handle<ShapeFix_ComposeShell> aShell = new ShapeFix_ComposeShell();
+  aShell->Init(aCompSurf, TopLoc_Location(), aFace, 1.e-7);
+  EXPECT_NO_THROW(aShell->SplitEdges());
+}
+
+// A live context, set before Perform(), must produce the same result as the self-created one.
+TEST(ShapeFix_ComposeShellTest, Perform_WithAndWithoutContext_SameResult)
+{
+  const TopoDS_Face aFace = squareFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(aFace);
+
+  occ::handle<NCollection_HArray2<occ::handle<Geom_Surface>>> aGridA =
+    new NCollection_HArray2<occ::handle<Geom_Surface>>(1, 1, 1, 1);
+  aGridA->SetValue(1, 1, aSurf);
+  occ::handle<ShapeFix_ComposeShell> aShellNoContext = new ShapeFix_ComposeShell();
+  aShellNoContext->Init(new ShapeExtend_CompositeSurface(aGridA), TopLoc_Location(), aFace, 1.e-7);
+  const bool aDoneNoContext = aShellNoContext->Perform();
+
+  occ::handle<NCollection_HArray2<occ::handle<Geom_Surface>>> aGridB =
+    new NCollection_HArray2<occ::handle<Geom_Surface>>(1, 1, 1, 1);
+  aGridB->SetValue(1, 1, aSurf);
+  occ::handle<ShapeFix_ComposeShell> aShellWithContext = new ShapeFix_ComposeShell();
+  aShellWithContext->SetContext(new ShapeBuild_ReShape);
+  aShellWithContext->Init(new ShapeExtend_CompositeSurface(aGridB),
+                          TopLoc_Location(),
+                          aFace,
+                          1.e-7);
+  const bool aDoneWithContext = aShellWithContext->Perform();
+
+  EXPECT_EQ(aDoneNoContext, aDoneWithContext);
+  EXPECT_EQ(aShellNoContext->Result().IsNull(), aShellWithContext->Result().IsNull());
+}

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeUpgrade_WireDivide_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeUpgrade_WireDivide_Test.cxx
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <gtest/gtest.h>
+
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <Geom_Plane.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeUpgrade_WireDivide.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp_Pln.hxx>
+
+namespace
+{
+TopoDS_Face squareFace()
+{
+  BRepBuilderAPI_MakePolygon aPoly;
+  aPoly.Add(gp_Pnt(0, 0, 0));
+  aPoly.Add(gp_Pnt(10, 0, 0));
+  aPoly.Add(gp_Pnt(10, 10, 0));
+  aPoly.Add(gp_Pnt(0, 10, 0));
+  aPoly.Close();
+  occ::handle<Geom_Plane> aPln = new Geom_Plane(gp_Pln(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)));
+  BRepBuilderAPI_MakeFace aMakeFace(aPln, aPoly.Wire(), true);
+  return aMakeFace.IsDone() ? aMakeFace.Face() : TopoDS_Face();
+}
+
+TopoDS_Wire outerWireOf(const TopoDS_Face& theFace)
+{
+  TopExp_Explorer anExp(theFace, TopAbs_WIRE);
+  return anExp.More() ? TopoDS::Wire(anExp.Current()) : TopoDS_Wire();
+}
+} // namespace
+
+// Test for issue #1409: ShapeUpgrade_WireDivide crashes with null context.
+TEST(ShapeUpgrade_WireDivideTest, Perform_WithoutContext_DoesNotCrash)
+{
+  const TopoDS_Face aFace = squareFace();
+  ASSERT_FALSE(aFace.IsNull());
+  const TopoDS_Wire aWire = outerWireOf(aFace);
+  ASSERT_FALSE(aWire.IsNull());
+
+  occ::handle<ShapeUpgrade_WireDivide> aDivider = new ShapeUpgrade_WireDivide();
+  aDivider->Init(aWire, aFace);
+  EXPECT_NO_THROW(aDivider->Perform());
+  EXPECT_FALSE(aDivider->Wire().IsNull());
+}
+
+// A live context, set before Perform(), must produce the same result as the self-created one.
+TEST(ShapeUpgrade_WireDivideTest, Perform_WithAndWithoutContext_SameResult)
+{
+  const TopoDS_Face aFace = squareFace();
+  ASSERT_FALSE(aFace.IsNull());
+  const TopoDS_Wire aWire = outerWireOf(aFace);
+  ASSERT_FALSE(aWire.IsNull());
+
+  occ::handle<ShapeUpgrade_WireDivide> aDividerNoContext = new ShapeUpgrade_WireDivide();
+  aDividerNoContext->Init(aWire, aFace);
+  aDividerNoContext->Perform();
+
+  occ::handle<ShapeUpgrade_WireDivide> aDividerWithContext = new ShapeUpgrade_WireDivide();
+  aDividerWithContext->SetContext(new ShapeBuild_ReShape);
+  aDividerWithContext->Init(aWire, aFace);
+  aDividerWithContext->Perform();
+
+  EXPECT_EQ(aDividerNoContext->Wire().IsNull(), aDividerWithContext->Wire().IsNull());
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
@@ -205,6 +205,11 @@ void ShapeFix_ComposeShell::Init(const occ::handle<ShapeExtend_CompositeSurface>
 
 bool ShapeFix_ComposeShell::Perform()
 {
+  if (Context().IsNull())
+  {
+    SetContext(new ShapeBuild_ReShape);
+  }
+
   myStatus           = ShapeExtend::EncodeStatus(ShapeExtend_OK);
   myInvertEdgeStatus = false;
 
@@ -258,6 +263,11 @@ bool ShapeFix_ComposeShell::Perform()
 
 void ShapeFix_ComposeShell::SplitEdges()
 {
+  if (Context().IsNull())
+  {
+    SetContext(new ShapeBuild_ReShape);
+  }
+
   myStatus = ShapeExtend::EncodeStatus(ShapeExtend_OK);
 
   NCollection_Sequence<ShapeFix_WireSegment> seqw; // working data: wire segments

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_ComposeShell.cxx
@@ -205,6 +205,12 @@ void ShapeFix_ComposeShell::Init(const occ::handle<ShapeExtend_CompositeSurface>
 
 bool ShapeFix_ComposeShell::Perform()
 {
+  // Every Context() dereference below assumes a live context; SetContext() is optional
+  if (Context().IsNull())
+  {
+    SetContext(new ShapeBuild_ReShape);
+  }
+
   myStatus           = ShapeExtend::EncodeStatus(ShapeExtend_OK);
   myInvertEdgeStatus = false;
 
@@ -258,6 +264,12 @@ bool ShapeFix_ComposeShell::Perform()
 
 void ShapeFix_ComposeShell::SplitEdges()
 {
+  // LoadWires()/SplitByGrid() below dereference Context(); SetContext() is optional
+  if (Context().IsNull())
+  {
+    SetContext(new ShapeBuild_ReShape);
+  }
+
   myStatus = ShapeExtend::EncodeStatus(ShapeExtend_OK);
 
   NCollection_Sequence<ShapeFix_WireSegment> seqw; // working data: wire segments

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
@@ -276,6 +276,12 @@ static void CorrectSplitValues(const occ::handle<NCollection_HSequence<double>>&
 
 void ShapeUpgrade_WireDivide::Perform()
 {
+  // Every Context() dereference below assumes a live context, as in the
+  // ShapeUpgrade_FaceDivide::Perform() that drives this class; SetContext() is optional
+  if (Context().IsNull())
+  {
+    SetContext(new ShapeBuild_ReShape);
+  }
 
   myStatus = ShapeExtend::EncodeStatus(ShapeExtend_OK);
 

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_WireDivide.cxx
@@ -276,6 +276,10 @@ static void CorrectSplitValues(const occ::handle<NCollection_HSequence<double>>&
 
 void ShapeUpgrade_WireDivide::Perform()
 {
+  if (Context().IsNull())
+  {
+    SetContext(new ShapeBuild_ReShape);
+  }
 
   myStatus = ShapeExtend::EncodeStatus(ShapeExtend_OK);
 


### PR DESCRIPTION
Fixes #1409.

### Problem

`ShapeFix_ComposeShell::Perform()`, `ShapeFix_ComposeShell::SplitEdges()` and `ShapeUpgrade_WireDivide::Perform()` dereference `Context()` unconditionally. `ShapeFix_Root::Context()` returns `myContext`, which the base constructor leaves null and only an explicit, optional `SetContext()` ever fills — so `Init(...)` + `Perform()`, the usage both classes' public API invites, is a null-handle dereference (SIGSEGV at address 0, uncatchable in-process). A plain 4-edge planar square face reproduces it 100% of the time; see #1409 for a self-contained reproducer.

The reason this has gone unnoticed: in-kernel, both classes are only ever driven by `ShapeUpgrade_FaceDivide::Perform()`, which already self-creates a context and hands it down (`ShapeUpgrade_FaceDivide.cxx:185` for the compose shell, `:238` for the wire divide). Reached that way neither class ever sees a null context, so the existing tests never exercise the crash.

### Fix

Add the guard that nine other classes in the same package already use — `ShapeFix_Shape::Init`, `ShapeFix_Shell::Perform`, `ShapeFix_Solid::Perform`, `ShapeFix_FixSmallFace::Init`, `ShapeFix_SplitCommonVertex::Init`, `ShapeFix_Wireframe` (both entry points), `ShapeFix_Wire::FixGap3d`/`FixGap2d`, `ShapeFix_Face::FixMissingSeam`, `ShapeUpgrade_ShapeDivide::Perform` — to the three public entry points that were missing it:

```cpp
if (Context().IsNull())
{
  SetContext(new ShapeBuild_ReShape);
}
```

`ShapeFix_ComposeShell`'s other context-dereferencing methods (`LoadWires`, `SplitWire`, `SplitByLine`, `MakeFacesOnPatch`, `DispatchWires`) are all reached through `Perform()` or `SplitEdges()`, so guarding those two covers them; they are also `const`, so they could not create a context themselves.

Same defect class as #1378 / #1380 (merged), which fixed `ShapeFix_Face::FixPeriodicDegenerated`.

### Validation

Verified downstream on `V8_0_0_p1` with the two patched translation units linked ahead of the stock archive, so only these symbols change:

- **Crash closed** — the reproducer from #1409, plus the same two calls against an unbounded-cylindrical face, SIGSEGV 100% of the time before and complete normally after.
- **No behaviour change on the working path** — with a context set (the only path that worked before), the result is byte-identical before and after: `BRepTools::Write` dump hash plus face/wire/edge/vertex counts, for both a planar and a cylindrical face, both classes. The guard only fires when there was no context, and in that case it produces exactly what an explicitly-provided context produces.
- `clang-format` clean on both files.
