### PR TITLE
Modeling - Correct BRepTools transformations

### DIFF
--- a/src/ModelingAlgorithms/TKTopAlgo/BRepBuilderAPI/BRepBuilderAPI_GTransform.cxx
+++ b/src/ModelingAlgorithms/TKTopAlgo/BRepBuilderAPI/BRepBuilderAPI_GTransform.cxx
@@ -52,7 +52,7 @@ void BRepBuilderAPI_GTransform::Perform(const TopoDS_Shape& S, const bool Copy)
   TopoDS_Shape                             Slocal = nc.Shape();
   occ::handle<BRepTools_GTrsfModification> theModif =
     occ::down_cast<BRepTools_GTrsfModification>(myModification);
-  theModif->GTrsf() = myGTrsf;
+  theModif->SetGTrsf(myGTrsf);
   DoModif(Slocal, myModification);
   //  myHist.Filter (Shape());
 }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.cxx
@@ -25,10 +25,10 @@
 #include <Geom_Curve.hxx>
 #include <Geom_Surface.hxx>
 #include <Geom_TrimmedCurve.hxx>
-#include <GeomLib.hxx>
 #include <gp_GTrsf.hxx>
+#include <gp_Mat.hxx>
 #include <gp_Pnt.hxx>
-#include <gp_Quaternion.hxx>
+#include <gp_Trsf.hxx>
 #include <gp_XYZ.hxx>
 #include <Standard_NoSuchObject.hxx>
 #include <Standard_Type.hxx>
@@ -36,37 +36,84 @@
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Vertex.hxx>
 
+#include <algorithm>
+#include <cmath>
+
 IMPLEMENT_STANDARD_RTTIEXT(BRepTools_GTrsfModification, BRepTools_Modification)
+
+namespace
+{
+
+//=================================================================================================
+
+double maxAbsCoefficient(const gp_GTrsf& theGTrsf)
+{
+  return std::max({std::abs(theGTrsf.Value(1, 1)),
+                   std::abs(theGTrsf.Value(1, 2)),
+                   std::abs(theGTrsf.Value(1, 3)),
+                   std::abs(theGTrsf.Value(2, 1)),
+                   std::abs(theGTrsf.Value(2, 2)),
+                   std::abs(theGTrsf.Value(2, 3)),
+                   std::abs(theGTrsf.Value(3, 1)),
+                   std::abs(theGTrsf.Value(3, 2)),
+                   std::abs(theGTrsf.Value(3, 3))});
+}
+
+//=================================================================================================
+
+gp_Mat normalizedVectorialPart(const gp_GTrsf& theGTrsf, const double theScale)
+{
+  gp_Mat aMat = theGTrsf.VectorialPart();
+  if (theScale > 0.0)
+  {
+    aMat.Multiply(1.0 / theScale);
+  }
+  return aMat;
+}
+
+//=================================================================================================
+
+gp_Mat normalTransformation(const gp_Mat& theNormalizedVectorialPart, const bool theIsNegative)
+{
+  const gp_XYZ aCol1 = theNormalizedVectorialPart.Column(1);
+  const gp_XYZ aCol2 = theNormalizedVectorialPart.Column(2);
+  const gp_XYZ aCol3 = theNormalizedVectorialPart.Column(3);
+  gp_Mat       aNormalMat(aCol2.Crossed(aCol3), aCol3.Crossed(aCol1), aCol1.Crossed(aCol2));
+  if (theIsNegative)
+  {
+    aNormalMat *= -1.0;
+  }
+  return aNormalMat;
+}
+
+//=================================================================================================
+
+gp_GTrsf representationTransformation(const gp_GTrsf&        theGTrsf,
+                                      const TopLoc_Location& theSourceLocation,
+                                      const TopLoc_Location& theTargetLocation)
+{
+  gp_GTrsf aLocalTrsf(theTargetLocation.Transformation().Inverted());
+  aLocalTrsf.Multiply(theGTrsf);
+  aLocalTrsf.Multiply(theSourceLocation.Transformation());
+  return aLocalTrsf;
+}
+} // namespace
 
 //=================================================================================================
 
 BRepTools_GTrsfModification::BRepTools_GTrsfModification(const gp_GTrsf& T)
-    : myGTrsf(T)
+    : myGTrsf(T),
+      myGScale(maxAbsCoefficient(T))
 {
-  // use the sup norm as the maximum dilation for the tolerance
-  double loc1, loc2, loc3, loc4;
-
-  loc1 = std::max(std::abs(T.Value(1, 1)), std::abs(T.Value(1, 2)));
-  loc2 = std::max(std::abs(T.Value(2, 1)), std::abs(T.Value(2, 2)));
-  loc3 = std::max(std::abs(T.Value(3, 1)), std::abs(T.Value(3, 2)));
-  loc4 = std::max(std::abs(T.Value(1, 3)), std::abs(T.Value(2, 3)));
-
-  loc1 = std::max(loc1, loc2);
-  loc2 = std::max(loc3, loc4);
-
-  loc1 = std::max(loc1, loc2);
-
-  myGScale = std::max(loc1, std::abs(T.Value(3, 3)));
 }
 
 //=================================================================================================
 
-gp_GTrsf& BRepTools_GTrsfModification::GTrsf()
+void BRepTools_GTrsfModification::SetGTrsf(const gp_GTrsf& theGTrsf)
 {
-  return myGTrsf;
+  myGTrsf  = theGTrsf;
+  myGScale = maxAbsCoefficient(theGTrsf);
 }
