### PR TITLE
Data Exchange, STEP - add FieldKind enum and fix field handling

### DIFF
--- a/src/DataExchange/TKDESTEP/GTests/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/GTests/FILES.cmake
@@ -5,6 +5,7 @@ set(OCCT_TKDESTEP_GTests_FILES
     DESTEP_Provider_Test.cxx
     GDT_STEP_Storage_Test.cxx
     STEPConstruct_RenderingProperties_Test.cxx
+    StepData_Field_Test.cxx
     StepData_StepWriter_Test.cxx
     StepTidy_BaseTestFixture.pxx
     StepTidy_Axis2Placement3dReducer_Test.cxx

--- a/src/DataExchange/TKDESTEP/GTests/StepData_Field_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepData_Field_Test.cxx
@@ -1,0 +1,481 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <StepData_Field.hxx>
+
+#include <Interface_EntityIterator.hxx>
+#include <NCollection_HArray1.hxx>
+#include <NCollection_HArray2.hxx>
+#include <Standard_RangeError.hxx>
+#include <Standard_Transient.hxx>
+#include <StepData_ESDescr.hxx>
+#include <StepData_FieldListN.hxx>
+#include <StepData_PDescr.hxx>
+#include <StepData_SelectArrReal.hxx>
+#include <StepData_SelectInt.hxx>
+#include <StepData_SelectNamed.hxx>
+#include <StepData_SelectReal.hxx>
+#include <StepData_Simple.hxx>
+#include <TCollection_HAsciiString.hxx>
+
+#include <gtest/gtest.h>
+
+TEST(StepData_FieldTest, ScalarValuesKeepTheirKinds)
+{
+  StepData_Field aField;
+
+  aField.SetInteger(42);
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Integer);
+  EXPECT_EQ(aField.Integer(), 42);
+
+  aField.SetBoolean(true);
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Boolean);
+  EXPECT_TRUE(aField.Boolean());
+
+  aField.SetLogical(StepData_LUnknown);
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Logical);
+  EXPECT_EQ(aField.Logical(), StepData_LUnknown);
+
+  aField.SetEnum(4, ".FOUR.");
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Enum);
+  EXPECT_EQ(aField.Enum(), 4);
+  EXPECT_STREQ(aField.EnumText(), ".FOUR.");
+
+  aField.SetString(".OTHER.");
+  EXPECT_EQ(aField.Enum(), 4);
+  EXPECT_STREQ(aField.EnumText(), ".OTHER.");
+  EXPECT_TRUE(occ::is_kind<TCollection_HAsciiString>(aField.Transient()));
+
+  aField.SetString("text");
+  EXPECT_STREQ(aField.String(), "text");
+  EXPECT_TRUE(occ::is_kind<TCollection_HAsciiString>(aField.Transient()));
+}
+
+TEST(StepData_FieldTest, AggregateBoundsArePreserved)
+{
+  occ::handle<NCollection_HArray1<int>> anArray = new NCollection_HArray1<int>(-2, 0);
+  anArray->SetValue(-2, 10);
+  anArray->SetValue(-1, 20);
+  anArray->SetValue(0, 30);
+
+  StepData_Field aField;
+  aField.Set(anArray);
+
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Integer);
+  EXPECT_EQ(aField.Arity(), 1);
+  EXPECT_EQ(aField.Lower(), -2);
+  EXPECT_EQ(aField.Length(), 3);
+  EXPECT_EQ(aField.ItemKind(-2), StepData_Field::FieldKind::Integer);
+  EXPECT_EQ(aField.Integer(-2), 10);
+  EXPECT_EQ(aField.Integer(0), 30);
+}
+
+TEST(StepData_FieldTest, ItemKindReadsOneDimensionalAnyList)
+{
+  StepData_Field aField;
+  aField.SetList(4, -2);
+
+  occ::handle<NCollection_HArray1<occ::handle<Standard_Transient>>> anArray =
+    occ::down_cast<NCollection_HArray1<occ::handle<Standard_Transient>>>(aField.Transient());
+  ASSERT_FALSE(anArray.IsNull());
+
+  occ::handle<StepData_SelectInt> aSelect = new StepData_SelectInt;
+  aSelect->SetKind(static_cast<int>(StepData_Field::FieldKind::Integer));
+  occ::handle<Standard_Transient> anEntity = new Standard_Transient;
+  anArray->SetValue(-1, new TCollection_HAsciiString("text"));
+  anArray->SetValue(0, aSelect);
+  anArray->SetValue(1, anEntity);
+
+  EXPECT_EQ(aField.ItemKind(-2), StepData_Field::FieldKind::Undefined);
+  EXPECT_EQ(aField.ItemKind(-1), StepData_Field::FieldKind::String);
+  EXPECT_EQ(aField.ItemKind(0), StepData_Field::FieldKind::Integer);
+  EXPECT_EQ(aField.ItemKind(1), StepData_Field::FieldKind::Entity);
+}
+
+TEST(StepData_FieldTest, ItemKindReadsTwoDimensionalAnyList)
+{
+  StepData_Field aField;
+  aField.SetList2(1, 3, -1, 2);
+
+  occ::handle<NCollection_HArray2<occ::handle<Standard_Transient>>> anArray =
+    occ::down_cast<NCollection_HArray2<occ::handle<Standard_Transient>>>(aField.Transient());
+  ASSERT_FALSE(anArray.IsNull());
+
+  occ::handle<Standard_Transient> anEntity = new Standard_Transient;
+  anArray->SetValue(-1, 3, new TCollection_HAsciiString("text"));
+  anArray->SetValue(-1, 4, anEntity);
+
+  EXPECT_EQ(aField.ItemKind(-1, 2), StepData_Field::FieldKind::Undefined);
+  EXPECT_EQ(aField.ItemKind(-1, 3), StepData_Field::FieldKind::String);
+  EXPECT_EQ(aField.ItemKind(-1, 4), StepData_Field::FieldKind::Entity);
+}
+
+TEST(StepData_FieldTest, TwoDimensionalEntityArrayUsesRowAndColumnBounds)
+{
+  occ::handle<NCollection_HArray2<occ::handle<Standard_Transient>>> anArray =
+    new NCollection_HArray2<occ::handle<Standard_Transient>>(-1, 0, 3, 5);
+  occ::handle<Standard_Transient> anEntity = new Standard_Transient;
+  anArray->SetValue(0, 5, anEntity);
+
+  StepData_Field aField;
+  aField.Set(anArray);
+
+  EXPECT_EQ(aField.Lower(1), -1);
+  EXPECT_EQ(aField.Lower(2), 3);
+  EXPECT_EQ(aField.Length(1), 2);
+  EXPECT_EQ(aField.Length(2), 3);
+  EXPECT_EQ(aField.ItemKind(0, 5), StepData_Field::FieldKind::Entity);
+  EXPECT_EQ(aField.Entity(0, 5), anEntity);
+}
+
+TEST(StepData_FieldTest, ItemKindHandlesAnyKindWithIntegerArrays)
+{
+  occ::handle<NCollection_HArray1<int>> anArray1 = new NCollection_HArray1<int>(1, 1);
+  StepData_Field                        aField1;
+  aField1.Clear(StepData_Field::FieldKind::Any);
+  aField1.Set(anArray1);
+  EXPECT_EQ(aField1.ItemKind(1), StepData_Field::FieldKind::Any);
+
+  occ::handle<NCollection_HArray2<int>> anArray2 = new NCollection_HArray2<int>(1, 1, 1, 1);
+  StepData_Field                        aField2;
+  aField2.Clear(StepData_Field::FieldKind::Any);
+  aField2.Set(anArray2);
+  EXPECT_EQ(aField2.ItemKind(1, 1), StepData_Field::FieldKind::Any);
+}
+
+TEST(StepData_FieldTest, TwoDimensionalAggregateUsesRowAndColumnBounds)
+{
+  occ::handle<NCollection_HArray2<double>> anArray = new NCollection_HArray2<double>(-1, 0, 3, 5);
+  anArray->SetValue(-1, 3, 1.5);
+  anArray->SetValue(0, 5, 2.5);
+
+  StepData_Field aField;
+  aField.Set(anArray);
+
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Real);
+  EXPECT_EQ(aField.Arity(), 2);
+  EXPECT_EQ(aField.Lower(1), -1);
+  EXPECT_EQ(aField.Lower(2), 3);
+  EXPECT_EQ(aField.Length(1), 2);
+  EXPECT_EQ(aField.Length(2), 3);
+  EXPECT_DOUBLE_EQ(aField.Real(-1, 3), 1.5);
+  EXPECT_DOUBLE_EQ(aField.Real(0, 5), 2.5);
+}
+
+TEST(StepData_FieldTest, TwoDimensionalIntegerArrayPreservesValues)
+{
+  occ::handle<NCollection_HArray2<int>> anArray = new NCollection_HArray2<int>(-2, -1, 4, 5);
+  anArray->SetValue(-2, 4, 10);
+  anArray->SetValue(-1, 5, 20);
+
+  StepData_Field aField;
+  aField.Set(anArray);
+
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::Integer);
+  EXPECT_EQ(aField.Lower(1), -2);
+  EXPECT_EQ(aField.Lower(2), 4);
+  EXPECT_EQ(aField.Length(1), 2);
+  EXPECT_EQ(aField.Length(2), 2);
+  EXPECT_EQ(aField.Integer(-2, 4), 10);
+  EXPECT_EQ(aField.Integer(-1, 5), 20);
+}
+
+TEST(StepData_FieldTest, TwoDimensionalStringListKeepsTransientRepresentation)
+{
+  StepData_Field aField;
+  aField.SetString();
+  aField.SetList2(2, 3, -1, 4);
+
+  EXPECT_EQ(aField.Kind(), StepData_Field::FieldKind::String);
+  EXPECT_EQ(aField.Lower(1), -1);
+  EXPECT_EQ(aField.Lower(2), 4);
+  EXPECT_TRUE(
+    occ::is_kind<NCollection_HArray2<occ::handle<Standard_Transient>>>(aField.Transient()));
+}
+
+TEST(StepData_FieldTest, CopyPreservesValueOwnership)
+{
+  StepData_Field aStringField;
+  aStringField.SetString("text");
+
+  StepData_Field aStringCopy;
+  aStringCopy.CopyFrom(aStringField);
+  EXPECT_STREQ(aStringCopy.String(), "text");
+  EXPECT_NE(aStringCopy.Transient(), aStringField.Transient());
+
+  occ::handle<Standard_Transient> anEntity = new Standard_Transient;
+  StepData_Field                  anEntityField;
+  anEntityField.SetEntity(anEntity);
+
+  StepData_Field anEntityCopy;
+  anEntityCopy.CopyFrom(anEntityField);
+  EXPECT_EQ(anEntityCopy.Entity(), anEntity);
+}
+
+TEST(StepData_FieldTest, CopyPreservesListOwnership)
+{
+  StepData_Field aSource;
+  aSource.SetInteger();
+  aSource.SetList(2, -1);
+  aSource.SetInteger(-1, 10);
+  aSource.SetInteger(0, 20);
+
+  StepData_Field aCopy;
+  aCopy.CopyFrom(aSource);
+
+  EXPECT_NE(aCopy.Transient(), aSource.Transient());
+  EXPECT_EQ(aCopy.Lower(), -1);
+  EXPECT_EQ(aCopy.Integer(-1), 10);
+  EXPECT_EQ(aCopy.Integer(0), 20);
+
+  aSource.SetInteger(-1, 30);
+  EXPECT_EQ(aCopy.Integer(-1), 10);
+}
+
+TEST(StepData_FieldTest, CopyPreservesSparseStringList)
+{
+  StepData_Field aSource;
+  aSource.SetString();
+  aSource.SetList(2, -1);
+  aSource.SetString(0, "text");
+
+  StepData_Field aCopy;
+  aCopy.CopyFrom(aSource);
+
+  EXPECT_FALSE(aCopy.IsSet(-1));
+  EXPECT_TRUE(aCopy.IsSet(0));
+  EXPECT_STREQ(aCopy.String(0), "text");
+  EXPECT_NE(aCopy.Transient(), aSource.Transient());
+  aSource.SetString(0, "changed");
+  EXPECT_STREQ(aCopy.String(0), "text");
+}
+
+TEST(StepData_FieldTest, CopyPreservesSelectValues)
+{
+  occ::handle<StepData_SelectInt> anIntegerSelect = new StepData_SelectInt;
+  anIntegerSelect->SetKind(static_cast<int>(StepData_Field::FieldKind::Logical));
+  anIntegerSelect->SetInt(static_cast<int>(StepData_LUnknown));
+  StepData_Field anIntegerSource;
+  anIntegerSource.SetSelectMember(anIntegerSelect);
+
+  StepData_Field anIntegerCopy;
+  anIntegerCopy.CopyFrom(anIntegerSource);
+  occ::handle<StepData_SelectInt> aCopiedInteger =
+    occ::down_cast<StepData_SelectInt>(anIntegerCopy.Transient());
+  ASSERT_FALSE(aCopiedInteger.IsNull());
+  EXPECT_NE(aCopiedInteger, anIntegerSelect);
+  EXPECT_EQ(aCopiedInteger->Kind(), static_cast<int>(StepData_Field::FieldKind::Logical));
+  EXPECT_EQ(aCopiedInteger->Logical(), StepData_LUnknown);
+
+  occ::handle<StepData_SelectReal> aRealSelect = new StepData_SelectReal;
+  aRealSelect->SetReal(4.5);
+  StepData_Field aRealSource;
+  aRealSource.SetSelectMember(aRealSelect);
+
+  StepData_Field aRealCopy;
+  aRealCopy.CopyFrom(aRealSource);
+  occ::handle<StepData_SelectReal> aCopiedReal =
+    occ::down_cast<StepData_SelectReal>(aRealCopy.Transient());
+  ASSERT_FALSE(aCopiedReal.IsNull());
+  EXPECT_NE(aCopiedReal, aRealSelect);
+  EXPECT_DOUBLE_EQ(aCopiedReal->Real(), 4.5);
+}
+
+TEST(StepData_FieldTest, ClearItemClearsStringAndEntityLists)
+{
+  StepData_Field aStringField;
+  aStringField.SetString();
+  aStringField.SetList(1);
+  aStringField.SetString(1, "text");
+  ASSERT_TRUE(aStringField.IsSet(1));
+  aStringField.ClearItem(1);
+  EXPECT_FALSE(aStringField.IsSet(1));
+
+  StepData_Field anEntityField;
+  anEntityField.SetEntity();
+  anEntityField.SetList(1);
+  anEntityField.SetEntity(1, new Standard_Transient);
+  ASSERT_TRUE(anEntityField.IsSet(1));
+  anEntityField.ClearItem(1);
+  EXPECT_FALSE(anEntityField.IsSet(1));
+}
+
+TEST(StepData_FieldTest, LogicalSelectPreservesValue)
+{
+  occ::handle<StepData_SelectInt> aSelect = new StepData_SelectInt;
+  StepData_Field                  aField;
+  aField.SetSelectMember(aSelect);
+
+  aField.SetLogical(StepData_LFalse);
+  EXPECT_EQ(aSelect->Kind(), static_cast<int>(StepData_Field::FieldKind::Logical));
+  EXPECT_EQ(aSelect->Logical(), StepData_LFalse);
+
+  aField.SetLogical(StepData_LTrue);
+  EXPECT_EQ(aSelect->Logical(), StepData_LTrue);
+
+  aField.SetLogical(StepData_LUnknown);
+  EXPECT_EQ(aSelect->Logical(), StepData_LUnknown);
+}
+
+TEST(StepData_FieldTest, LogicalListPreservesAllValues)
+{
+  StepData_Field aField;
+  aField.SetLogical();
+  aField.SetList(3, -1);
+  aField.SetLogical(-1, StepData_LFalse);
+  aField.SetLogical(0, StepData_LTrue);
+  aField.SetLogical(1, StepData_LUnknown);
+
+  EXPECT_EQ(aField.Logical(-1), StepData_LFalse);
+  EXPECT_EQ(aField.Logical(0), StepData_LTrue);
+  EXPECT_EQ(aField.Logical(1), StepData_LUnknown);
+}
+
+TEST(StepData_FieldTest, FieldListFillSharedTraversesEntityAggregates)
+{
+  occ::handle<Standard_Transient> anEntity1 = new Standard_Transient;
+  occ::handle<Standard_Transient> anEntity2 = new Standard_Transient;
+  occ::handle<Standard_Transient> anEntity3 = new Standard_Transient;
+  occ::handle<Standard_Transient> anEntity4 = new Standard_Transient;
+
+  StepData_FieldListN aFields(3);
+  aFields.CField(1).SetEntity(anEntity1);
+
+  aFields.CField(2).SetEntity();
+  aFields.CField(2).SetList(2, -1);
+  aFields.CField(2).SetEntity(-1, anEntity2);
+  aFields.CField(2).SetEntity(0, anEntity3);
+
+  aFields.CField(3).SetEntity();
+  aFields.CField(3).SetList2(1, 1, 2, -3);
+  occ::handle<NCollection_HArray2<occ::handle<Standard_Transient>>> anArray =
+    occ::down_cast<NCollection_HArray2<occ::handle<Standard_Transient>>>(
+      aFields.CField(3).Transient());
+  ASSERT_FALSE(anArray.IsNull());
+  anArray->SetValue(2, -3, anEntity4);
+
+  Interface_EntityIterator anIterator;
+  aFields.FillShared(anIterator);
+  ASSERT_EQ(anIterator.NbEntities(), 4);
+
+  anIterator.Start();
+  EXPECT_EQ(anIterator.Value(), anEntity1);
+  anIterator.Next();
+  EXPECT_EQ(anIterator.Value(), anEntity2);
+  anIterator.Next();
+  EXPECT_EQ(anIterator.Value(), anEntity3);
+  anIterator.Next();
+  EXPECT_EQ(anIterator.Value(), anEntity4);
+}
+
+TEST(StepData_FieldTest, FieldListNValidatesFieldCount)
+{
+  EXPECT_EQ(StepData_FieldListN(0).NbFields(), 0);
+  EXPECT_EQ(StepData_FieldListN(3).NbFields(), 3);
+  EXPECT_THROW(StepData_FieldListN(-1), Standard_RangeError);
+}
+
+TEST(StepData_FieldTest, SimpleSharedTraversesFieldsAndSkipsNullEntities)
+{
+  occ::handle<StepData_ESDescr> aDescription = new StepData_ESDescr("TEST_ENTITY");
+  aDescription->SetNbFields(2);
+  occ::handle<StepData_Simple> anEntity = new StepData_Simple(aDescription);
+
+  occ::handle<Standard_Transient> aScalarEntity = new Standard_Transient;
+  occ::handle<Standard_Transient> anArrayEntity = new Standard_Transient;
+  anEntity->CFieldNum(1).SetEntity(aScalarEntity);
+
+  occ::handle<NCollection_HArray1<occ::handle<Standard_Transient>>> anArray =
+    new NCollection_HArray1<occ::handle<Standard_Transient>>(-1, 0);
+  anArray->SetValue(-1, anArrayEntity);
+  anEntity->CFieldNum(2).Set(anArray);
+
+  Interface_EntityIterator anIterator;
+  anEntity->Shared(anIterator);
+  ASSERT_EQ(anIterator.NbEntities(), 2);
+
+  anIterator.Start();
+  EXPECT_EQ(anIterator.Value(), aScalarEntity);
+  anIterator.Next();
+  EXPECT_EQ(anIterator.Value(), anArrayEntity);
+}
+
+TEST(StepData_FieldTest, PDescrSetFromPreservesFieldDefinition)
+{
+  occ::handle<StepData_PDescr> aSource = new StepData_PDescr;
+  aSource->SetEnum();
+  aSource->AddEnumDef(".FIRST.");
+  aSource->AddEnumDef(".SECOND.");
+  aSource->SetArity(2);
+  aSource->SetOptional();
+  aSource->SetDerived();
+  aSource->SetField("value", 3);
+
+  occ::handle<StepData_PDescr> aCopy = new StepData_PDescr;
+  aCopy->SetFrom(aSource);
+
+  EXPECT_TRUE(aCopy->IsEnum());
+  EXPECT_EQ(aCopy->EnumMax(), 1);
+  EXPECT_STREQ(aCopy->EnumText(0), ".FIRST.");
+  EXPECT_STREQ(aCopy->EnumText(1), ".SECOND.");
+  EXPECT_EQ(aCopy->Arity(), 2);
+  EXPECT_TRUE(aCopy->IsOptional());
+  EXPECT_TRUE(aCopy->IsDerived());
+  EXPECT_TRUE(aCopy->IsField());
+  EXPECT_STREQ(aCopy->FieldName(), "value");
+  EXPECT_EQ(aCopy->FieldRank(), 3);
+}
+
+TEST(StepData_FieldTest, SelectMemberUnsupportedKindHasMiscParameterType)
+{
+  occ::handle<StepData_SelectInt> aSelect = new StepData_SelectInt;
+  aSelect->SetKind(257);
+  EXPECT_EQ(aSelect->ParamType(), Interface_ParamMisc);
+}
+
+TEST(StepData_FieldTest, SelectRealStoresRealValue)
+{
+  occ::handle<StepData_SelectReal> aSelect = new StepData_SelectReal;
+  aSelect->SetReal(3.25);
+  EXPECT_EQ(aSelect->Kind(), static_cast<int>(StepData_Field::FieldKind::Real));
+  EXPECT_DOUBLE_EQ(aSelect->Real(), 3.25);
+}
+
+TEST(StepData_FieldTest, SelectNamedDelegatesValueToField)
+{
+  occ::handle<StepData_SelectNamed> aSelect = new StepData_SelectNamed;
+  aSelect->SetName("VALUE");
+  aSelect->SetKind(static_cast<int>(StepData_Field::FieldKind::Integer));
+  aSelect->SetInt(7);
+
+  EXPECT_TRUE(aSelect->HasName());
+  EXPECT_STREQ(aSelect->Name(), "VALUE");
+  EXPECT_EQ(aSelect->Kind(), static_cast<int>(StepData_Field::FieldKind::Integer));
+  EXPECT_EQ(aSelect->Int(), 7);
+
+  aSelect->SetKind(261);
+  EXPECT_EQ(aSelect->Kind(), static_cast<int>(StepData_Field::FieldKind::Undefined));
+}
+
+TEST(StepData_FieldTest, SelectArrRealPreservesArrayBounds)
+{
+  occ::handle<NCollection_HArray1<double>> anArray = new NCollection_HArray1<double>(-2, 0);
+  anArray->SetValue(-2, 1.0);
+  occ::handle<StepData_SelectArrReal> aSelect = new StepData_SelectArrReal;
+  aSelect->SetArrReal(anArray);
+
+  EXPECT_EQ(aSelect->Kind(), static_cast<int>(StepData_Field::FieldKind::Any));
+  ASSERT_FALSE(aSelect->ArrReal().IsNull());
+  EXPECT_EQ(aSelect->ArrReal()->Lower(), -2);
+  EXPECT_DOUBLE_EQ(aSelect->ArrReal()->Value(-2), 1.0);
+}

