### PR TITLE
Modeling Algorithms - Select parts of the tool, not the cut result, in BRepFeat_MakeCylindricalHole

### DIFF
--- a/src/ModelingAlgorithms/TKFeat/BRepFeat/BRepFeat_MakeCylindricalHole.cxx
+++ b/src/ModelingAlgorithms/TKFeat/BRepFeat/BRepFeat_MakeCylindricalHole.cxx
@@ -177,7 +177,7 @@ void BRepFeat_MakeCylindricalHole::PerformThruNext(const double Radius, const bo
 
   bool Fuse = false;
   AddTool(theTool);
-  SetOperation(Fuse);
+  SetOperation(Fuse, true);
   BOPAlgo_BOP::Perform();
   NCollection_List<TopoDS_Shape> parts;
   PartsOfTool(parts);
@@ -318,7 +318,7 @@ void BRepFeat_MakeCylindricalHole::PerformUntilEnd(const double Radius, const bo
 
   bool Fuse = false;
   AddTool(theTool);
-  SetOperation(Fuse);
+  SetOperation(Fuse, true);
   BOPAlgo_BOP::Perform();
   NCollection_List<TopoDS_Shape> parts;
   PartsOfTool(parts);
@@ -434,7 +434,7 @@ void BRepFeat_MakeCylindricalHole::Perform(const double Radius,
 
   bool Fuse = false;
   AddTool(theTool);
-  SetOperation(Fuse);
+  SetOperation(Fuse, true);
   BOPAlgo_BOP::Perform();
   NCollection_List<TopoDS_Shape> parts;
   PartsOfTool(parts);
@@ -566,7 +566,7 @@ void BRepFeat_MakeCylindricalHole::PerformBlind(const double Radius,
   // myBuilder.Perform(theTool,theList,Fuse);
   // myBuilder.BuildPartsOfTool();
   AddTool(theTool);
-  SetOperation(Fuse);
+  SetOperation(Fuse, true);
   BOPAlgo_BOP::Perform();
   NCollection_List<TopoDS_Shape> parts;
   PartsOfTool(parts);

--- a/src/ModelingAlgorithms/TKFeat/GTests/BRepFeat_MakeCylindricalHole_Test.cxx
+++ b/src/ModelingAlgorithms/TKFeat/GTests/BRepFeat_MakeCylindricalHole_Test.cxx
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepFeat_MakeCylindricalHole.hxx>
+#include <BRepGProp.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRep_Builder.hxx>
+#include <GProp_GProps.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Shape.hxx>
+#include <gp_Ax1.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+double volumeOf(const TopoDS_Shape& theShape)
+{
+  GProp_GProps aProps;
+  BRepGProp::VolumeProperties(theShape, aProps);
+  return aProps.Mass();
+}
+
+// Two 50x50x20 plates stacked on the Z axis: A at z in [-10, 10], B at z in [-50, -30].
+TopoDS_Shape twoPlateStack()
+{
+  TopoDS_Shape    aPlateA = BRepPrimAPI_MakeBox(gp_Pnt(-25, -25, -10), 50, 50, 20).Shape();
+  TopoDS_Shape    aPlateB = BRepPrimAPI_MakeBox(gp_Pnt(-25, -25, -50), 50, 50, 20).Shape();
+  TopoDS_Compound aCompound;
+  BRep_Builder    aBuilder;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, aPlateA);
+  aBuilder.Add(aCompound, aPlateB);
+  return aCompound;
+}
+} // namespace
+
+// Regression test: PartsOfTool() explores myShape, which only holds the tool split by the object
+// after a BOPAlgo_COMMON pass. The four modes that select which part to keep drove a CUT instead,
+// so on a stock whose cut result has two solids, the selection loop registered pieces of the CUT
+// RESULT as kept tool parts, and PerformResult() built with an empty keep set: no material
+// removed, status NoError throughout. A single-solid stock never reached the divergence, which is
+// why it was never caught.
+TEST(BRepFeat_MakeCylindricalHoleTest, PerformUntilEnd_TwoPlateStack_RemovesBothBores)
+{
+  const TopoDS_Shape aStock = twoPlateStack();
+  const double       aV0    = volumeOf(aStock);
+  const gp_Ax1       anAxis(gp_Pnt(0, 0, 15), gp_Dir(0, 0, -1));
+
+  BRepFeat_MakeCylindricalHole aHole;
+  aHole.Init(aStock, anAxis);
+  aHole.PerformUntilEnd(5.0);
+  ASSERT_EQ(aHole.Status(), BRepFeat_NoError);
+  aHole.Build();
+  ASSERT_FALSE(aHole.Shape().IsNull());
+
+  const double aRemoved = aV0 - volumeOf(aHole.Shape());
+  // Both plates are 20 thick; each bore removes pi * 5^2 * 20 = 1570.7963.
+  EXPECT_NEAR(aRemoved, 2 * M_PI * 25.0 * 20.0, 1.e-3);
+}
+
+TEST(BRepFeat_MakeCylindricalHoleTest, PerformBlind_TwoPlateStack_RemovesPartialBore)
+{
+  const TopoDS_Shape aStock = twoPlateStack();
+  const double       aV0    = volumeOf(aStock);
+  const gp_Ax1       anAxis(gp_Pnt(0, 0, 15), gp_Dir(0, 0, -1));
+
+  BRepFeat_MakeCylindricalHole aHole;
+  aHole.Init(aStock, anAxis);
+  // The axis origin sits 5 units above plate A's entry face (axis parameter 5); a blind depth of
+  // 20 reaches axis parameter 20, boring 15 of plate A's 20 units of thickness.
+  aHole.PerformBlind(5.0, 20.0);
+  ASSERT_EQ(aHole.Status(), BRepFeat_NoError);
+  aHole.Build();
+  ASSERT_FALSE(aHole.Shape().IsNull());
+
+  const double aRemoved = aV0 - volumeOf(aHole.Shape());
+  EXPECT_NEAR(aRemoved, M_PI * 25.0 * 15.0, 1.e-3);
+}
+
+TEST(BRepFeat_MakeCylindricalHoleTest, PerformRanged_TwoPlateStack_RemovesBothBores)
+{
+  const TopoDS_Shape aStock = twoPlateStack();
+  const double       aV0    = volumeOf(aStock);
+  const gp_Ax1       anAxis(gp_Pnt(0, 0, 15), gp_Dir(0, 0, -1));
+
+  BRepFeat_MakeCylindricalHole aHole;
+  aHole.Init(aStock, anAxis);
+  aHole.Perform(5.0, 0.0, 70.0);
+  ASSERT_EQ(aHole.Status(), BRepFeat_NoError);
+  aHole.Build();
+  ASSERT_FALSE(aHole.Shape().IsNull());
+
+  const double aRemoved = aV0 - volumeOf(aHole.Shape());
+  EXPECT_NEAR(aRemoved, 2 * M_PI * 25.0 * 20.0, 1.e-3);
+}
+
+// Perform(Radius) (the infinite-cylinder through-all mode) selects no parts and was already
+// unaffected; kept as a control against the same stock.
+TEST(BRepFeat_MakeCylindricalHoleTest, PerformThroughAll_TwoPlateStack_RemovesBothBores)
+{
+  const TopoDS_Shape aStock = twoPlateStack();
+  const double       aV0    = volumeOf(aStock);
+  const gp_Ax1       anAxis(gp_Pnt(0, 0, 15), gp_Dir(0, 0, -1));
+
+  BRepFeat_MakeCylindricalHole aHole;
+  aHole.Init(aStock, anAxis);
+  aHole.Perform(5.0);
+  ASSERT_EQ(aHole.Status(), BRepFeat_NoError);
+  aHole.Build();
+  ASSERT_FALSE(aHole.Shape().IsNull());
+
+  const double aRemoved = aV0 - volumeOf(aHole.Shape());
+  EXPECT_NEAR(aRemoved, 2 * M_PI * 25.0 * 20.0, 1.e-3);
+}
+
+// A single plate never reaches the divergence (the cut result stays one solid); unaffected by
+// this fix, byte-identical before and after.
+TEST(BRepFeat_MakeCylindricalHoleTest, PerformUntilEnd_SinglePlate_Unaffected)
+{
+  const TopoDS_Shape aStock = BRepPrimAPI_MakeBox(gp_Pnt(-25, -25, -10), 50, 50, 20).Shape();
+  const double       aV0    = volumeOf(aStock);
+  const gp_Ax1       anAxis(gp_Pnt(0, 0, 15), gp_Dir(0, 0, -1));
+
+  BRepFeat_MakeCylindricalHole aHole;
+  aHole.Init(aStock, anAxis);
+  aHole.PerformUntilEnd(5.0);
+  ASSERT_EQ(aHole.Status(), BRepFeat_NoError);
+  aHole.Build();
+  ASSERT_FALSE(aHole.Shape().IsNull());
+
+  const double aRemoved = aV0 - volumeOf(aHole.Shape());
+  EXPECT_NEAR(aRemoved, M_PI * 25.0 * 20.0, 1.e-3);
+}

--- a/src/ModelingAlgorithms/TKFeat/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKFeat/GTests/FILES.cmake
@@ -2,4 +2,5 @@
 set(OCCT_TKFeat_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKFeat_GTests_FILES
+  BRepFeat_MakeCylindricalHole_Test.cxx
 )


### PR DESCRIPTION
`PerformThruNext`, `PerformUntilEnd`, the ranged `Perform(Radius, PFrom, PTo)`, and `PerformBlind` all choose which part of the drilling tool to keep by driving `BRepFeat_Builder` with the wrong operation:

```cpp
SetOperation(Fuse);        // -> BOPAlgo_CUT
BOPAlgo_BOP::Perform();    // myShape := object CUT tool
PartsOfTool(parts);        // explores myShape for solids
```

`BRepFeat_Builder::PartsOfTool()` collects the solids of `myShape`, which only holds the tool split by the object after a `BOPAlgo_COMMON` operation. After a `BOPAlgo_CUT`, `myShape` is the finished workpiece, so the selection loop compares barycentres of the cut result and registers pieces of it as kept parts of the tool. `PerformResult()` then takes the kept-parts path with a keep set containing no tool part at all, returning the object with the cylinder's faces imprinted on it and no material removed, while reporting `BRepFeat_NoError` throughout.

`BRepFeat_Form` (`BRepFeat_Form.cxx:806`) and `BRepFeat_RibSlot` (`BRepFeat_RibSlot.cxx:224`), the other two users of the same builder, both call the two-argument `SetOperation(myFuse, bFlag)` with `bFlag` true before `Perform()`, selecting `BOPAlgo_COMMON` so that `PartsOfTool()` means what its name says. `PerformResult()` resets `myOperation` from `myFuse` before building, so the operation finally built is still a `CUT` either way. `BRepFeat_MakeCylindricalHole` calls the one-argument overload at all four selecting sites. `Perform(Radius)`, the infinite-cylinder through-all mode, selects no parts and is unaffected.

The defect is hidden whenever the cut result has one solid, the case every existing test covers. It shows up as soon as it has two: a drill axis crossing two bodies of a compound, or, with no compound at all, a single bar the bore severs in half.

## Measured

Two 50 x 50 x 20 plates stacked on the drill axis, drilled at `r = 5` from `(0, 0, 15)` along `-Z` (one bore removes `1570.7963`):

| call | status | before | after |
|---|---|---|---|
| `Perform(R)` | `NoError` | 3141.5927 | 3141.5927 (unaffected) |
| `PerformUntilEnd` | `NoError` | **0.0000** | 3141.5927 |
| `PerformThruNext` | `NoError` | 1570.7963 | 1570.7963 (unaffected) |
| `PerformBlind(20)` | `NoError` | **0.0000** | 1178.0972 |
| `Perform(R, 0, 70)` | `NoError` | **0.0000** | 3141.5927 |
| `Perform(R, 0, 30)` | `NoError` | 1570.7963 | 1570.7963 |
| `Perform(R, 30, 70)` | `NoError` | 1570.7963 | 1570.7963 |

`PerformBlind(20)`'s length is measured from the axis origin `(0, 0, 15)`, which sits 5 units above plate A's entry face at axis parameter 5, not from that face. A blind depth of 20 therefore reaches axis parameter 20, boring only 15 units of the plate's 20-unit thickness: `1178.0972`, matching `pi * r^2 * 15`. That is the mode's own contract, not a discrepancy against the other rows.

A single 8mm bar an `r = 5` bore severs, where the CUT result is one workpiece split into two pieces rather than two separate bodies:

| call | status | before | after |
|---|---|---|---|
| `PerformUntilEnd` | `NoError` | **0.0000** | 1407.2952 |
| `PerformThruNext` | `NoError` | **0.0000** | 1407.2952 |
| `Perform(R, 0, 30)` | `NoError` | **0.0000** | 1407.2952 |

A single plate (one solid before and after the CUT) is byte-identical before and after; `nbparts` never reaches 2 there.

## Two behaviour changes worth flagging

**A status change for an oversized radius.** A radius large enough to swallow the whole workpiece used to report `BRepFeat_InvalidPlacement` for `PerformUntilEnd` and `PerformThruNext`, because the CUT emptied `myShape` and `nbparts` was 0. Under `BOPAlgo_COMMON` the tool meets the whole workpiece, `nbparts` is 1, and both modes now return the same result `Perform(Radius)` already returns for the same input (measured directly against this change: both go from `InvalidPlacement` to `NoError`, matching `Perform(Radius)`'s existing `NoError`).

**A second, separate defect in the same heuristic, reported here but not fixed.** `PerformThruNext`'s closest-interval fallback nests its `// parbar > Last` branch inside `if (parbar < First)`, as the `else` of the distance comparison, so the "beyond `Last`" case is unreachable as written:

```cpp
if (parbar < First)
{
  if (First - parbar < dmin)
  {
    dmin   = First - parbar;
    tokeep = its.Value();
  }
  else
  { // parbar > Last
    ...
  }
}
```

`PerformBlind`'s equivalent fallback has no such structure. It compares `std::abs(First - parbar) < dmin` uniformly. The fallback only runs when no tool part's barycentre lies in `[First, Last]`, which none of the geometries measured here reach, so it is left alone: changing it without a case that exercises it would be a guess.

## Validation

- `git apply --check` against current `master` (this PR's base): applies with no fuzz.
- `git clang-format` against the repository's own `.clang-format`, restricted to the changed lines: no reformatting.
- Compiled `BRepFeat_MakeCylindricalHole.cxx` from current `master`, once unmodified and once with this change, as override translation units linked ahead of a prebuilt OCCT 8.0.1 archive (`-DNo_Exception`, matching a release build), and ran a probe that drives all four modes plus the unaffected `Perform(Radius)` over six geometries (a single plate, two- and three-plate compounds, a one-solid channel with two spans on the axis, a bar the bore severs, and a hollow box). The unmodified build reproduces every "before" figure above; the changed build reproduces every "after" figure, and the two non-regression geometries (channel, hollow box) are byte-identical between the two builds.
- Separately verified the oversized-radius status change (`InvalidPlacement` to `NoError`) the same way.
- Read `BRepFeat_Builder::SetOperation`/`PerformResult` on current `master` directly to confirm the two-argument overload's semantics and that `PerformResult()` re-derives the final operation from `myFuse` regardless of the earlier call.

Found while measuring hole-drilling extents for the OCCTSwift wrapper, which currently works around this bridge-side by driving `BRepAlgoAPI_Cut` directly (`Shape.drilled`) rather than this class for a stack. Full writeup, reproducer and before/after transcripts: https://github.com/SecondMouseAU/OCCTSwift/tree/main/Scripts/repro/532-cylindrical-hole-part-selection
