### PR TITLE
Modeling Data - Refactor Geom_OsculatingSurface

### DIFF
--- a/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.cxx
@@ -670,33 +670,13 @@ bool Geom_OsculatingSurface::isQPunctual(const GeomAdaptor_Surface& theAdaptor,
                                          double                     theTolMin,
                                          double                     theTolMax) const
 {
-  const bool   anIsIsoV = theIT == GeomAbs_IsoV;
-  const double aPmin    = anIsIsoV ? theAdaptor.FirstUParameter() : theAdaptor.FirstVParameter();
-  const double aPmax    = anIsIsoV ? theAdaptor.LastUParameter() : theAdaptor.LastVParameter();
-  const int    aNbIntervals =
-    anIsIsoV ? theAdaptor.NbUIntervals(GeomAbs_CN) : theAdaptor.NbVIntervals(GeomAbs_CN);
-  if (aNbIntervals < 1)
-  {
-    return false;
-  }
-
-  NCollection_LocalArray<double> aIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
-  NCollection_Array1<double>     aIntervals(aIntervalStorage.begin()[0], 1, aNbIntervals + 1);
-  if (anIsIsoV)
-  {
-    theAdaptor.UIntervals(aIntervals, GeomAbs_CN);
-  }
-  else
-  {
-    theAdaptor.VIntervals(aIntervals, GeomAbs_CN);
-  }
-  aIntervals.ChangeAt(0)                                 = aPmin;
-  aIntervals.ChangeAt(static_cast<size_t>(aNbIntervals)) = aPmax;
-
-  const int    aDegree      = anIsIsoV ? theAdaptor.UDegree() : theAdaptor.VDegree();
-  const size_t aNbSamples   = static_cast<size_t>(std::max(aDegree, 1));
-  double       aD1NormMax   = 0.0;
-  auto         updateD1Norm = [&](const double theParameter) {
+  const bool    anIsIsoV = theIT == GeomAbs_IsoV;
+  const double  aPmin    = anIsIsoV ? theAdaptor.FirstUParameter() : theAdaptor.FirstVParameter();
+  const double  aPmax    = anIsIsoV ? theAdaptor.LastUParameter() : theAdaptor.LastVParameter();
+  constexpr int THE_NB_SUBDIVISIONS = 10;
+  const double  aRange              = aPmax - aPmin;
+  double        aD1NormMax          = 0.0;
+  auto          updateD1Norm        = [&](const double theParameter) {
     if (anIsIsoV)
     {
       const Geom_Surface::ResD1 aResult = theAdaptor.EvalD1(theParameter, theParam);
@@ -709,19 +689,14 @@ bool Geom_OsculatingSurface::isQPunctual(const GeomAdaptor_Surface& theAdaptor,
     }
   };
 
-  for (size_t anInterval = 0; anInterval < static_cast<size_t>(aNbIntervals); ++anInterval)
+  // Keep the historical sampling density while avoiding floating-point loop progress.
+  for (int anIndex = 0; anIndex <= THE_NB_SUBDIVISIONS; ++anIndex)
   {
-    const double aFirst = aIntervals.At(anInterval);
-    const double aLast  = aIntervals.At(anInterval + 1);
-    const double aRange = aLast - aFirst;
-    for (size_t anIndex = 0; anIndex <= aNbSamples; ++anIndex)
-    {
-      const double aParameter =
-        anIndex == aNbSamples
-          ? aLast
-          : aFirst + aRange * static_cast<double>(anIndex) / static_cast<double>(aNbSamples);
-      updateD1Norm(aParameter);
-    }
+    const double aParameter =
+      anIndex == THE_NB_SUBDIVISIONS
+        ? aPmax
+        : aPmin + aRange * static_cast<double>(anIndex) / THE_NB_SUBDIVISIONS;
+    updateD1Norm(aParameter);
   }
 
   return !(aD1NormMax > theTolMax || aD1NormMax < theTolMin);

--- a/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.cxx
@@ -18,14 +18,41 @@
 #include <Geom_BezierSurface.hxx>
 #include <Geom_BSplineSurface.hxx>
 #include <Geom_Surface.hxx>
+#include <GeomAdaptor_Surface.hxx>
+#include <NCollection_LocalArray.hxx>
 #include <PLib.hxx>
 #include <gp_Pnt.hxx>
 #include <NCollection_Array2.hxx>
-#include <gp_Vec.hxx>
-#include <NCollection_HArray2.hxx>
-#include <Standard_Integer.hxx>
 #include <NCollection_Array1.hxx>
-#include <NCollection_HArray1.hxx>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+namespace
+{
+//! Clears osculating-surface flags unless initialization completes successfully.
+class OsculatingSurfaceInitGuard
+{
+public:
+  OsculatingSurfaceInitGuard(std::array<bool, 4>& theFlags, bool& theIsDone)
+      : myFlags(theFlags), myIsDone(theIsDone)
+  {
+  }
+
+  ~OsculatingSurfaceInitGuard()
+  {
+    if (!myIsDone)
+    {
+      myFlags.fill(false);
+    }
+  }
+
+private:
+  std::array<bool, 4>& myFlags;
+  bool&                 myIsDone;
+};
+} // namespace
 
 //=================================================================================================
 
@@ -57,7 +84,6 @@ Geom_OsculatingSurface::Geom_OsculatingSurface(Geom_OsculatingSurface&& theOther
       myTol(theOther.myTol),
       myOsculSurf1(std::move(theOther.myOsculSurf1)),
       myOsculSurf2(std::move(theOther.myOsculSurf2)),
-      myKdeg(std::move(theOther.myKdeg)),
       myAlong(theOther.myAlong)
 {
   theOther.myTol = 0.0;
@@ -74,7 +100,6 @@ Geom_OsculatingSurface& Geom_OsculatingSurface::operator=(const Geom_OsculatingS
     myTol        = theOther.myTol;
     myOsculSurf1 = theOther.myOsculSurf1;
     myOsculSurf2 = theOther.myOsculSurf2;
-    myKdeg       = theOther.myKdeg;
     myAlong      = theOther.myAlong;
   }
   return *this;
@@ -91,7 +116,6 @@ Geom_OsculatingSurface& Geom_OsculatingSurface::operator=(
     myTol        = theOther.myTol;
     myOsculSurf1 = std::move(theOther.myOsculSurf1);
     myOsculSurf2 = std::move(theOther.myOsculSurf2);
-    myKdeg       = std::move(theOther.myKdeg);
     myAlong      = theOther.myAlong;
 
     theOther.myTol = 0.0;
@@ -104,290 +128,229 @@ Geom_OsculatingSurface& Geom_OsculatingSurface::operator=(
 
 void Geom_OsculatingSurface::Init(const occ::handle<Geom_Surface>& theBS, double theTol)
 {
-  clearOsculFlags();
-  myTol            = theTol;
-  double TolMin    = 0.; // consider all singularities below Tol, not just above 1.e-12
-  bool   OsculSurf = true;
-  myBasisSurf      = occ::down_cast<Geom_Surface>(theBS->Copy());
+  myAlong.fill(false);
+  bool aIsDone = false;
+  OsculatingSurfaceInitGuard aInitGuard(myAlong, aIsDone);
+
+  myTol = theTol;
+  myBasisSurf.Nullify();
   myOsculSurf1.Clear();
   myOsculSurf2.Clear();
-  myKdeg.Clear();
 
-  if ((theBS->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
-      || (theBS->IsKind(STANDARD_TYPE(Geom_BezierSurface))))
+  if (theBS.IsNull())
   {
-    double U1 = 0, U2 = 0, V1 = 0, V2 = 0;
+    return;
+  }
 
-    int i = 1;
-    theBS->Bounds(U1, U2, V1, V2);
-    myAlong[0] = isQPunctual(theBS, V1, GeomAbs_IsoV, TolMin, theTol);
-    myAlong[1] = isQPunctual(theBS, V2, GeomAbs_IsoV, TolMin, theTol);
-    myAlong[2] = isQPunctual(theBS, U1, GeomAbs_IsoU, TolMin, theTol);
-    myAlong[3] = isQPunctual(theBS, U2, GeomAbs_IsoU, TolMin, theTol);
-#ifdef OCCT_DEBUG
-    std::cout << myAlong[0] << std::endl
-              << myAlong[1] << std::endl
-              << myAlong[2] << std::endl
-              << myAlong[3] << std::endl;
-#endif
-    if (myAlong[0] || myAlong[1] || myAlong[2] || myAlong[3])
+  myBasisSurf = occ::down_cast<Geom_Surface>(theBS->Copy());
+
+  const bool aIsBSpline = theBS->IsKind(STANDARD_TYPE(Geom_BSplineSurface));
+  const bool aIsBezier  = theBS->IsKind(STANDARD_TYPE(Geom_BezierSurface));
+  if (!aIsBSpline && !aIsBezier)
+  {
+    return;
+  }
+
+  // Consider all singularities below myTol, not just above 1.e-12.
+  constexpr double THE_TOL_MIN = 0.0;
+
+  double aU1 = 0.0;
+  double aU2 = 0.0;
+  double aV1 = 0.0;
+  double aV2 = 0.0;
+  theBS->Bounds(aU1, aU2, aV1, aV2);
+  const GeomAdaptor_Surface anAdaptor(theBS, aU1, aU2, aV1, aV2);
+  myAlong[0] = isQPunctual(anAdaptor, aV1, GeomAbs_IsoV, THE_TOL_MIN, theTol);
+  myAlong[1] = isQPunctual(anAdaptor, aV2, GeomAbs_IsoV, THE_TOL_MIN, theTol);
+  myAlong[2] = isQPunctual(anAdaptor, aU1, GeomAbs_IsoU, THE_TOL_MIN, theTol);
+  myAlong[3] = isQPunctual(anAdaptor, aU2, GeomAbs_IsoU, THE_TOL_MIN, theTol);
+
+  if (!HasOscSurf())
+  {
+    return;
+  }
+
+  // Promote Bezier to BSpline so the iso-scan can use the shared knot indexing.
+  occ::handle<Geom_BSplineSurface> aInitSurf;
+  if (aIsBezier)
+  {
+    const occ::handle<Geom_BezierSurface> aBzS = occ::down_cast<Geom_BezierSurface>(theBS);
+    NCollection_LocalArray<double, 2>     aUKnotStorage(2);
+    NCollection_LocalArray<double, 2>     aVKnotStorage(2);
+    NCollection_LocalArray<int, 2>        aUMultStorage(2);
+    NCollection_LocalArray<int, 2>        aVMultStorage(2);
+    NCollection_Array1<double>            aUKnots(aUKnotStorage.begin()[0], 1, 2);
+    NCollection_Array1<double>            aVKnots(aVKnotStorage.begin()[0], 1, 2);
+    NCollection_Array1<int>               aUMults(aUMultStorage.begin()[0], 1, 2);
+    NCollection_Array1<int>               aVMults(aVMultStorage.begin()[0], 1, 2);
+    for (size_t i = 0; i < 2; ++i)
     {
-      occ::handle<Geom_BSplineSurface> InitSurf, L, S;
-      if (theBS->IsKind(STANDARD_TYPE(Geom_BezierSurface)))
-      {
-        occ::handle<Geom_BezierSurface> BzS = occ::down_cast<Geom_BezierSurface>(theBS);
-        NCollection_Array1<double>      UKnots(1, 2);
-        NCollection_Array1<double>      VKnots(1, 2);
-        NCollection_Array1<int>         UMults(1, 2);
-        NCollection_Array1<int>         VMults(1, 2);
-        for (i = 1; i <= 2; i++)
-        {
-          UKnots.SetValue(i, (i - 1));
-          VKnots.SetValue(i, (i - 1));
-          UMults.SetValue(i, BzS->UDegree() + 1);
-          VMults.SetValue(i, BzS->VDegree() + 1);
-        }
-        InitSurf = new Geom_BSplineSurface(BzS->Poles(),
-                                           UKnots,
-                                           VKnots,
-                                           UMults,
-                                           VMults,
-                                           BzS->UDegree(),
-                                           BzS->VDegree(),
-                                           BzS->IsUPeriodic(),
-                                           BzS->IsVPeriodic());
-      }
-      else
-      {
-        InitSurf = occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
-      }
-#ifdef OCCT_DEBUG
-      std::cout << "UDEG: " << InitSurf->UDegree() << std::endl;
-      std::cout << "VDEG: " << InitSurf->VDegree() << std::endl;
-#endif
-
-      if (IsAlongU() && IsAlongV())
-      {
-        clearOsculFlags();
-      }
-
-      if ((IsAlongU() && InitSurf->VDegree() > 1) || (IsAlongV() && InitSurf->UDegree() > 1))
-      {
-        int  k = 0;
-        bool IsQPunc;
-        int  UKnot, VKnot;
-        if (myAlong[0] || myAlong[1])
-        {
-          for (i = 1; i < InitSurf->NbUKnots(); i++)
-          {
-            if (myAlong[0])
-            {
-              S       = InitSurf;
-              k       = 0;
-              IsQPunc = true;
-              UKnot   = i;
-              VKnot   = 1;
-              while (IsQPunc)
-              {
-                OsculSurf = buildOsculatingSurface(V1, UKnot, VKnot, S, L);
-                if (!OsculSurf)
-                {
-                  break;
-                }
-                k++;
-#ifdef OCCT_DEBUG
-                std::cout << "1.k = " << k << std::endl;
-#endif
-                IsQPunc = isQPunctual(L, V1, GeomAbs_IsoV, 0., theTol);
-                UKnot   = 1;
-                VKnot   = 1;
-                S       = L;
-              }
-              if (OsculSurf)
-              {
-                myOsculSurf1.Append(L);
-              }
-              else
-              {
-                clearOsculFlags();
-              }
-              if (myAlong[1] && OsculSurf)
-              {
-                S       = InitSurf;
-                k       = 0;
-                IsQPunc = true;
-                UKnot   = i;
-                VKnot   = InitSurf->NbVKnots() - 1;
-
-                while (IsQPunc)
-                {
-                  OsculSurf = buildOsculatingSurface(V2, UKnot, VKnot, S, L);
-                  if (!OsculSurf)
-                  {
-                    break;
-                  }
-                  k++;
-#ifdef OCCT_DEBUG
-                  std::cout << "2.k = " << k << std::endl;
-#endif
-                  IsQPunc = isQPunctual(L, V2, GeomAbs_IsoV, 0., theTol);
-                  UKnot   = 1;
-                  VKnot   = 1;
-                  S       = L;
-                }
-                if (OsculSurf)
-                {
-                  myOsculSurf2.Append(L);
-                  myKdeg.Append(k);
-                }
-              }
-            }
-            else
-            {
-              S       = InitSurf;
-              k       = 0;
-              IsQPunc = true;
-              UKnot   = i;
-              VKnot   = InitSurf->NbVKnots() - 1;
-              while (IsQPunc)
-              {
-                OsculSurf = buildOsculatingSurface(V2, UKnot, VKnot, S, L);
-                if (!OsculSurf)
-                {
-                  break;
-                }
-                k++;
-#ifdef OCCT_DEBUG
-                std::cout << "2.k = " << k << std::endl;
-#endif
-                IsQPunc = isQPunctual(L, V2, GeomAbs_IsoV, 0., theTol);
-                UKnot   = 1;
-                VKnot   = 1;
-                S       = L;
-              }
-              if (OsculSurf)
-              {
-                myOsculSurf2.Append(L);
-                myKdeg.Append(k);
-              }
-              else
-              {
-                clearOsculFlags();
-              }
-            }
-          }
-        }
-        if (myAlong[2] || myAlong[3])
-        {
-          for (i = 1; i < InitSurf->NbVKnots(); i++)
-          {
-            if (myAlong[2])
-            {
-              S       = InitSurf;
-              k       = 0;
-              IsQPunc = true;
-              UKnot   = 1;
-              VKnot   = i;
-              while (IsQPunc)
-              {
-                OsculSurf = buildOsculatingSurface(U1, UKnot, VKnot, S, L);
-                if (!OsculSurf)
-                {
-                  break;
-                }
-                k++;
-#ifdef OCCT_DEBUG
-                std::cout << "1.k = " << k << std::endl;
-#endif
-                IsQPunc = isQPunctual(L, U1, GeomAbs_IsoU, 0., theTol);
-                UKnot   = 1;
-                VKnot   = 1;
-                S       = L;
-              }
-              if (OsculSurf)
-              {
-                myOsculSurf1.Append(L);
-              }
-              else
-              {
-                clearOsculFlags();
-              }
-              if (myAlong[3] && OsculSurf)
-              {
-                S       = InitSurf;
-                k       = 0;
-                IsQPunc = true;
-                UKnot   = InitSurf->NbUKnots() - 1;
-                VKnot   = i;
-                while (IsQPunc)
-                {
-                  OsculSurf = buildOsculatingSurface(U2, UKnot, VKnot, S, L);
-                  if (!OsculSurf)
-                  {
-                    break;
-                  }
-                  k++;
-#ifdef OCCT_DEBUG
-                  std::cout << "2.k = " << k << std::endl;
-#endif
-                  IsQPunc = isQPunctual(L, U2, GeomAbs_IsoU, 0., theTol);
-                  UKnot   = 1;
-                  VKnot   = 1;
-                  S       = L;
-                }
-                if (OsculSurf)
-                {
-                  myOsculSurf2.Append(L);
-                  myKdeg.Append(k);
-                }
-              }
-            }
-            else
-            {
-              S       = InitSurf;
-              k       = 0;
-              IsQPunc = true;
-              UKnot   = InitSurf->NbUKnots() - 1;
-              VKnot   = i;
-              while (IsQPunc)
-              {
-                OsculSurf = buildOsculatingSurface(U2, UKnot, VKnot, S, L);
-                if (!OsculSurf)
-                {
-                  break;
-                }
-                k++;
-#ifdef OCCT_DEBUG
-                std::cout << "2.k = " << k << std::endl;
-#endif
-                IsQPunc = isQPunctual(L, U2, GeomAbs_IsoU, 0., theTol);
-                UKnot   = 1;
-                VKnot   = 1;
-                S       = L;
-              }
-              if (OsculSurf)
-              {
-                myOsculSurf2.Append(L);
-                myKdeg.Append(k);
-              }
-              else
-              {
-                clearOsculFlags();
-              }
-            }
-          }
-        }
-      }
-      else
-      {
-        clearOsculFlags();
-      }
+      aUKnots.ChangeAt(i) = static_cast<double>(i);
+      aVKnots.ChangeAt(i) = static_cast<double>(i);
+      aUMults.ChangeAt(i) = aBzS->UDegree() + 1;
+      aVMults.ChangeAt(i) = aBzS->VDegree() + 1;
     }
+    aInitSurf = new Geom_BSplineSurface(aBzS->Poles(),
+                                        aUKnots,
+                                        aVKnots,
+                                        aUMults,
+                                        aVMults,
+                                        aBzS->UDegree(),
+                                        aBzS->VDegree(),
+                                        aBzS->IsUPeriodic(),
+                                        aBzS->IsVPeriodic());
   }
   else
   {
-    clearOsculFlags();
+    aInitSurf = occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
   }
+
+  // Cannot handle simultaneous degeneracy in both directions.
+  if (IsAlongU() && IsAlongV())
+  {
+    return;
+  }
+
+  // The reduction needs at least one direction to have degree > 1.
+  if ((IsAlongU() && aInitSurf->VDegree() <= 1)
+      || (IsAlongV() && aInitSurf->UDegree() <= 1))
+  {
+    return;
+  }
+
+  const size_t aNbSurfaces = IsAlongU()
+                               ? static_cast<size_t>(aInitSurf->NbUKnots() - 1)
+                               : static_cast<size_t>(aInitSurf->NbVKnots() - 1);
+  myOsculSurf1.Reserve(aNbSurfaces);
+  myOsculSurf2.Reserve(aNbSurfaces);
+
+  if (myAlong[0] || myAlong[1])
+  {
+    // One reduction per U-span; both V-bound isos share the same span.
+    for (int i = 1; i < aInitSurf->NbUKnots(); ++i)
+    {
+      occ::handle<Geom_BSplineSurface> aSurface;
+      size_t                           aNbReductions = 0;
+      if (myAlong[0])
+      {
+        if (!reduceAlongIso(aInitSurf,
+                            aV1,
+                            GeomAbs_IsoV,
+                            i,
+                            1,
+                            aSurface,
+                            aNbReductions))
+        {
+          return;
+        }
+        myOsculSurf1.Append(aSurface);
+      }
+      if (myAlong[1])
+      {
+        if (!reduceAlongIso(aInitSurf,
+                            aV2,
+                            GeomAbs_IsoV,
+                            i,
+                            aInitSurf->NbVKnots() - 1,
+                            aSurface,
+                            aNbReductions))
+        {
+          return;
+        }
+        appendOsculatingSurface2(aSurface, aNbReductions);
+      }
+    }
+  }
+  if (myAlong[2] || myAlong[3])
+  {
+    // One reduction per V-span; both U-bound isos share the same span.
+    for (int i = 1; i < aInitSurf->NbVKnots(); ++i)
+    {
+      occ::handle<Geom_BSplineSurface> aSurface;
+      size_t                           aNbReductions = 0;
+      if (myAlong[2])
+      {
+        if (!reduceAlongIso(aInitSurf,
+                            aU1,
+                            GeomAbs_IsoU,
+                            1,
+                            i,
+                            aSurface,
+                            aNbReductions))
+        {
+          return;
+        }
+        myOsculSurf1.Append(aSurface);
+      }
+      if (myAlong[3])
+      {
+        if (!reduceAlongIso(aInitSurf,
+                            aU2,
+                            GeomAbs_IsoU,
+                            aInitSurf->NbUKnots() - 1,
+                            i,
+                            aSurface,
+                            aNbReductions))
+        {
+          return;
+        }
+        appendOsculatingSurface2(aSurface, aNbReductions);
+      }
+    }
+  }
+
+  aIsDone = true;
+}
+
+//=================================================================================================
+
+bool Geom_OsculatingSurface::reduceAlongIso(
+  const occ::handle<Geom_BSplineSurface>& theInitSurf,
+  double                                  theParam,
+  GeomAbs_IsoType                         theIso,
+  int                                     theInitUKnot,
+  int                                     theInitVKnot,
+  occ::handle<Geom_BSplineSurface>&       theSurface,
+  size_t&                                  theNbReductions) const
+{
+  theSurface.Nullify();
+  theNbReductions = 0;
+
+  occ::handle<Geom_BSplineSurface> aSurface = theInitSurf;
+  occ::handle<Geom_BSplineSurface> aReducedSurface;
+  int                              aUKnot = theInitUKnot;
+  int                              aVKnot = theInitVKnot;
+  bool                             aIsQPunctual = true;
+  GeomAdaptor_Surface              anAdaptor;
+  while (aIsQPunctual)
+  {
+    if (!buildOsculatingSurface(theParam, aUKnot, aVKnot, aSurface, aReducedSurface))
+    {
+      return false;
+    }
+
+    ++theNbReductions;
+    anAdaptor.Load(aReducedSurface);
+    aIsQPunctual = isQPunctual(anAdaptor, theParam, theIso, 0.0, myTol);
+    aUKnot        = 1;
+    aVKnot        = 1;
+    aSurface      = aReducedSurface;
+  }
+
+  theSurface = aSurface;
+  return true;
+}
+
+//=================================================================================================
+
+void Geom_OsculatingSurface::appendOsculatingSurface2(
+  const occ::handle<Geom_BSplineSurface>& theSurface,
+  size_t                                   theNbReductions)
+{
+  OsculatingSurfaceData anOsculatingSurface;
+  anOsculatingSurface.Surface     = theSurface;
+  anOsculatingSurface.IsOpposite = (theNbReductions % 2) != 0;
+  myOsculSurf2.Append(anOsculatingSurface);
 }
 
 //=================================================================================================
@@ -397,67 +360,54 @@ bool Geom_OsculatingSurface::UOsculatingSurface(double                          
                                                 bool&                             theT,
                                                 occ::handle<Geom_BSplineSurface>& theL) const
 {
-  bool along = false;
-  if (myAlong[0] || myAlong[1])
+  if (!(myAlong[0] || myAlong[1]))
   {
-    int    NU = 1, NV = 1;
-    double u1, u2, v1, v2;
-    theT = false;
-    myBasisSurf->Bounds(u1, u2, v1, v2);
-    int  NbUK, NbVK;
-    bool isToSkipSecond = false;
-    if (myBasisSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
-    {
-      occ::handle<Geom_BSplineSurface> BSur    = occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
-      NbUK                                     = BSur->NbUKnots();
-      NbVK                                     = BSur->NbVKnots();
-      const NCollection_Array1<double>& UKnots = BSur->UKnots();
-      const NCollection_Array1<double>& VKnots = BSur->VKnots();
-      BSplCLib::Hunt(UKnots, theU, NU);
-      BSplCLib::Hunt(VKnots, theV, NV);
-      if (NU < 1)
-      {
-        NU = 1;
-      }
-      if (NU >= NbUK)
-      {
-        NU = NbUK - 1;
-      }
-      if (NbVK == 2 && NV == 1)
-      {
-        // Need to find the closest end
-        if (VKnots(NbVK) - theV > theV - VKnots(1))
-        {
-          isToSkipSecond = true;
-        }
-      }
-    }
-    else
-    {
-      NU   = 1;
-      NV   = 1;
-      NbVK = 2;
-    }
+    return false;
+  }
 
-    if (myAlong[0] && NV == 1)
+  theT = false;
+  int  aNU             = 1;
+  int  aNV             = 1;
+  int  aNbUK           = 2;
+  int  aNbVK           = 2;
+  bool aIsToSkipSecond = false;
+  if (myBasisSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
+  {
+    const occ::handle<Geom_BSplineSurface> aBSur =
+      occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
+    aNbUK                                      = aBSur->NbUKnots();
+    aNbVK                                      = aBSur->NbVKnots();
+    const NCollection_Array1<double>& aUKnots = aBSur->UKnots();
+    const NCollection_Array1<double>& aVKnots = aBSur->VKnots();
+    BSplCLib::Hunt(aUKnots, theU, aNU);
+    BSplCLib::Hunt(aVKnots, theV, aNV);
+    aNU = std::clamp(aNU, 1, aNbUK - 1);
+    if (aNbVK == 2 && aNV == 1)
     {
-      theL  = myOsculSurf1.Value(NU);
-      along = true;
-    }
-    if (myAlong[1] && (NV == NbVK - 1) && !isToSkipSecond)
-    {
-      // theT means that derivative vector of osculating surface is opposite
-      // to the original. This happens when (v-t)^k is negative, i.e.
-      // difference between degrees (k) is odd and t is the last parameter
-      if (myKdeg.Value(NU) % 2)
+      // Pick the closest V end when the surface has a single span.
+      if (aVKnots(aNbVK) - theV > theV - aVKnots(1))
       {
-        theT = true;
+        aIsToSkipSecond = true;
       }
-      theL  = myOsculSurf2.Value(NU);
-      along = true;
     }
   }
-  return along;
+
+  bool aAlong = false;
+  if (myAlong[0] && aNV == 1)
+  {
+    theL  = myOsculSurf1.Value(static_cast<size_t>(aNU - 1));
+    aAlong = true;
+  }
+  if (myAlong[1] && aNV == aNbVK - 1 && !aIsToSkipSecond)
+  {
+    // The derivative is reversed when the number of reductions is odd.
+    const OsculatingSurfaceData& anOsculatingSurface =
+      myOsculSurf2.Value(static_cast<size_t>(aNU - 1));
+    theT = anOsculatingSurface.IsOpposite;
+    theL = anOsculatingSurface.Surface;
+    aAlong = true;
+  }
+  return aAlong;
 }
 
 //=================================================================================================
@@ -467,373 +417,331 @@ bool Geom_OsculatingSurface::VOsculatingSurface(double                          
                                                 bool&                             theT,
                                                 occ::handle<Geom_BSplineSurface>& theL) const
 {
-  bool along = false;
-  if (myAlong[2] || myAlong[3])
+  if (!(myAlong[2] || myAlong[3]))
   {
-    int    NU = 1, NV = 1;
-    double u1, u2, v1, v2;
-    theT = false;
-    myBasisSurf->Bounds(u1, u2, v1, v2);
-    int  NbUK, NbVK;
-    bool isToSkipSecond = false;
-    if (myBasisSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
+    return false;
+  }
+
+  theT = false;
+  int  aNU             = 1;
+  int  aNV             = 1;
+  int  aNbUK           = 2;
+  int  aNbVK           = 2;
+  bool aIsToSkipSecond = false;
+  if (myBasisSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
+  {
+    const occ::handle<Geom_BSplineSurface> aBSur =
+      occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
+    aNbUK                                      = aBSur->NbUKnots();
+    aNbVK                                      = aBSur->NbVKnots();
+    const NCollection_Array1<double>& aUKnots = aBSur->UKnots();
+    const NCollection_Array1<double>& aVKnots = aBSur->VKnots();
+    BSplCLib::Hunt(aUKnots, theU, aNU);
+    BSplCLib::Hunt(aVKnots, theV, aNV);
+    aNV = std::clamp(aNV, 1, aNbVK - 1);
+    if (aNbUK == 2 && aNU == 1)
     {
-      occ::handle<Geom_BSplineSurface> BSur    = occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
-      NbUK                                     = BSur->NbUKnots();
-      NbVK                                     = BSur->NbVKnots();
-      const NCollection_Array1<double>& UKnots = BSur->UKnots();
-      const NCollection_Array1<double>& VKnots = BSur->VKnots();
-      BSplCLib::Hunt(UKnots, theU, NU);
-      BSplCLib::Hunt(VKnots, theV, NV);
-      if (NV < 1)
+      // Pick the closest U end when the surface has a single span.
+      if (aUKnots(aNbUK) - theU > theU - aUKnots(1))
       {
-        NV = 1;
+        aIsToSkipSecond = true;
       }
-      if (NV >= NbVK)
+    }
+  }
+
+  bool aAlong = false;
+  if (myAlong[2] && aNU == 1)
+  {
+    theL  = myOsculSurf1.Value(static_cast<size_t>(aNV - 1));
+    aAlong = true;
+  }
+  if (myAlong[3] && aNU == aNbUK - 1 && !aIsToSkipSecond)
+  {
+    const OsculatingSurfaceData& anOsculatingSurface =
+      myOsculSurf2.Value(static_cast<size_t>(aNV - 1));
+    theT = anOsculatingSurface.IsOpposite;
+    theL = anOsculatingSurface.Surface;
+    aAlong = true;
+  }
+  return aAlong;
+}
+
+//=================================================================================================
+
+bool Geom_OsculatingSurface::buildOsculatingSurface(
+  double                                  theParam,
+  int                                     theSUKnot,
+  int                                     theSVKnot,
+  const occ::handle<Geom_BSplineSurface>& theBS,
+  occ::handle<Geom_BSplineSurface>&       theBSpl) const
+{
+  const int aUDeg = theBS->UDegree();
+  const int aVDeg = theBS->VDegree();
+  if ((IsAlongU() && aVDeg <= 1) || (IsAlongV() && aUDeg <= 1))
+  {
+    return false;
+  }
+
+  const int aMinDeg = std::min(aUDeg, aVDeg);
+  const int aMaxDeg = std::max(aUDeg, aVDeg);
+
+  NCollection_Array2<gp_Pnt> aCachePoles(1, aMaxDeg + 1, 1, aMinDeg + 1);
+
+  NCollection_LocalArray<int, 2>    aNumCoeffStorage(2);
+  NCollection_LocalArray<double, 2> aPolyUStorage(2);
+  NCollection_LocalArray<double, 2> aPolyVStorage(2);
+  NCollection_LocalArray<double, 2> aTrueUStorage(2);
+  NCollection_LocalArray<double, 2> aTrueVStorage(2);
+  NCollection_Array2<int>           aNumCoeffPerSurface(
+    aNumCoeffStorage.begin()[0], 1, 1, 1, 2);
+  NCollection_Array1<double> aPolyUIntervals(aPolyUStorage.begin()[0], 1, 2);
+  NCollection_Array1<double> aPolyVIntervals(aPolyVStorage.begin()[0], 1, 2);
+  NCollection_Array1<double> aTrueUIntervals(aTrueUStorage.begin()[0], 1, 2);
+  NCollection_Array1<double> aTrueVIntervals(aTrueVStorage.begin()[0], 1, 2);
+
+  for (size_t i = 0; i < 2; ++i)
+  {
+    aPolyUIntervals.ChangeAt(i) = static_cast<double>(i);
+    aPolyVIntervals.ChangeAt(i) = static_cast<double>(i);
+    aTrueUIntervals.ChangeAt(i) = theBS->UKnot(theSUKnot + static_cast<int>(i));
+    aTrueVIntervals.ChangeAt(i) = theBS->VKnot(theSVKnot + static_cast<int>(i));
+  }
+
+  int aOscUNumCoeff = 0;
+  int aOscVNumCoeff = 0;
+  if (IsAlongU())
+  {
+    aOscUNumCoeff = aUDeg + 1;
+    aOscVNumCoeff = aVDeg;
+  }
+  if (IsAlongV())
+  {
+    aOscUNumCoeff = aUDeg;
+    aOscVNumCoeff = aVDeg + 1;
+  }
+  aNumCoeffPerSurface.ChangeAt(0, 0) = aOscUNumCoeff;
+  aNumCoeffPerSurface.ChangeAt(0, 1) = aOscVNumCoeff;
+  const int aNbCoef = aOscUNumCoeff * aOscVNumCoeff * 3;
+  if (aNbCoef == 0)
+  {
+    return false;
+  }
+
+  NCollection_LocalArray<double> aCoefficientStorage(static_cast<size_t>(aNbCoef));
+  NCollection_Array1<double>      aCoefficients(aCoefficientStorage.begin()[0], 1, aNbCoef);
+
+  const NCollection_Array2<gp_Pnt>& aPoles     = theBS->Poles();
+  const NCollection_Array1<double>& aUFlatKnts = theBS->UKnotSequence();
+  const NCollection_Array1<double>& aVFlatKnts = theBS->VKnotSequence();
+
+  double       aUCacheParam = theBS->UKnot(theSUKnot);
+  double       aVCacheParam = theBS->VKnot(theSVKnot);
+  const double aUSpanLen    = theBS->UKnot(theSUKnot + 1) - aUCacheParam;
+  const double aVSpanLen    = theBS->VKnot(theSVKnot + 1) - aVCacheParam;
+
+  // Always reduce to a parametrization such that locally it is the iso
+  // u=0 or v=0 that is degenerate.
+  const bool aIsVNeg = theParam > aVCacheParam + aVSpanLen / 2;
+  const bool aIsUNeg = theParam > aUCacheParam + aUSpanLen / 2;
+  if (IsAlongU() && aIsVNeg)
+  {
+    aVCacheParam += aVSpanLen;
+  }
+  if (IsAlongV() && aIsUNeg)
+  {
+    aUCacheParam += aUSpanLen;
+  }
+
+  BSplSLib::BuildCache(aUCacheParam,
+                       aVCacheParam,
+                       aUSpanLen,
+                       aVSpanLen,
+                       theBS->IsUPeriodic(),
+                       theBS->IsVPeriodic(),
+                       aUDeg,
+                       aVDeg,
+                       /*ULocalIndex*/ 0,
+                       /*VLocalIndex*/ 0,
+                       aUFlatKnts,
+                       aVFlatKnts,
+                       aPoles,
+                       BSplSLib::NoWeights(),
+                       aCachePoles,
+                       BSplSLib::NoWeights());
+
+  NCollection_Array2<gp_Pnt> aOscCoeff(1, aOscUNumCoeff, 1, aOscVNumCoeff);
+  const size_t               aUNbPoles = static_cast<size_t>(aUDeg) + 1;
+  const size_t               aVNbPoles = static_cast<size_t>(aVDeg) + 1;
+
+  if (IsAlongU())
+  {
+    if (aUDeg > aVDeg)
+    {
+      for (size_t n = 0; n < aUNbPoles; ++n)
       {
-        NV = NbVK - 1;
-      }
-      if (NbUK == 2 && NU == 1)
-      {
-        // Need to find the closest end
-        if (UKnots(NbUK) - theU > theU - UKnots(1))
+        for (size_t m = 0; m < aVNbPoles - 1; ++m)
         {
-          isToSkipSecond = true;
+          aOscCoeff.ChangeAt(n, m) = aCachePoles.At(n, m + 1);
         }
       }
     }
     else
     {
-      NU   = 1;
-      NV   = 1;
-      NbUK = 2;
-    }
-
-    if (myAlong[2] && NU == 1)
-    {
-      theL  = myOsculSurf1.Value(NV);
-      along = true;
-    }
-    if (myAlong[3] && (NU == NbUK - 1) && !isToSkipSecond)
-    {
-      if (myKdeg.Value(NV) % 2)
+      for (size_t n = 0; n < aUNbPoles; ++n)
       {
-        theT = true;
-      }
-      theL  = myOsculSurf2.Value(NV);
-      along = true;
-    }
-  }
-  return along;
-}
-
-//=================================================================================================
-
-bool Geom_OsculatingSurface::buildOsculatingSurface(double theParam,
-                                                    int    theSUKnot,
-                                                    int    theSVKnot,
-                                                    const occ::handle<Geom_BSplineSurface>& theBS,
-                                                    occ::handle<Geom_BSplineSurface>& theBSpl) const
-{
-  bool OsculSurf = true;
-#ifdef OCCT_DEBUG
-  std::cout << "t = " << theParam << std::endl;
-  std::cout << "======================================" << std::endl << std::endl;
-#endif
-
-  // for cache
-  int    MinDegree, MaxDegree;
-  double udeg, vdeg;
-  udeg = theBS->UDegree();
-  vdeg = theBS->VDegree();
-  if ((IsAlongU() && vdeg <= 1) || (IsAlongV() && udeg <= 1))
-  {
-#ifdef OCCT_DEBUG
-    std::cout << " surface osculatrice nulle " << std::endl;
-#endif
-    OsculSurf = false;
-  }
-  else
-  {
-    MinDegree = (int)std::min(udeg, vdeg);
-    MaxDegree = (int)std::max(udeg, vdeg);
-
-    NCollection_Array2<gp_Pnt> cachepoles(1, MaxDegree + 1, 1, MinDegree + 1);
-    // end for cache
-
-    // for polynomial grid
-    int MaxUDegree, MaxVDegree;
-    int UContinuity, VContinuity;
-
-    occ::handle<NCollection_HArray2<int>> NumCoeffPerSurface =
-      new NCollection_HArray2<int>(1, 1, 1, 2);
-    occ::handle<NCollection_HArray1<double>> PolynomialUIntervals =
-      new NCollection_HArray1<double>(1, 2);
-    occ::handle<NCollection_HArray1<double>> PolynomialVIntervals =
-      new NCollection_HArray1<double>(1, 2);
-    occ::handle<NCollection_HArray1<double>> TrueUIntervals = new NCollection_HArray1<double>(1, 2);
-    occ::handle<NCollection_HArray1<double>> TrueVIntervals = new NCollection_HArray1<double>(1, 2);
-    MaxUDegree                                              = (int)udeg;
-    MaxVDegree                                              = (int)vdeg;
-
-    for (int i = 1; i <= 2; i++)
-    {
-      PolynomialUIntervals->ChangeValue(i) = i - 1;
-      PolynomialVIntervals->ChangeValue(i) = i - 1;
-      TrueUIntervals->ChangeValue(i)       = theBS->UKnot(theSUKnot + i - 1);
-      TrueVIntervals->ChangeValue(i)       = theBS->VKnot(theSVKnot + i - 1);
-    }
-
-    int OscUNumCoeff = 0, OscVNumCoeff = 0;
-    if (IsAlongU())
-    {
-#ifdef OCCT_DEBUG
-      std::cout << ">>>>>>>>>>> AlongU" << std::endl;
-#endif
-      OscUNumCoeff = (int)udeg + 1;
-      OscVNumCoeff = (int)vdeg;
-    }
-    if (IsAlongV())
-    {
-#ifdef OCCT_DEBUG
-      std::cout << ">>>>>>>>>>> AlongV" << std::endl;
-#endif
-      OscUNumCoeff = (int)udeg;
-      OscVNumCoeff = (int)vdeg + 1;
-    }
-    NumCoeffPerSurface->ChangeValue(1, 1) = OscUNumCoeff;
-    NumCoeffPerSurface->ChangeValue(1, 2) = OscVNumCoeff;
-    int nbc = NumCoeffPerSurface->Value(1, 1) * NumCoeffPerSurface->Value(1, 2) * 3;
-    //
-    if (nbc == 0)
-    {
-      return false;
-    }
-    //
-    occ::handle<NCollection_HArray1<double>> Coefficients = new NCollection_HArray1<double>(1, nbc);
-    //    end for polynomial grid
-
-    //    building the cache
-    int    ULocalIndex, VLocalIndex;
-    double ucacheparameter, vcacheparameter, uspanlength, vspanlength;
-
-    const NCollection_Array2<gp_Pnt>& aPoles     = theBS->Poles();
-    const NCollection_Array1<double>& aUFlatKnts = theBS->UKnotSequence();
-    const NCollection_Array1<double>& aVFlatKnts = theBS->VKnotSequence();
-
-    VLocalIndex     = 0;
-    ULocalIndex     = 0;
-    ucacheparameter = theBS->UKnot(theSUKnot);
-    vcacheparameter = theBS->VKnot(theSVKnot);
-    vspanlength     = theBS->VKnot(theSVKnot + 1) - theBS->VKnot(theSVKnot);
-    uspanlength     = theBS->UKnot(theSUKnot + 1) - theBS->UKnot(theSUKnot);
-
-    // Always reduce to a parametrization such that locally it is the iso
-    // u=0 or v=0 that is degenerate
-
-    bool IsVNegative = theParam > vcacheparameter + vspanlength / 2;
-    bool IsUNegative = theParam > ucacheparameter + uspanlength / 2;
-
-    if (IsAlongU() && (theParam > vcacheparameter + vspanlength / 2))
-    {
-      vcacheparameter = vcacheparameter + vspanlength;
-    }
-    if (IsAlongV() && (theParam > ucacheparameter + uspanlength / 2))
-    {
-      ucacheparameter = ucacheparameter + uspanlength;
-    }
-
-    BSplSLib::BuildCache(ucacheparameter,
-                         vcacheparameter,
-                         uspanlength,
-                         vspanlength,
-                         theBS->IsUPeriodic(),
-                         theBS->IsVPeriodic(),
-                         theBS->UDegree(),
-                         theBS->VDegree(),
-                         ULocalIndex,
-                         VLocalIndex,
-                         aUFlatKnts,
-                         aVFlatKnts,
-                         aPoles,
-                         BSplSLib::NoWeights(),
-                         cachepoles,
-                         BSplSLib::NoWeights());
-    int                        m, n, index;
-    NCollection_Array2<gp_Pnt> OscCoeff(1, OscUNumCoeff, 1, OscVNumCoeff);
-
-    if (IsAlongU())
-    {
-      if (udeg > vdeg)
-      {
-        for (n = 1; n <= (int)udeg + 1; n++)
+        for (size_t m = 0; m < aVNbPoles - 1; ++m)
         {
-          for (m = 1; m <= (int)vdeg; m++)
-          {
-            OscCoeff(n, m) = cachepoles(n, m + 1);
-          }
-        }
-      }
-      else
-      {
-        for (n = 1; n <= (int)udeg + 1; n++)
-        {
-          for (m = 1; m <= (int)vdeg; m++)
-          {
-            OscCoeff(n, m) = cachepoles(m + 1, n);
-          }
-        }
-      }
-      if (IsVNegative)
-      {
-        PLib::VTrimming(-1, 0, OscCoeff, PLib::NoWeights2());
-      }
-
-      index = 1;
-      for (n = 1; n <= (int)udeg + 1; n++)
-      {
-        for (m = 1; m <= (int)vdeg; m++)
-        {
-          Coefficients->ChangeValue(index++) = OscCoeff(n, m).X();
-          Coefficients->ChangeValue(index++) = OscCoeff(n, m).Y();
-          Coefficients->ChangeValue(index++) = OscCoeff(n, m).Z();
+          aOscCoeff.ChangeAt(n, m) = aCachePoles.At(m + 1, n);
         }
       }
     }
-
-    if (IsAlongV())
+    if (aIsVNeg)
     {
-      if (udeg > vdeg)
-      {
-        for (n = 1; n <= (int)udeg; n++)
-        {
-          for (m = 1; m <= (int)vdeg + 1; m++)
-          {
-            OscCoeff(n, m) = cachepoles(n + 1, m);
-          }
-        }
-      }
-      else
-      {
-        for (n = 1; n <= (int)udeg; n++)
-        {
-          for (m = 1; m <= (int)vdeg + 1; m++)
-          {
-            OscCoeff(n, m) = cachepoles(m, n + 1);
-          }
-        }
-      }
-      if (IsUNegative)
-      {
-        PLib::UTrimming(-1, 0, OscCoeff, PLib::NoWeights2());
-      }
-      index = 1;
-      for (n = 1; n <= (int)udeg; n++)
-      {
-        for (m = 1; m <= (int)vdeg + 1; m++)
-        {
-          Coefficients->ChangeValue(index++) = OscCoeff(n, m).X();
-          Coefficients->ChangeValue(index++) = OscCoeff(n, m).Y();
-          Coefficients->ChangeValue(index++) = OscCoeff(n, m).Z();
-        }
-      }
+      PLib::VTrimming(-1, 0, aOscCoeff, PLib::NoWeights2());
     }
 
-    if (IsAlongU())
+    size_t aIdx = 0;
+    for (size_t n = 0; n < aUNbPoles; ++n)
     {
-      MaxVDegree--;
-    }
-    if (IsAlongV())
-    {
-      MaxUDegree--;
-    }
-    UContinuity = -1;
-    VContinuity = -1;
-
-    Convert_GridPolynomialToPoles Data(1,
-                                       1,
-                                       UContinuity,
-                                       VContinuity,
-                                       MaxUDegree,
-                                       MaxVDegree,
-                                       NumCoeffPerSurface,
-                                       Coefficients,
-                                       PolynomialUIntervals,
-                                       PolynomialVIntervals,
-                                       TrueUIntervals,
-                                       TrueVIntervals);
-
-    theBSpl = new Geom_BSplineSurface(Data.Poles(),
-                                      Data.UKnots(),
-                                      Data.VKnots(),
-                                      Data.UMultiplicities(),
-                                      Data.VMultiplicities(),
-                                      Data.UDegree(),
-                                      Data.VDegree(),
-                                      false,
-                                      false);
-#ifdef OCCT_DEBUG
-    std::cout << "^====================================^" << std::endl << std::endl;
-#endif
-  }
-  return OsculSurf;
-}
-
-//=================================================================================================
-
-bool Geom_OsculatingSurface::isQPunctual(const occ::handle<Geom_Surface>& theS,
-                                         double                           theParam,
-                                         GeomAbs_IsoType                  theIT,
-                                         double                           theTolMin,
-                                         double                           theTolMax) const
-{
-  double U1 = 0, U2 = 0, V1 = 0, V2 = 0, T;
-  bool   Along = true;
-  theS->Bounds(U1, U2, V1, V2);
-  gp_Vec D1U, D1V;
-  gp_Pnt P;
-  double Step, D1NormMax;
-  if (theIT == GeomAbs_IsoV)
-  {
-    Step      = (U2 - U1) / 10;
-    D1NormMax = 0.;
-    for (T = U1; T <= U2; T = T + Step)
-    {
-      theS->D1(T, theParam, P, D1U, D1V);
-      D1NormMax = std::max(D1NormMax, D1U.Magnitude());
-    }
-
-#ifdef OCCT_DEBUG
-    std::cout << " D1NormMax = " << D1NormMax << std::endl;
-#endif
-    if (D1NormMax > theTolMax || D1NormMax < theTolMin)
-    {
-      Along = false;
+      for (size_t m = 0; m < aVNbPoles - 1; ++m)
+      {
+        const gp_Pnt& aPole = aOscCoeff.At(n, m);
+        aCoefficients.ChangeAt(aIdx++) = aPole.X();
+        aCoefficients.ChangeAt(aIdx++) = aPole.Y();
+        aCoefficients.ChangeAt(aIdx++) = aPole.Z();
+      }
     }
   }
   else
   {
-    Step      = (V2 - V1) / 10;
-    D1NormMax = 0.;
-    for (T = V1; T <= V2; T = T + Step)
+    if (aUDeg > aVDeg)
     {
-      theS->D1(theParam, T, P, D1U, D1V);
-      D1NormMax = std::max(D1NormMax, D1V.Magnitude());
+      for (size_t n = 0; n < aUNbPoles - 1; ++n)
+      {
+        for (size_t m = 0; m < aVNbPoles; ++m)
+        {
+          aOscCoeff.ChangeAt(n, m) = aCachePoles.At(n + 1, m);
+        }
+      }
     }
-#ifdef OCCT_DEBUG
-    std::cout << " D1NormMax = " << D1NormMax << std::endl;
-#endif
-    if (D1NormMax > theTolMax || D1NormMax < theTolMin)
+    else
     {
-      Along = false;
+      for (size_t n = 0; n < aUNbPoles - 1; ++n)
+      {
+        for (size_t m = 0; m < aVNbPoles; ++m)
+        {
+          aOscCoeff.ChangeAt(n, m) = aCachePoles.At(m, n + 1);
+        }
+      }
+    }
+    if (aIsUNeg)
+    {
+      PLib::UTrimming(-1, 0, aOscCoeff, PLib::NoWeights2());
+    }
+
+    size_t aIdx = 0;
+    for (size_t n = 0; n < aUNbPoles - 1; ++n)
+    {
+      for (size_t m = 0; m < aVNbPoles; ++m)
+      {
+        const gp_Pnt& aPole = aOscCoeff.At(n, m);
+        aCoefficients.ChangeAt(aIdx++) = aPole.X();
+        aCoefficients.ChangeAt(aIdx++) = aPole.Y();
+        aCoefficients.ChangeAt(aIdx++) = aPole.Z();
+      }
     }
   }
-  return Along;
+
+  const int aMaxUDegOut = IsAlongV() ? aUDeg - 1 : aUDeg;
+  const int aMaxVDegOut = IsAlongU() ? aVDeg - 1 : aVDeg;
+
+  Convert_GridPolynomialToPoles aData(1,
+                                      1,
+                                      /*UContinuity*/ -1,
+                                      /*VContinuity*/ -1,
+                                      aMaxUDegOut,
+                                      aMaxVDegOut,
+                                      aNumCoeffPerSurface,
+                                      aCoefficients,
+                                      aPolyUIntervals,
+                                      aPolyVIntervals,
+                                      aTrueUIntervals,
+                                      aTrueVIntervals);
+
+  theBSpl = new Geom_BSplineSurface(aData.Poles(),
+                                    aData.UKnots(),
+                                    aData.VKnots(),
+                                    aData.UMultiplicities(),
+                                    aData.VMultiplicities(),
+                                    aData.UDegree(),
+                                    aData.VDegree(),
+                                    false,
+                                    false);
+  return true;
 }
 
 //=================================================================================================
 
-void Geom_OsculatingSurface::clearOsculFlags()
+bool Geom_OsculatingSurface::isQPunctual(const GeomAdaptor_Surface& theAdaptor,
+                                         double                      theParam,
+                                         GeomAbs_IsoType             theIT,
+                                         double                      theTolMin,
+                                         double                      theTolMax) const
 {
-  myAlong.fill(false);
+  const bool   anIsIsoV = theIT == GeomAbs_IsoV;
+  const double aPmin    = anIsIsoV ? theAdaptor.FirstUParameter() : theAdaptor.FirstVParameter();
+  const double aPmax    = anIsIsoV ? theAdaptor.LastUParameter() : theAdaptor.LastVParameter();
+  const int    aNbIntervals = anIsIsoV ? theAdaptor.NbUIntervals(GeomAbs_CN)
+                                      : theAdaptor.NbVIntervals(GeomAbs_CN);
+  if (aNbIntervals < 1)
+  {
+    return false;
+  }
+
+  NCollection_LocalArray<double> aIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
+  NCollection_Array1<double>      aIntervals(aIntervalStorage.begin()[0], 1, aNbIntervals + 1);
+  if (anIsIsoV)
+  {
+    theAdaptor.UIntervals(aIntervals, GeomAbs_CN);
+  }
+  else
+  {
+    theAdaptor.VIntervals(aIntervals, GeomAbs_CN);
+  }
+  aIntervals.ChangeAt(0) = aPmin;
+  aIntervals.ChangeAt(static_cast<size_t>(aNbIntervals)) = aPmax;
+
+  const int aDegree = anIsIsoV ? theAdaptor.UDegree() : theAdaptor.VDegree();
+  const size_t aNbSamples = static_cast<size_t>(std::max(aDegree, 1));
+  double       aD1NormMax = 0.0;
+  auto updateD1Norm = [&](const double theParameter)
+  {
+    if (anIsIsoV)
+    {
+      const Geom_Surface::ResD1 aResult = theAdaptor.EvalD1(theParameter, theParam);
+      aD1NormMax = std::max(aD1NormMax, aResult.D1U.Magnitude());
+    }
+    else
+    {
+      const Geom_Surface::ResD1 aResult = theAdaptor.EvalD1(theParam, theParameter);
+      aD1NormMax = std::max(aD1NormMax, aResult.D1V.Magnitude());
+    }
+  };
+
+  for (size_t anInterval = 0; anInterval < static_cast<size_t>(aNbIntervals); ++anInterval)
+  {
+    const double aFirst = aIntervals.At(anInterval);
+    const double aLast  = aIntervals.At(anInterval + 1);
+    const double aRange = aLast - aFirst;
+    for (size_t anIndex = 0; anIndex <= aNbSamples; ++anIndex)
+    {
+      const double aParameter = anIndex == aNbSamples
+                                  ? aLast
+                                  : aFirst + aRange * static_cast<double>(anIndex)
+                                               / static_cast<double>(aNbSamples);
+      updateD1Norm(aParameter);
+    }
+  }
+
+  return !(aD1NormMax > theTolMax || aD1NormMax < theTolMin);
 }

--- a/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.cxx
@@ -36,7 +36,8 @@ class OsculatingSurfaceInitGuard
 {
 public:
   OsculatingSurfaceInitGuard(std::array<bool, 4>& theFlags, bool& theIsDone)
-      : myFlags(theFlags), myIsDone(theIsDone)
+      : myFlags(theFlags),
+        myIsDone(theIsDone)
   {
   }
 
@@ -50,7 +51,7 @@ public:
 
 private:
   std::array<bool, 4>& myFlags;
-  bool&                 myIsDone;
+  bool&                myIsDone;
 };
 } // namespace
 
@@ -129,7 +130,7 @@ Geom_OsculatingSurface& Geom_OsculatingSurface::operator=(
 void Geom_OsculatingSurface::Init(const occ::handle<Geom_Surface>& theBS, double theTol)
 {
   myAlong.fill(false);
-  bool aIsDone = false;
+  bool                       aIsDone = false;
   OsculatingSurfaceInitGuard aInitGuard(myAlong, aIsDone);
 
   myTol = theTol;
@@ -212,15 +213,13 @@ void Geom_OsculatingSurface::Init(const occ::handle<Geom_Surface>& theBS, double
   }
 
   // The reduction needs at least one direction to have degree > 1.
-  if ((IsAlongU() && aInitSurf->VDegree() <= 1)
-      || (IsAlongV() && aInitSurf->UDegree() <= 1))
+  if ((IsAlongU() && aInitSurf->VDegree() <= 1) || (IsAlongV() && aInitSurf->UDegree() <= 1))
   {
     return;
   }
 
-  const size_t aNbSurfaces = IsAlongU()
-                               ? static_cast<size_t>(aInitSurf->NbUKnots() - 1)
-                               : static_cast<size_t>(aInitSurf->NbVKnots() - 1);
+  const size_t aNbSurfaces = IsAlongU() ? static_cast<size_t>(aInitSurf->NbUKnots() - 1)
+                                        : static_cast<size_t>(aInitSurf->NbVKnots() - 1);
   myOsculSurf1.Reserve(aNbSurfaces);
   myOsculSurf2.Reserve(aNbSurfaces);
 
@@ -233,13 +232,7 @@ void Geom_OsculatingSurface::Init(const occ::handle<Geom_Surface>& theBS, double
       size_t                           aNbReductions = 0;
       if (myAlong[0])
       {
-        if (!reduceAlongIso(aInitSurf,
-                            aV1,
-                            GeomAbs_IsoV,
-                            i,
-                            1,
-                            aSurface,
-                            aNbReductions))
+        if (!reduceAlongIso(aInitSurf, aV1, GeomAbs_IsoV, i, 1, aSurface, aNbReductions))
         {
           return;
         }
@@ -270,13 +263,7 @@ void Geom_OsculatingSurface::Init(const occ::handle<Geom_Surface>& theBS, double
       size_t                           aNbReductions = 0;
       if (myAlong[2])
       {
-        if (!reduceAlongIso(aInitSurf,
-                            aU1,
-                            GeomAbs_IsoU,
-                            1,
-                            i,
-                            aSurface,
-                            aNbReductions))
+        if (!reduceAlongIso(aInitSurf, aU1, GeomAbs_IsoU, 1, i, aSurface, aNbReductions))
         {
           return;
         }
@@ -304,22 +291,21 @@ void Geom_OsculatingSurface::Init(const occ::handle<Geom_Surface>& theBS, double
 
 //=================================================================================================
 
-bool Geom_OsculatingSurface::reduceAlongIso(
-  const occ::handle<Geom_BSplineSurface>& theInitSurf,
-  double                                  theParam,
-  GeomAbs_IsoType                         theIso,
-  int                                     theInitUKnot,
-  int                                     theInitVKnot,
-  occ::handle<Geom_BSplineSurface>&       theSurface,
-  size_t&                                  theNbReductions) const
+bool Geom_OsculatingSurface::reduceAlongIso(const occ::handle<Geom_BSplineSurface>& theInitSurf,
+                                            double                                  theParam,
+                                            GeomAbs_IsoType                         theIso,
+                                            int                                     theInitUKnot,
+                                            int                                     theInitVKnot,
+                                            occ::handle<Geom_BSplineSurface>&       theSurface,
+                                            size_t& theNbReductions) const
 {
   theSurface.Nullify();
   theNbReductions = 0;
 
   occ::handle<Geom_BSplineSurface> aSurface = theInitSurf;
   occ::handle<Geom_BSplineSurface> aReducedSurface;
-  int                              aUKnot = theInitUKnot;
-  int                              aVKnot = theInitVKnot;
+  int                              aUKnot       = theInitUKnot;
+  int                              aVKnot       = theInitVKnot;
   bool                             aIsQPunctual = true;
   GeomAdaptor_Surface              anAdaptor;
   while (aIsQPunctual)
@@ -332,9 +318,9 @@ bool Geom_OsculatingSurface::reduceAlongIso(
     ++theNbReductions;
     anAdaptor.Load(aReducedSurface);
     aIsQPunctual = isQPunctual(anAdaptor, theParam, theIso, 0.0, myTol);
-    aUKnot        = 1;
-    aVKnot        = 1;
-    aSurface      = aReducedSurface;
+    aUKnot       = 1;
+    aVKnot       = 1;
+    aSurface     = aReducedSurface;
   }
 
   theSurface = aSurface;
@@ -345,10 +331,10 @@ bool Geom_OsculatingSurface::reduceAlongIso(
 
 void Geom_OsculatingSurface::appendOsculatingSurface2(
   const occ::handle<Geom_BSplineSurface>& theSurface,
-  size_t                                   theNbReductions)
+  size_t                                  theNbReductions)
 {
   OsculatingSurfaceData anOsculatingSurface;
-  anOsculatingSurface.Surface     = theSurface;
+  anOsculatingSurface.Surface    = theSurface;
   anOsculatingSurface.IsOpposite = (theNbReductions % 2) != 0;
   myOsculSurf2.Append(anOsculatingSurface);
 }
@@ -365,7 +351,7 @@ bool Geom_OsculatingSurface::UOsculatingSurface(double                          
     return false;
   }
 
-  theT = false;
+  theT                 = false;
   int  aNU             = 1;
   int  aNV             = 1;
   int  aNbUK           = 2;
@@ -373,12 +359,11 @@ bool Geom_OsculatingSurface::UOsculatingSurface(double                          
   bool aIsToSkipSecond = false;
   if (myBasisSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
   {
-    const occ::handle<Geom_BSplineSurface> aBSur =
-      occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
-    aNbUK                                      = aBSur->NbUKnots();
-    aNbVK                                      = aBSur->NbVKnots();
-    const NCollection_Array1<double>& aUKnots = aBSur->UKnots();
-    const NCollection_Array1<double>& aVKnots = aBSur->VKnots();
+    const occ::handle<Geom_BSplineSurface> aBSur = occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
+    aNbUK                                        = aBSur->NbUKnots();
+    aNbVK                                        = aBSur->NbVKnots();
+    const NCollection_Array1<double>& aUKnots    = aBSur->UKnots();
+    const NCollection_Array1<double>& aVKnots    = aBSur->VKnots();
     BSplCLib::Hunt(aUKnots, theU, aNU);
     BSplCLib::Hunt(aVKnots, theV, aNV);
     aNU = std::clamp(aNU, 1, aNbUK - 1);
@@ -395,7 +380,7 @@ bool Geom_OsculatingSurface::UOsculatingSurface(double                          
   bool aAlong = false;
   if (myAlong[0] && aNV == 1)
   {
-    theL  = myOsculSurf1.Value(static_cast<size_t>(aNU - 1));
+    theL   = myOsculSurf1.Value(static_cast<size_t>(aNU - 1));
     aAlong = true;
   }
   if (myAlong[1] && aNV == aNbVK - 1 && !aIsToSkipSecond)
@@ -403,8 +388,8 @@ bool Geom_OsculatingSurface::UOsculatingSurface(double                          
     // The derivative is reversed when the number of reductions is odd.
     const OsculatingSurfaceData& anOsculatingSurface =
       myOsculSurf2.Value(static_cast<size_t>(aNU - 1));
-    theT = anOsculatingSurface.IsOpposite;
-    theL = anOsculatingSurface.Surface;
+    theT   = anOsculatingSurface.IsOpposite;
+    theL   = anOsculatingSurface.Surface;
     aAlong = true;
   }
   return aAlong;
@@ -422,7 +407,7 @@ bool Geom_OsculatingSurface::VOsculatingSurface(double                          
     return false;
   }
 
-  theT = false;
+  theT                 = false;
   int  aNU             = 1;
   int  aNV             = 1;
   int  aNbUK           = 2;
@@ -430,12 +415,11 @@ bool Geom_OsculatingSurface::VOsculatingSurface(double                          
   bool aIsToSkipSecond = false;
   if (myBasisSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
   {
-    const occ::handle<Geom_BSplineSurface> aBSur =
-      occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
-    aNbUK                                      = aBSur->NbUKnots();
-    aNbVK                                      = aBSur->NbVKnots();
-    const NCollection_Array1<double>& aUKnots = aBSur->UKnots();
-    const NCollection_Array1<double>& aVKnots = aBSur->VKnots();
+    const occ::handle<Geom_BSplineSurface> aBSur = occ::down_cast<Geom_BSplineSurface>(myBasisSurf);
+    aNbUK                                        = aBSur->NbUKnots();
+    aNbVK                                        = aBSur->NbVKnots();
+    const NCollection_Array1<double>& aUKnots    = aBSur->UKnots();
+    const NCollection_Array1<double>& aVKnots    = aBSur->VKnots();
     BSplCLib::Hunt(aUKnots, theU, aNU);
     BSplCLib::Hunt(aVKnots, theV, aNV);
     aNV = std::clamp(aNV, 1, aNbVK - 1);
@@ -452,15 +436,15 @@ bool Geom_OsculatingSurface::VOsculatingSurface(double                          
   bool aAlong = false;
   if (myAlong[2] && aNU == 1)
   {
-    theL  = myOsculSurf1.Value(static_cast<size_t>(aNV - 1));
+    theL   = myOsculSurf1.Value(static_cast<size_t>(aNV - 1));
     aAlong = true;
   }
   if (myAlong[3] && aNU == aNbUK - 1 && !aIsToSkipSecond)
   {
     const OsculatingSurfaceData& anOsculatingSurface =
       myOsculSurf2.Value(static_cast<size_t>(aNV - 1));
-    theT = anOsculatingSurface.IsOpposite;
-    theL = anOsculatingSurface.Surface;
+    theT   = anOsculatingSurface.IsOpposite;
+    theL   = anOsculatingSurface.Surface;
     aAlong = true;
   }
   return aAlong;
@@ -468,12 +452,11 @@ bool Geom_OsculatingSurface::VOsculatingSurface(double                          
 
 //=================================================================================================
 
-bool Geom_OsculatingSurface::buildOsculatingSurface(
-  double                                  theParam,
-  int                                     theSUKnot,
-  int                                     theSVKnot,
-  const occ::handle<Geom_BSplineSurface>& theBS,
-  occ::handle<Geom_BSplineSurface>&       theBSpl) const
+bool Geom_OsculatingSurface::buildOsculatingSurface(double theParam,
+                                                    int    theSUKnot,
+                                                    int    theSVKnot,
+                                                    const occ::handle<Geom_BSplineSurface>& theBS,
+                                                    occ::handle<Geom_BSplineSurface>& theBSpl) const
 {
   const int aUDeg = theBS->UDegree();
   const int aVDeg = theBS->VDegree();
@@ -492,12 +475,11 @@ bool Geom_OsculatingSurface::buildOsculatingSurface(
   NCollection_LocalArray<double, 2> aPolyVStorage(2);
   NCollection_LocalArray<double, 2> aTrueUStorage(2);
   NCollection_LocalArray<double, 2> aTrueVStorage(2);
-  NCollection_Array2<int>           aNumCoeffPerSurface(
-    aNumCoeffStorage.begin()[0], 1, 1, 1, 2);
-  NCollection_Array1<double> aPolyUIntervals(aPolyUStorage.begin()[0], 1, 2);
-  NCollection_Array1<double> aPolyVIntervals(aPolyVStorage.begin()[0], 1, 2);
-  NCollection_Array1<double> aTrueUIntervals(aTrueUStorage.begin()[0], 1, 2);
-  NCollection_Array1<double> aTrueVIntervals(aTrueVStorage.begin()[0], 1, 2);
+  NCollection_Array2<int>           aNumCoeffPerSurface(aNumCoeffStorage.begin()[0], 1, 1, 1, 2);
+  NCollection_Array1<double>        aPolyUIntervals(aPolyUStorage.begin()[0], 1, 2);
+  NCollection_Array1<double>        aPolyVIntervals(aPolyVStorage.begin()[0], 1, 2);
+  NCollection_Array1<double>        aTrueUIntervals(aTrueUStorage.begin()[0], 1, 2);
+  NCollection_Array1<double>        aTrueVIntervals(aTrueVStorage.begin()[0], 1, 2);
 
   for (size_t i = 0; i < 2; ++i)
   {
@@ -521,14 +503,14 @@ bool Geom_OsculatingSurface::buildOsculatingSurface(
   }
   aNumCoeffPerSurface.ChangeAt(0, 0) = aOscUNumCoeff;
   aNumCoeffPerSurface.ChangeAt(0, 1) = aOscVNumCoeff;
-  const int aNbCoef = aOscUNumCoeff * aOscVNumCoeff * 3;
+  const int aNbCoef                  = aOscUNumCoeff * aOscVNumCoeff * 3;
   if (aNbCoef == 0)
   {
     return false;
   }
 
   NCollection_LocalArray<double> aCoefficientStorage(static_cast<size_t>(aNbCoef));
-  NCollection_Array1<double>      aCoefficients(aCoefficientStorage.begin()[0], 1, aNbCoef);
+  NCollection_Array1<double>     aCoefficients(aCoefficientStorage.begin()[0], 1, aNbCoef);
 
   const NCollection_Array2<gp_Pnt>& aPoles     = theBS->Poles();
   const NCollection_Array1<double>& aUFlatKnts = theBS->UKnotSequence();
@@ -605,7 +587,7 @@ bool Geom_OsculatingSurface::buildOsculatingSurface(
     {
       for (size_t m = 0; m < aVNbPoles - 1; ++m)
       {
-        const gp_Pnt& aPole = aOscCoeff.At(n, m);
+        const gp_Pnt& aPole            = aOscCoeff.At(n, m);
         aCoefficients.ChangeAt(aIdx++) = aPole.X();
         aCoefficients.ChangeAt(aIdx++) = aPole.Y();
         aCoefficients.ChangeAt(aIdx++) = aPole.Z();
@@ -644,7 +626,7 @@ bool Geom_OsculatingSurface::buildOsculatingSurface(
     {
       for (size_t m = 0; m < aVNbPoles; ++m)
       {
-        const gp_Pnt& aPole = aOscCoeff.At(n, m);
+        const gp_Pnt& aPole            = aOscCoeff.At(n, m);
         aCoefficients.ChangeAt(aIdx++) = aPole.X();
         aCoefficients.ChangeAt(aIdx++) = aPole.Y();
         aCoefficients.ChangeAt(aIdx++) = aPole.Z();
@@ -683,23 +665,23 @@ bool Geom_OsculatingSurface::buildOsculatingSurface(
 //=================================================================================================
 
 bool Geom_OsculatingSurface::isQPunctual(const GeomAdaptor_Surface& theAdaptor,
-                                         double                      theParam,
-                                         GeomAbs_IsoType             theIT,
-                                         double                      theTolMin,
-                                         double                      theTolMax) const
+                                         double                     theParam,
+                                         GeomAbs_IsoType            theIT,
+                                         double                     theTolMin,
+                                         double                     theTolMax) const
 {
   const bool   anIsIsoV = theIT == GeomAbs_IsoV;
   const double aPmin    = anIsIsoV ? theAdaptor.FirstUParameter() : theAdaptor.FirstVParameter();
   const double aPmax    = anIsIsoV ? theAdaptor.LastUParameter() : theAdaptor.LastVParameter();
-  const int    aNbIntervals = anIsIsoV ? theAdaptor.NbUIntervals(GeomAbs_CN)
-                                      : theAdaptor.NbVIntervals(GeomAbs_CN);
+  const int    aNbIntervals =
+    anIsIsoV ? theAdaptor.NbUIntervals(GeomAbs_CN) : theAdaptor.NbVIntervals(GeomAbs_CN);
   if (aNbIntervals < 1)
   {
     return false;
   }
 
   NCollection_LocalArray<double> aIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
-  NCollection_Array1<double>      aIntervals(aIntervalStorage.begin()[0], 1, aNbIntervals + 1);
+  NCollection_Array1<double>     aIntervals(aIntervalStorage.begin()[0], 1, aNbIntervals + 1);
   if (anIsIsoV)
   {
     theAdaptor.UIntervals(aIntervals, GeomAbs_CN);
@@ -708,23 +690,22 @@ bool Geom_OsculatingSurface::isQPunctual(const GeomAdaptor_Surface& theAdaptor,
   {
     theAdaptor.VIntervals(aIntervals, GeomAbs_CN);
   }
-  aIntervals.ChangeAt(0) = aPmin;
+  aIntervals.ChangeAt(0)                                 = aPmin;
   aIntervals.ChangeAt(static_cast<size_t>(aNbIntervals)) = aPmax;
 
-  const int aDegree = anIsIsoV ? theAdaptor.UDegree() : theAdaptor.VDegree();
-  const size_t aNbSamples = static_cast<size_t>(std::max(aDegree, 1));
-  double       aD1NormMax = 0.0;
-  auto updateD1Norm = [&](const double theParameter)
-  {
+  const int    aDegree      = anIsIsoV ? theAdaptor.UDegree() : theAdaptor.VDegree();
+  const size_t aNbSamples   = static_cast<size_t>(std::max(aDegree, 1));
+  double       aD1NormMax   = 0.0;
+  auto         updateD1Norm = [&](const double theParameter) {
     if (anIsIsoV)
     {
       const Geom_Surface::ResD1 aResult = theAdaptor.EvalD1(theParameter, theParam);
-      aD1NormMax = std::max(aD1NormMax, aResult.D1U.Magnitude());
+      aD1NormMax                        = std::max(aD1NormMax, aResult.D1U.Magnitude());
     }
     else
     {
       const Geom_Surface::ResD1 aResult = theAdaptor.EvalD1(theParam, theParameter);
-      aD1NormMax = std::max(aD1NormMax, aResult.D1V.Magnitude());
+      aD1NormMax                        = std::max(aD1NormMax, aResult.D1V.Magnitude());
     }
   };
 
@@ -735,10 +716,10 @@ bool Geom_OsculatingSurface::isQPunctual(const GeomAdaptor_Surface& theAdaptor,
     const double aRange = aLast - aFirst;
     for (size_t anIndex = 0; anIndex <= aNbSamples; ++anIndex)
     {
-      const double aParameter = anIndex == aNbSamples
-                                  ? aLast
-                                  : aFirst + aRange * static_cast<double>(anIndex)
-                                               / static_cast<double>(aNbSamples);
+      const double aParameter =
+        anIndex == aNbSamples
+          ? aLast
+          : aFirst + aRange * static_cast<double>(anIndex) / static_cast<double>(aNbSamples);
       updateD1Norm(aParameter);
     }
   }

--- a/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.pxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.pxx
@@ -124,31 +124,31 @@ private:
                       int                                     theInitUKnot,
                       int                                     theInitVKnot,
                       occ::handle<Geom_BSplineSurface>&       theSurface,
-                       size_t&                                  theNbReductions) const;
+                      size_t&                                 theNbReductions) const;
 
   //! Returns true if the isoparametric is quasi-punctual.
   bool isQPunctual(const GeomAdaptor_Surface& theAdaptor,
-                   double                    theParam,
-                   GeomAbs_IsoType           theIT,
-                   double                    theTolMin,
-                   double                    theTolMax) const;
+                   double                     theParam,
+                   GeomAbs_IsoType            theIT,
+                   double                     theTolMin,
+                   double                     theTolMax) const;
 
   struct OsculatingSurfaceData
   {
     occ::handle<Geom_BSplineSurface> Surface;
-    bool                              IsOpposite = false;
+    bool                             IsOpposite = false;
   };
 
   //! Append a second osculating surface and its derivative orientation.
   void appendOsculatingSurface2(const occ::handle<Geom_BSplineSurface>& theSurface,
-                                 size_t                                   theNbReductions);
+                                size_t                                  theNbReductions);
 
 private:
-  occ::handle<Geom_Surface>                              myBasisSurf;
-  double                                                 myTol;
+  occ::handle<Geom_Surface>                                  myBasisSurf;
+  double                                                     myTol;
   NCollection_LinearVector<occ::handle<Geom_BSplineSurface>> myOsculSurf1;
   NCollection_LinearVector<OsculatingSurfaceData>            myOsculSurf2;
-  std::array<bool, 4>                                    myAlong;
+  std::array<bool, 4>                                        myAlong;
 };
 
 #endif // _Geom_OsculatingSurface_HeaderFile

--- a/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.pxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_OsculatingSurface.pxx
@@ -19,15 +19,14 @@
 
 #include <GeomAbs_IsoType.hxx>
 #include <Geom_BSplineSurface.hxx>
-#include <NCollection_Sequence.hxx>
-#include <Standard_Integer.hxx>
-#include <Standard_Real.hxx>
-#include <NCollection_Array1.hxx>
+#include <NCollection_LinearVector.hxx>
 
 #include <array>
+#include <cstddef>
 
 class Geom_Surface;
 class Geom_BSplineSurface;
+class GeomAdaptor_Surface;
 
 //! Internal helper class for Geom_OffsetSurface.
 //! Detects if the surface has punctual U or V isoparametric curve
@@ -110,22 +109,45 @@ private:
                               const occ::handle<Geom_BSplineSurface>& theBS,
                               occ::handle<Geom_BSplineSurface>&       theL) const;
 
-  //! Returns true if the isoparametric is quasi-punctual.
-  bool isQPunctual(const occ::handle<Geom_Surface>& theS,
-                   double                           theParam,
-                   GeomAbs_IsoType                  theIT,
-                   double                           theTolMin,
-                   double                           theTolMax) const;
+  //! Iteratively reduce an iso until the result is no longer quasi-punctual.
+  //! @param[in]  theInitSurf starting surface for this knot span
+  //! @param[in]  theParam parameter of the degenerate iso
+  //! @param[in]  theIso direction of the degenerate iso
+  //! @param[in]  theInitUKnot initial U-knot index
+  //! @param[in]  theInitVKnot initial V-knot index
+  //! @param[out] theSurface final reduced surface
+  //! @param[out] theNbReductions number of reductions performed
+  //! @return false if a reduction cannot be built
+  bool reduceAlongIso(const occ::handle<Geom_BSplineSurface>& theInitSurf,
+                      double                                  theParam,
+                      GeomAbs_IsoType                         theIso,
+                      int                                     theInitUKnot,
+                      int                                     theInitVKnot,
+                      occ::handle<Geom_BSplineSurface>&       theSurface,
+                       size_t&                                  theNbReductions) const;
 
-  //! Clear osculating flags.
-  void clearOsculFlags();
+  //! Returns true if the isoparametric is quasi-punctual.
+  bool isQPunctual(const GeomAdaptor_Surface& theAdaptor,
+                   double                    theParam,
+                   GeomAbs_IsoType           theIT,
+                   double                    theTolMin,
+                   double                    theTolMax) const;
+
+  struct OsculatingSurfaceData
+  {
+    occ::handle<Geom_BSplineSurface> Surface;
+    bool                              IsOpposite = false;
+  };
+
+  //! Append a second osculating surface and its derivative orientation.
+  void appendOsculatingSurface2(const occ::handle<Geom_BSplineSurface>& theSurface,
+                                 size_t                                   theNbReductions);
 
 private:
   occ::handle<Geom_Surface>                              myBasisSurf;
   double                                                 myTol;
-  NCollection_Sequence<occ::handle<Geom_BSplineSurface>> myOsculSurf1;
-  NCollection_Sequence<occ::handle<Geom_BSplineSurface>> myOsculSurf2;
-  NCollection_Sequence<int>                              myKdeg;
+  NCollection_LinearVector<occ::handle<Geom_BSplineSurface>> myOsculSurf1;
+  NCollection_LinearVector<OsculatingSurfaceData>            myOsculSurf2;
   std::array<bool, 4>                                    myAlong;
 };
 


### PR DESCRIPTION
- Replace sequence storage with linear vectors and paired orientation data.
- Reuse GeomAdaptor_Surface for EvalD1-based quasi-punctual checks.
- Use LocalArray-backed buffers with At()/ChangeAt() access.
- Sample geometry-driven intervals without fixed floating-point loops.
- Preserve initialization failure cleanup with RAII.