--- a/src/DataExchange/TKDESTEP/GTests/StepData_StepWriter_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepData_StepWriter_Test.cxx
@@ -11,10 +11,92 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <NCollection_HArray1.hxx>
+#include <StepData_Field.hxx>
+#include <StepData_SelectArrReal.hxx>
+#include <StepData_SelectInt.hxx>
+#include <StepData_StepModel.hxx>
 #include <StepData_StepWriter.hxx>
 #include <TCollection_AsciiString.hxx>
 
 #include <gtest/gtest.h>
+
+namespace
+{
+//=================================================================================================
+
+TCollection_AsciiString writeField(const StepData_Field& theField)
+{
+  occ::handle<StepData_StepModel> aModel = new StepData_StepModel;
+  StepData_StepWriter             aWriter(aModel);
+  aWriter.StartEntity("TEST");
+  aWriter.SendField(theField, {});
+  aWriter.EndEntity();
+  return TCollection_AsciiString(aWriter.Line(1)->ToCString());
+}
+} // namespace
+
+TEST(StepData_StepWriterTest, SendField_UnsupportedValuesWriteUndefined)
+{
+  StepData_Field aField;
+  aField.Clear(10);
+  EXPECT_STREQ(writeField(aField).ToCString(), "TEST($);");
+
+  aField.Clear(StepData_Field::FieldKind::Select);
+  EXPECT_STREQ(writeField(aField).ToCString(), "TEST($);");
+
+  aField.SetEnum(-1, "");
+  EXPECT_STREQ(writeField(aField).ToCString(), "TEST($);");
+}
+
+TEST(StepData_StepWriterTest, SendSelect_UnsupportedKindWritesUndefined)
+{
+  occ::handle<StepData_SelectInt> aSelect = new StepData_SelectInt;
+  aSelect->SetKind(static_cast<int>(StepData_Field::FieldKind::Any));
+
+  StepData_Field aField;
+  aField.SetSelectMember(aSelect);
+  EXPECT_STREQ(writeField(aField).ToCString(), "TEST($);");
+
+  aSelect->SetKind(261);
+  EXPECT_STREQ(writeField(aField).ToCString(), "TEST($);");
+}
+
+TEST(StepData_StepWriterTest, SendSelect_RealArrayPreservesBoundsAndParameterPosition)
+{
+  occ::handle<NCollection_HArray1<double>> anArray = new NCollection_HArray1<double>(-2, 0);
+  anArray->SetValue(-2, 1.0);
+  anArray->SetValue(-1, 2.0);
+  anArray->SetValue(0, 3.0);
+
+  occ::handle<StepData_SelectArrReal> aSelect = new StepData_SelectArrReal;
+  aSelect->SetArrReal(anArray);
+
+  occ::handle<StepData_StepModel> aModel = new StepData_StepModel;
+  StepData_StepWriter             aWriter(aModel);
+  aWriter.StartEntity("TEST");
+  aWriter.Send(9);
+  aWriter.SendSelect(aSelect, {});
+  aWriter.Send(10);
+  aWriter.EndEntity();
+  EXPECT_STREQ(aWriter.Line(1)->ToCString(), "TEST(9,(1.,2.,3.),10);");
+
+  aSelect->SetName("VALUES");
+  StepData_StepWriter aNamedWriter(aModel);
+  aNamedWriter.StartEntity("TEST");
+  aNamedWriter.SendSelect(aSelect, {});
+  aNamedWriter.EndEntity();
+  EXPECT_STREQ(aNamedWriter.Line(1)->ToCString(), "TEST(VALUES((1.,2.,3.)));");
+}
+
+TEST(StepData_StepWriterTest, SendSelect_NullRealArrayWritesUndefined)
+{
+  occ::handle<StepData_SelectArrReal> aSelect = new StepData_SelectArrReal;
+
+  StepData_Field aField;
+  aField.SetSelectMember(aSelect);
+  EXPECT_STREQ(writeField(aField).ToCString(), "TEST($);");
+}
 
 // Test CleanTextForSend with basic character escaping
 TEST(StepData_StepWriterTest, CleanTextForSend_BasicEscaping)

