### PR TITLE
 Coding - Restore deprecated type alias headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1116,8 +1116,10 @@ COLLECT_AND_INSTALL_OCCT_HEADER_FILES ("${CMAKE_BINARY_DIR}" "${BUILD_TOOLKITS}"
 # Create and install Standard_Version.hxx
 CONFIGURE_AND_INSTALL_VERSION_HEADER()
 
-# Install deprecated NCollection alias headers for backward compatibility
-install(DIRECTORY src/Deprecated/NCollectionAliases/
+# Install deprecated alias headers for backward compatibility. These headers are intentionally
+# excluded from toolkit manifests and are therefore available only in installed OCCT packages.
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/Deprecated/PACKAGES.cmake")
+install(DIRECTORY ${OCCT_DEPRECATED_HEADER_DIRECTORIES}
         DESTINATION "${INSTALL_DIR_INCLUDE}")
 
 string(TIMESTAMP CURRENT_TIME "%H:%M:%S")

--- a/src/Deprecated/PACKAGES.cmake
+++ b/src/Deprecated/PACKAGES.cmake
@@ -1,0 +1,5 @@
+# Directories containing install-only deprecated headers
+set(OCCT_DEPRECATED_HEADER_DIRECTORIES
+  "${CMAKE_CURRENT_LIST_DIR}/NCollectionAliases/"
+  "${CMAKE_CURRENT_LIST_DIR}/TypeAliases/"
+)

--- a/src/Deprecated/TypeAliases/BOPAlgo_PArgumentAnalyzer.hxx
+++ b/src/Deprecated/TypeAliases/BOPAlgo_PArgumentAnalyzer.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPAlgo_PArgumentAnalyzer.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPAlgo_PArgumentAnalyzer_HeaderFile
+#define _BOPAlgo_PArgumentAnalyzer_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPAlgo_ArgumentAnalyzer;
+
+Standard_HEADER_DEPRECATED("BOPAlgo_PArgumentAnalyzer.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPAlgo_PArgumentAnalyzer is deprecated, use the underlying type directly")
+typedef BOPAlgo_ArgumentAnalyzer* BOPAlgo_PArgumentAnalyzer;
+
+#endif // _BOPAlgo_PArgumentAnalyzer_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPAlgo_PBOP.hxx
+++ b/src/Deprecated/TypeAliases/BOPAlgo_PBOP.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPAlgo_PBOP.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPAlgo_PBOP_HeaderFile
+#define _BOPAlgo_PBOP_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPAlgo_BOP;
+
+Standard_HEADER_DEPRECATED("BOPAlgo_PBOP.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPAlgo_PBOP is deprecated, use the underlying type directly")
+typedef BOPAlgo_BOP* BOPAlgo_PBOP;
+
+#endif // _BOPAlgo_PBOP_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPAlgo_PBuilder.hxx
+++ b/src/Deprecated/TypeAliases/BOPAlgo_PBuilder.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPAlgo_PBuilder.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPAlgo_PBuilder_HeaderFile
+#define _BOPAlgo_PBuilder_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPAlgo_Builder;
+
+Standard_HEADER_DEPRECATED("BOPAlgo_PBuilder.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPAlgo_PBuilder is deprecated, use the underlying type directly")
+typedef BOPAlgo_Builder* BOPAlgo_PBuilder;
+
+#endif // _BOPAlgo_PBuilder_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPAlgo_PPaveFiller.hxx
+++ b/src/Deprecated/TypeAliases/BOPAlgo_PPaveFiller.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPAlgo_PPaveFiller.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPAlgo_PPaveFiller_HeaderFile
+#define _BOPAlgo_PPaveFiller_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPAlgo_PaveFiller;
+
+Standard_HEADER_DEPRECATED("BOPAlgo_PPaveFiller.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPAlgo_PPaveFiller is deprecated, use the underlying type directly")
+typedef BOPAlgo_PaveFiller* BOPAlgo_PPaveFiller;
+
+#endif // _BOPAlgo_PPaveFiller_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPAlgo_PSection.hxx
+++ b/src/Deprecated/TypeAliases/BOPAlgo_PSection.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPAlgo_PSection.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPAlgo_PSection_HeaderFile
+#define _BOPAlgo_PSection_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPAlgo_Section;
+
+Standard_HEADER_DEPRECATED("BOPAlgo_PSection.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPAlgo_PSection is deprecated, use the underlying type directly")
+typedef BOPAlgo_Section* BOPAlgo_PSection;
+
+#endif // _BOPAlgo_PSection_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPAlgo_PWireEdgeSet.hxx
+++ b/src/Deprecated/TypeAliases/BOPAlgo_PWireEdgeSet.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPAlgo_PWireEdgeSet.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPAlgo_PWireEdgeSet_HeaderFile
+#define _BOPAlgo_PWireEdgeSet_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPAlgo_WireEdgeSet;
+
+Standard_HEADER_DEPRECATED("BOPAlgo_PWireEdgeSet.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPAlgo_PWireEdgeSet is deprecated, use the underlying type directly")
+typedef BOPAlgo_WireEdgeSet* BOPAlgo_PWireEdgeSet;
+
+#endif // _BOPAlgo_PWireEdgeSet_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPDS_PDS.hxx
+++ b/src/Deprecated/TypeAliases/BOPDS_PDS.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPDS_PDS.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPDS_PDS_HeaderFile
+#define _BOPDS_PDS_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPDS_DS;
+
+Standard_HEADER_DEPRECATED("BOPDS_PDS.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPDS_PDS is deprecated, use the underlying type directly")
+typedef BOPDS_DS* BOPDS_PDS;
+
+#endif // _BOPDS_PDS_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPDS_PIterator.hxx
+++ b/src/Deprecated/TypeAliases/BOPDS_PIterator.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPDS_PIterator.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPDS_PIterator_HeaderFile
+#define _BOPDS_PIterator_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPDS_Iterator;
+
+Standard_HEADER_DEPRECATED("BOPDS_PIterator.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPDS_PIterator is deprecated, use the underlying type directly")
+typedef BOPDS_Iterator* BOPDS_PIterator;
+
+#endif // _BOPDS_PIterator_HeaderFile

--- a/src/Deprecated/TypeAliases/BOPDS_PIteratorSI.hxx
+++ b/src/Deprecated/TypeAliases/BOPDS_PIteratorSI.hxx
@@ -1,0 +1,33 @@
+// Created by: Peter KURNEV
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BOPDS_PIteratorSI.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BOPDS_PIteratorSI_HeaderFile
+#define _BOPDS_PIteratorSI_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BOPDS_IteratorSI;
+
+Standard_HEADER_DEPRECATED("BOPDS_PIteratorSI.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BOPDS_PIteratorSI is deprecated, use the underlying type directly")
+typedef BOPDS_IteratorSI* BOPDS_PIteratorSI;
+
+#endif // _BOPDS_PIteratorSI_HeaderFile

--- a/src/Deprecated/TypeAliases/BRepOffsetAPI_Sewing.hxx
+++ b/src/Deprecated/TypeAliases/BRepOffsetAPI_Sewing.hxx
@@ -1,0 +1,36 @@
+// Created on: 1999-10-11
+// Created by: Atelier CAS2000
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BRepOffsetAPI_Sewing.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BRepOffsetAPI_Sewing_HeaderFile
+#define _BRepOffsetAPI_Sewing_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+
+//! Sew the shapes along their common edges
+
+Standard_HEADER_DEPRECATED("BRepOffsetAPI_Sewing.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BRepOffsetAPI_Sewing is deprecated, use the underlying type directly")
+typedef BRepBuilderAPI_Sewing BRepOffsetAPI_Sewing;
+
+#endif // _BRepOffsetAPI_Sewing_HeaderFile

--- a/src/Deprecated/TypeAliases/BinObjMgt_PByte.hxx
+++ b/src/Deprecated/TypeAliases/BinObjMgt_PByte.hxx
@@ -1,0 +1,33 @@
+// Created on: 2007-08-10
+// Created by: Vlad ROMASHKO
+// Copyright (c) 2007-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinObjMgt_PByte.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef BinObjMgt_PByte_HeaderFile
+#define BinObjMgt_PByte_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("BinObjMgt_PByte.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinObjMgt_PByte is deprecated, use the underlying type directly")
+typedef uint8_t* BinObjMgt_PByte;
+
+#endif // BinObjMgt_PByte_HeaderFile

--- a/src/Deprecated/TypeAliases/BinObjMgt_PChar.hxx
+++ b/src/Deprecated/TypeAliases/BinObjMgt_PChar.hxx
@@ -1,0 +1,33 @@
+// Created on: 2003-03-24
+// Created by: Michael SAZONOV
+// Copyright (c) 2003-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinObjMgt_PChar.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef BinObjMgt_PChar_HeaderFile
+#define BinObjMgt_PChar_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("BinObjMgt_PChar.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinObjMgt_PChar is deprecated, use the underlying type directly")
+typedef char* BinObjMgt_PChar;
+
+#endif

--- a/src/Deprecated/TypeAliases/BinObjMgt_PExtChar.hxx
+++ b/src/Deprecated/TypeAliases/BinObjMgt_PExtChar.hxx
@@ -1,0 +1,33 @@
+// Created on: 2003-03-24
+// Created by: Michael SAZONOV
+// Copyright (c) 2003-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinObjMgt_PExtChar.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef BinObjMgt_PExtChar_HeaderFile
+#define BinObjMgt_PExtChar_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("BinObjMgt_PExtChar.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinObjMgt_PExtChar is deprecated, use the underlying type directly")
+typedef char16_t* BinObjMgt_PExtChar;
+
+#endif

--- a/src/Deprecated/TypeAliases/BinObjMgt_PInteger.hxx
+++ b/src/Deprecated/TypeAliases/BinObjMgt_PInteger.hxx
@@ -1,0 +1,33 @@
+// Created on: 2002-10-31
+// Created by: Michael SAZONOV
+// Copyright (c) 2002-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinObjMgt_PInteger.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef BinObjMgt_PInteger_HeaderFile
+#define BinObjMgt_PInteger_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("BinObjMgt_PInteger.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinObjMgt_PInteger is deprecated, use the underlying type directly")
+typedef int* BinObjMgt_PInteger;
+
+#endif

--- a/src/Deprecated/TypeAliases/BinObjMgt_PReal.hxx
+++ b/src/Deprecated/TypeAliases/BinObjMgt_PReal.hxx
@@ -1,0 +1,33 @@
+// Created on: 2003-03-24
+// Created by: Michael SAZONOV
+// Copyright (c) 2003-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinObjMgt_PReal.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef BinObjMgt_PReal_HeaderFile
+#define BinObjMgt_PReal_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("BinObjMgt_PReal.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinObjMgt_PReal is deprecated, use the underlying type directly")
+typedef double* BinObjMgt_PReal;
+
+#endif

--- a/src/Deprecated/TypeAliases/BinObjMgt_PShortReal.hxx
+++ b/src/Deprecated/TypeAliases/BinObjMgt_PShortReal.hxx
@@ -1,0 +1,33 @@
+// Created on: 2003-03-24
+// Created by: Michael SAZONOV
+// Copyright (c) 2003-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinObjMgt_PShortReal.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef BinObjMgt_PShortReal_HeaderFile
+#define BinObjMgt_PShortReal_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("BinObjMgt_PShortReal.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinObjMgt_PShortReal is deprecated, use the underlying type directly")
+typedef float* BinObjMgt_PShortReal;
+
+#endif

--- a/src/Deprecated/TypeAliases/BinTools_LocationSetPtr.hxx
+++ b/src/Deprecated/TypeAliases/BinTools_LocationSetPtr.hxx
@@ -1,0 +1,34 @@
+// Created on: 2004-05-11
+// Created by: Sergey ZARITCHNY <szy@opencascade.com>
+// Copyright (c) 2004-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file BinTools_LocationSetPtr.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _BinTools_LocationSetPtr_HeaderFile
+#define _BinTools_LocationSetPtr_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BinTools_LocationSet;
+
+Standard_HEADER_DEPRECATED("BinTools_LocationSetPtr.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("BinTools_LocationSetPtr is deprecated, use the underlying type directly")
+typedef BinTools_LocationSet* BinTools_LocationSetPtr;
+
+#endif // _BinTools_LocationSetPtr_HeaderFile

--- a/src/Deprecated/TypeAliases/CDM_DocumentPointer.hxx
+++ b/src/Deprecated/TypeAliases/CDM_DocumentPointer.hxx
@@ -1,0 +1,35 @@
+// Created on: 1997-05-06
+// Created by: Jean-Louis Frenkel, Remi Lequette
+// Copyright (c) 1997-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file CDM_DocumentPointer.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _CDM_DocumentPointer_HeaderFile
+#define _CDM_DocumentPointer_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class CDM_Document;
+
+Standard_HEADER_DEPRECATED("CDM_DocumentPointer.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("CDM_DocumentPointer is deprecated, use the underlying type directly")
+typedef CDM_Document* CDM_DocumentPointer;
+
+#endif // _CDM_DocumentPointer_HeaderFile

--- a/src/Deprecated/TypeAliases/Draw_PInterp.hxx
+++ b/src/Deprecated/TypeAliases/Draw_PInterp.hxx
@@ -1,0 +1,35 @@
+// Created on: 1995-02-23
+// Created by: Remi LEQUETTE
+// Copyright (c) 1995-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file Draw_PInterp.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _Draw_PInterp_HeaderFile
+#define _Draw_PInterp_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+struct Tcl_Interp;
+
+Standard_HEADER_DEPRECATED("Draw_PInterp.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("Draw_PInterp is deprecated, use the underlying type directly")
+typedef Tcl_Interp* Draw_PInterp;
+
+#endif

--- a/src/Deprecated/TypeAliases/Extrema_CCLocFOfLocECC2d.hxx
+++ b/src/Deprecated/TypeAliases/Extrema_CCLocFOfLocECC2d.hxx
@@ -1,0 +1,50 @@
+// Created on: 1991-02-26
+// Created by: Isabelle GRIGNON
+// Copyright (c) 1991-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file Extrema_CCLocFOfLocECC2d.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _Extrema_CCLocFOfLocECC2d_HeaderFile
+#define _Extrema_CCLocFOfLocECC2d_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Adaptor2d_Curve2d.hxx>
+#include <Extrema_Curve2dTool.hxx>
+#include <Extrema_GFuncExtCC.hxx>
+#include <Extrema_POnCurv2d.hxx>
+#include <NCollection_Sequence.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+
+//! Type alias for 2D curve-curve extremum function.
+
+Standard_HEADER_DEPRECATED("Extrema_CCLocFOfLocECC2d.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("Extrema_CCLocFOfLocECC2d is deprecated, use the underlying type directly")
+typedef Extrema_GFuncExtCC<Adaptor2d_Curve2d,
+                           Extrema_Curve2dTool,
+                           Adaptor2d_Curve2d,
+                           Extrema_Curve2dTool,
+                           Extrema_POnCurv2d,
+                           gp_Pnt2d,
+                           gp_Vec2d,
+                           NCollection_Sequence<Extrema_POnCurv2d>>
+  Extrema_CCLocFOfLocECC2d;
+
+#endif // _Extrema_CCLocFOfLocECC2d_HeaderFile

--- a/src/Deprecated/TypeAliases/Extrema_LocECC2d.hxx
+++ b/src/Deprecated/TypeAliases/Extrema_LocECC2d.hxx
@@ -1,0 +1,44 @@
+// Created on: 1991-02-26
+// Created by: Isabelle GRIGNON
+// Copyright (c) 1991-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file Extrema_LocECC2d.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _Extrema_LocECC2d_HeaderFile
+#define _Extrema_LocECC2d_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Adaptor2d_Curve2d.hxx>
+#include <Extrema_CCLocFOfLocECC2d.hxx>
+#include <Extrema_Curve2dTool.hxx>
+#include <Extrema_GenLocateExtCC.hxx>
+#include <Extrema_POnCurv2d.hxx>
+
+//! Type alias for 2D curve-curve local extremum locator.
+
+Standard_HEADER_DEPRECATED("Extrema_LocECC2d.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("Extrema_LocECC2d is deprecated, use the underlying type directly")
+typedef Extrema_GenLocateExtCC<Adaptor2d_Curve2d,
+                               Extrema_Curve2dTool,
+                               Extrema_POnCurv2d,
+                               Extrema_CCLocFOfLocECC2d>
+  Extrema_LocECC2d;
+
+#endif // _Extrema_LocECC2d_HeaderFile

--- a/src/Deprecated/TypeAliases/FSD_BStream.hxx
+++ b/src/Deprecated/TypeAliases/FSD_BStream.hxx
@@ -1,0 +1,32 @@
+// Copyright (c) 1998-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file FSD_BStream.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _FSD_BStream_HeaderFile
+#define _FSD_BStream_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <stdio.h>
+
+Standard_HEADER_DEPRECATED("FSD_BStream.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("FSD_BStream is deprecated, use the underlying type directly")
+typedef FILE* FSD_BStream;
+
+#endif

--- a/src/Deprecated/TypeAliases/GeomLib_DenominatorMultiplierPtr.hxx
+++ b/src/Deprecated/TypeAliases/GeomLib_DenominatorMultiplierPtr.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-07-07
+// Created by: Jean Claude VAUTHIER
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file GeomLib_DenominatorMultiplierPtr.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _GeomLib_DenominatorMultiplierPtr_HeaderFile
+#define _GeomLib_DenominatorMultiplierPtr_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class GeomLib_DenominatorMultiplier;
+
+Standard_HEADER_DEPRECATED("GeomLib_DenominatorMultiplierPtr.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "GeomLib_DenominatorMultiplierPtr is deprecated, use the underlying type directly")
+typedef GeomLib_DenominatorMultiplier* GeomLib_DenominatorMultiplierPtr;
+
+#endif // _GeomLib_DenominatorMultiplierPtr_HeaderFile

--- a/src/Deprecated/TypeAliases/IntPolyh_PMaillageAffinage.hxx
+++ b/src/Deprecated/TypeAliases/IntPolyh_PMaillageAffinage.hxx
@@ -1,0 +1,35 @@
+// Created on: 1999-03-03
+// Created by: Fabrice SERVANT
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file IntPolyh_PMaillageAffinage.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _IntPolyh_PMaillageAffinage_HeaderFile
+#define _IntPolyh_PMaillageAffinage_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class IntPolyh_MaillageAffinage;
+
+Standard_HEADER_DEPRECATED("IntPolyh_PMaillageAffinage.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("IntPolyh_PMaillageAffinage is deprecated, use the underlying type directly")
+typedef IntPolyh_MaillageAffinage* IntPolyh_PMaillageAffinage;
+
+#endif // _IntPolyh_PMaillageAffinage_HeaderFile

--- a/src/Deprecated/TypeAliases/Interface_ValueInterpret.hxx
+++ b/src/Deprecated/TypeAliases/Interface_ValueInterpret.hxx
@@ -1,0 +1,36 @@
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file Interface_ValueInterpret.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _Interface_ValueInterpret_HeaderFile
+#define _Interface_ValueInterpret_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <TCollection_HAsciiString.hxx>
+
+class Interface_TypedValue;
+
+Standard_HEADER_DEPRECATED("Interface_ValueInterpret.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("Interface_ValueInterpret is deprecated, use the underlying type directly")
+typedef occ::handle<TCollection_HAsciiString> (*Interface_ValueInterpret)(
+  const occ::handle<Interface_TypedValue>&     typval,
+  const occ::handle<TCollection_HAsciiString>& val,
+  const bool                                   native);
+
+#endif

--- a/src/Deprecated/TypeAliases/Interface_ValueSatisfies.hxx
+++ b/src/Deprecated/TypeAliases/Interface_ValueSatisfies.hxx
@@ -1,0 +1,31 @@
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file Interface_ValueSatisfies.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _Interface_ValueSatisfies_HeaderFile
+#define _Interface_ValueSatisfies_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <TCollection_HAsciiString.hxx>
+
+Standard_HEADER_DEPRECATED("Interface_ValueSatisfies.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("Interface_ValueSatisfies is deprecated, use the underlying type directly")
+typedef bool (*Interface_ValueSatisfies)(const occ::handle<TCollection_HAsciiString>& val);
+
+#endif

--- a/src/Deprecated/TypeAliases/LProp_SLProps3d.hxx
+++ b/src/Deprecated/TypeAliases/LProp_SLProps3d.hxx
@@ -1,0 +1,36 @@
+// Created on: 2002-08-02
+// Created by: Alexander KARTOMIN  (akm)
+// Copyright (c) 2002-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file LProp_SLProps3d.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _LProp_SLProps3d_HeaderFile
+#define _LProp_SLProps3d_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Adaptor3d_Surface.hxx>
+#include <GeomLProp_SLProps.hxx>
+
+//! Alias for surface local properties using Adaptor3d_Surface interface.
+
+Standard_HEADER_DEPRECATED("LProp_SLProps3d.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("LProp_SLProps3d is deprecated, use the underlying type directly")
+typedef GeomLProp_SLPropsBase<occ::handle<Adaptor3d_Surface>> LProp_SLProps3d;
+
+#endif // _LProp_SLProps3d_HeaderFile

--- a/src/Deprecated/TypeAliases/ProjLib_HProjectedCurve.hxx
+++ b/src/Deprecated/TypeAliases/ProjLib_HProjectedCurve.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-08-11
+// Created by: Bruno DUMORTIER
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file ProjLib_HProjectedCurve.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _ProjLib_HProjectedCurve_HeaderFile
+#define _ProjLib_HProjectedCurve_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <ProjLib_ProjectedCurve.hxx>
+
+// alias for porting old code
+
+Standard_HEADER_DEPRECATED("ProjLib_HProjectedCurve.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("ProjLib_HProjectedCurve is deprecated, use the underlying type directly")
+typedef ProjLib_ProjectedCurve ProjLib_HProjectedCurve;
+
+#endif // _ProjLib_HProjectedCurve_HeaderFile

--- a/src/Deprecated/TypeAliases/Standard_PByte.hxx
+++ b/src/Deprecated/TypeAliases/Standard_PByte.hxx
@@ -1,0 +1,31 @@
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file Standard_PByte.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _Standard_PByte_HeaderFile
+#define _Standard_PByte_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <Standard_TypeDef.hxx>
+
+Standard_HEADER_DEPRECATED("Standard_PByte.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("Standard_PByte is deprecated, use the underlying type directly")
+typedef uint8_t* Standard_PByte;
+
+#endif

--- a/src/Deprecated/TypeAliases/TDF_LabelNodePtr.hxx
+++ b/src/Deprecated/TypeAliases/TDF_LabelNodePtr.hxx
@@ -1,0 +1,34 @@
+// Created by: DAUTRY Philippe
+// Copyright (c) 1997-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TDF_LabelNodePtr.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TDF_LabelNodePtr_HeaderFile
+#define _TDF_LabelNodePtr_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TDF_LabelNode;
+
+Standard_HEADER_DEPRECATED("TDF_LabelNodePtr.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TDF_LabelNodePtr is deprecated, use the underlying type directly")
+typedef TDF_LabelNode* TDF_LabelNodePtr;
+
+#endif // _TDF_LabelNodePtr_HeaderFile

--- a/src/Deprecated/TypeAliases/TDataStd_PtrTreeNode.hxx
+++ b/src/Deprecated/TypeAliases/TDataStd_PtrTreeNode.hxx
@@ -1,0 +1,35 @@
+// Created on: 1995-05-10
+// Created by: Denis PASCAL
+// Copyright (c) 1995-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TDataStd_PtrTreeNode.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TDataStd_PtrTreeNode_HeaderFile
+#define _TDataStd_PtrTreeNode_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TDataStd_TreeNode;
+
+Standard_HEADER_DEPRECATED("TDataStd_PtrTreeNode.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TDataStd_PtrTreeNode is deprecated, use the underlying type directly")
+typedef TDataStd_TreeNode* TDataStd_PtrTreeNode;
+
+#endif // _TDataStd_PtrTreeNode_HeaderFile

--- a/src/Deprecated/TypeAliases/TDocStd_XLinkPtr.hxx
+++ b/src/Deprecated/TypeAliases/TDocStd_XLinkPtr.hxx
@@ -1,0 +1,35 @@
+// Created on: 1999-04-07
+// Created by: Denis PASCAL
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TDocStd_XLinkPtr.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TDocStd_XLinkPtr_HeaderFile
+#define _TDocStd_XLinkPtr_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TDocStd_XLink;
+
+Standard_HEADER_DEPRECATED("TDocStd_XLinkPtr.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TDocStd_XLinkPtr is deprecated, use the underlying type directly")
+typedef TDocStd_XLink* TDocStd_XLinkPtr;
+
+#endif // _TDocStd_XLinkPtr_HeaderFile

--- a/src/Deprecated/TypeAliases/TNaming_PtrAttribute.hxx
+++ b/src/Deprecated/TypeAliases/TNaming_PtrAttribute.hxx
@@ -1,0 +1,35 @@
+// Created on: 1997-03-17
+// Created by: Yves FRICAUD
+// Copyright (c) 1997-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TNaming_PtrAttribute.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TNaming_PtrAttribute_HeaderFile
+#define _TNaming_PtrAttribute_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TNaming_NamedShape;
+
+Standard_HEADER_DEPRECATED("TNaming_PtrAttribute.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TNaming_PtrAttribute is deprecated, use the underlying type directly")
+typedef TNaming_NamedShape* TNaming_PtrAttribute;
+
+#endif // _TNaming_PtrAttribute_HeaderFile

--- a/src/Deprecated/TypeAliases/TNaming_PtrNode.hxx
+++ b/src/Deprecated/TypeAliases/TNaming_PtrNode.hxx
@@ -1,0 +1,35 @@
+// Created on: 1997-03-17
+// Created by: Yves FRICAUD
+// Copyright (c) 1997-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TNaming_PtrNode.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TNaming_PtrNode_HeaderFile
+#define _TNaming_PtrNode_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TNaming_Node;
+
+Standard_HEADER_DEPRECATED("TNaming_PtrNode.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TNaming_PtrNode is deprecated, use the underlying type directly")
+typedef TNaming_Node* TNaming_PtrNode;
+
+#endif // _TNaming_PtrNode_HeaderFile

--- a/src/Deprecated/TypeAliases/TNaming_PtrRefShape.hxx
+++ b/src/Deprecated/TypeAliases/TNaming_PtrRefShape.hxx
@@ -1,0 +1,35 @@
+// Created on: 1997-03-17
+// Created by: Yves FRICAUD
+// Copyright (c) 1997-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TNaming_PtrRefShape.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TNaming_PtrRefShape_HeaderFile
+#define _TNaming_PtrRefShape_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TNaming_RefShape;
+
+Standard_HEADER_DEPRECATED("TNaming_PtrRefShape.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TNaming_PtrRefShape is deprecated, use the underlying type directly")
+typedef TNaming_RefShape* TNaming_PtrRefShape;
+
+#endif // _TNaming_PtrRefShape_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepBuild_PBuilder.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepBuild_PBuilder.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepBuild_PBuilder.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepBuild_PBuilder_HeaderFile
+#define _TopOpeBRepBuild_PBuilder_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRepBuild_Builder;
+
+Standard_HEADER_DEPRECATED("TopOpeBRepBuild_PBuilder.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRepBuild_PBuilder is deprecated, use the underlying type directly")
+typedef TopOpeBRepBuild_Builder* TopOpeBRepBuild_PBuilder;
+
+#endif // _TopOpeBRepBuild_PBuilder_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepBuild_PGTopo.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepBuild_PGTopo.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepBuild_PGTopo.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepBuild_PGTopo_HeaderFile
+#define _TopOpeBRepBuild_PGTopo_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRepBuild_GTopo;
+
+Standard_HEADER_DEPRECATED("TopOpeBRepBuild_PGTopo.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRepBuild_PGTopo is deprecated, use the underlying type directly")
+typedef TopOpeBRepBuild_GTopo* TopOpeBRepBuild_PGTopo;
+
+#endif // _TopOpeBRepBuild_PGTopo_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepBuild_PWireEdgeSet.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepBuild_PWireEdgeSet.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepBuild_PWireEdgeSet.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepBuild_PWireEdgeSet_HeaderFile
+#define _TopOpeBRepBuild_PWireEdgeSet_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRepBuild_WireEdgeSet;
+
+Standard_HEADER_DEPRECATED("TopOpeBRepBuild_PWireEdgeSet.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "TopOpeBRepBuild_PWireEdgeSet is deprecated, use the underlying type directly")
+typedef TopOpeBRepBuild_WireEdgeSet* TopOpeBRepBuild_PWireEdgeSet;
+
+#endif // _TopOpeBRepBuild_PWireEdgeSet_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepDS_PDataStructure.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepDS_PDataStructure.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepDS_PDataStructure.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepDS_PDataStructure_HeaderFile
+#define _TopOpeBRepDS_PDataStructure_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRepDS_DataStructure;
+
+Standard_HEADER_DEPRECATED("TopOpeBRepDS_PDataStructure.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRepDS_PDataStructure is deprecated, use the underlying type directly")
+typedef TopOpeBRepDS_DataStructure* TopOpeBRepDS_PDataStructure;
+
+#endif // _TopOpeBRepDS_PDataStructure_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepTool_PShapeClassifier.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepTool_PShapeClassifier.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepTool_PShapeClassifier.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepTool_PShapeClassifier_HeaderFile
+#define _TopOpeBRepTool_PShapeClassifier_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRepTool_ShapeClassifier;
+
+Standard_HEADER_DEPRECATED("TopOpeBRepTool_PShapeClassifier.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "TopOpeBRepTool_PShapeClassifier is deprecated, use the underlying type directly")
+typedef TopOpeBRepTool_ShapeClassifier* TopOpeBRepTool_PShapeClassifier;
+
+#endif // _TopOpeBRepTool_PShapeClassifier_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepTool_PSoClassif.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepTool_PSoClassif.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepTool_PSoClassif.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepTool_PSoClassif_HeaderFile
+#define _TopOpeBRepTool_PSoClassif_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class BRepClass3d_SolidClassifier;
+
+Standard_HEADER_DEPRECATED("TopOpeBRepTool_PSoClassif.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRepTool_PSoClassif is deprecated, use the underlying type directly")
+typedef BRepClass3d_SolidClassifier* TopOpeBRepTool_PSoClassif;
+
+#endif // _TopOpeBRepTool_PSoClassif_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRepTool_Plos.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRepTool_Plos.hxx
@@ -1,0 +1,35 @@
+// Created on: 1994-03-10
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1994-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRepTool_Plos.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRepTool_Plos_HeaderFile
+#define _TopOpeBRepTool_Plos_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <TopoDS_Shape.hxx>
+#include <NCollection_List.hxx>
+
+Standard_HEADER_DEPRECATED("TopOpeBRepTool_Plos.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRepTool_Plos is deprecated, use the underlying type directly")
+typedef NCollection_List<TopoDS_Shape>* TopOpeBRepTool_Plos;
+
+#endif // _TopOpeBRepTool_Plos_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PEdgesIntersector.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PEdgesIntersector.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PEdgesIntersector.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PEdgesIntersector_HeaderFile
+#define _TopOpeBRep_PEdgesIntersector_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRep_EdgesIntersector;
+
+Standard_HEADER_DEPRECATED("TopOpeBRep_PEdgesIntersector.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "TopOpeBRep_PEdgesIntersector is deprecated, use the underlying type directly")
+typedef TopOpeBRep_EdgesIntersector* TopOpeBRep_PEdgesIntersector;
+
+#endif // _TopOpeBRep_PEdgesIntersector_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PFacesFiller.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PFacesFiller.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PFacesFiller.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PFacesFiller_HeaderFile
+#define _TopOpeBRep_PFacesFiller_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRep_FacesFiller;
+
+Standard_HEADER_DEPRECATED("TopOpeBRep_PFacesFiller.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRep_PFacesFiller is deprecated, use the underlying type directly")
+typedef TopOpeBRep_FacesFiller* TopOpeBRep_PFacesFiller;
+
+#endif // _TopOpeBRep_PFacesFiller_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PFacesIntersector.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PFacesIntersector.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PFacesIntersector.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PFacesIntersector_HeaderFile
+#define _TopOpeBRep_PFacesIntersector_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRep_FacesIntersector;
+
+Standard_HEADER_DEPRECATED("TopOpeBRep_PFacesIntersector.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "TopOpeBRep_PFacesIntersector is deprecated, use the underlying type directly")
+typedef TopOpeBRep_FacesIntersector* TopOpeBRep_PFacesIntersector;
+
+#endif // _TopOpeBRep_PFacesIntersector_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PIntRes2d_IntersectionPoint.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PIntRes2d_IntersectionPoint.hxx
@@ -1,0 +1,37 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PIntRes2d_IntersectionPoint.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PIntRes2d_IntersectionPoint_HeaderFile
+#define _TopOpeBRep_PIntRes2d_IntersectionPoint_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class IntRes2d_IntersectionPoint;
+
+Standard_HEADER_DEPRECATED(
+  "TopOpeBRep_PIntRes2d_IntersectionPoint.hxx is deprecated since OCCT 8.1.0. "
+  "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "TopOpeBRep_PIntRes2d_IntersectionPoint is deprecated, use the underlying type directly")
+typedef IntRes2d_IntersectionPoint* TopOpeBRep_PIntRes2d_IntersectionPoint;
+
+#endif // _TopOpeBRep_PIntRes2d_IntersectionPoint_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PLineInter.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PLineInter.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PLineInter.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PLineInter_HeaderFile
+#define _TopOpeBRep_PLineInter_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopOpeBRep_LineInter;
+
+Standard_HEADER_DEPRECATED("TopOpeBRep_PLineInter.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRep_PLineInter is deprecated, use the underlying type directly")
+typedef TopOpeBRep_LineInter* TopOpeBRep_PLineInter;
+
+#endif // _TopOpeBRep_PLineInter_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PPntOn2S.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PPntOn2S.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PPntOn2S.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PPntOn2S_HeaderFile
+#define _TopOpeBRep_PPntOn2S_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class IntSurf_PntOn2S;
+
+Standard_HEADER_DEPRECATED("TopOpeBRep_PPntOn2S.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopOpeBRep_PPntOn2S is deprecated, use the underlying type directly")
+typedef IntSurf_PntOn2S* TopOpeBRep_PPntOn2S;
+
+#endif // _TopOpeBRep_PPntOn2S_HeaderFile

--- a/src/Deprecated/TypeAliases/TopOpeBRep_PThePointOfIntersection.hxx
+++ b/src/Deprecated/TypeAliases/TopOpeBRep_PThePointOfIntersection.hxx
@@ -1,0 +1,36 @@
+// Created on: 1993-06-17
+// Created by: Jean Yves LEBEY
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopOpeBRep_PThePointOfIntersection.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopOpeBRep_PThePointOfIntersection_HeaderFile
+#define _TopOpeBRep_PThePointOfIntersection_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class IntPatch_Point;
+
+Standard_HEADER_DEPRECATED("TopOpeBRep_PThePointOfIntersection.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED(
+    "TopOpeBRep_PThePointOfIntersection is deprecated, use the underlying type directly")
+typedef IntPatch_Point* TopOpeBRep_PThePointOfIntersection;
+
+#endif // _TopOpeBRep_PThePointOfIntersection_HeaderFile

--- a/src/Deprecated/TypeAliases/TopTools_LocationSetPtr.hxx
+++ b/src/Deprecated/TypeAliases/TopTools_LocationSetPtr.hxx
@@ -1,0 +1,35 @@
+// Created on: 1993-01-14
+// Created by: Remi LEQUETTE
+// Copyright (c) 1993-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file TopTools_LocationSetPtr.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _TopTools_LocationSetPtr_HeaderFile
+#define _TopTools_LocationSetPtr_HeaderFile
+
+#include <Standard_Macro.hxx>
+
+class TopTools_LocationSet;
+
+Standard_HEADER_DEPRECATED("TopTools_LocationSetPtr.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("TopTools_LocationSetPtr is deprecated, use the underlying type directly")
+typedef TopTools_LocationSet* TopTools_LocationSetPtr;
+
+#endif // _TopTools_LocationSetPtr_HeaderFile

--- a/src/Deprecated/TypeAliases/XCAFDoc_PartId.hxx
+++ b/src/Deprecated/TypeAliases/XCAFDoc_PartId.hxx
@@ -1,0 +1,32 @@
+// Copyright (c) 1998-1999 Matra Datavision
+// Copyright (c) 1999-2017 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+//! @file XCAFDoc_PartId.hxx
+//! @brief Deprecated typedef for backward compatibility.
+//! @deprecated This header is deprecated since OCCT 8.1.0.
+//!             Use the underlying type directly instead.
+
+#ifndef _XCAFDoc_PartId_HeaderFile
+#define _XCAFDoc_PartId_HeaderFile
+
+#include <Standard_Macro.hxx>
+#include <TCollection_AsciiString.hxx>
+
+Standard_HEADER_DEPRECATED("XCAFDoc_PartId.hxx is deprecated since OCCT 8.1.0. "
+                           "Use the underlying type directly instead.")
+
+  Standard_DEPRECATED("XCAFDoc_PartId is deprecated, use the underlying type directly")
+typedef TCollection_AsciiString XCAFDoc_PartId;
+
+#endif // _XCAFDoc_PartId_HeaderFile


### PR DESCRIPTION
- Restore compatibility headers for removed typedef-only declarations.
- Mark restored headers and aliases deprecated since OCCT 8.1.0.
- Group legacy typedefs under Deprecated/TypeAliases.
- Keep aliases of fully removed classes excluded.