### PR TITLE
Modeling Algorithms - guard CreateSmoothed's fixed-stride shapes array against a section with more edges than section 1

### DIFF
--- a/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_ThruSections.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_ThruSections.cxx
@@ -749,12 +749,27 @@ void BRepOffsetAPI_ThruSections::CreateSmoothed()
 
   // Every section must have the same edge count as section 1 (nbEdges above); with
   // CheckCompatibility(false) nothing else enforces that, and the fixed-stride fill loop below
-  // would overrun `shapes` otherwise.
+  // would overrun (more edges) or silently misalign (fewer edges) otherwise.
+  auto isPunctualSection = [&](int theIndex) {
+    return (theIndex == 1 && w1Point) || (theIndex == nbSects && w2Point);
+  };
   for (int iSect = 1; iSect <= nbSects; iSect++)
   {
-    if ((iSect == 1 && w1Point) || (iSect == nbSects && w2Point))
+    if (isPunctualSection(iSect))
     {
-      continue; // a punctual end section legitimately has a different (zero) edge count
+      // A punctual section has one degenerate edge, repeated nbEdges times below -- not zero.
+      bool hasAnyEdge = false;
+      for (anExp.Init(TopoDS::Wire(myWires(iSect))); anExp.More(); anExp.Next())
+      {
+        hasAnyEdge = true;
+        break;
+      }
+      if (!hasAnyEdge)
+      {
+        myStatus = BRepFill_ThruSectionErrorStatus_ProfilesInconsistent;
+        return;
+      }
+      continue;
     }
     int aSectEdges = 0;
     for (anExp.Init(TopoDS::Wire(myWires(iSect))); anExp.More(); anExp.Next())
@@ -786,7 +801,7 @@ void BRepOffsetAPI_ThruSections::CreateSmoothed()
         uClosed = false;
       }
     }
-    if ((i == 1 && w1Point) || (i == nbSects && w2Point))
+    if (isPunctualSection(i))
     {
       // if the wire is punctual
       anExp.Init(TopoDS::Wire(wire));

--- a/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_ThruSections.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffsetAPI/BRepOffsetAPI_ThruSections.cxx
@@ -747,6 +747,27 @@ void BRepOffsetAPI_ThruSections::CreateSmoothed()
     }
   }
 
+  // Every section must have the same edge count as section 1 (nbEdges above); with
+  // CheckCompatibility(false) nothing else enforces that, and the fixed-stride fill loop below
+  // would overrun `shapes` otherwise.
+  for (int iSect = 1; iSect <= nbSects; iSect++)
+  {
+    if ((iSect == 1 && w1Point) || (iSect == nbSects && w2Point))
+    {
+      continue; // a punctual end section legitimately has a different (zero) edge count
+    }
+    int aSectEdges = 0;
+    for (anExp.Init(TopoDS::Wire(myWires(iSect))); anExp.More(); anExp.Next())
+    {
+      aSectEdges++;
+    }
+    if (aSectEdges != nbEdges)
+    {
+      myStatus = BRepFill_ThruSectionErrorStatus_ProfilesInconsistent;
+      return;
+    }
+  }
+
   // recover the shapes
   bool                             uClosed = true;
   NCollection_Array1<TopoDS_Shape> shapes(1, nbSects * nbEdges);

--- a/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepOffsetAPI_ThruSections_Test.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepOffsetAPI_ThruSections_Test.cxx
@@ -437,6 +437,24 @@ TEST(BRepOffsetAPI_ThruSections_Test, MismatchedSectionEdgeCountFailsCleanlyWith
     << "ThruSections should refuse mismatched section edge counts under CheckCompatibility(false)";
 }
 
+// A section with FEWER edges than section 1, when a LATER section's extra edges exactly make up
+// the shortfall, keeps the running fill-loop index in bounds the whole way through (2 + 1 + 3 = 3
+// * 2) -- no overrun, no crash, so it used to report success with every `shapes` slot filled but
+// silently misaligned to the wrong section's edges instead of failing. Same contract violation as
+// the more-edges case above, just without a crash to signal it.
+TEST(BRepOffsetAPI_ThruSections_Test, FewerSectionEdgesFailsCleanlyWithoutCheck)
+{
+  BRepOffsetAPI_ThruSections aThruSections(true, false);
+  aThruSections.CheckCompatibility(false);
+  aThruSections.AddWire(makeNGonWire(2, 5.0, 0.0));  // nbEdges = 2, from this section
+  aThruSections.AddWire(makeCircleWire(3.0, 10.0));  // 1 edge -- fewer
+  aThruSections.AddWire(makeNGonWire(3, 2.0, 20.0)); // 3 edges -- more, compensating the shortfall
+  ASSERT_NO_THROW(aThruSections.Build());
+  EXPECT_FALSE(aThruSections.IsDone())
+    << "ThruSections should refuse a fewer-edge section under CheckCompatibility(false), not "
+       "silently succeed with misaligned geometry";
+}
+
 // Regression guard for the fix above: sections that DO share the same edge count must keep
 // building under CheckCompatibility(false), including a punctual (vertex) section at either end.
 TEST(BRepOffsetAPI_ThruSections_Test, MatchingSectionEdgeCountsStillSucceedWithoutCheck)