--- a/src/DataExchange/TKDESTEP/StepData/StepData_Field.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_Field.cxx
@@ -11,12 +11,13 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <StepData_Field.hxx>
+
 #include <TCollection_HAsciiString.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_HArray1.hxx>
 #include <MoniTool_Macros.hxx>
 #include <Standard_Transient.hxx>
-#include <StepData_Field.hxx>
 #include <StepData_SelectInt.hxx>
 #include <StepData_SelectMember.hxx>
 #include <StepData_SelectNamed.hxx>
@@ -25,39 +26,14 @@
 #include <NCollection_Array2.hxx>
 #include <NCollection_HArray2.hxx>
 
-//  The kind encodes the data type, access mode (direct or via Select),
-//  and arity (simple, list, square array)
-//  Values for Kind: 0 = Clear/Undefined
-//  KindInteger KindBoolean KindLogical KindEnum KindReal KindString KindEntity
-//  + KindSelect which substitutes and can combine with them
-//  + KindList and KindList2 which can combine with them
-//  (on KindArity mask and ShiftArity offset)
-#define KindInteger 1
-#define KindBoolean 2
-#define KindLogical 3
-#define KindEnum 4
-#define KindReal 5
-#define KindString 6
-#define KindEntity 7
-#define KindAny 8
-#define KindDerived 9
-
-#define KindType 15
-#define KindSelect 16
-#define KindArity 192
-#define KindList 64
-#define KindList2 128
-#define ShiftArity 6
-
-static int TrueKind(const int kind)
-{
-  return (kind & KindType);
-}
+//=================================================================================================
 
 StepData_Field::StepData_Field()
 {
   Clear();
 }
+
+//=================================================================================================
 
 StepData_Field::StepData_Field(const StepData_Field& other, const bool copy)
 {
@@ -72,13 +48,15 @@ StepData_Field::StepData_Field(const StepData_Field& other, const bool copy)
   theany  = other.Transient();
 }
 
+//=================================================================================================
+
 void StepData_Field::CopyFrom(const StepData_Field& other)
 {
   thekind = other.Kind(false);
   theint  = other.Int();
   thereal = other.Real();
   theany  = other.Transient();
-  if (thekind == KindString || thekind == KindEnum)
+  if (thekind == FieldKind::String || thekind == FieldKind::Enum)
   {
     DeclareAndCast(TCollection_HAsciiString, str, theany);
     if (!str.IsNull())
@@ -87,9 +65,8 @@ void StepData_Field::CopyFrom(const StepData_Field& other)
     }
     return;
   }
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
-    //  Differents cas
     DeclareAndCast(StepData_SelectReal, sr, theany);
     if (!sr.IsNull())
     {
@@ -123,7 +100,7 @@ void StepData_Field::CopyFrom(const StepData_Field& other)
     }
   }
   //    Les listes ...
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     int i, low, up;
     DeclareAndCast(NCollection_HArray1<int>, hi, theany);
@@ -136,6 +113,7 @@ void StepData_Field::CopyFrom(const StepData_Field& other)
       {
         hi2->SetValue(i, hi->Value(i));
       }
+      theany = hi2;
       return;
     }
     DeclareAndCast(NCollection_HArray1<double>, hr, theany);
@@ -148,6 +126,7 @@ void StepData_Field::CopyFrom(const StepData_Field& other)
       {
         hr2->SetValue(i, hr->Value(i));
       }
+      theany = hr2;
       return;
     }
     DeclareAndCast(NCollection_HArray1<occ::handle<TCollection_HAsciiString>>, hs, theany);
@@ -159,8 +138,13 @@ void StepData_Field::CopyFrom(const StepData_Field& other)
         new NCollection_HArray1<occ::handle<TCollection_HAsciiString>>(low, up);
       for (i = low; i <= up; i++)
       {
-        hs2->SetValue(i, new TCollection_HAsciiString(hs->Value(i)));
+        const occ::handle<TCollection_HAsciiString>& aString = hs->Value(i);
+        if (!aString.IsNull())
+        {
+          hs2->SetValue(i, new TCollection_HAsciiString(aString->ToCString()));
+        }
       }
+      theany = hs2;
       return;
     }
     DeclareAndCast(NCollection_HArray1<occ::handle<Standard_Transient>>, ht, theany);
@@ -170,36 +154,45 @@ void StepData_Field::CopyFrom(const StepData_Field& other)
       up  = ht->Upper();
       occ::handle<NCollection_HArray1<occ::handle<Standard_Transient>>> ht2 =
         new NCollection_HArray1<occ::handle<Standard_Transient>>(low, up);
-      //  Should handle SelectMember cases...
       for (i = low; i <= up; i++)
       {
         ht2->SetValue(i, ht->Value(i));
       }
+      theany = ht2;
       return;
     }
   }
-  //    Remains the 2D list...
-  //  if ((thekind & KindArity) == KindList2) {
-  //    DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>,ht,theany);
-  //  }
 }
 
-void StepData_Field::Clear(const int kind)
+//=================================================================================================
+
+void StepData_Field::Clear(const FieldKind theKind)
 {
-  thekind = kind;
+  thekind = theKind;
   theint  = 0;
   thereal = 0.;
   theany.Nullify();
 }
 
+//=================================================================================================
+
+void StepData_Field::Clear(const int kind)
+{
+  Clear(KindTools::FromInt(kind));
+}
+
+//=================================================================================================
+
 void StepData_Field::SetDerived()
 {
-  Clear(KindDerived);
+  Clear(FieldKind::Derived);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetInt(const int val)
 {
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -208,17 +201,19 @@ void StepData_Field::SetInt(const int val)
       return;
     }
   }
-  if (thekind == KindInteger || thekind == KindBoolean || thekind == KindLogical
-      || thekind == KindEnum)
+  if (thekind == FieldKind::Integer || thekind == FieldKind::Boolean
+      || thekind == FieldKind::Logical || thekind == FieldKind::Enum)
   {
     theint = val;
   }
   //  else ?
 }
 
+//=================================================================================================
+
 void StepData_Field::SetInteger(const int val)
 {
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -227,13 +222,15 @@ void StepData_Field::SetInteger(const int val)
       return;
     }
   }
-  Clear(KindInteger);
+  Clear(FieldKind::Integer);
   theint = val;
 }
 
+//=================================================================================================
+
 void StepData_Field::SetBoolean(const bool val)
 {
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -242,13 +239,15 @@ void StepData_Field::SetBoolean(const bool val)
       return;
     }
   }
-  Clear(KindBoolean);
+  Clear(FieldKind::Boolean);
   theint = (val ? 1 : 0);
 }
 
+//=================================================================================================
+
 void StepData_Field::SetLogical(const StepData_Logical val)
 {
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -257,7 +256,7 @@ void StepData_Field::SetLogical(const StepData_Logical val)
       return;
     }
   }
-  Clear(KindLogical);
+  Clear(FieldKind::Logical);
   if (val == StepData_LFalse)
   {
     theint = 0;
@@ -272,9 +271,11 @@ void StepData_Field::SetLogical(const StepData_Logical val)
   }
 }
 
