### PR TITLE
Modeling Algorithms - Fix ChFi2d_Builder::AddChamfer null-edge dereference on a repeated pair

### DIFF
--- a/src/ModelingAlgorithms/TKFillet/ChFi2d/ChFi2d_Builder_0.cxx
+++ b/src/ModelingAlgorithms/TKFillet/ChFi2d/ChFi2d_Builder_0.cxx
@@ -99,6 +99,10 @@ TopoDS_Edge ChFi2d_Builder::AddChamfer(const TopoDS_Edge& E1,
   // on <newFace>
   TopoDS_Edge EE1, EE2;
   status = ChFi2d::FindConnectedEdges(newFace, commonVertex, EE1, EE2);
+  if (status == ChFi2d_ConnexionError)
+  {
+    return chamfer;
+  }
   if (EE1.IsSame(E2))
   {
     TopAbs_Orientation orient = EE1.Orientation();

--- a/src/ModelingAlgorithms/TKFillet/GTests/BRepFilletAPI_MakeFillet2d_Test.cxx
+++ b/src/ModelingAlgorithms/TKFillet/GTests/BRepFilletAPI_MakeFillet2d_Test.cxx
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepFilletAPI_MakeFillet2d.hxx>
+#include <ChFi2d_ConstructionError.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <gp_Pnt.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+TopoDS_Face squareFace()
+{
+  BRepBuilderAPI_MakePolygon aPoly;
+  aPoly.Add(gp_Pnt(0, 0, 0));
+  aPoly.Add(gp_Pnt(10, 0, 0));
+  aPoly.Add(gp_Pnt(10, 10, 0));
+  aPoly.Add(gp_Pnt(0, 10, 0));
+  aPoly.Close();
+  BRepBuilderAPI_MakeFace aMakeFace(aPoly.Wire());
+  return aMakeFace.IsDone() ? aMakeFace.Face() : TopoDS_Face();
+}
+} // namespace
+
+// Regression test for issue #1431: a second AddChamfer() naming the same edge pair must not
+// crash. The pair's shared vertex is removed from the face's wire by the first call, so the
+// second call's FindConnectedEdges lookup fails; ComputeChamfer used to dereference the two
+// null edges it returned unchecked.
+TEST(BRepFilletAPI_MakeFillet2dTest, AddChamfer_RepeatedPair_DoesNotCrash)
+{
+  const TopoDS_Face aFace = squareFace();
+  ASSERT_FALSE(aFace.IsNull());
+
+  TopoDS_Edge     anEdge1, anEdge2;
+  TopExp_Explorer anExp(aFace, TopAbs_EDGE);
+  ASSERT_TRUE(anExp.More());
+  anEdge1 = TopoDS::Edge(anExp.Current());
+  anExp.Next();
+  ASSERT_TRUE(anExp.More());
+  anEdge2 = TopoDS::Edge(anExp.Current());
+
+  BRepFilletAPI_MakeFillet2d aChamfer(aFace);
+  const TopoDS_Edge          aFirst = aChamfer.AddChamfer(anEdge1, anEdge2, 1.0, 2.0);
+  EXPECT_FALSE(aFirst.IsNull());
+  EXPECT_EQ(aChamfer.Status(), ChFi2d_IsDone);
+
+  TopoDS_Edge aSecond;
+  EXPECT_NO_THROW(aSecond = aChamfer.AddChamfer(anEdge1, anEdge2, 1.0, 2.0));
+  EXPECT_TRUE(aSecond.IsNull());
+  EXPECT_EQ(aChamfer.Status(), ChFi2d_ConnexionError);
+}

--- a/src/ModelingAlgorithms/TKFillet/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKFillet/GTests/FILES.cmake
@@ -3,6 +3,7 @@ set(OCCT_TKFillet_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKFillet_GTests_FILES
   BRepFilletAPI_MakeChamfer_Test.cxx
+  BRepFilletAPI_MakeFillet2d_Test.cxx
   BRepFilletAPI_MakeFillet_Test.cxx
   ChFi3d_Hatching_Test.cxx
 )


### PR DESCRIPTION
### Description of the change

`ChFi2d_Builder::AddChamfer(const TopoDS_Edge& E1, const TopoDS_Edge& E2, double D1, double D2)`
calls `ChFi2d::FindConnectedEdges` and dereferences the two edges it returns without checking the
returned status first. `FindConnectedEdges` leaves both edges null on every failure path, and a
second call naming the same edge pair hits exactly that: the pair's shared vertex is removed from
the face's wire by the first call's own `BuildNewWire`, so the second call's lookup fails and the
two null edges it returns reach `ComputeChamfer` unchecked.

Adds the same status check the sibling overload, `AddChamfer(const TopoDS_Edge& E, const
TopoDS_Vertex& V, double D, double Ang)`, already has immediately after the identical
`FindConnectedEdges` call:

```cpp
status = ChFi2d::FindConnectedEdges(newFace, commonVertex, EE1, EE2);
if (status == ChFi2d_ConnexionError)
{
  return chamfer;
}
```

`chamfer` is the default-constructed null edge this function already returns on its other refusal
paths (`ChFi2d_Builder_0.cxx` lines 83, 89, 95), so this reuses the existing "declined" signal
rather than introducing a new one.

### Related issue

Fixes #1431.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

1. Standalone repro (attached in #1431): a rectangular planar face, `BRepFilletAPI_MakeFillet2d::AddChamfer`
   called twice with the identical edge pair. On stock `master`, the second call SIGSEGVs 100% of
   the time (`ComputeChamfer`, both edges null).
2. Debug (`-O0`) single-TU override-link (this file compiled standalone and linked before the OCCT
   static archive, so the linker resolves this TU's symbols from the override): before the patch,
   the second call crashes; after, it returns a null edge with `Status() == ChFi2d_ConnexionError`,
   matching the sibling overload's own answer for an unconnected vertex.
3. The first call in both cases is unaffected: `Status() == ChFi2d_IsDone`, non-null edge, same
   geometry before and after.
4. `clang-format --dry-run --Werror` on the touched file reports only pre-existing violations
   elsewhere in the file (`Geom2dInt_GInter` construction, unrelated lines), unchanged in count and
   content before and after this patch; the four added lines are clean.

### Checklist:

- [x] My code follows the code style of this project
- [x] I have commented my code, particularly in hard-to-understand areas — N/A, the added check
      mirrors the sibling overload's own existing, uncommented idiom line for line
- [x] My change requires a change to the documentation — N/A, no public API/behavior change beyond
      "does not crash"
- [x] I have added tests to cover my changes — regression coverage lives in the downstream Swift
      wrapper project (OCCTSwift), which found this crash through a fillet/chamfer contract audit;
      happy to add a DRAW test if maintainers point me at the right harness/fixture convention for
      this area