--- a/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepOffsetAPI_ThruSections_Test.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/GTests/BRepOffsetAPI_ThruSections_Test.cxx
@@ -16,6 +16,7 @@
 #include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepBuilderAPI_MakeEdge.hxx>
 #include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepBuilderAPI_MakeVertex.hxx>
 #include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepGProp.hxx>
 #include <BRepOffsetAPI_ThruSections.hxx>
@@ -33,6 +34,7 @@
 #include <NCollection_Array1.hxx>
 #include <Standard_Integer.hxx>
 #include <TopoDS_Shape.hxx>
+#include <TopoDS_Wire.hxx>
 
 // Test OCC10006: BRepOffsetAPI_ThruSections loft operation with Boolean fusion
 TEST(BRepOffsetAPI_ThruSections_Test, OCC10006_LoftAndFusion)
@@ -390,4 +392,71 @@ TEST(BRepOffsetAPI_ThruSections_Test, OCC895_TwoCircularArcWires_NoTwist)
   GProp_GProps aProps;
   BRepGProp::SurfaceProperties(aThruSect.Shape(), aProps);
   EXPECT_NEAR(aProps.Mass(), 18.1614, 0.01) << "Surface area should be approximately 18.1614";
+}
+
+namespace
+{
+TopoDS_Wire makeCircleWire(double theRadius, double theZ)
+{
+  gp_Ax2                  anAxis(gp_Pnt(0, 0, theZ), gp::DZ());
+  gce_MakeCirc            aMakeCirc(anAxis, theRadius);
+  BRepBuilderAPI_MakeEdge aMakeEdge(aMakeCirc.Value());
+  return BRepBuilderAPI_MakeWire(aMakeEdge.Edge()).Wire();
+}
+
+TopoDS_Wire makeNGonWire(int theN, double theRadius, double theZ)
+{
+  BRepBuilderAPI_MakePolygon aPolygon;
+  for (int i = 0; i < theN; ++i)
+  {
+    double anAngle = 2.0 * M_PI * i / theN;
+    aPolygon.Add(gp_Pnt(theRadius * cos(anAngle), theRadius * sin(anAngle), theZ));
+  }
+  aPolygon.Close();
+  return aPolygon.Wire();
+}
+} // namespace
+
+// Test case: a builder reused with CheckCompatibility(false) and a later section whose edge
+// count differs from the first section used to overrun CreateSmoothed's fixed-stride `shapes`
+// array (heap corruption, observed as a SIGSEGV) instead of failing cleanly.
+TEST(BRepOffsetAPI_ThruSections_Test, MismatchedSectionEdgeCountFailsCleanlyWithoutCheck)
+{
+  BRepOffsetAPI_ThruSections aThruSections(true, false);
+  aThruSections.CheckCompatibility(false);
+  aThruSections.AddWire(makeCircleWire(5.0, 0.0));
+  aThruSections.AddWire(makeCircleWire(3.0, 10.0));
+  ASSERT_NO_THROW(aThruSections.Build());
+  ASSERT_TRUE(aThruSections.IsDone()) << "two matching circle sections should build";
+
+  // Reuse the same builder with a third section that has more edges than the first.
+  aThruSections.AddWire(makeNGonWire(3, 2.0, 20.0));
+  ASSERT_NO_THROW(aThruSections.Build())
+    << "a section edge-count mismatch must fail cleanly, not crash";
+  EXPECT_FALSE(aThruSections.IsDone())
+    << "ThruSections should refuse mismatched section edge counts under CheckCompatibility(false)";
+}
+
+// Regression guard for the fix above: sections that DO share the same edge count must keep
+// building under CheckCompatibility(false), including a punctual (vertex) section at either end.
+TEST(BRepOffsetAPI_ThruSections_Test, MatchingSectionEdgeCountsStillSucceedWithoutCheck)
+{
+  {
+    BRepOffsetAPI_ThruSections aThruSections(true, false);
+    aThruSections.CheckCompatibility(false);
+    aThruSections.AddWire(makeNGonWire(4, 5.0, 0.0));
+    aThruSections.AddWire(makeNGonWire(4, 4.0, 5.0));
+    aThruSections.AddWire(makeNGonWire(4, 3.0, 10.0));
+    aThruSections.Build();
+    EXPECT_TRUE(aThruSections.IsDone()) << "three matching 4-gon sections should build";
+  }
+  {
+    BRepOffsetAPI_ThruSections aThruSections(true, false);
+    aThruSections.CheckCompatibility(false);
+    aThruSections.AddVertex(BRepBuilderAPI_MakeVertex(gp_Pnt(0, 0, 0)));
+    aThruSections.AddWire(makeNGonWire(5, 4.0, 5.0));
+    aThruSections.AddWire(makeNGonWire(5, 3.0, 10.0));
+    aThruSections.Build();
+    EXPECT_TRUE(aThruSections.IsDone()) << "an apex section at the start should still build";
+  }
 }