+//=================================================================================================
+
 void StepData_Field::SetReal(const double val)
 {
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -283,13 +284,15 @@ void StepData_Field::SetReal(const double val)
       return;
     }
   }
-  Clear(KindReal);
+  Clear(FieldKind::Real);
   thereal = val;
 }
 
+//=================================================================================================
+
 void StepData_Field::SetString(const char* const val)
 {
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -298,16 +301,18 @@ void StepData_Field::SetString(const char* const val)
       return;
     }
   }
-  if (thekind != KindEnum)
+  if (thekind != FieldKind::Enum)
   {
-    Clear(KindString);
+    Clear(FieldKind::String);
   }
   theany = new TCollection_HAsciiString(val);
 }
 
+//=================================================================================================
+
 void StepData_Field::SetEnum(const int val, const char* const text)
 {
-  Clear(KindEnum);
+  Clear(FieldKind::Enum);
   SetInt(val);
   if (text && text[0] != '\0')
   {
@@ -315,27 +320,35 @@ void StepData_Field::SetEnum(const int val, const char* const text)
   }
 }
 
+//=================================================================================================
+
 void StepData_Field::SetSelectMember(const occ::handle<StepData_SelectMember>& val)
 {
   if (val.IsNull())
   {
     return;
   }
-  Clear(KindSelect);
+  Clear(FieldKind::Select);
   theany = val;
 }
 
+//=================================================================================================
+
 void StepData_Field::SetEntity(const occ::handle<Standard_Transient>& val)
 {
-  Clear(KindEntity);
+  Clear(FieldKind::Entity);
   theany = val;
 }
+
+//=================================================================================================
 
 void StepData_Field::SetEntity()
 {
   occ::handle<Standard_Transient> nulent;
   SetEntity(nulent);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetList(const int size, const int first)
 {
@@ -346,16 +359,16 @@ void StepData_Field::SetList(const int size, const int first)
   theany.Nullify(); // ?? agrandissement ??
   switch (thekind)
   {
-    case KindInteger:
-    case KindBoolean:
-    case KindLogical:
+    case FieldKind::Integer:
+    case FieldKind::Boolean:
+    case FieldKind::Logical:
       theany = new NCollection_HArray1<int>(first, first + size - 1);
       break;
-    case KindReal:
+    case FieldKind::Real:
       theany = new NCollection_HArray1<double>(first, first + size - 1);
       break;
-    case KindEnum:
-    case KindString:
+    case FieldKind::Enum:
+    case FieldKind::String:
       theany =
         new NCollection_HArray1<occ::handle<TCollection_HAsciiString>>(first, first + size - 1);
       break;
@@ -363,12 +376,14 @@ void StepData_Field::SetList(const int size, const int first)
     default:
       theany = new NCollection_HArray1<occ::handle<Standard_Transient>>(first, first + size - 1);
   }
-  if (thekind == 0)
+  if (thekind == FieldKind::Undefined)
   {
-    thekind = KindAny;
+    thekind = FieldKind::Any;
   }
-  thekind |= KindList;
+  thekind = KindTools::Combine(thekind, FieldKind::List);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetList2(const int siz1, const int siz2, const int f1, const int f2)
 {
@@ -377,27 +392,27 @@ void StepData_Field::SetList2(const int siz1, const int siz2, const int f1, cons
   theint  = siz1;
   thereal = double(siz2);
   theany.Nullify();
-  int kind = thekind;
-  if (thekind == KindSelect)
+  FieldKind kind = thekind;
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
     {
-      kind = sm->Kind();
+      kind = KindTools::FromInt(sm->Kind());
     }
   }
   switch (kind)
   {
-    case KindInteger:
-    case KindBoolean:
-    case KindLogical:
+    case FieldKind::Integer:
+    case FieldKind::Boolean:
+    case FieldKind::Logical:
       theany = new NCollection_HArray2<int>(f1, f1 + siz1 - 1, f2, f2 + siz2 - 1);
       break;
-    case KindReal:
+    case FieldKind::Real:
       theany = new NCollection_HArray2<double>(f1, f1 + siz1 - 1, f2, f2 + siz2 - 1);
       break;
-    case KindEnum:
-    case KindString:
+    case FieldKind::Enum:
+    case FieldKind::String:
       theany = new NCollection_HArray2<occ::handle<Standard_Transient>>(f1,
                                                                         f1 + siz1 - 1,
                                                                         f2,
@@ -410,16 +425,18 @@ void StepData_Field::SetList2(const int siz1, const int siz2, const int f1, cons
                                                                         f2,
                                                                         f2 + siz2 - 1);
   }
-  if (thekind == 0)
+  if (thekind == FieldKind::Undefined)
   {
-    thekind = KindAny;
+    thekind = FieldKind::Any;
   }
-  thekind |= KindList2;
+  thekind = KindTools::Combine(thekind, FieldKind::List2);
 }
+
+//=================================================================================================
 
 void StepData_Field::Set(const occ::handle<Standard_Transient>& val)
 {
-  int kind = thekind;
+  FieldKind kind = thekind;
   Clear();
   theany = val;
   if (val.IsNull())
@@ -428,84 +445,86 @@ void StepData_Field::Set(const occ::handle<Standard_Transient>& val)
   }
   if (val->IsKind(STANDARD_TYPE(TCollection_HAsciiString)))
   {
-    thekind = KindString;
+    thekind = FieldKind::String;
     return;
   }
   DeclareAndCast(StepData_SelectMember, sm, val);
   if (!sm.IsNull())
   {
-    thekind = KindSelect;
+    thekind = FieldKind::Select;
     return;
   }
   DeclareAndCast(NCollection_HArray1<int>, hi, val);
   if (!hi.IsNull())
   {
-    if (kind == 0)
+    if (kind == FieldKind::Undefined)
     {
-      kind = KindInteger;
+      kind = FieldKind::Integer;
     }
-    thekind = kind | KindList;
+    thekind = KindTools::Combine(kind, FieldKind::List);
     theint  = hi->Length();
     return;
   }
   DeclareAndCast(NCollection_HArray1<double>, hr, val);
   if (!hr.IsNull())
   {
-    thekind = KindReal | KindList;
+    thekind = KindTools::Combine(FieldKind::Real, FieldKind::List);
     theint  = hr->Length();
     return;
   }
   DeclareAndCast(NCollection_HArray1<occ::handle<TCollection_HAsciiString>>, hs, val);
   if (!hs.IsNull())
   {
-    thekind = KindString | KindList;
+    thekind = KindTools::Combine(FieldKind::String, FieldKind::List);
     theint  = hs->Length();
     return;
   }
   DeclareAndCast(NCollection_HArray1<occ::handle<Standard_Transient>>, ht, val);
   if (!ht.IsNull())
   {
-    if (kind == 0)
+    if (kind == FieldKind::Undefined)
     {
-      kind = KindAny;
+      kind = FieldKind::Any;
     }
-    thekind = kind | KindList;
+    thekind = KindTools::Combine(kind, FieldKind::List);
     theint  = ht->Length();
     return;
   }
   DeclareAndCast(NCollection_HArray2<int>, hi2, val);
   if (!hi2.IsNull())
   {
-    if (kind == 0)
+    if (kind == FieldKind::Undefined)
     {
-      kind = KindInteger;
+      kind = FieldKind::Integer;
     }
-    thekind = kind | KindList2;
-    theint  = hi2->ColLength();
-    thereal = double(hi2->RowLength());
+    thekind = KindTools::Combine(kind, FieldKind::List2);
+    theint  = hi2->NbRows();
+    thereal = double(hi2->NbColumns());
     return;
   }
   DeclareAndCast(NCollection_HArray2<double>, hr2, val);
   if (!hr2.IsNull())
   {
-    thekind = KindInteger | KindList2;
-    theint  = hr2->ColLength();
-    thereal = double(hi2->RowLength());
+    thekind = KindTools::Combine(FieldKind::Real, FieldKind::List2);
+    theint  = hr2->NbRows();
+    thereal = double(hr2->NbColumns());
     return;
   }
   DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht2, val);
   if (!ht2.IsNull())
   {
-    if (kind == 0)
+    if (kind == FieldKind::Undefined)
     {
-      kind = KindAny;
+      kind = FieldKind::Any;
     }
-    thekind = kind | KindList2;
-    theint  = ht2->ColLength();
-    thereal = double(hi2->RowLength());
+    thekind = KindTools::Combine(kind, FieldKind::List2);
+    theint  = ht2->NbRows();
+    thereal = double(ht2->NbColumns());
     return;
   }
 }
+
+//=================================================================================================
 
 void StepData_Field::ClearItem(const int num)
 {
@@ -521,7 +540,9 @@ void StepData_Field::ClearItem(const int num)
   }
 }
 
-void StepData_Field::SetInt(const int num, const int val, const int kind)
+//=================================================================================================
+
+void StepData_Field::SetInt(const int num, const int val, const FieldKind kind)
 {
   DeclareAndCast(NCollection_HArray1<int>, hi, theany);
   if (!hi.IsNull())
@@ -535,42 +556,39 @@ void StepData_Field::SetInt(const int num, const int val, const int kind)
   {
     return; // yena erreur, ou alors OfReal
   }
-  thekind = KindAny | KindList;
+  thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
   DeclareAndCast(StepData_SelectMember, sm, ht->Value(num));
   if (sm.IsNull())
   {
     sm = new StepData_SelectInt;
     ht->SetValue(num, sm);
   }
-  sm->SetKind(kind);
+  sm->SetKind(KindTools::ToInt(kind));
   sm->SetInt(val);
 }
 
