### PR TITLE
Modeling Data - Fix CPnts arc length integrated with one Gauss rule for the whole range

### DIFF
--- a/src/ModelingData/TKGeomBase/CPnts/CPnts_AbscissaPoint.cxx
+++ b/src/ModelingData/TKGeomBase/CPnts/CPnts_AbscissaPoint.cxx
@@ -26,13 +26,13 @@
 #include <Adaptor2d_Curve2d.hxx>
 #include <Adaptor3d_Curve.hxx>
 #include <CPnts_AbscissaPoint.hxx>
+#include <CPnts_AdaptiveIntegration.hxx>
 #include <Geom2d_BezierCurve.hxx>
 #include <Geom2d_BSplineCurve.hxx>
 #include <Geom_BezierCurve.hxx>
 #include <gp_Vec.hxx>
 #include <gp_Vec2d.hxx>
 #include <math_FunctionRoot.hxx>
-#include <math_GaussSingleIntegration.hxx>
 #include <Precision.hxx>
 #include <Standard_ConstructionError.hxx>
 #include <StdFail_NotDone.hxx>
@@ -134,13 +134,12 @@ double CPnts_AbscissaPoint::Length(const Adaptor3d_Curve& C, const double U1, co
   // POP pout WNT
   CPnts_RealFunction rf = f3d;
   FG.Init(rf, (void*)&C);
-  //  FG.Init(f3d,(void*)&C);
-  math_GaussSingleIntegration TheLength(FG, U1, U2, order(C));
-  if (!TheLength.IsDone())
+  double aLength = 0.;
+  if (!CPnts_AdaptiveIntegrate(FG, U1, U2, order(C), nullptr, aLength))
   {
     throw Standard_ConstructionError();
   }
-  return std::abs(TheLength.Value());
+  return std::abs(aLength);
 }
 
 //=================================================================================================
@@ -151,13 +150,12 @@ double CPnts_AbscissaPoint::Length(const Adaptor2d_Curve2d& C, const double U1, 
   // POP pout WNT
   CPnts_RealFunction rf = f2d;
   FG.Init(rf, (void*)&C);
-  //  FG.Init(f2d,(void*)&C);
-  math_GaussSingleIntegration TheLength(FG, U1, U2, order(C));
-  if (!TheLength.IsDone())
+  double aLength = 0.;
+  if (!CPnts_AdaptiveIntegrate(FG, U1, U2, order(C), nullptr, aLength))
   {
     throw Standard_ConstructionError();
   }
-  return std::abs(TheLength.Value());
+  return std::abs(aLength);
 }
 
 //=======================================================================
@@ -174,13 +172,12 @@ double CPnts_AbscissaPoint::Length(const Adaptor3d_Curve& C,
   // POP pout WNT
   CPnts_RealFunction rf = f3d;
   FG.Init(rf, (void*)&C);
-  //  FG.Init(f3d,(void*)&C);
-  math_GaussSingleIntegration TheLength(FG, U1, U2, order(C), Tol);
-  if (!TheLength.IsDone())
+  double aLength = 0.;
+  if (!CPnts_AdaptiveIntegrate(FG, U1, U2, order(C), &Tol, aLength))
   {
     throw Standard_ConstructionError();
   }
-  return std::abs(TheLength.Value());
+  return std::abs(aLength);
 }
 
 //=======================================================================