-
-//=================================================================================================
 
 bool BRepTools_GTrsfModification::NewSurface(const TopoDS_Face&         F,
                                              occ::handle<Geom_Surface>& S,
@@ -75,21 +122,15 @@ bool BRepTools_GTrsfModification::NewSurface(const TopoDS_Face&         F,
                                              bool&                      RevWires,
                                              bool&                      RevFace)
 {
-  gp_GTrsf gtrsf;
-  gtrsf.SetVectorialPart(myGTrsf.VectorialPart());
-  gtrsf.SetTranslationPart(myGTrsf.TranslationPart());
   S = BRep_Tool::Surface(F, L);
   if (S.IsNull())
   {
     // processing the case when there is no geometry
     return false;
   }
-  S = occ::down_cast<Geom_Surface>(S->Copy());
-
-  Tol = BRep_Tool::Tolerance(F);
-  Tol *= myGScale;
+  Tol      = BRep_Tool::Tolerance(F) * myGScale;
   RevWires = false;
-  RevFace  = myGTrsf.IsNegative();
+  RevFace  = normalizedVectorialPart(myGTrsf, myGScale).Determinant() < 0.0;
   S        = occ::down_cast<Geom_Surface>(S->Transformed(L.Transformation()));
 
   occ::handle<Standard_Type> TheTypeS = S->DynamicType();
@@ -100,10 +141,9 @@ bool BRepTools_GTrsfModification::NewSurface(const TopoDS_Face&         F,
     {
       for (int j = 1; j <= S2->NbVPoles(); j++)
       {
-        gp_XYZ coor(S2->Pole(i, j).Coord());
-        gtrsf.Transforms(coor);
-        gp_Pnt P(coor);
-        S2->SetPole(i, j, P);
+        gp_Pnt aPole = S2->Pole(i, j);
+        myGTrsf.Transforms(aPole.ChangeCoord());
+        S2->SetPole(i, j, aPole);
       }
     }
   }
@@ -114,10 +154,9 @@ bool BRepTools_GTrsfModification::NewSurface(const TopoDS_Face&         F,
     {
       for (int j = 1; j <= S2->NbVPoles(); j++)
       {
-        gp_XYZ coor(S2->Pole(i, j).Coord());
-        gtrsf.Transforms(coor);
-        gp_Pnt P(coor);
-        S2->SetPole(i, j, P);
+        gp_Pnt aPole = S2->Pole(i, j);
+        myGTrsf.Transforms(aPole.ChangeCoord());
+        S2->SetPole(i, j, aPole);
       }
     }
   }
@@ -137,26 +176,22 @@ bool BRepTools_GTrsfModification::NewCurve(const TopoDS_Edge&       E,
                                            TopLoc_Location&         L,
                                            double&                  Tol)
 {
-  double   f, l;
-  gp_GTrsf gtrsf;
-  gtrsf.SetVectorialPart(myGTrsf.VectorialPart());
-  gtrsf.SetTranslationPart(myGTrsf.TranslationPart());
+  double f, l;
   Tol = BRep_Tool::Tolerance(E) * myGScale;
   C   = BRep_Tool::Curve(E, L, f, l);
 
   if (!C.IsNull())
   {
-    C = occ::down_cast<Geom_Curve>(C->Copy()->Transformed(L.Transformation()));
+    C = occ::down_cast<Geom_Curve>(C->Transformed(L.Transformation()));
     occ::handle<Standard_Type> TheTypeC = C->DynamicType();
     if (TheTypeC == STANDARD_TYPE(Geom_BSplineCurve))
     {
       occ::handle<Geom_BSplineCurve> C2 = occ::down_cast<Geom_BSplineCurve>(C);
       for (int i = 1; i <= C2->NbPoles(); i++)
       {
-        gp_XYZ coor(C2->Pole(i).Coord());
-        gtrsf.Transforms(coor);
-        gp_Pnt P(coor);
-        C2->SetPole(i, P);
+        gp_Pnt aPole = C2->Pole(i);
+        myGTrsf.Transforms(aPole.ChangeCoord());
+        C2->SetPole(i, aPole);
       }
     }
     else if (TheTypeC == STANDARD_TYPE(Geom_BezierCurve))
@@ -164,10 +199,9 @@ bool BRepTools_GTrsfModification::NewCurve(const TopoDS_Edge&       E,
       occ::handle<Geom_BezierCurve> C2 = occ::down_cast<Geom_BezierCurve>(C);
       for (int i = 1; i <= C2->NbPoles(); i++)
       {
-        gp_XYZ coor(C2->Pole(i).Coord());
-        gtrsf.Transforms(coor);
-        gp_Pnt P(coor);
-        C2->SetPole(i, P);
+        gp_Pnt aPole = C2->Pole(i);
+        myGTrsf.Transforms(aPole.ChangeCoord());
+        C2->SetPole(i, aPole);
       }
     }
     else
@@ -185,8 +219,7 @@ bool BRepTools_GTrsfModification::NewCurve(const TopoDS_Edge&       E,
 bool BRepTools_GTrsfModification::NewPoint(const TopoDS_Vertex& V, gp_Pnt& P, double& Tol)
 {
   gp_Pnt Pnt = BRep_Tool::Pnt(V);
-  Tol        = BRep_Tool::Tolerance(V);
-  Tol *= myGScale;
+  Tol        = BRep_Tool::Tolerance(V) * myGScale;
   gp_XYZ coor(Pnt.Coord());
   myGTrsf.Transforms(coor);
   P.SetXYZ(coor);
@@ -203,9 +236,7 @@ bool BRepTools_GTrsfModification::NewCurve2d(const TopoDS_Edge& E,
                                              occ::handle<Geom2d_Curve>& C,
                                              double&                    Tol)
 {
-  TopLoc_Location loc;
-  Tol = BRep_Tool::Tolerance(E);
-  Tol *= myGScale;
+  Tol = BRep_Tool::Tolerance(E) * myGScale;
   double f, l;
   C = BRep_Tool::CurveOnSurface(E, F, f, l);
   if (C.IsNull())
@@ -224,9 +255,8 @@ bool BRepTools_GTrsfModification::NewParameter(const TopoDS_Vertex& V,
                                                double&              P,
                                                double&              Tol)
 {
-  Tol = BRep_Tool::Tolerance(V);
-  Tol *= myGScale;
-  P = BRep_Tool::Parameter(V, E);
+  Tol = BRep_Tool::Tolerance(V) * myGScale;
+  P   = BRep_Tool::Parameter(V, E);
   return true;
 }
 
@@ -255,14 +285,13 @@ bool BRepTools_GTrsfModification::NewTriangulation(
     return false;
   }
 
-  gp_GTrsf aGTrsf;
-  aGTrsf.SetVectorialPart(myGTrsf.VectorialPart());
-  aGTrsf.SetTranslationPart(myGTrsf.TranslationPart());
-  aGTrsf.Multiply(aLoc.Transformation());
+  const gp_GTrsf aGTrsf = representationTransformation(myGTrsf, aLoc, theFace.Location());
+  const gp_Mat   aNormalizedVectorialPart = normalizedVectorialPart(aGTrsf, myGScale);
+  const bool     aIsNegative               = aNormalizedVectorialPart.Determinant() < 0.0;
 
   theTriangulation = theTriangulation->Copy();
   theTriangulation->SetCachedMinMax(Bnd_Box()); // clear bounding box
-  theTriangulation->Deflection(theTriangulation->Deflection() * std::abs(myGScale));
+  theTriangulation->Deflection(theTriangulation->Deflection() * myGScale);
   // apply transformation to 3D nodes
   for (int anInd = 1; anInd <= theTriangulation->NbNodes(); ++anInd)
   {
@@ -271,7 +300,7 @@ bool BRepTools_GTrsfModification::NewTriangulation(
     theTriangulation->SetNode(anInd, aP);
   }
   // modify triangles orientation in case of mirror transformation
-  if (myGScale < 0.0)
+  if (aIsNegative)
   {
     for (int anInd = 1; anInd <= theTriangulation->NbTriangles(); ++anInd)
     {
@@ -285,16 +314,21 @@ bool BRepTools_GTrsfModification::NewTriangulation(
   // modify normals
   if (theTriangulation->HasNormals())
   {
+    const gp_Mat aNormalMat =
+      normalTransformation(aNormalizedVectorialPart, aIsNegative);
     for (int anInd = 1; anInd <= theTriangulation->NbNodes(); ++anInd)
     {
-      gp_Dir aNormal = theTriangulation->Normal(anInd);
-      gp_Mat aMat    = aGTrsf.VectorialPart();
-      aMat.SetDiagonal(1., 1., 1.);
-      gp_Trsf aTrsf;
-      aTrsf.SetForm(gp_Rotation);
-      (gp_Mat&)aTrsf.HVectorialPart() = aMat;
-      aNormal.Transform(aTrsf);
-      theTriangulation->SetNormal(anInd, aNormal);
+      gp_XYZ aNormal = theTriangulation->Normal(anInd).XYZ();
+      aNormal.Multiply(aNormalMat);
+      const double aScale =
+        std::max({std::abs(aNormal.X()), std::abs(aNormal.Y()), std::abs(aNormal.Z())});
+      if (aScale == 0.0)
+      {
+        // A collapsed tangent plane has no transformed normal; preserve the source cache value.
+        continue;
+      }
+      aNormal.Divide(aScale);
+      theTriangulation->SetNormal(anInd, gp_Dir(aNormal));
     }
   }
 
@@ -313,13 +347,10 @@ bool BRepTools_GTrsfModification::NewPolygon(const TopoDS_Edge&           theEdg
     return false;
   }
 
-  gp_GTrsf aGTrsf;
-  aGTrsf.SetVectorialPart(myGTrsf.VectorialPart());
-  aGTrsf.SetTranslationPart(myGTrsf.TranslationPart());
-  aGTrsf.Multiply(aLoc.Transformation());
+  const gp_GTrsf aGTrsf = representationTransformation(myGTrsf, aLoc, theEdge.Location());
 
   thePoly = thePoly->Copy();
-  thePoly->Deflection(thePoly->Deflection() * std::abs(myGScale));
+  thePoly->Deflection(thePoly->Deflection() * myGScale);
   // transform nodes
   NCollection_Array1<gp_Pnt>& aNodesArray = thePoly->ChangeNodes();
   for (int anId = aNodesArray.Lower(); anId <= aNodesArray.Upper(); ++anId)
@@ -349,5 +380,5 @@ bool BRepTools_GTrsfModification::NewPolygonOnTriangulation(
   {
     thePoly = thePoly->Copy();
   }
-  return true;
+  return !thePoly.IsNull();
 }

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.cxx
@@ -63,7 +63,15 @@ double maxAbsCoefficient(const gp_GTrsf& theGTrsf)
 
 gp_Mat normalizedVectorialPart(const gp_GTrsf& theGTrsf, const double theScale)
 {
-  gp_Mat aMat = theGTrsf.VectorialPart();
+  gp_Mat aMat(theGTrsf.Value(1, 1),
+              theGTrsf.Value(1, 2),
+              theGTrsf.Value(1, 3),
+              theGTrsf.Value(2, 1),
+              theGTrsf.Value(2, 2),
+              theGTrsf.Value(2, 3),
+              theGTrsf.Value(3, 1),
+              theGTrsf.Value(3, 2),
+              theGTrsf.Value(3, 3));
   if (theScale > 0.0)
   {
     aMat.Multiply(1.0 / theScale);

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.cxx
@@ -287,7 +287,7 @@ bool BRepTools_GTrsfModification::NewTriangulation(
 
   const gp_GTrsf aGTrsf = representationTransformation(myGTrsf, aLoc, theFace.Location());
   const gp_Mat   aNormalizedVectorialPart = normalizedVectorialPart(aGTrsf, myGScale);
-  const bool     aIsNegative               = aNormalizedVectorialPart.Determinant() < 0.0;
+  const bool     aIsNegative              = aNormalizedVectorialPart.Determinant() < 0.0;
 
   theTriangulation = theTriangulation->Copy();
   theTriangulation->SetCachedMinMax(Bnd_Box()); // clear bounding box
@@ -314,8 +314,7 @@ bool BRepTools_GTrsfModification::NewTriangulation(
   // modify normals
   if (theTriangulation->HasNormals())
   {
-    const gp_Mat aNormalMat =
-      normalTransformation(aNormalizedVectorialPart, aIsNegative);
+    const gp_Mat aNormalMat = normalTransformation(aNormalizedVectorialPart, aIsNegative);
     for (int anInd = 1; anInd <= theTriangulation->NbNodes(); ++anInd)
     {
       gp_XYZ aNormal = theTriangulation->Normal(anInd).XYZ();

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.hxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_GTrsfModification.hxx
@@ -32,17 +32,18 @@ class TopoDS_Vertex;
 class gp_Pnt;
 class Geom2d_Curve;
 
-//! Defines a modification of the geometry by a GTrsf
-//! from gp. All methods return True and transform the
-//! geometry.
+//! Defines a modification of geometry and polygonal representations by a gp_GTrsf.
 class BRepTools_GTrsfModification : public BRepTools_Modification
 {
 
 public:
   Standard_EXPORT BRepTools_GTrsfModification(const gp_GTrsf& T);
 
-  //! Gives an access on the GTrsf.
-  Standard_EXPORT gp_GTrsf& GTrsf();
+  //! Sets the general transformation.
+  Standard_EXPORT void SetGTrsf(const gp_GTrsf& theGTrsf);
+
+  //! Returns the general transformation.
+  const gp_GTrsf& GTrsf() const { return myGTrsf; }
 
   //! Returns true if the face <F> has been
   //! modified. In this case, <S> is the new geometric
@@ -53,8 +54,7 @@ public:
   //! reversed). <RevFace> has to be set to
   //! true if the orientation of the modified
   //! face changes in the shells which contain it.
-  //! Here, <RevFace> will return true if the
-  //! - gp_Trsf is negative.
+  //! Here, <RevFace> will return true if the gp_GTrsf is negative.
   Standard_EXPORT bool NewSurface(const TopoDS_Face&         F,
                                   occ::handle<Geom_Surface>& S,
                                   TopLoc_Location&           L,

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_TrsfModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_TrsfModification.cxx
@@ -57,8 +57,7 @@ gp_Trsf representationTransformation(const gp_Trsf&         theTrsf,
 
 //=================================================================================================
 
-gp_Trsf representationTransformation(const gp_Trsf&         theTrsf,
-                                     const TopLoc_Location& theLocation)
+gp_Trsf representationTransformation(const gp_Trsf& theTrsf, const TopLoc_Location& theLocation)
 {
   return representationTransformation(theTrsf, theLocation, theLocation);
 }
@@ -219,8 +218,8 @@ bool BRepTools_TrsfModification::NewPolygon(const TopoDS_Edge&           theE,
     occ::handle<Geom_Curve> aCurve = BRep_Tool::Curve(theE, aCurveLoc, aFirst, aLast);
     if (!aCurve.IsNull())
     {
-      const gp_Trsf aCurveTrsf = representationTransformation(myTrsf, aCurveLoc);
-      double aReparametrization = aCurve->ParametricTransformation(aCurveTrsf);
+      const gp_Trsf aCurveTrsf         = representationTransformation(myTrsf, aCurveLoc);
+      double        aReparametrization = aCurve->ParametricTransformation(aCurveTrsf);
       if (std::abs(aReparametrization - 1.0) > Precision::PConfusion())
       {
         NCollection_Array1<double>& aParams = theP->ChangeParameters();
@@ -395,9 +394,9 @@ bool BRepTools_TrsfModification::NewCurve2d(const TopoDS_Edge& E,
   if (std::abs(scale) != 1.)
   {
 
-    NewC = new Geom2d_TrimmedCurve(NewC, f, l);
+    NewC                     = new Geom2d_TrimmedCurve(NewC, f, l);
     const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, loc);
-    gp_GTrsf2d gtrsf = S->ParametricTransformation(aLocalTrsf);
+    gp_GTrsf2d    gtrsf      = S->ParametricTransformation(aLocalTrsf);
 
     if (gtrsf.Form() != gp_Identity)
     {
@@ -446,7 +445,7 @@ bool BRepTools_TrsfModification::NewParameter(const TopoDS_Vertex& V,
   if (!C.IsNull())
   {
     const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, loc);
-    P = C->TransformedParameter(P, aLocalTrsf);
+    P                        = C->TransformedParameter(P, aLocalTrsf);
   }
 
   return true;

--- a/src/ModelingData/TKBRep/BRepTools/BRepTools_TrsfModification.cxx
+++ b/src/ModelingData/TKBRep/BRepTools/BRepTools_TrsfModification.cxx
@@ -38,6 +38,33 @@
 
 IMPLEMENT_STANDARD_RTTIEXT(BRepTools_TrsfModification, BRepTools_Modification)
 
+namespace
+{
+
+//=================================================================================================
+
+gp_Trsf representationTransformation(const gp_Trsf&         theTrsf,
+                                     const TopLoc_Location& theSourceLocation,
+                                     const TopLoc_Location& theTargetLocation)
+{
+  if (theSourceLocation.IsIdentity() && theTargetLocation.IsIdentity())
+  {
+    return theTrsf;
+  }
+  return theTargetLocation.Transformation().Inverted() * theTrsf
+         * theSourceLocation.Transformation();
+}
+
+//=================================================================================================
+
+gp_Trsf representationTransformation(const gp_Trsf&         theTrsf,
+                                     const TopLoc_Location& theLocation)
+{
+  return representationTransformation(theTrsf, theLocation, theLocation);
+}
+
+} // namespace
+
 //=================================================================================================
 
 BRepTools_TrsfModification::BRepTools_TrsfModification(const gp_Trsf& T)
@@ -81,12 +108,8 @@ bool BRepTools_TrsfModification::NewSurface(const TopoDS_Face&         F,
   RevWires = false;
   RevFace  = myTrsf.IsNegative();
 
-  gp_Trsf LT = L.Transformation();
-  LT.Invert();
-  LT.Multiply(myTrsf);
-  LT.Multiply(L.Transformation());
-
-  S = occ::down_cast<Geom_Surface>(S->Transformed(LT));
+  const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, L);
+  S                        = occ::down_cast<Geom_Surface>(S->Transformed(aLocalTrsf));
 
   return true;
 }
@@ -109,11 +132,7 @@ bool BRepTools_TrsfModification::NewTriangulation(const TopoDS_Face&            
     return false;
   }
 
-  gp_Trsf aTrsf = myTrsf;
-  if (!aLoc.IsIdentity())
-  {
-    aTrsf = aLoc.Transformation().Inverted() * aTrsf * aLoc.Transformation();
-  }
+  const gp_Trsf aTrsf = representationTransformation(myTrsf, aLoc, theFace.Location());
 
   theTriangulation = theTriangulation->Copy();
   theTriangulation->SetCachedMinMax(Bnd_Box()); // clear bounding box
@@ -129,12 +148,13 @@ bool BRepTools_TrsfModification::NewTriangulation(const TopoDS_Face&            
   occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(theFace, aLoc);
   if (theTriangulation->HasUVNodes() && !aSurf.IsNull())
   {
+    const gp_Trsf aSurfaceTrsf = representationTransformation(myTrsf, aLoc);
     for (int anInd = 1; anInd <= theTriangulation->NbNodes(); ++anInd)
     {
       gp_Pnt2d aP2d = theTriangulation->UVNode(anInd);
       aSurf->TransformParameters(aP2d.ChangeCoord().ChangeCoord(1),
                                  aP2d.ChangeCoord().ChangeCoord(2),
-                                 myTrsf);
+                                 aSurfaceTrsf);
       theTriangulation->SetUVNode(anInd, aP2d);
     }
   }
@@ -181,11 +201,7 @@ bool BRepTools_TrsfModification::NewPolygon(const TopoDS_Edge&           theE,
     return false;
   }
 
-  gp_Trsf aTrsf = myTrsf;
-  if (!aLoc.IsIdentity())
-  {
-    aTrsf = aLoc.Transformation().Inverted() * aTrsf * aLoc.Transformation();
-  }
+  const gp_Trsf aTrsf = representationTransformation(myTrsf, aLoc, theE.Location());
 
   theP = theP->Copy();
   theP->Deflection(theP->Deflection() * std::abs(myTrsf.ScaleFactor()));
@@ -203,7 +219,8 @@ bool BRepTools_TrsfModification::NewPolygon(const TopoDS_Edge&           theE,
     occ::handle<Geom_Curve> aCurve = BRep_Tool::Curve(theE, aCurveLoc, aFirst, aLast);
     if (!aCurve.IsNull())
     {
-      double aReparametrization = aCurve->ParametricTransformation(aTrsf);
+      const gp_Trsf aCurveTrsf = representationTransformation(myTrsf, aCurveLoc);
+      double aReparametrization = aCurve->ParametricTransformation(aCurveTrsf);
       if (std::abs(aReparametrization - 1.0) > Precision::PConfusion())
       {
         NCollection_Array1<double>& aParams = theP->ChangeParameters();
@@ -249,10 +266,11 @@ bool BRepTools_TrsfModification::NewPolygonOnTriangulation(
   occ::handle<Geom_Surface> aSurf = BRep_Tool::Surface(theF, aLoc);
   double                    aFirst, aLast;
   occ::handle<Geom2d_Curve> aC2d = BRep_Tool::CurveOnSurface(theE, theF, aFirst, aLast);
-  if (!aSurf.IsNull() && !aC2d.IsNull()
+  if (theP->HasParameters() && !aSurf.IsNull() && !aC2d.IsNull()
       && std::abs(std::abs(myTrsf.ScaleFactor()) - 1.0) > TopLoc_Location::ScalePrec())
   {
-    gp_GTrsf2d aGTrsf = aSurf->ParametricTransformation(myTrsf);
+    const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, aLoc);
+    gp_GTrsf2d    aGTrsf     = aSurf->ParametricTransformation(aLocalTrsf);
     if (aGTrsf.Form() != gp_Identity)
     {
       occ::handle<Geom2d_Curve> aNewC2d = GeomLib::GTransform(aC2d, aGTrsf);
@@ -283,14 +301,10 @@ bool BRepTools_TrsfModification::NewCurve(const TopoDS_Edge&       E,
   Tol = BRep_Tool::Tolerance(E);
   Tol *= std::abs(myTrsf.ScaleFactor());
 
-  gp_Trsf LT = L.Transformation();
-  LT.Invert();
-  LT.Multiply(myTrsf);
-  LT.Multiply(L.Transformation());
-
   if (!C.IsNull())
   {
-    C = occ::down_cast<Geom_Curve>(C->Transformed(LT));
+    const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, L);
+    C                        = occ::down_cast<Geom_Curve>(C->Transformed(aLocalTrsf));
   }
 
   return true;
@@ -381,8 +395,9 @@ bool BRepTools_TrsfModification::NewCurve2d(const TopoDS_Edge& E,
   if (std::abs(scale) != 1.)
   {
 
-    NewC             = new Geom2d_TrimmedCurve(NewC, f, l);
-    gp_GTrsf2d gtrsf = S->ParametricTransformation(myTrsf);
+    NewC = new Geom2d_TrimmedCurve(NewC, f, l);
+    const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, loc);
+    gp_GTrsf2d gtrsf = S->ParametricTransformation(aLocalTrsf);
 
     if (gtrsf.Form() != gp_Identity)
     {
@@ -430,7 +445,8 @@ bool BRepTools_TrsfModification::NewParameter(const TopoDS_Vertex& V,
   occ::handle<Geom_Curve> C = BRep_Tool::Curve(E, loc, f, l);
   if (!C.IsNull())
   {
-    P = C->TransformedParameter(P, myTrsf);
+    const gp_Trsf aLocalTrsf = representationTransformation(myTrsf, loc);
+    P = C->TransformedParameter(P, aLocalTrsf);
   }
 
   return true;

--- a/src/ModelingData/TKBRep/GTests/BRepTools_GTrsfModification_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepTools_GTrsfModification_Test.cxx
@@ -192,7 +192,7 @@ TEST(BRepTools_GTrsfModificationTest, Surface_LocatedBezierTransformsEvaluatedGe
   aBuilder.MakeFace(aFace, aSurface, aLocation, 0.2);
 
   const gp_GTrsf              aGTrsf(gp_Mat(2.0, 0.5, 0.0, 0.0, 3.0, 0.25, 0.0, 0.0, 4.0),
-                                     gp_XYZ(7.0, 8.0, 9.0));
+                        gp_XYZ(7.0, 8.0, 9.0));
   BRepTools_GTrsfModification aModification(aGTrsf);
   occ::handle<Geom_Surface>   aResult;
   TopLoc_Location             aResultLocation;
@@ -231,7 +231,7 @@ TEST(BRepTools_GTrsfModificationTest, Curve_LocatedBezierPreservesRangeAndSource
   aBuilder.Range(anEdge, 0.2, 0.8);
 
   const gp_GTrsf              aGTrsf(gp_Mat(1.0, 0.5, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0),
-                                     gp_XYZ(2.0, -1.0, 5.0));
+                        gp_XYZ(2.0, -1.0, 5.0));
   BRepTools_GTrsfModification aModification(aGTrsf);
   occ::handle<Geom_Curve>     aResult;
   TopLoc_Location             aResultLocation;

--- a/src/ModelingData/TKBRep/GTests/BRepTools_GTrsfModification_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepTools_GTrsfModification_Test.cxx
@@ -1,0 +1,491 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepTools_GTrsfModification.hxx>
+#include <BRepTools_Modifier.hxx>
+#include <Geom2d_Line.hxx>
+#include <NCollection_Array1.hxx>
+#include <NCollection_Array2.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_BezierSurface.hxx>
+#include <Geom_Curve.hxx>
+#include <Geom_Surface.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Poly_Triangle.hxx>
+#include <Poly_Triangulation.hxx>
+#include <Precision.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_GTrsf.hxx>
+#include <gp_Mat.hxx>
+#include <gp_Ax2d.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Trsf.hxx>
+#include <gp_Vec.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+occ::handle<Poly_Triangulation> makeTriangulation(const bool theHasNormals)
+{
+  occ::handle<Poly_Triangulation> aTriangulation =
+    new Poly_Triangulation(3, 1, false, theHasNormals);
+  aTriangulation->SetNode(1, gp_Pnt(0.0, 0.0, 0.0));
+  aTriangulation->SetNode(2, gp_Pnt(1.0, 0.0, 0.0));
+  aTriangulation->SetNode(3, gp_Pnt(0.0, 1.0, 1.0));
+  aTriangulation->SetTriangle(1, Poly_Triangle(1, 2, 3));
+  aTriangulation->Deflection(0.25);
+  if (theHasNormals)
+  {
+    const gp_Dir aNormal(0.0, -1.0, 1.0);
+    for (int anIndex = 1; anIndex <= 3; ++anIndex)
+    {
+      aTriangulation->SetNormal(anIndex, aNormal);
+    }
+  }
+  return aTriangulation;
+}
+
+gp_GTrsf makeGTrsf(const gp_Mat& theMatrix)
+{
+  gp_GTrsf aGTrsf;
+  aGTrsf.SetVectorialPart(theMatrix);
+  return aGTrsf;
+}
+
+void expectPointNear(const gp_Pnt& theActual, const gp_Pnt& theExpected)
+{
+  EXPECT_LT(theActual.Distance(theExpected), 1.0e-12);
+}
+} // namespace
+
+TEST(BRepTools_GTrsfModificationTest, Triangulation_ReflectionPreservesWindingAndNormals)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Poly_Triangulation> aSource = makeTriangulation(true);
+  aSource->UpdateCachedMinMax();
+  ASSERT_TRUE(aSource->HasCachedMinMax());
+  aBuilder.MakeFace(aFace, aSource);
+
+  const gp_GTrsf aGTrsf = makeGTrsf(gp_Mat(-2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0));
+  BRepTools_GTrsfModification     aModification(aGTrsf);
+  occ::handle<Poly_Triangulation> aResult;
+  ASSERT_TRUE(aModification.NewTriangulation(aFace, aResult));
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_FALSE(aResult->HasCachedMinMax());
+  EXPECT_TRUE(aSource->HasCachedMinMax());
+
+  int aNode1 = 0, aNode2 = 0, aNode3 = 0;
+  aResult->Triangle(1).Get(aNode1, aNode2, aNode3);
+  EXPECT_EQ(aNode1, 1);
+  EXPECT_EQ(aNode2, 3);
+  EXPECT_EQ(aNode3, 2);
+
+  const gp_Dir anExpectedNormal(0.0, -1.0 / 3.0, 1.0 / 4.0);
+  for (int anIndex = 1; anIndex <= 3; ++anIndex)
+  {
+    EXPECT_LT(aResult->Normal(anIndex).Angle(anExpectedNormal), 1.0e-6);
+  }
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 1.0);
+  EXPECT_DOUBLE_EQ(aSource->Deflection(), 0.25);
+  expectPointNear(aSource->Node(2), gp_Pnt(1.0, 0.0, 0.0));
+}
+
+TEST(BRepTools_GTrsfModificationTest, Triangulation_NegativeUniformScalePreservesOrientation)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Poly_Triangulation> aSource = makeTriangulation(true);
+  aBuilder.MakeFace(aFace, aSource);
+
+  gp_Trsf aScale;
+  aScale.SetScale(gp_Pnt(0.0, 0.0, 0.0), -2.0);
+  BRepTools_GTrsfModification     aModification{gp_GTrsf(aScale)};
+  occ::handle<Poly_Triangulation> aResult;
+  ASSERT_TRUE(aModification.NewTriangulation(aFace, aResult));
+
+  int aNode1 = 0, aNode2 = 0, aNode3 = 0;
+  aResult->Triangle(1).Get(aNode1, aNode2, aNode3);
+  EXPECT_EQ(aNode1, 1);
+  EXPECT_EQ(aNode2, 3);
+  EXPECT_EQ(aNode3, 2);
+
+  const gp_Dir anExpectedNormal(0.0, 1.0, -1.0);
+  EXPECT_LT(aResult->Normal(1).Angle(anExpectedNormal), 1.0e-6);
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 0.5);
+}
+
+TEST(BRepTools_GTrsfModificationTest, Triangulation_NormalTransformationIsScaleInvariant)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Poly_Triangulation> aSource = makeTriangulation(true);
+  aBuilder.MakeFace(aFace, aSource);
+
+  const double aScales[] = {Precision::PConfusion(), Precision::Infinite()};
+  for (const double aScale : aScales)
+  {
+    BRepTools_GTrsfModification aModification{
+      makeGTrsf(gp_Mat(aScale, 0.0, 0.0, 0.0, aScale, 0.0, 0.0, 0.0, aScale))};
+    occ::handle<Poly_Triangulation> aResult;
+    ASSERT_TRUE(aModification.NewTriangulation(aFace, aResult));
+    EXPECT_LT(aResult->Normal(1).Angle(aSource->Normal(1)), 1.0e-6);
+  }
+}
+
+TEST(BRepTools_GTrsfModificationTest, Triangulation_SingularAffinityHandlesNormals)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Poly_Triangulation> aSource = makeTriangulation(true);
+  aBuilder.MakeFace(aFace, aSource);
+
+  BRepTools_GTrsfModification aRankTwoModification{
+    makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 0.0))};
+  occ::handle<Poly_Triangulation> aResult;
+  ASSERT_TRUE(aRankTwoModification.NewTriangulation(aFace, aResult));
+  ASSERT_TRUE(aResult->HasNormals());
+  EXPECT_LT(aResult->Normal(1).Angle(gp_Dir(0.0, 0.0, 1.0)), 1.0e-6);
+
+  BRepTools_GTrsfModification aRankOneModification{
+    makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))};
+  ASSERT_TRUE(aRankOneModification.NewTriangulation(aFace, aResult));
+  ASSERT_TRUE(aResult->HasNormals());
+  EXPECT_LT(aResult->Normal(1).Angle(aSource->Normal(1)), 1.0e-6);
+}
+
+TEST(BRepTools_GTrsfModificationTest, Surface_LocatedBezierTransformsEvaluatedGeometry)
+{
+  NCollection_Array2<gp_Pnt> aPoles(1, 2, 1, 2);
+  aPoles(1, 1)                                   = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2, 1)                                   = gp_Pnt(2.0, 0.0, 1.0);
+  aPoles(1, 2)                                   = gp_Pnt(0.0, 3.0, 1.0);
+  aPoles(2, 2)                                   = gp_Pnt(2.0, 3.0, 2.0);
+  const occ::handle<Geom_BezierSurface> aSurface = new Geom_BezierSurface(aPoles);
+
+  gp_Trsf aLocationTrsf;
+  aLocationTrsf.SetTranslation(gp_Vec(4.0, -2.0, 5.0));
+  const TopLoc_Location aLocation(aLocationTrsf);
+  BRep_Builder          aBuilder;
+  TopoDS_Face           aFace;
+  aBuilder.MakeFace(aFace, aSurface, aLocation, 0.2);
+
+  const gp_GTrsf              aGTrsf(gp_Mat(2.0, 0.5, 0.0, 0.0, 3.0, 0.25, 0.0, 0.0, 4.0),
+                                     gp_XYZ(7.0, 8.0, 9.0));
+  BRepTools_GTrsfModification aModification(aGTrsf);
+  occ::handle<Geom_Surface>   aResult;
+  TopLoc_Location             aResultLocation;
+  double                      aTolerance     = 0.0;
+  bool                        toReverseWires = true;
+  bool                        toReverseFace  = true;
+  ASSERT_TRUE(
+    aModification
+      .NewSurface(aFace, aResult, aResultLocation, aTolerance, toReverseWires, toReverseFace));
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_TRUE(aResultLocation.IsIdentity());
+  EXPECT_FALSE(toReverseWires);
+  EXPECT_FALSE(toReverseFace);
+
+  gp_Pnt anExpected = aSurface->Value(0.35, 0.65).Transformed(aLocationTrsf);
+  aGTrsf.Transforms(anExpected.ChangeCoord());
+  expectPointNear(aResult->Value(0.35, 0.65), anExpected);
+  expectPointNear(aSurface->Pole(2, 2), gp_Pnt(2.0, 3.0, 2.0));
+  EXPECT_DOUBLE_EQ(aTolerance, 0.8);
+}
+
+TEST(BRepTools_GTrsfModificationTest, Curve_LocatedBezierPreservesRangeAndSource)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 3);
+  aPoles(1)                                  = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2)                                  = gp_Pnt(1.0, 2.0, 0.0);
+  aPoles(3)                                  = gp_Pnt(3.0, 2.0, 1.0);
+  const occ::handle<Geom_BezierCurve> aCurve = new Geom_BezierCurve(aPoles);
+
+  gp_Trsf aLocationTrsf;
+  aLocationTrsf.SetTranslation(gp_Vec(-3.0, 4.0, 2.0));
+  const TopLoc_Location aLocation(aLocationTrsf);
+  BRep_Builder          aBuilder;
+  TopoDS_Edge           anEdge;
+  aBuilder.MakeEdge(anEdge, aCurve, aLocation, 0.1);
+  aBuilder.Range(anEdge, 0.2, 0.8);
+
+  const gp_GTrsf              aGTrsf(gp_Mat(1.0, 0.5, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 3.0),
+                                     gp_XYZ(2.0, -1.0, 5.0));
+  BRepTools_GTrsfModification aModification(aGTrsf);
+  occ::handle<Geom_Curve>     aResult;
+  TopLoc_Location             aResultLocation;
+  double                      aTolerance = 0.0;
+  ASSERT_TRUE(aModification.NewCurve(anEdge, aResult, aResultLocation, aTolerance));
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_TRUE(aResultLocation.IsIdentity());
+  EXPECT_DOUBLE_EQ(aResult->FirstParameter(), 0.2);
+  EXPECT_DOUBLE_EQ(aResult->LastParameter(), 0.8);
+
+  gp_Pnt anExpected = aCurve->Value(0.4).Transformed(aLocationTrsf);
+  aGTrsf.Transforms(anExpected.ChangeCoord());
+  expectPointNear(aResult->Value(0.4), anExpected);
+  expectPointNear(aCurve->Pole(2), gp_Pnt(1.0, 2.0, 0.0));
+}
+
+TEST(BRepTools_GTrsfModificationTest, Polygon3D_RepresentationLocationTransformsToEdgeFrame)
+{
+  NCollection_Array1<gp_Pnt> aNodes(1, 2);
+  aNodes(1) = gp_Pnt(1.0, 2.0, 3.0);
+  aNodes(2) = gp_Pnt(4.0, 5.0, 6.0);
+  NCollection_Array1<double> aParameters(1, 2);
+  aParameters(1)                             = 0.25;
+  aParameters(2)                             = 0.75;
+  const occ::handle<Poly_Polygon3D> aPolygon = new Poly_Polygon3D(aNodes, aParameters);
+  aPolygon->Deflection(0.5);
+
+  gp_Trsf aRepresentationTrsf;
+  aRepresentationTrsf.SetTranslation(gp_Vec(10.0, 0.0, 0.0));
+  gp_Trsf anEdgeTrsf;
+  anEdgeTrsf.SetTranslation(gp_Vec(0.0, 20.0, 0.0));
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  aBuilder.UpdateEdge(anEdge, aPolygon, TopLoc_Location(aRepresentationTrsf));
+  anEdge.Location(TopLoc_Location(anEdgeTrsf));
+
+  const gp_GTrsf aGTrsf = makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0));
+  BRepTools_GTrsfModification aModification(aGTrsf);
+  occ::handle<Poly_Polygon3D> aResult;
+  ASSERT_TRUE(aModification.NewPolygon(anEdge, aResult));
+  ASSERT_FALSE(aResult.IsNull());
+
+  TopLoc_Location aSourceLocation;
+  ASSERT_FALSE(BRep_Tool::Polygon3D(anEdge, aSourceLocation).IsNull());
+  for (int anIndex = 1; anIndex <= aResult->NbNodes(); ++anIndex)
+  {
+    gp_Pnt anExpected = aPolygon->Nodes()(anIndex).Transformed(aSourceLocation.Transformation());
+    aGTrsf.Transforms(anExpected.ChangeCoord());
+    const gp_Pnt anActual =
+      aResult->Nodes()(anIndex).Transformed(anEdge.Location().Transformation());
+    expectPointNear(anActual, anExpected);
+    EXPECT_DOUBLE_EQ(aResult->Parameters()(anIndex), aParameters(anIndex));
+  }
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 2.0);
+  EXPECT_DOUBLE_EQ(aPolygon->Deflection(), 0.5);
+}
+
+TEST(BRepTools_GTrsfModificationTest, MissingPolygonRepresentationsReturnFalse)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  TopoDS_Face  aFace;
+  aBuilder.MakeEdge(anEdge);
+  const occ::handle<Poly_Triangulation> aTriangulation = makeTriangulation(false);
+  aBuilder.MakeFace(aFace, aTriangulation);
+
+  BRepTools_GTrsfModification              aModification{gp_GTrsf()};
+  occ::handle<Poly_Polygon3D>              aPolygon3d = new Poly_Polygon3D(2, false);
+  occ::handle<Poly_PolygonOnTriangulation> aPolygonOnTriangulation =
+    new Poly_PolygonOnTriangulation(2, false);
+  EXPECT_FALSE(aModification.NewPolygon(anEdge, aPolygon3d));
+  EXPECT_TRUE(aPolygon3d.IsNull());
+  EXPECT_FALSE(aModification.NewPolygonOnTriangulation(anEdge, aFace, aPolygonOnTriangulation));
+  EXPECT_TRUE(aPolygonOnTriangulation.IsNull());
+}
+
+TEST(BRepTools_GTrsfModificationTest, Curve2dAndVertexParameterPreserveParametrization)
+{
+  NCollection_Array2<gp_Pnt> aSurfacePoles(1, 2, 1, 2);
+  aSurfacePoles(1, 1)                            = gp_Pnt(0.0, 0.0, 0.0);
+  aSurfacePoles(2, 1)                            = gp_Pnt(1.0, 0.0, 0.0);
+  aSurfacePoles(1, 2)                            = gp_Pnt(0.0, 1.0, 0.0);
+  aSurfacePoles(2, 2)                            = gp_Pnt(1.0, 1.0, 0.0);
+  const occ::handle<Geom_BezierSurface> aSurface = new Geom_BezierSurface(aSurfacePoles);
+
+  NCollection_Array1<gp_Pnt> aCurvePoles(1, 2);
+  aCurvePoles(1)                             = gp_Pnt(0.0, 0.0, 0.0);
+  aCurvePoles(2)                             = gp_Pnt(1.0, 0.0, 0.0);
+  const occ::handle<Geom_BezierCurve> aCurve = new Geom_BezierCurve(aCurvePoles);
+
+  BRep_Builder  aBuilder;
+  TopoDS_Face   aFace;
+  TopoDS_Edge   anEdge;
+  TopoDS_Vertex aVertex;
+  aBuilder.MakeFace(aFace, aSurface, 0.05);
+  aBuilder.MakeEdge(anEdge, aCurve, 0.05);
+  aBuilder.Range(anEdge, 0.2, 0.8);
+  const occ::handle<Geom2d_Line> aPcurve =
+    new Geom2d_Line(gp_Ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)));
+  aBuilder.UpdateEdge(anEdge, aPcurve, aFace, 0.05);
+  aBuilder.Range(anEdge, aFace, 0.2, 0.8);
+  aBuilder.MakeVertex(aVertex, aCurve->Value(0.25), 0.02);
+  aBuilder.Add(anEdge, aVertex);
+  aBuilder.UpdateVertex(aVertex, 0.25, anEdge, 0.02);
+
+  double aSourceFirst = 0.0, aSourceLast = 0.0;
+  ASSERT_FALSE(BRep_Tool::CurveOnSurface(anEdge, aFace, aSourceFirst, aSourceLast).IsNull());
+
+  const gp_GTrsf aGTrsf = makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 1.0));
+  BRepTools_GTrsfModification aModification(aGTrsf);
+  occ::handle<Geom2d_Curve>   aResultCurve;
+  double                      aTolerance = 0.0;
+  ASSERT_TRUE(aModification
+                .NewCurve2d(anEdge, aFace, TopoDS_Edge(), TopoDS_Face(), aResultCurve, aTolerance));
+  ASSERT_FALSE(aResultCurve.IsNull());
+  EXPECT_DOUBLE_EQ(aResultCurve->FirstParameter(), aSourceFirst);
+  EXPECT_DOUBLE_EQ(aResultCurve->LastParameter(), aSourceLast);
+  EXPECT_LT(aResultCurve->Value(0.4).Distance(aPcurve->Value(0.4)), 1.0e-12);
+  EXPECT_DOUBLE_EQ(aTolerance, 0.15);
+
+  double aParameter = 0.0;
+  ASSERT_TRUE(aModification.NewParameter(aVertex, anEdge, aParameter, aTolerance));
+  EXPECT_DOUBLE_EQ(aParameter, 0.25);
+  EXPECT_DOUBLE_EQ(aTolerance, 0.06);
+}
+
+TEST(BRepTools_GTrsfModificationTest, Modifier_LocatedSurfaceAndMeshStayCoincident)
+{
+  NCollection_Array2<gp_Pnt> aPoles(1, 2, 1, 2);
+  aPoles(1, 1)                                         = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2, 1)                                         = gp_Pnt(1.0, 0.0, 0.0);
+  aPoles(1, 2)                                         = gp_Pnt(0.0, 1.0, 1.0);
+  aPoles(2, 2)                                         = gp_Pnt(1.0, 1.0, 1.0);
+  const occ::handle<Geom_BezierSurface> aSurface       = new Geom_BezierSurface(aPoles);
+  const occ::handle<Poly_Triangulation> aTriangulation = makeTriangulation(false);
+
+  BRep_Builder aBuilder;
+  TopoDS_Face  aFace;
+  aBuilder.MakeFace(aFace, aSurface, 0.1);
+  aBuilder.UpdateFace(aFace, aTriangulation);
+  gp_Trsf aLocationTrsf;
+  aLocationTrsf.SetTranslation(gp_Vec(10.0, 20.0, 30.0));
+  aFace.Location(TopLoc_Location(aLocationTrsf));
+
+  const gp_GTrsf aGTrsf(gp_Mat(2.0, 0.5, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0), gp_XYZ(5.0, 6.0, 7.0));
+  occ::handle<BRepTools_GTrsfModification> aModification = new BRepTools_GTrsfModification(aGTrsf);
+  BRepTools_Modifier                       aModifier(aFace, aModification);
+  ASSERT_TRUE(aModifier.IsDone());
+  const TopoDS_Face aResultFace = TopoDS::Face(aModifier.ModifiedShape(aFace));
+  ASSERT_FALSE(aResultFace.IsNull());
+
+  TopLoc_Location           aResultSurfaceLocation;
+  occ::handle<Geom_Surface> aResultSurface =
+    BRep_Tool::Surface(aResultFace, aResultSurfaceLocation);
+  ASSERT_FALSE(aResultSurface.IsNull());
+  gp_Pnt anExpectedSurface = aSurface->Value(0.25, 0.75).Transformed(aLocationTrsf);
+  aGTrsf.Transforms(anExpectedSurface.ChangeCoord());
+  expectPointNear(
+    aResultSurface->Value(0.25, 0.75).Transformed(aResultSurfaceLocation.Transformation()),
+    anExpectedSurface);
+
+  TopLoc_Location                       aResultMeshLocation;
+  const occ::handle<Poly_Triangulation> aResultTriangulation =
+    BRep_Tool::Triangulation(aResultFace, aResultMeshLocation);
+  ASSERT_FALSE(aResultTriangulation.IsNull());
+  for (int anIndex = 1; anIndex <= aTriangulation->NbNodes(); ++anIndex)
+  {
+    gp_Pnt anExpectedNode = aTriangulation->Node(anIndex).Transformed(aLocationTrsf);
+    aGTrsf.Transforms(anExpectedNode.ChangeCoord());
+    expectPointNear(
+      aResultTriangulation->Node(anIndex).Transformed(aResultMeshLocation.Transformation()),
+      anExpectedNode);
+  }
+}
+
+TEST(BRepTools_GTrsfModificationTest, Triangulation_LocatedFaceUsesLocalCoordinates)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Poly_Triangulation> aSource = makeTriangulation(false);
+  aBuilder.MakeFace(aFace, aSource);
+
+  gp_Trsf aLocationTrsf;
+  aLocationTrsf.SetTranslation(gp_Vec(10.0, 20.0, 30.0));
+  aFace.Location(TopLoc_Location(aLocationTrsf));
+
+  const gp_GTrsf aGTrsf = makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0));
+  BRepTools_GTrsfModification     aModification(aGTrsf);
+  occ::handle<Poly_Triangulation> aResult;
+  ASSERT_TRUE(aModification.NewTriangulation(aFace, aResult));
+
+  TopLoc_Location aResultLocation;
+  ASSERT_FALSE(BRep_Tool::Triangulation(aFace, aResultLocation).IsNull());
+  for (int anIndex = 1; anIndex <= aSource->NbNodes(); ++anIndex)
+  {
+    gp_Pnt anExpected = aSource->Node(anIndex).Transformed(aResultLocation.Transformation());
+    aGTrsf.Transforms(anExpected.ChangeCoord());
+    const gp_Pnt anActual = aResult->Node(anIndex).Transformed(aResultLocation.Transformation());
+    EXPECT_LT(anActual.Distance(anExpected), 1.0e-12);
+  }
+}
+
+TEST(BRepTools_GTrsfModificationTest, Tolerance_TracksCurrentTransformation)
+{
+  BRep_Builder  aBuilder;
+  TopoDS_Vertex aVertex;
+  aBuilder.MakeVertex(aVertex, gp_Pnt(1.0, 2.0, 3.0), 0.1);
+
+  BRepTools_GTrsfModification aModification{gp_GTrsf()};
+  aModification.SetGTrsf(makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0)));
+  gp_Pnt aPoint;
+  double aTolerance = 0.0;
+  ASSERT_TRUE(aModification.NewPoint(aVertex, aPoint, aTolerance));
+  EXPECT_DOUBLE_EQ(aTolerance, 0.4);
+  expectPointNear(aPoint, gp_Pnt(2.0, 6.0, 12.0));
+
+  aModification.SetGTrsf(makeGTrsf(gp_Mat(1.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0)));
+  ASSERT_TRUE(aModification.NewPoint(aVertex, aPoint, aTolerance));
+  EXPECT_DOUBLE_EQ(aTolerance, 0.1);
+  expectPointNear(aPoint, gp_Pnt(3.0, 2.0, 3.0));
+
+  const double aCos = std::sqrt(0.5);
+  aModification.SetGTrsf(makeGTrsf(gp_Mat(aCos, -aCos, 0.0, aCos, aCos, 0.0, 0.0, 0.0, 1.0)));
+  ASSERT_TRUE(aModification.NewPoint(aVertex, aPoint, aTolerance));
+  EXPECT_NEAR(aTolerance, 0.1, 1.0e-14);
+
+  gp_Trsf aScale;
+  aScale.SetScale(gp_Pnt(0.0, 0.0, 0.0), 3.0);
+  aModification.SetGTrsf(gp_GTrsf(aScale));
+  ASSERT_TRUE(aModification.NewPoint(aVertex, aPoint, aTolerance));
+  EXPECT_DOUBLE_EQ(aTolerance, 0.3);
+  expectPointNear(aPoint, gp_Pnt(3.0, 6.0, 9.0));
+}
+
+TEST(BRepTools_GTrsfModificationTest, PolygonOnTriangulation_PreservesDeflection)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  TopoDS_Edge                           anEdge;
+  const occ::handle<Poly_Triangulation> aTriangulation = makeTriangulation(false);
+  aBuilder.MakeFace(aFace, aTriangulation);
+
+  NCollection_Array1<int> aNodes(1, 2);
+  aNodes(1)                                         = 1;
+  aNodes(2)                                         = 2;
+  occ::handle<Poly_PolygonOnTriangulation> aPolygon = new Poly_PolygonOnTriangulation(aNodes);
+  aPolygon->Deflection(0.25);
+  aBuilder.MakeEdge(anEdge, aPolygon, aTriangulation);
+
+  const gp_GTrsf aGTrsf = makeGTrsf(gp_Mat(2.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0, 0.0, 4.0));
+  BRepTools_GTrsfModification              aModification(aGTrsf);
+  occ::handle<Poly_PolygonOnTriangulation> aResult;
+  ASSERT_TRUE(aModification.NewPolygonOnTriangulation(anEdge, aFace, aResult));
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 0.25);
+}

--- a/src/ModelingData/TKBRep/GTests/BRepTools_TrsfModification_Test.cxx
+++ b/src/ModelingData/TKBRep/GTests/BRepTools_TrsfModification_Test.cxx
@@ -1,0 +1,177 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepTools_TrsfModification.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom_Plane.hxx>
+#include <NCollection_Array1.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Poly_Triangle.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopLoc_Location.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <gp_Ax2d.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Dir2d.hxx>
+#include <gp_Pln.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Trsf.hxx>
+#include <gp_Vec.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+occ::handle<Poly_Triangulation> makeTriangulation(const bool theHasNormals = false)
+{
+  occ::handle<Poly_Triangulation> aTriangulation =
+    new Poly_Triangulation(3, 1, false, theHasNormals);
+  aTriangulation->SetNode(1, gp_Pnt(0.0, 0.0, 0.0));
+  aTriangulation->SetNode(2, gp_Pnt(1.0, 0.0, 0.0));
+  aTriangulation->SetNode(3, gp_Pnt(0.0, 1.0, 1.0));
+  aTriangulation->SetTriangle(1, Poly_Triangle(1, 2, 3));
+  aTriangulation->Deflection(0.25);
+  if (theHasNormals)
+  {
+    const gp_Dir aNormal(0.0, -1.0, 1.0);
+    for (int anIndex = 1; anIndex <= 3; ++anIndex)
+    {
+      aTriangulation->SetNormal(anIndex, aNormal);
+    }
+  }
+  return aTriangulation;
+}
+
+gp_Trsf makeScale(const double theScale)
+{
+  gp_Trsf aTrsf;
+  aTrsf.SetScale(gp_Pnt(0.0, 0.0, 0.0), theScale);
+  return aTrsf;
+}
+
+void expectPointNear(const gp_Pnt& theActual, const gp_Pnt& theExpected)
+{
+  EXPECT_LT(theActual.Distance(theExpected), 1.0e-12);
+}
+} // namespace
+
+TEST(BRepTools_TrsfModificationTest, CopyMeshFlag_SkipsCachedMeshOnGeometricFace)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Geom_Plane>         aPlane         = new Geom_Plane(gp_Pln());
+  const occ::handle<Poly_Triangulation> aTriangulation = makeTriangulation();
+  aBuilder.MakeFace(aFace, aPlane, 0.1);
+  aBuilder.UpdateFace(aFace, aTriangulation);
+
+  BRepTools_TrsfModification            aModification(makeScale(2.0));
+  occ::handle<Poly_Triangulation>       aResult   = makeTriangulation();
+  const occ::handle<Poly_Triangulation> aSentinel = aResult;
+  EXPECT_FALSE(aModification.NewTriangulation(aFace, aResult));
+  EXPECT_EQ(aResult, aSentinel);
+
+  aModification.IsCopyMesh() = true;
+  ASSERT_TRUE(aModification.NewTriangulation(aFace, aResult));
+  expectPointNear(aResult->Node(2), gp_Pnt(2.0, 0.0, 0.0));
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 0.5);
+  expectPointNear(aTriangulation->Node(2), gp_Pnt(1.0, 0.0, 0.0));
+}
+
+TEST(BRepTools_TrsfModificationTest, Polygon3D_DistinctRepresentationLocation)
+{
+  NCollection_Array1<gp_Pnt> aNodes(1, 2);
+  aNodes(1)                                  = gp_Pnt(1.0, 2.0, 3.0);
+  aNodes(2)                                  = gp_Pnt(4.0, 5.0, 6.0);
+  const occ::handle<Poly_Polygon3D> aPolygon = new Poly_Polygon3D(aNodes);
+
+  gp_Trsf aRepresentationTrsf;
+  aRepresentationTrsf.SetTranslation(gp_Vec(10.0, 0.0, 0.0));
+  gp_Trsf anEdgeTrsf;
+  anEdgeTrsf.SetTranslation(gp_Vec(0.0, 20.0, 0.0));
+  BRep_Builder aBuilder;
+  TopoDS_Edge  anEdge;
+  aBuilder.MakeEdge(anEdge);
+  aBuilder.UpdateEdge(anEdge, aPolygon, TopLoc_Location(aRepresentationTrsf));
+  anEdge.Location(TopLoc_Location(anEdgeTrsf));
+
+  BRepTools_TrsfModification aModification(makeScale(2.0));
+  aModification.IsCopyMesh() = true;
+  occ::handle<Poly_Polygon3D> aResult;
+  ASSERT_TRUE(aModification.NewPolygon(anEdge, aResult));
+
+  TopLoc_Location aSourceLocation;
+  ASSERT_FALSE(BRep_Tool::Polygon3D(anEdge, aSourceLocation).IsNull());
+  for (int anIndex = 1; anIndex <= aResult->NbNodes(); ++anIndex)
+  {
+    gp_Pnt anExpected = aPolygon->Nodes()(anIndex).Transformed(aSourceLocation.Transformation());
+    anExpected.Transform(makeScale(2.0));
+    const gp_Pnt anActual =
+      aResult->Nodes()(anIndex).Transformed(anEdge.Location().Transformation());
+    expectPointNear(anActual, anExpected);
+  }
+}
+
+TEST(BRepTools_TrsfModificationTest, ParameterlessPolygonOnTriangulationDoesNotThrow)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  TopoDS_Edge                           anEdge;
+  const occ::handle<Geom_Plane>         aPlane         = new Geom_Plane(gp_Pln());
+  const occ::handle<Poly_Triangulation> aTriangulation = makeTriangulation();
+  aBuilder.MakeFace(aFace, aPlane, 0.1);
+  aBuilder.UpdateFace(aFace, aTriangulation);
+
+  NCollection_Array1<int> aNodes(1, 2);
+  aNodes(1)                                               = 1;
+  aNodes(2)                                               = 2;
+  const occ::handle<Poly_PolygonOnTriangulation> aPolygon = new Poly_PolygonOnTriangulation(aNodes);
+  aPolygon->Deflection(0.25);
+  aBuilder.MakeEdge(anEdge, aPolygon, aTriangulation);
+  const occ::handle<Geom2d_Line> aPcurve =
+    new Geom2d_Line(gp_Ax2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)));
+  aBuilder.UpdateEdge(anEdge, aPcurve, aFace, 0.1);
+  aBuilder.Range(anEdge, aFace, 0.0, 1.0);
+
+  BRepTools_TrsfModification aModification(makeScale(2.0));
+  aModification.IsCopyMesh() = true;
+  occ::handle<Poly_PolygonOnTriangulation> aResult;
+  EXPECT_NO_THROW(EXPECT_TRUE(aModification.NewPolygonOnTriangulation(anEdge, aFace, aResult)));
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_FALSE(aResult->HasParameters());
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 0.5);
+}
+
+TEST(BRepTools_TrsfModificationTest, NegativeScaleUpdatesWindingNormalsAndDeflection)
+{
+  BRep_Builder                          aBuilder;
+  TopoDS_Face                           aFace;
+  const occ::handle<Poly_Triangulation> aTriangulation = makeTriangulation(true);
+  aBuilder.MakeFace(aFace, aTriangulation);
+
+  BRepTools_TrsfModification aModification(makeScale(-2.0));
+  aModification.IsCopyMesh() = true;
+  occ::handle<Poly_Triangulation> aResult;
+  ASSERT_TRUE(aModification.NewTriangulation(aFace, aResult));
+  int aNode1 = 0, aNode2 = 0, aNode3 = 0;
+  aResult->Triangle(1).Get(aNode1, aNode2, aNode3);
+  EXPECT_EQ(aNode1, 1);
+  EXPECT_EQ(aNode2, 3);
+  EXPECT_EQ(aNode3, 2);
+  EXPECT_LT(aResult->Normal(1).Angle(gp_Dir(0.0, 1.0, -1.0)), 1.0e-6);
+  EXPECT_DOUBLE_EQ(aResult->Deflection(), 0.5);
+}

--- a/src/ModelingData/TKBRep/GTests/FILES.cmake
+++ b/src/ModelingData/TKBRep/GTests/FILES.cmake
@@ -55,6 +55,8 @@ set(OCCT_TKBRep_GTests_FILES
   BRepGraph_SparseModel_Test.cxx
   BRepGraph_Deduplicate_Test.cxx
   BRepTools_ReShape_Test.cxx
+  BRepTools_GTrsfModification_Test.cxx
+  BRepTools_TrsfModification_Test.cxx
   BRepTools_Test.cxx
   TopExp_Test.cxx
   TopoDS_Builder_Test.cxx


### PR DESCRIPTION
- Transform geometry and polygonal data in their representation frames.
- Correct triangulation winding and normals for mirrored and general transformations.
- Stabilize normal transformation for very small, large, and singular scales.
- Preserve absent and parameterless polygonal representations correctly.
- Keep the cached general-transformation scale synchronized through the restricted API.