+//=================================================================================================
+
 void StepData_Field::SetInteger(const int num, const int val)
 {
-  SetInt(num, val, KindInteger);
+  SetInt(num, val, FieldKind::Integer);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetBoolean(const int num, const bool val)
 {
-  SetInt(num, (val ? 1 : 0), KindBoolean);
+  SetInt(num, (val ? 1 : 0), FieldKind::Boolean);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetLogical(const int num, const StepData_Logical val)
 {
-  if (val == StepData_LFalse)
-  {
-    SetInt(num, 0, KindLogical);
-  }
-  if (val == StepData_LTrue)
-  {
-    SetInt(num, 1, KindLogical);
-  }
-  if (val == StepData_LUnknown)
-  {
-    SetInt(num, 2, KindLogical);
-  }
+  SetInt(num, static_cast<int>(val), FieldKind::Logical);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetEnum(const int num, const int val, const char* const text)
 {
@@ -581,7 +599,7 @@ void StepData_Field::SetEnum(const int num, const int val, const char* const tex
     return;
   }
   DeclareAndCast(StepData_SelectMember, sm, ht->Value(num));
-  thekind = KindAny | KindList;
+  thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
   if (sm.IsNull())
   {
     sm = new StepData_SelectNamed;
@@ -589,6 +607,8 @@ void StepData_Field::SetEnum(const int num, const int val, const char* const tex
   }
   sm->SetEnum(val, text);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetReal(const int num, const double val)
 {
@@ -604,7 +624,7 @@ void StepData_Field::SetReal(const int num, const double val)
   {
     return; // yena erreur, ou alors OfInteger
   }
-  thekind = KindAny | KindList;
+  thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
   DeclareAndCast(StepData_SelectMember, sm, ht->Value(num));
   if (sm.IsNull())
   {
@@ -613,6 +633,8 @@ void StepData_Field::SetReal(const int num, const double val)
   }
   sm->SetReal(val);
 }
+
+//=================================================================================================
 
 void StepData_Field::SetString(const int num, const char* const val)
 {
@@ -628,9 +650,11 @@ void StepData_Field::SetString(const int num, const char* const val)
   {
     return;
   }
-  thekind = KindAny | KindList;
+  thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
   ht->SetValue(num, new TCollection_HAsciiString(val));
 }
+
+//=================================================================================================
 
 void StepData_Field::SetEntity(const int num, const occ::handle<Standard_Transient>& val)
 {
@@ -647,7 +671,7 @@ void StepData_Field::SetEntity(const int num, const occ::handle<Standard_Transie
     occ::handle<NCollection_HArray1<occ::handle<Standard_Transient>>> ht =
       new NCollection_HArray1<occ::handle<Standard_Transient>>(low, up);
     occ::handle<StepData_SelectMember> sm;
-    int                                kind = Kind();
+    FieldKind                          kind = Kind();
     for (int i = low; i <= up; i++)
     {
       if (i == num)
@@ -657,12 +681,12 @@ void StepData_Field::SetEntity(const int num, const occ::handle<Standard_Transie
       else
       {
         sm = new StepData_SelectInt;
-        sm->SetKind(kind);
+        sm->SetKind(KindTools::ToInt(kind));
         sm->SetInt(hi->Value(i));
         ht->SetValue(i, sm);
       }
     }
-    thekind = KindAny | KindList;
+    thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
     return;
   }
   DeclareAndCast(NCollection_HArray1<double>, hr, theany);
@@ -685,7 +709,7 @@ void StepData_Field::SetEntity(const int num, const occ::handle<Standard_Transie
         ht->SetValue(i, sm);
       }
     }
-    thekind = KindAny | KindList;
+    thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
     return;
   }
   DeclareAndCast(NCollection_HArray1<occ::handle<TCollection_HAsciiString>>, hs, theany);
@@ -705,20 +729,22 @@ void StepData_Field::SetEntity(const int num, const occ::handle<Standard_Transie
         ht->SetValue(i, hs->Value(i));
       }
     }
-    thekind = KindAny | KindList;
+    thekind = KindTools::Combine(FieldKind::Any, FieldKind::List);
     return;
   }
 }
 
 //     QUERIES
 
+//=================================================================================================
+
 bool StepData_Field::IsSet(const int n1, const int n2) const
 {
-  if (thekind == 0)
+  if (thekind == FieldKind::Undefined)
   {
     return false;
   }
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (sm.IsNull())
@@ -727,7 +753,7 @@ bool StepData_Field::IsSet(const int n1, const int n2) const
     }
     return (sm->Kind() != 0);
   }
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<occ::handle<Standard_Transient>>, ht, theany);
     if (!ht.IsNull())
@@ -740,7 +766,7 @@ bool StepData_Field::IsSet(const int n1, const int n2) const
       return (!hs->Value(n1).IsNull());
     }
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
     DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht, theany);
     if (!ht.IsNull())
@@ -751,32 +777,35 @@ bool StepData_Field::IsSet(const int n1, const int n2) const
   return true;
 }
 
-int StepData_Field::ItemKind(const int n1, const int n2) const
+//=================================================================================================
+
+StepData_Field::FieldKind StepData_Field::ItemKind(const int n1, const int n2) const
 {
-  if ((thekind & KindArity) == 0)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == 0)
   {
     return Kind(true);
   }
-  int kind = TrueKind(thekind); // si Any, evaluer ...
-  if (kind != KindAny)
+  FieldKind kind = KindTools::TypeOf(thekind); // si Any, evaluer ...
+  if (kind != FieldKind::Any)
   {
     return kind;
   }
   //  Otherwise, look for a Transient
   occ::handle<Standard_Transient> item;
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<occ::handle<Standard_Transient>>, ht, theany);
-    if (!ht.IsNull())
+    if (ht.IsNull())
     {
       return kind;
     }
     item = ht->Value(n1);
   }
-  else if ((thekind & KindArity) == KindList2)
+  else if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK)
+           == KindTools::ToInt(FieldKind::List2))
   {
     DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht, theany);
-    if (!ht.IsNull())
+    if (ht.IsNull())
     {
       return kind;
     }
@@ -784,49 +813,55 @@ int StepData_Field::ItemKind(const int n1, const int n2) const
   }
   if (item.IsNull())
   {
-    return 0;
+    return FieldKind::Undefined;
   }
   if (item->IsKind(STANDARD_TYPE(TCollection_HAsciiString)))
   {
-    return KindString;
+    return FieldKind::String;
   }
   DeclareAndCast(StepData_SelectMember, sm, item);
   if (sm.IsNull())
   {
-    return KindEntity;
+    return FieldKind::Entity;
   }
-  return sm->Kind();
+  return KindTools::FromInt(sm->Kind());
 }
 
-int StepData_Field::Kind(const bool type) const
+//=================================================================================================
+
+StepData_Field::FieldKind StepData_Field::Kind(const bool type) const
 {
   if (!type)
   {
     return thekind;
   }
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
     {
-      return TrueKind(sm->Kind());
+      return KindTools::TypeOf(KindTools::FromInt(sm->Kind()));
     }
   }
-  return TrueKind(thekind);
+  return KindTools::TypeOf(thekind);
 }
+
+//=================================================================================================
 
 int StepData_Field::Arity() const
 {
-  return (thekind & KindArity) >> ShiftArity;
+  return KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) >> KindTools::THE_ARITY_SHIFT;
 }
+
+//=================================================================================================
 
 int StepData_Field::Length(const int index) const
 {
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     return theint;
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
     if (index == 2)
     {
@@ -840,9 +875,11 @@ int StepData_Field::Length(const int index) const
   return 0;
 }
 
+//=================================================================================================
+
 int StepData_Field::Lower(const int index) const
 {
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<int>, hi, theany);
     if (!hi.IsNull())
@@ -865,8 +902,18 @@ int StepData_Field::Lower(const int index) const
       return ht->Lower();
     }
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
+    DeclareAndCast(NCollection_HArray2<int>, hi, theany);
+    if (!hi.IsNull())
+    {
+      return index == 1 ? hi->LowerRow() : (index == 2 ? hi->LowerCol() : 0);
+    }
+    DeclareAndCast(NCollection_HArray2<double>, hr, theany);
+    if (!hr.IsNull())
+    {
+      return index == 1 ? hr->LowerRow() : (index == 2 ? hr->LowerCol() : 0);
+    }
     DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht, theany);
     if (ht.IsNull())
     {
@@ -874,26 +921,30 @@ int StepData_Field::Lower(const int index) const
     }
     if (index == 1)
     {
-      return ht->LowerCol();
+      return ht->LowerRow();
     }
     if (index == 2)
     {
-      return ht->LowerRow();
+      return ht->LowerCol();
     }
   }
   return 0;
 }
+
+//=================================================================================================
 
 int StepData_Field::Int() const
 {
   return theint;
 }
 
+//=================================================================================================
+
 int StepData_Field::Integer(const int n1, const int n2) const
 {
-  if ((thekind & KindArity) == 0)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == 0)
   {
-    if (thekind == KindSelect)
+    if (thekind == FieldKind::Select)
     {
       DeclareAndCast(StepData_SelectMember, sm, theany);
       if (!sm.IsNull())
@@ -903,7 +954,7 @@ int StepData_Field::Integer(const int n1, const int n2) const
     }
     return theint;
   }
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<int>, hi, theany);
     if (!hi.IsNull())
@@ -921,8 +972,13 @@ int StepData_Field::Integer(const int n1, const int n2) const
       return sm->Int();
     }
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
+    DeclareAndCast(NCollection_HArray2<int>, hi, theany);
+    if (!hi.IsNull())
+    {
+      return hi->Value(n1, n2);
+    }
     DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht, theany);
     if (ht.IsNull())
     {
@@ -937,10 +993,14 @@ int StepData_Field::Integer(const int n1, const int n2) const
   return 0;
 }
 
+//=================================================================================================
+
 bool StepData_Field::Boolean(const int n1, const int n2) const
 {
   return (Integer(n1, n2) > 0);
 }
+
+//=================================================================================================
 
 StepData_Logical StepData_Field::Logical(const int n1, const int n2) const
 {
@@ -956,11 +1016,13 @@ StepData_Logical StepData_Field::Logical(const int n1, const int n2) const
   return StepData_LUnknown;
 }
 
+//=================================================================================================
+
 double StepData_Field::Real(const int n1, const int n2) const
 {
-  if ((thekind & KindArity) == 0)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == 0)
   {
-    if (thekind == KindSelect)
+    if (thekind == FieldKind::Select)
     {
       DeclareAndCast(StepData_SelectMember, sm, theany);
       if (!sm.IsNull())
@@ -970,7 +1032,7 @@ double StepData_Field::Real(const int n1, const int n2) const
     }
     return thereal;
   }
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<double>, hr, theany);
     if (!hr.IsNull())
@@ -988,7 +1050,7 @@ double StepData_Field::Real(const int n1, const int n2) const
       return sm->Real();
     }
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
     DeclareAndCast(NCollection_HArray2<double>, hr, theany);
     if (!hr.IsNull())
@@ -1009,9 +1071,11 @@ double StepData_Field::Real(const int n1, const int n2) const
   return 0.0;
 }
 
+//=================================================================================================
+
 const char* StepData_Field::String(const int n1, const int n2) const
 {
-  if (thekind == KindString || thekind == KindEnum)
+  if (thekind == FieldKind::String || thekind == FieldKind::Enum)
   {
     DeclareAndCast(TCollection_HAsciiString, str, theany);
     if (!str.IsNull())
@@ -1023,7 +1087,7 @@ const char* StepData_Field::String(const int n1, const int n2) const
       return "";
     }
   }
-  if (thekind == KindSelect)
+  if (thekind == FieldKind::Select)
   {
     DeclareAndCast(StepData_SelectMember, sm, theany);
     if (!sm.IsNull())
@@ -1031,7 +1095,7 @@ const char* StepData_Field::String(const int n1, const int n2) const
       return sm->String();
     }
   }
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<occ::handle<TCollection_HAsciiString>>, hs, theany);
     if (!hs.IsNull())
@@ -1061,7 +1125,7 @@ const char* StepData_Field::String(const int n1, const int n2) const
       return sm->String();
     }
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
     DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht, theany);
     if (ht.IsNull())
@@ -1082,28 +1146,34 @@ const char* StepData_Field::String(const int n1, const int n2) const
   return "";
 }
 
+//=================================================================================================
+
 int StepData_Field::Enum(const int n1, const int n2) const
 {
   return Integer(n1, n2);
 }
+
+//=================================================================================================
 
 const char* StepData_Field::EnumText(const int n1, const int n2) const
 {
   return String(n1, n2);
 }
 
+//=================================================================================================
+
 occ::handle<Standard_Transient> StepData_Field::Entity(const int n1, const int n2) const
 {
   occ::handle<Standard_Transient> nulval; // null handle
-  if ((thekind & KindArity) == 0)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == 0)
   {
-    if (thekind == KindEntity)
+    if (thekind == FieldKind::Entity)
     {
       return theany;
     }
     return nulval;
   }
-  if ((thekind & KindArity) == KindList)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List))
   {
     DeclareAndCast(NCollection_HArray1<occ::handle<Standard_Transient>>, ht, theany);
     if (ht.IsNull())
@@ -1122,7 +1192,7 @@ occ::handle<Standard_Transient> StepData_Field::Entity(const int n1, const int n
     }
     return nulval;
   }