@@ -197,13 +194,12 @@ double CPnts_AbscissaPoint::Length(const Adaptor2d_Curve2d& C,
   // POP pout WNT
   CPnts_RealFunction rf = f2d;
   FG.Init(rf, (void*)&C);
-  //  FG.Init(f2d,(void*)&C);
-  math_GaussSingleIntegration TheLength(FG, U1, U2, order(C), Tol);
-  if (!TheLength.IsDone())
+  double aLength = 0.;
+  if (!CPnts_AdaptiveIntegrate(FG, U1, U2, order(C), &Tol, aLength))
   {
     throw Standard_ConstructionError();
   }
-  return std::abs(TheLength.Value());
+  return std::abs(aLength);
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKGeomBase/CPnts/CPnts_AdaptiveIntegration.hxx
+++ b/src/ModelingData/TKGeomBase/CPnts/CPnts_AdaptiveIntegration.hxx
@@ -1,0 +1,95 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _CPnts_AdaptiveIntegration_HeaderFile
+#define _CPnts_AdaptiveIntegration_HeaderFile
+
+#include <cmath>
+#include <math_Function.hxx>
+#include <math_GaussSingleIntegration.hxx>
+
+//! Relative agreement two successive subdivision levels must reach.
+constexpr double CPnts_IntegrationTolerance = 1.e-9;
+
+//! Ceiling on the equal parts the range may be split into.
+constexpr int CPnts_IntegrationMaxParts = 512;
+
+//! One theOrder-point Gauss quadrature of theF over [theU1, theU2].
+inline bool CPnts_GaussIntegrate(math_Function& theF,
+                                 const double   theU1,
+                                 const double   theU2,
+                                 const int      theOrder,
+                                 const double*  theTol,
+                                 double&        theValue)
+{
+  math_GaussSingleIntegration anIntegral =
+    theTol != nullptr ? math_GaussSingleIntegration(theF, theU1, theU2, theOrder, *theTol)
+                      : math_GaussSingleIntegration(theF, theU1, theU2, theOrder);
+  if (!anIntegral.IsDone())
+  {
+    return false;
+  }
+  theValue = anIntegral.Value();
+  return true;
+}
+
+//! Integrate theF over [theU1, theU2], splitting the range into two, four, ... equal parts until
+//! two successive levels agree to CPnts_IntegrationTolerance relatively.
+//!
+//! A single fixed-order Gauss rule cannot resolve an integrand that varies sharply across the
+//! range it covers, and the arc-length integrand |C'(u)| does: over a whole ellipse it has four
+//! extrema, and the order-10 rule order() gives a conic reads a 1 x 0.05 ellipse 1.7% long. The
+//! error follows the width of one integration interval rather than the curve's type, so the same
+//! rule applied to each GeomAbs_CN span of a B-spline is out by 6.0e-5 on a 5-point interpolation.
+inline bool CPnts_AdaptiveIntegrate(math_Function& theF,
+                                    const double   theU1,
+                                    const double   theU2,
+                                    const int      theOrder,
+                                    const double*  theTol,
+                                    double&        theValue)
+{
+  double aPrevious = 0.;
+  if (!CPnts_GaussIntegrate(theF, theU1, theU2, theOrder, theTol, aPrevious))
+  {
+    return false;
+  }
+  for (int aNbParts = 2; aNbParts <= CPnts_IntegrationMaxParts; aNbParts *= 2)
+  {
+    const double aStep  = (theU2 - theU1) / aNbParts;
+    double       aTotal = 0.;
+    for (int aPart = 0; aPart < aNbParts; ++aPart)
+    {
+      double aPartValue = 0.;
+      if (!CPnts_GaussIntegrate(theF,
+                                theU1 + aPart * aStep,
+                                aPart + 1 == aNbParts ? theU2 : theU1 + (aPart + 1) * aStep,
+                                theOrder,
+                                theTol,
+                                aPartValue))
+      {
+        return false;
+      }
+      aTotal += aPartValue;
+    }
+    if (std::abs(aTotal - aPrevious) <= CPnts_IntegrationTolerance * std::abs(aTotal))
+    {
+      theValue = aTotal;
+      return true;
+    }
+    aPrevious = aTotal;
+  }
+  theValue = aPrevious;
+  return true;
+}
+
+#endif // _CPnts_AdaptiveIntegration_HeaderFile

--- a/src/ModelingData/TKGeomBase/CPnts/CPnts_MyRootFunction.cxx
+++ b/src/ModelingData/TKGeomBase/CPnts/CPnts_MyRootFunction.cxx
@@ -13,7 +13,7 @@
 // commercial license or contractual agreement.
 
 #include <CPnts_MyRootFunction.hxx>
-#include <math_GaussSingleIntegration.hxx>
+#include <CPnts_AdaptiveIntegration.hxx>
 #include <Standard_DomainError.hxx>
 
 void CPnts_MyRootFunction::Init(const CPnts_RealFunction& F, void* const D, const int Order)
@@ -38,26 +38,15 @@ void CPnts_MyRootFunction::Init(const double X0, const double L, const double To
 
 bool CPnts_MyRootFunction::Value(const double X, double& F)
 {
-  math_GaussSingleIntegration Length;
-
-  if (myTol <= 0)
-  {
-    Length = math_GaussSingleIntegration(myFunction, myX0, X, myOrder);
-  }
-  else
-  {
-    Length = math_GaussSingleIntegration(myFunction, myX0, X, myOrder, myTol);
-  }
-
-  if (Length.IsDone())
-  {
-    F = Length.Value() - myL;
-    return true;
-  }
-  else
+  // Subdivided like CPnts_AbscissaPoint::Length, whose integral this inverts: on a single rule the
+  // parameter returned would not agree with the length it was given.
+  double aLength = 0.;
+  if (!CPnts_AdaptiveIntegrate(myFunction, myX0, X, myOrder, myTol > 0 ? &myTol : nullptr, aLength))
   {
     return false;
   }
+  F = aLength - myL;
+  return true;
 }
 
 bool CPnts_MyRootFunction::Derivative(const double X, double& Df)
@@ -67,24 +56,11 @@ bool CPnts_MyRootFunction::Derivative(const double X, double& Df)
 
 bool CPnts_MyRootFunction::Values(const double X, double& F, double& Df)
 {
-  math_GaussSingleIntegration Length;
-
-  if (myTol <= 0)
-  {
-    Length = math_GaussSingleIntegration(myFunction, myX0, X, myOrder);
-  }
-  else
-  {
-    Length = math_GaussSingleIntegration(myFunction, myX0, X, myOrder, myTol);
-  }
-
-  if (Length.IsDone())
-  {
-    F = Length.Value() - myL;
-    return myFunction.Value(X, Df);
-  }
-  else
+  double aLength = 0.;
+  if (!CPnts_AdaptiveIntegrate(myFunction, myX0, X, myOrder, myTol > 0 ? &myTol : nullptr, aLength))
   {
     return false;
   }
+  F = aLength - myL;
+  return myFunction.Value(X, Df);
 }

--- a/src/ModelingData/TKGeomBase/CPnts/FILES.cmake
+++ b/src/ModelingData/TKGeomBase/CPnts/FILES.cmake
@@ -5,6 +5,7 @@ set(OCCT_CPnts_FILES
   CPnts_AbscissaPoint.cxx
   CPnts_AbscissaPoint.hxx
   CPnts_AbscissaPoint.lxx
+  CPnts_AdaptiveIntegration.hxx
   CPnts_MyGaussFunction.cxx
   CPnts_MyGaussFunction.hxx
   CPnts_MyGaussFunction.lxx


### PR DESCRIPTION
`CPnts_AbscissaPoint::Length` integrates `|C'(u)|` with a **single** fixed-order Gauss rule over whatever range it is handed. `order()` (`CPnts_AbscissaPoint.cxx:57`) gives 10 to a conic, 5 to a parabola, `2 * Degree` to a Bezier and `min(24, 2 * NbPoles - 1)` to a B-spline, and none of those resolves an integrand that varies sharply across a wide range. `|C'(u)|` on an ellipse has four extrema per period.

`GCPnts_AbscissaPoint::Length` splits at the `GeomAbs_CN` interval boundaries and applies that rule per interval, so a multi-span B-spline is mostly saved by the split. A conic has exactly one interval, so nothing is split.

Measured against a 16-point composite Gauss-Legendre quadrature of `|C'(u)|` over 40,000 panels, cross-checked against a Richardson-extrapolated chord sum (the two agree to 12 digits):

| curve | `GCPnts_AbscissaPoint::Length` | truth | error |
|---|---|---|---|
| ellipse 8 × 3 | 36.489426687 | 36.366862783 | +0.337% |
| ellipse 10 × 1 | 41.243157870 | 40.639741801 | +1.485% |
| ellipse 1 × 0.05 | 4.089251430 | 4.019425619 | +1.737% |
| parabola f=3 over `[-100, 100]` | 1638.523403092 | 1690.708711624 | **−3.087%** |
| hyperbola 5/2 over `[-4, 4]` | 285.669841141 | 285.479768689 | +0.067% |
| Bezier degree 3, whipping poles | 48.124450786 | 48.215369891 | −0.189% |
| interpolated B-spline, 5 points | 110.963893077 | 110.970568312 | −0.0060% |
| circle r=5, line | exact | exact | length-parametrized, no quadrature |

**The error follows the width of one integration interval, not the curve's type.** The same 8 × 3 ellipse is 0.337% out over `[0, 2π]`, 0.0001% over `[0, π]` and exact over `[0, π/2]`. So the `GeomAbs_CN` split is a mitigation rather than a fix, and it is weakest where spans are wide: a 5-point interpolation is 100× worse than a 40-point one.

Called **directly**, with nothing splitting at all, `CPnts_AbscissaPoint::Length` is much worse — the `min(24, ...)` cap means one order-24 rule covers the entire domain:

| curve | `CPnts_AbscissaPoint::Length` | error |
|---|---|---|
| interpolated B-spline, 5 points | 107.021974495 | 3.6e-2 |
| interpolated B-spline, 40 points | 935.955911353 | 7.4e-2 |
| interpolated B-spline, 200 points | 4582.565404480 | **1.0e-1** |

## Proposed solution

A new header-only `CPnts_AdaptiveIntegration.hxx` integrates the range, then the same range split into two, four, … equal parts, until two successive levels agree to `1e-9` relatively (ceiling 512 parts). All four `CPnts_AbscissaPoint::Length` overloads use it.

**`CPnts_MyRootFunction` has to change with it, not after it.** That class is the function `math_FunctionRoot` drives to answer "which parameter is this far along?", and its `Value(X)` is *the same integral*: one Gauss rule over `[myX0, X]` minus the target. Today it inverts exactly the bias `Length` has, which is why `GCPnts_AbscissaPoint(C, GCPnts_AbscissaPoint::Length(C), first)` still lands on the last parameter, and why `GCPnts_UniformAbscissa` spaces its points uniformly in *true* arc despite computing a total that is 0.337% wrong. Changing `Length` alone would break both of those.

Changed together, the sampler's spacing is unchanged and every intermediate fraction becomes accurate:

| `GCPnts_AbscissaPoint(ellipse 8 × 3, fraction × Length, first)` | before | after |
|---|---|---|
| 0.25 | u = 1.574626454 | u = 1.570796327 |
| 0.50 | u = 3.162016203 | u = 3.141592654 |
| 1.00 | u = 6.283185307 (of a total 0.337% wrong) | u = 6.283185307 (of an accurate total) |

## Validation

Both an override-linked build (the two patched TUs ahead of the archive, `-DNDEBUG -DNo_Exception` to match a release build) and a full rebuild of the library from source, on macOS arm64. The rebuilt binary reproduces the override-linked prediction line for line.

- Every relative error in the first table drops to **≤ 2.6e-13**; the direct `CPnts_AbscissaPoint::Length` errors from **1.0e-1 to 2.8e-8**.
- The inverse goes from 3.4e-3 / 1.5e-2 / 1.7e-2 in arc at the full length to **≤ 1.8e-13 at every fraction**.
- `GCPnts_UniformAbscissa` spacing, measured as *true* arc between consecutive samples, is unchanged: 2.90e-14 → 2.90e-14 on an 8 × 3 ellipse and 1.59e-10 → 1.59e-10 on a 1 × 0.05 one, at 7 and 9 points.
- `GeomAbs_Line` / `GeomAbs_Circle` / 2-pole Bezier and B-spline are length-parametrized in `GCPnts` and never reach the integrator; their values are byte-identical before and after.
- Full downstream test suite of the OCCTSwift wrapper against the rebuilt library: 5096 tests, no change from before the rebuild.

Cost is three quadratures where there was one at the floor, and converges in one or two levels on ordinary curves:

| | before | after |
|---|---|---|
| `GCPnts_AbscissaPoint::Length`, ellipse 8 × 3 | 0.24 µs | 7.2 µs |
| `GCPnts_AbscissaPoint::Length`, 200-span B-spline | 87 µs | 444 µs |
| `GCPnts_UniformAbscissa`, 500 points on an ellipse | 2.71 ms | 6.20 ms |
| circle, line | 0.01 µs | 0.01 µs |

## Scope

`BRepGProp::LinearProperties` runs its own integrator and is not reached by this change — it still reports 41.243157870 for a 10 × 1 elliptical edge against a true 40.639741801 (confirmed unchanged against the rebuilt binary). Same defect class, different code; worth its own fix.

Found while auditing arc-length measurement in the OCCTSwift wrapper, which currently works around this bridge-side. Carried there as patch `0020`; the three touched files are byte-identical between `master` and the `V8_0_0_p1` tag that project pins, so this is the same change on both. Full writeup, reproducer and before/after transcripts: https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/603-single-span-quadrature