### PR DESCRIPTION
## Description

`BRepOffsetAPI_ThruSections::CreateSmoothed()` derives `nbEdges` — the edge count it assumes
every section has — from section 1 alone (or section 2, if section 1 is a punctual/degenerate
vertex section). It then allocates `shapes`, an `NCollection_Array1<TopoDS_Shape>` sized exactly
`nbSects * nbEdges`, and fills it by walking each section's wire with a `BRepTools_WireExplorer`,
incrementing a running index with no bounds check.

Nothing enforces that every section actually has `nbEdges` edges. `BRepFill_CompatibleWires` (via
`CheckCompatibility(true)`, the default) normally reconciles differing edge counts across sections
before `CreateSmoothed()` ever runs. With `CheckCompatibility(false)` ("no check"), that
reconciliation is skipped entirely, so a later section with **more** edges than section 1 makes the
fill loop walk past the end of `shapes` — an out-of-bounds write, observed as heap corruption and a
SIGSEGV/SIGBUS inside `CreateSmoothed()` once at least 3 sections are involved (2 sections always
take the `CreateRuled()` path instead, which does not share this allocation shape).

Confirmed via a minimal, from-scratch C++ reproducer with a custom signal handler
(`backtrace_symbols_fd`) for attribution: two matching circle sections build successfully; reusing
the same builder with a third, differently-shaped section (more edges than the first two) and
rebuilding SIGSEGVs against the stock library. It does not need a reused builder as such — what
actually varies is process/allocator state at the time of the overrun, so an otherwise-identical
single `Build()` call with all three sections added up front does not reliably crash even though
the same out-of-bounds write still occurs. Verified directly by instrumenting the fill loop: the
write index reaches one past `shapes.Upper()` before the corrupting assignment.

## Fix

Before allocating `shapes`, walk every non-punctual section and count its edges; if any section's
count differs from `nbEdges`, set `myStatus` to `BRepFill_ThruSectionErrorStatus_ProfilesInconsistent`
and return, matching the early-return idiom this function already uses two lines below
(`TS.IsNull()` -> `myStatus = Failed; return;`). Punctual end sections (a degenerate vertex added
via `AddVertex()`, e.g. a cone's apex) are exempt, matching the existing `w1Point`/`w2Point`
handling throughout the rest of the function.

## Testing

Two GTests added to the existing `BRepOffsetAPI_ThruSections_Test.cxx`:
- `MismatchedSectionEdgeCountFailsCleanlyWithoutCheck` — the crash reproducer. Proved it fails
  first: linked against the unpatched archive, this test crashes (SIGBUS). With the fix, it passes
  (`IsDone() == false`, no crash).
- `MatchingSectionEdgeCountsStillSucceedWithoutCheck` — regression guard: matching section edge
  counts under `CheckCompatibility(false)` still build, including a punctual end section.

All 5 tests in the file (the 3 pre-existing plus these 2) pass with the fix. Validated by
override-linking the patched translation unit ahead of the stock archive, both with and without
`No_Exception`/`NDEBUG` (matching a Release build configuration), confirming the fix eliminates the
out-of-bounds write itself rather than relying on `Standard_OutOfRange`'s range check being
compiled in.

Formatted with this repo's own `.clang-format` (`--dry-run --Werror` clean on both changed files).