-  if ((thekind & KindArity) == KindList2)
+  if (KindTools::Bits(thekind, KindTools::THE_ARITY_MASK) == KindTools::ToInt(FieldKind::List2))
   {
     DeclareAndCast(NCollection_HArray2<occ::handle<Standard_Transient>>, ht, theany);
     if (ht.IsNull())
@@ -1143,6 +1213,8 @@ occ::handle<Standard_Transient> StepData_Field::Entity(const int n1, const int n
   }
   return nulval;
 }
+
+//=================================================================================================
 
 occ::handle<Standard_Transient> StepData_Field::Transient() const
 {

--- a/src/DataExchange/TKDESTEP/StepData/StepData_Field.hxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_Field.hxx
@@ -21,9 +21,12 @@
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
 
+#include <Standard_CString.hxx>
 #include <Standard_Integer.hxx>
 #include <StepData_Logical.hxx>
-#include <Standard_CString.hxx>
+
+#include <cstdint>
+
 class StepData_SelectMember;
 
 //! Defines a generally defined Field for STEP data : can be used
@@ -41,6 +44,60 @@ class StepData_Field
 {
 public:
   DEFINE_STANDARD_ALLOC
+
+  //! Encoded kind values used by StepData_Field and StepData_SelectMember.
+  //! Numeric values are kept compatible with the historical StepData API.
+  enum class FieldKind : uint8_t
+  {
+    Undefined = 0,
+    Integer   = 1,
+    Boolean   = 2,
+    Logical   = 3,
+    Enum      = 4,
+    Real      = 5,
+    String    = 6,
+    Entity    = 7,
+    Any       = 8,
+    Derived   = 9,
+
+    Select = 16,
+    List   = 64,
+    List2  = 128
+  };
+
+  //! Helpers for manipulating encoded field kinds.
+  struct KindTools
+  {
+    static constexpr int THE_TYPE_MASK   = 0x0F;
+    static constexpr int THE_ARITY_MASK  = 0xC0;
+    static constexpr int THE_ARITY_SHIFT = 6;
+
+    static constexpr int ToInt(const FieldKind theKind) noexcept
+    {
+      return static_cast<int>(theKind);
+    }
+
+    static constexpr FieldKind FromInt(const int theKind) noexcept
+    {
+      return theKind >= 0 && theKind <= 0xFF ? static_cast<FieldKind>(theKind)
+                                             : FieldKind::Undefined;
+    }
+
+    static constexpr FieldKind Combine(const FieldKind theLeft, const FieldKind theRight) noexcept
+    {
+      return FromInt(ToInt(theLeft) | ToInt(theRight));
+    }
+
+    static constexpr int Bits(const FieldKind theKind, const int theMask) noexcept
+    {
+      return ToInt(theKind) & theMask;
+    }
+
+    static constexpr FieldKind TypeOf(const FieldKind theKind) noexcept
+    {
+      return FromInt(Bits(theKind, THE_TYPE_MASK));
+    }
+  };
 
   //! Creates a Field, empty ("no value defined")
   Standard_EXPORT StepData_Field();
@@ -62,7 +119,10 @@ public:
   //! Clears the field, to set it as "no value defined"
   //! Just before SetList, predeclares it as "any"
   //! A Kind can be directly set here to declare a type
-  Standard_EXPORT void Clear(const int kind = 0);
+  Standard_EXPORT void Clear(const FieldKind theKind = FieldKind::Undefined);
+
+  //! Clears the field using the legacy encoded kind value.
+  Standard_EXPORT void Clear(const int theKind);
 
   //! Codes a Field as derived (no proper value)
   Standard_EXPORT void SetDerived();
@@ -123,7 +183,7 @@ public:
   Standard_EXPORT void ClearItem(const int num);
 
   //! Internal access to an Integer Value for a list, plus its kind
-  Standard_EXPORT void SetInt(const int num, const int val, const int kind);
+  Standard_EXPORT void SetInt(const int num, const int val, const FieldKind kind);
 
   //! Sets an Integer Value for a list (rank num)
   //! (recognizes a SelectMember)
@@ -148,12 +208,12 @@ public:
   //! Returns the kind of an item in a list or double list
   //! It is the kind of the list, except if it is "Any", in such a
   //! case the true kind is determined and returned
-  Standard_EXPORT int ItemKind(const int n1 = 1, const int n2 = 1) const;
+  Standard_EXPORT FieldKind ItemKind(const int n1 = 1, const int n2 = 1) const;
 
   //! Returns the kind of the field
   //! <type> True (D) : returns only the type itself
   //! else, returns the complete kind
-  Standard_EXPORT int Kind(const bool type = true) const;
+  Standard_EXPORT FieldKind Kind(const bool type = true) const;
 
   Standard_EXPORT int Arity() const;
 
@@ -182,7 +242,7 @@ public:
   Standard_EXPORT occ::handle<Standard_Transient> Transient() const;
 
 private:
-  int                             thekind;
+  FieldKind                       thekind;
   int                             theint;
   double                          thereal;
   occ::handle<Standard_Transient> theany;

--- a/src/DataExchange/TKDESTEP/StepData/StepData_FieldList.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_FieldList.cxx
@@ -37,31 +37,39 @@ StepData_Field& StepData_FieldList::CField(const int)
   throw Standard_OutOfRange("StepData_FieldList : CField");
 }
 
-void StepData_FieldList::FillShared(Interface_EntityIterator& iter) const
+void StepData_FieldList::FillShared(Interface_EntityIterator& theIterator) const
 {
-  int i, nb = NbFields();
-  for (i = 1; i <= nb; i++)
+  for (int aFieldIndex = 1; aFieldIndex <= NbFields(); ++aFieldIndex)
   {
-    const StepData_Field& fi = Field(i);
-    if (fi.Kind() != 7)
+    const StepData_Field& aField = Field(aFieldIndex);
+    if (aField.Kind() != StepData_Field::FieldKind::Entity)
     {
-      continue; // KindEntity
+      continue;
     }
-    int i1, i2, nb1 = 1, nb2 = 1, ari = fi.Arity();
-    if (ari == 1)
+
+    const int anArity  = aField.Arity();
+    int       aLower1  = 1;
+    int       aLength1 = 1;
+    int       aLower2  = 1;
+    int       aLength2 = 1;
+    if (anArity == 1)
     {
-      nb1 = fi.Length();
+      aLower1  = aField.Lower(1);
+      aLength1 = aField.Length(1);
     }
-    if (ari == 2)
+    else if (anArity == 2)
     {
-      nb1 = fi.Length(1);
-      nb2 = fi.Length(2);
+      aLower1  = aField.Lower(1);
+      aLength1 = aField.Length(1);
+      aLower2  = aField.Lower(2);
+      aLength2 = aField.Length(2);
     }
-    for (i1 = 1; i1 <= nb1; i1++)
+
+    for (int anOffset1 = 0; anOffset1 < aLength1; ++anOffset1)
     {
-      for (i2 = 1; i2 <= nb2; i2++)
+      for (int anOffset2 = 0; anOffset2 < aLength2; ++anOffset2)
       {
-        iter.AddItem(fi.Entity(i1, i2));
+        theIterator.AddItem(aField.Entity(aLower1 + anOffset1, aLower2 + anOffset2));
       }
     }
   }

--- a/src/DataExchange/TKDESTEP/StepData/StepData_FieldListN.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_FieldListN.cxx
@@ -12,15 +12,23 @@
 // commercial license or contractual agreement.
 
 #include <StepData_FieldListN.hxx>
+#include <Standard_RangeError.hxx>
 
 StepData_FieldListN::StepData_FieldListN(const int nb)
-    : thefields((nb == 0 ? 0 : 1), nb)
 {
+  if (nb < 0)
+  {
+    throw Standard_RangeError("StepData_FieldListN: negative field count");
+  }
+  if (nb > 0)
+  {
+    thefields.Resize(1, nb, false);
+  }
 }
 
 int StepData_FieldListN::NbFields() const
 {
-  return thefields.Upper();
+  return thefields.Length();
 }
 
 const StepData_Field& StepData_FieldListN::Field(const int num) const

--- a/src/DataExchange/TKDESTEP/StepData/StepData_PDescr.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_PDescr.cxx
@@ -19,17 +19,9 @@
 
 IMPLEMENT_STANDARD_RTTIEXT(StepData_PDescr, Standard_Transient)
 
-#define KindInteger 1
-#define KindBoolean 2
-#define KindLogical 3
-#define KindEnum 4
-#define KindReal 5
-#define KindString 6
-#define KindEntity 7
-
 StepData_PDescr::StepData_PDescr()
     : thesel(0),
-      thekind(0),
+      thekind(StepData_Field::FieldKind::Undefined),
       thearit(0),
       theopt(false),
       theder(false),
@@ -48,7 +40,7 @@ const char* StepData_PDescr::Name() const
   return thename.ToCString();
 }
 
-int StepData_PDescr::Kind() const
+StepData_Field::FieldKind StepData_PDescr::Kind() const
 {
   return thekind;
 }
@@ -76,15 +68,16 @@ void StepData_PDescr::AddMember(const occ::handle<StepData_PDescr>& member)
   {
     return;
   }
-  if (thekind < KindEntity && thenext->Kind() >= KindEntity)
+  if (thekind < StepData_Field::FieldKind::Entity
+      && thenext->Kind() >= StepData_Field::FieldKind::Entity)
   {
     thesel = 3;
   }
-  else if (thekind < KindEntity && (thesel == 2 || thesel == 4))
+  else if (thekind < StepData_Field::FieldKind::Entity && (thesel == 2 || thesel == 4))
   {
     thesel = 3;
   }
-  else if (thekind >= KindEntity && (thesel == 1 || thesel == 4))
+  else if (thekind >= StepData_Field::FieldKind::Entity && (thesel == 1 || thesel == 4))
   {
     thesel = 2;
   }
@@ -98,32 +91,32 @@ void StepData_PDescr::SetMemberName(const char* const memname)
 
 void StepData_PDescr::SetInteger()
 {
-  thekind = KindInteger;
+  thekind = StepData_Field::FieldKind::Integer;
 }
 
 void StepData_PDescr::SetReal()
 {
-  thekind = KindReal;
+  thekind = StepData_Field::FieldKind::Real;
 }
 
 void StepData_PDescr::SetString()
 {
-  thekind = KindString;
+  thekind = StepData_Field::FieldKind::String;
 }
 
 void StepData_PDescr::SetBoolean()
 {
-  thekind = KindBoolean;
+  thekind = StepData_Field::FieldKind::Boolean;
 }
 
 void StepData_PDescr::SetLogical()
 {
-  thekind = KindLogical;
+  thekind = StepData_Field::FieldKind::Logical;
 }
 
 void StepData_PDescr::SetEnum()
 {
-  thekind = KindEnum;
+  thekind = StepData_Field::FieldKind::Enum;
 }
 
 void StepData_PDescr::AddEnumDef(const char* const enumdef)
@@ -133,14 +126,14 @@ void StepData_PDescr::AddEnumDef(const char* const enumdef)
 
 void StepData_PDescr::SetType(const occ::handle<Standard_Type>& atype)
 {
-  thekind = KindEntity;
+  thekind = StepData_Field::FieldKind::Entity;
   thetype = atype;
   thednam.Clear();
 }
 
 void StepData_PDescr::SetDescr(const char* const dscnam)
 {
-  thekind = KindEntity;
+  thekind = StepData_Field::FieldKind::Entity;
   thetype.Nullify();
   thednam.Clear();
   thednam.AssignCat(dscnam);
@@ -227,32 +220,33 @@ occ::handle<StepData_PDescr> StepData_PDescr::Member(const char* const name) con
 
 bool StepData_PDescr::IsInteger() const
 {
-  return (thekind == KindInteger);
+  return (thekind == StepData_Field::FieldKind::Integer);
 }
 
 bool StepData_PDescr::IsReal() const
 {
-  return (thekind == KindReal);
+  return (thekind == StepData_Field::FieldKind::Real);
 }
 
 bool StepData_PDescr::IsString() const
 {
-  return (thekind == KindString);
+  return (thekind == StepData_Field::FieldKind::String);
 }
 
 bool StepData_PDescr::IsBoolean() const
 {
-  return (thekind == KindBoolean || thekind == KindLogical);
+  return (thekind == StepData_Field::FieldKind::Boolean
+          || thekind == StepData_Field::FieldKind::Logical);
 }
 
 bool StepData_PDescr::IsLogical() const
 {
-  return (thekind == KindLogical);
+  return (thekind == StepData_Field::FieldKind::Logical);
 }
 
 bool StepData_PDescr::IsEnum() const
 {
-  return (thekind == KindEnum);
+  return (thekind == StepData_Field::FieldKind::Enum);
 }
 
 int StepData_PDescr::EnumMax() const
@@ -272,7 +266,7 @@ const char* StepData_PDescr::EnumText(const int val) const
 
 bool StepData_PDescr::IsEntity() const
 {
-  return (thekind == KindEntity);
+  return (thekind == StepData_Field::FieldKind::Entity);
 }
 
 bool StepData_PDescr::IsType(const occ::handle<Standard_Type>& atype) const

--- a/src/DataExchange/TKDESTEP/StepData/StepData_PDescr.hxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_PDescr.hxx
@@ -23,10 +23,10 @@
 #include <TCollection_AsciiString.hxx>
 #include <Standard_Integer.hxx>
 #include <StepData_EnumTool.hxx>
+#include <StepData_Field.hxx>
 #include <Standard_Transient.hxx>
 #include <Standard_CString.hxx>
 class StepData_EDescr;
-class StepData_Field;
 class Interface_Check;
 
 //! This class is intended to describe the authorized form for a
@@ -206,13 +206,13 @@ public:
   DEFINE_STANDARD_RTTIEXT(StepData_PDescr, Standard_Transient)
 
 private:
-  Standard_EXPORT int Kind() const;
+  Standard_EXPORT StepData_Field::FieldKind Kind() const;
 
   TCollection_AsciiString      thename;
   int                          thesel;
   TCollection_AsciiString      thesnam;
   occ::handle<StepData_PDescr> thenext;
-  int                          thekind;
+  StepData_Field::FieldKind    thekind;
   StepData_EnumTool            theenum;
   occ::handle<Standard_Type>   thetype;
   TCollection_AsciiString      thednam;

--- a/src/DataExchange/TKDESTEP/StepData/StepData_SelectArrReal.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_SelectArrReal.cxx
@@ -12,11 +12,9 @@
 // commercial license or contractual agreement.
 
 #include <StepData_SelectArrReal.hxx>
+#include <StepData_Field.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(StepData_SelectArrReal, StepData_SelectNamed)
-
-//  Definitions : cf Field
-#define myKindArrReal 8
 
 //=================================================================================================
 
@@ -26,7 +24,7 @@ StepData_SelectArrReal::StepData_SelectArrReal() = default;
 
 int StepData_SelectArrReal::Kind() const
 {
-  return myKindArrReal;
+  return static_cast<int>(StepData_Field::FieldKind::Any);
 }
 
 //=================================================================================================

--- a/src/DataExchange/TKDESTEP/StepData/StepData_SelectMember.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_SelectMember.cxx
@@ -12,17 +12,10 @@
 // commercial license or contractual agreement.
 
 #include <Standard_Type.hxx>
+#include <StepData_Field.hxx>
 #include <StepData_SelectMember.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(StepData_SelectMember, Standard_Transient)
-
-//  Definitions taken from Field:
-#define KindInteger 1
-#define KindBoolean 2
-#define KindLogical 3
-#define KindEnum 4
-#define KindReal 5
-#define KindString 6
 
 StepData_SelectMember::StepData_SelectMember() = default;
 
@@ -55,28 +48,29 @@ void StepData_SelectMember::SetKind(const int) {}
 
 Interface_ParamType StepData_SelectMember::ParamType() const
 {
-  int kind = Kind();
-  if (kind == 0)
+  const int aKind = Kind();
+  if (aKind == static_cast<int>(StepData_Field::FieldKind::Undefined))
   {
     return Interface_ParamVoid;
   }
-  if (kind == 1)
+  if (aKind == static_cast<int>(StepData_Field::FieldKind::Integer))
   {
     return Interface_ParamInteger;
   }
-  if (kind == 2 || kind == 3)
+  if (aKind == static_cast<int>(StepData_Field::FieldKind::Boolean)
+      || aKind == static_cast<int>(StepData_Field::FieldKind::Logical))
   {
     return Interface_ParamLogical;
   }
-  if (kind == 4)
+  if (aKind == static_cast<int>(StepData_Field::FieldKind::Enum))
   {
     return Interface_ParamEnum;
   }
-  if (kind == 5)
+  if (aKind == static_cast<int>(StepData_Field::FieldKind::Real))
   {
     return Interface_ParamReal;
   }
-  if (kind == 6)
+  if (aKind == static_cast<int>(StepData_Field::FieldKind::String))
   {
     return Interface_ParamText;
   }
@@ -97,7 +91,7 @@ int StepData_SelectMember::Integer() const
 
 void StepData_SelectMember::SetInteger(const int val)
 {
-  SetKind(KindInteger);
+  SetKind(static_cast<int>(StepData_Field::FieldKind::Integer));
   SetInt(val);
 }
 
@@ -108,7 +102,7 @@ bool StepData_SelectMember::Boolean() const
 
 void StepData_SelectMember::SetBoolean(const bool val)
 {
-  SetKind(KindBoolean);
+  SetKind(static_cast<int>(StepData_Field::FieldKind::Boolean));
   SetInt((val ? 1 : 0));
 }
 
@@ -128,19 +122,8 @@ StepData_Logical StepData_SelectMember::Logical() const
 
 void StepData_SelectMember::SetLogical(const StepData_Logical val)
 {
-  SetKind(KindLogical);
-  if (val == StepData_LFalse)
-  {
-    SetInt(0);
-  }
-  if (val == StepData_LTrue)
-  {
-    SetInt(0);
-  }
-  if (val == StepData_LUnknown)
-  {
-    SetInt(0);
-  }
+  SetKind(static_cast<int>(StepData_Field::FieldKind::Logical));
+  SetInt(static_cast<int>(val));
 }
 
 double StepData_SelectMember::Real() const
@@ -169,7 +152,7 @@ const char* StepData_SelectMember::EnumText() const
 
 void StepData_SelectMember::SetEnum(const int val, const char* const text)
 {
-  SetKind(KindEnum);
+  SetKind(static_cast<int>(StepData_Field::FieldKind::Enum));
   SetInt(val);
   if (text && text[0] != '\0')
   {

--- a/src/DataExchange/TKDESTEP/StepData/StepData_SelectNamed.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_SelectNamed.cxx
@@ -15,14 +15,6 @@
 
 IMPLEMENT_STANDARD_RTTIEXT(StepData_SelectNamed, StepData_SelectMember)
 
-//  Definitions taken from Field:
-#define KindInteger 1
-#define KindBoolean 2
-#define KindLogical 3
-#define KindEnum 4
-#define KindReal 5
-#define KindString 6
-
 StepData_SelectNamed::StepData_SelectNamed()
 {
   theval.Clear();
@@ -58,7 +50,7 @@ StepData_Field& StepData_SelectNamed::CField()
 
 int StepData_SelectNamed::Kind() const
 {
-  return theval.Kind();
+  return static_cast<int>(theval.Kind());
 }
 
 void StepData_SelectNamed::SetKind(const int kind)

--- a/src/DataExchange/TKDESTEP/StepData/StepData_SelectReal.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_SelectReal.cxx
@@ -12,12 +12,10 @@
 // commercial license or contractual agreement.
 
 #include <Standard_Type.hxx>
+#include <StepData_Field.hxx>
 #include <StepData_SelectReal.hxx>
 
 IMPLEMENT_STANDARD_RTTIEXT(StepData_SelectReal, StepData_SelectMember)
-
-//  Definitions : cf Field
-#define KindReal 5
 
 StepData_SelectReal::StepData_SelectReal()
 {
@@ -26,7 +24,7 @@ StepData_SelectReal::StepData_SelectReal()
 
 int StepData_SelectReal::Kind() const
 {
-  return KindReal;
+  return static_cast<int>(StepData_Field::FieldKind::Real);
 }
 
 double StepData_SelectReal::Real() const

--- a/src/DataExchange/TKDESTEP/StepData/StepData_Simple.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_Simple.cxx
@@ -110,30 +110,38 @@ StepData_FieldListN& StepData_Simple::CFields()
 void StepData_Simple::Check(occ::handle<Interface_Check>& /*ach*/) const {
 } // something? see the description
 
-void StepData_Simple::Shared(Interface_EntityIterator& list) const
+void StepData_Simple::Shared(Interface_EntityIterator& theIterator) const
 {
-  int i, nb = thefields.NbFields();
-  for (i = 1; i <= nb; i++)
+  for (int aFieldIndex = 1; aFieldIndex <= thefields.NbFields(); ++aFieldIndex)
   {
-    const StepData_Field& fi = thefields.Field(i);
-    int                   j1, j2, l1, l2;
-    l1 = l2 = 1;
-    if (fi.Arity() >= 1)
+    const StepData_Field& aField   = thefields.Field(aFieldIndex);
+    const int             anArity  = aField.Arity();
+    int                   aLower1  = 1;
+    int                   aLength1 = 1;
+    int                   aLower2  = 1;
+    int                   aLength2 = 1;
+    if (anArity == 1)
     {
-      l1 = fi.Length(1);
+      aLower1  = aField.Lower(1);
+      aLength1 = aField.Length(1);
     }
-    if (fi.Arity() > 1)
+    else if (anArity == 2)
     {
-      l2 = fi.Length(2);
+      aLower1  = aField.Lower(1);
+      aLength1 = aField.Length(1);
+      aLower2  = aField.Lower(2);
+      aLength2 = aField.Length(2);
     }
-    for (j1 = 1; j1 <= l1; j1++)
+
+    for (int anOffset1 = 0; anOffset1 < aLength1; ++anOffset1)
     {
-      for (j2 = 1; j2 <= l2; j2++)
+      for (int anOffset2 = 0; anOffset2 < aLength2; ++anOffset2)
       {
-        occ::handle<Standard_Transient> ent = fi.Entity(j1, j2);
-        if (!ent.IsNull())
+        const occ::handle<Standard_Transient> anEntity =
+          aField.Entity(aLower1 + anOffset1, aLower2 + anOffset2);
+        if (!anEntity.IsNull())
         {
-          list.AddItem(ent);
+          theIterator.AddItem(anEntity);
         }
       }
     }

--- a/src/DataExchange/TKDESTEP/StepData/StepData_StepWriter.cxx
+++ b/src/DataExchange/TKDESTEP/StepData/StepData_StepWriter.cxx
@@ -23,6 +23,7 @@
 #include <Standard_Transient.hxx>
 #include <StepData_ESDescr.hxx>
 #include <StepData_FieldList.hxx>
+#include <StepData_Field.hxx>
 #include <StepData_PDescr.hxx>
 #include <StepData_Protocol.hxx>
 #include <StepData_ReadWriteModule.hxx>
@@ -612,53 +613,54 @@ void StepData_StepWriter::EndComplex()
 void StepData_StepWriter::SendField(const StepData_Field&               fild,
                                     const occ::handle<StepData_PDescr>& descr)
 {
-  bool done = true;
-  int  kind = fild.Kind(false); // valeur interne
+  const StepData_Field::FieldKind aFieldKind = fild.Kind(false);
 
-  if (kind == 16)
+  if (aFieldKind == StepData_Field::FieldKind::Select)
   {
-    DeclareAndCast(StepData_SelectMember, sm, fild.Transient());
+    const occ::handle<StepData_SelectMember> sm =
+      occ::down_cast<StepData_SelectMember>(fild.Transient());
     SendSelect(sm, descr);
     return;
   }
-  switch (kind)
+  bool isSent = true;
+  switch (aFieldKind)
   {
       //   here the simple cases; then we cast and see
-    case 0:
+    case StepData_Field::FieldKind::Undefined:
       SendUndef();
       break;
-    case 1:
+    case StepData_Field::FieldKind::Integer:
       Send(fild.Integer());
       break;
-    case 2:
+    case StepData_Field::FieldKind::Boolean:
       SendBoolean(fild.Boolean());
       break;
-    case 3:
+    case StepData_Field::FieldKind::Logical:
       SendLogical(fild.Logical());
       break;
-    case 4:
+    case StepData_Field::FieldKind::Enum:
       SendEnum(fild.EnumText());
       break; // enum : descr ?
-    case 5:
+    case StepData_Field::FieldKind::Real:
       Send(fild.Real());
       break;
-    case 6:
+    case StepData_Field::FieldKind::String:
       Send(fild.String());
       break;
-    case 7:
+    case StepData_Field::FieldKind::Entity:
       Send(fild.Entity());
       break;
-    case 8:
-      done = false;
+    case StepData_Field::FieldKind::Any:
+      isSent = false;
       break;
-    case 9:
+    case StepData_Field::FieldKind::Derived:
       SendDerived();
       break;
     default:
-      done = false;
+      isSent = false;
       break;
   }
-  if (done)
+  if (isSent)
   {
     return;
   }
@@ -673,40 +675,39 @@ void StepData_StepWriter::SendField(const StepData_Field&               fild,
   if (arity == 1)
   {
     OpenSub();
-    int i, low = fild.Lower(), up = low + fild.Length() - 1;
-    for (i = low; i <= up; i++)
+    const int aLower  = fild.Lower();
+    const int anUpper = aLower + fild.Length() - 1;
+    for (int anIndex = aLower; anIndex <= anUpper; ++anIndex)
     {
-      kind = fild.ItemKind(i);
-      done = true;
-      switch (kind)
+      const StepData_Field::FieldKind anItemKind = fild.ItemKind(anIndex);
+      switch (anItemKind)
       {
-        case 0:
+        case StepData_Field::FieldKind::Undefined:
           SendUndef();
           break;
-        case 1:
-          Send(fild.Integer(i));
+        case StepData_Field::FieldKind::Integer:
+          Send(fild.Integer(anIndex));
           break;
-        case 2:
-          SendBoolean(fild.Boolean(i));
+        case StepData_Field::FieldKind::Boolean:
+          SendBoolean(fild.Boolean(anIndex));
           break;
-        case 3:
-          SendLogical(fild.Logical(i));
+        case StepData_Field::FieldKind::Logical:
+          SendLogical(fild.Logical(anIndex));
           break;
-        case 4:
-          SendEnum(fild.EnumText(i));
+        case StepData_Field::FieldKind::Enum:
+          SendEnum(fild.EnumText(anIndex));
           break;
-        case 5:
-          Send(fild.Real(i));
+        case StepData_Field::FieldKind::Real:
+          Send(fild.Real(anIndex));
           break;
-        case 6:
-          Send(fild.String(i));
+        case StepData_Field::FieldKind::String:
+          Send(fild.String(anIndex));
           break;
-        case 7:
-          Send(fild.Entity(i));
+        case StepData_Field::FieldKind::Entity:
+          Send(fild.Entity(anIndex));
           break;
         default:
           SendUndef();
-          done = false;
           break; // ANORMAL
       }
     }
@@ -716,44 +717,44 @@ void StepData_StepWriter::SendField(const StepData_Field&               fild,
   if (arity == 2)
   {
     OpenSub();
-    int j, low1 = fild.Lower(1), up1 = low1 + fild.Length(1) - 1;
-    for (j = low1; j <= up1; j++)
+    const int aRowLower  = fild.Lower(1);
+    const int anRowUpper = aRowLower + fild.Length(1) - 1;
+    for (int aRow = aRowLower; aRow <= anRowUpper; ++aRow)
     {
-      int i = 0, low2 = fild.Lower(2), up2 = low2 + fild.Length(2) - 1;
+      const int aColumnLower = fild.Lower(2);
+      const int aColumnUpper = aColumnLower + fild.Length(2) - 1;
       OpenSub();
-      for (i = low2; i <= up2; i++)
+      for (int aColumn = aColumnLower; aColumn <= aColumnUpper; ++aColumn)
       {
-        kind = fild.ItemKind(i, j);
-        done = true;
-        switch (kind)
+        const StepData_Field::FieldKind anItemKind = fild.ItemKind(aRow, aColumn);
+        switch (anItemKind)
         {
-          case 0:
+          case StepData_Field::FieldKind::Undefined:
             SendUndef();
             break;
-          case 1:
-            Send(fild.Integer(i, j));
+          case StepData_Field::FieldKind::Integer:
+            Send(fild.Integer(aRow, aColumn));
             break;
-          case 2:
-            SendBoolean(fild.Boolean(i, j));
+          case StepData_Field::FieldKind::Boolean:
+            SendBoolean(fild.Boolean(aRow, aColumn));
             break;
-          case 3:
-            SendLogical(fild.Logical(i, j));
+          case StepData_Field::FieldKind::Logical:
+            SendLogical(fild.Logical(aRow, aColumn));
             break;
-          case 4:
-            SendEnum(fild.EnumText(i, j));
+          case StepData_Field::FieldKind::Enum:
+            SendEnum(fild.EnumText(aRow, aColumn));
             break;
-          case 5:
-            Send(fild.Real(i, j));
+          case StepData_Field::FieldKind::Real:
+            Send(fild.Real(aRow, aColumn));
             break;
-          case 6:
-            Send(fild.String(i, j));
+          case StepData_Field::FieldKind::String:
+            Send(fild.String(aRow, aColumn));
             break;
-          case 7:
-            Send(fild.Entity(i, j));
+          case StepData_Field::FieldKind::Entity:
+            Send(fild.Entity(aRow, aColumn));
             break;
           default:
             SendUndef();
-            done = false;
             break; // ANORMAL
         }
       }
@@ -762,6 +763,7 @@ void StepData_StepWriter::SendField(const StepData_Field&               fild,
     CloseSub();
     return;
   }
+  SendUndef();
 }
 
 //=================================================================================================
@@ -774,7 +776,8 @@ void StepData_StepWriter::SendSelect(const occ::handle<StepData_SelectMember>& s
   bool selname = false;
   if (sm.IsNull())
   {
-    return; // ??
+    SendUndef();
+    return;
   }
   if (sm->HasName())
   {
@@ -783,35 +786,42 @@ void StepData_StepWriter::SendSelect(const occ::handle<StepData_SelectMember>& s
     //    AddString(textlist);     // SANS AJOUT DE PARAMETRE !!
     OpenTypedSub(sm->Name());
   }
-  int kind = sm->Kind();
-  switch (kind)
+  switch (sm->Kind())
   {
-    case 0:
+    case static_cast<int>(StepData_Field::FieldKind::Undefined):
       SendUndef();
       break;
-    case 1:
+    case static_cast<int>(StepData_Field::FieldKind::Integer):
       Send(sm->Integer());
       break;
-    case 2:
+    case static_cast<int>(StepData_Field::FieldKind::Boolean):
       SendBoolean(sm->Boolean());
       break;
-    case 3:
+    case static_cast<int>(StepData_Field::FieldKind::Logical):
       SendLogical(sm->Logical());
       break;
-    case 4:
+    case static_cast<int>(StepData_Field::FieldKind::Enum):
       SendEnum(sm->EnumText());
       break; // enum : descr ?
-    case 5:
+    case static_cast<int>(StepData_Field::FieldKind::Real):
       Send(sm->Real());
       break;
-    case 6:
+    case static_cast<int>(StepData_Field::FieldKind::String):
       Send(sm->String());
       break;
-    case 8:
-      SendArrReal(occ::down_cast<StepData_SelectArrReal>(sm)->ArrReal());
+    case static_cast<int>(StepData_Field::FieldKind::Any):
+      if (occ::is_kind<StepData_SelectArrReal>(sm))
+      {
+        SendArrReal(occ::down_cast<StepData_SelectArrReal>(sm)->ArrReal());
+      }
+      else
+      {
+        SendUndef();
+      }
       break;
     default:
-      break; // ??
+      SendUndef();
+      break;
   }
   if (selname)
   {
@@ -1126,7 +1136,7 @@ void StepData_StepWriter::SendString(const char* const val)
 
 void StepData_StepWriter::SendEnum(const TCollection_AsciiString& val)
 {
-  if (val.Length() == 1 && val.Value(1) == '$')
+  if (val.IsEmpty() || (val.Length() == 1 && val.Value(1) == '$'))
   {
     SendUndef();
     return;
@@ -1150,8 +1160,7 @@ void StepData_StepWriter::SendEnum(const TCollection_AsciiString& val)
 
 void StepData_StepWriter::SendEnum(const char* const val)
 {
-
-  if (val[0] == '$' && val[1] == '\0')
+  if (val == nullptr || val[0] == '\0' || (val[0] == '$' && val[1] == '\0'))
   {
     SendUndef();
     return;
@@ -1164,19 +1173,18 @@ void StepData_StepWriter::SendEnum(const char* const val)
 
 void StepData_StepWriter::SendArrReal(const occ::handle<NCollection_HArray1<double>>& anArr)
 {
-  AddString(textlist);
-  if (anArr->Length() > 0)
+  if (anArr.IsNull())
   {
-    // add real
-    Send(anArr->Value(1));
-    for (int i = 2; i <= anArr->Length(); i++)
-    {
-      //      AddString(textparam);
-      // add real
-      Send(anArr->Value(i));
-    }
+    SendUndef();
+    return;
   }
-  AddString(textendlist);
+
+  OpenSub();
+  for (int anIndex = anArr->Lower(); anIndex <= anArr->Upper(); ++anIndex)
+  {
+    Send(anArr->Value(anIndex));
+  }
+  CloseSub();
 }
 
 //=================================================================================================


### PR DESCRIPTION
- introduce StepData_Field::FieldKind and remove duplicated numeric kind macros
- preserve compact field storage while correcting 2D dimensions and bounds
- fix integer access and independent copying of one-dimensional lists
- preserve false, true, and unknown logical select values
- iterate entity fields from their actual array lower bounds
- validate StepData_FieldListN sizes
- handle null and unsupported values safely in StepData_StepWriter
- support arbitrary lower bounds when writing real arrays