### PR TITLE
Shape Healing - Restore removed connectivity and sewing tools

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/FILES.cmake
@@ -7,8 +7,11 @@ set(OCCT_TKShHealing_GTests_FILES
   ShapeAnalysis_FreeBounds_Test.cxx
   ShapeBuild_ReShape_Test.cxx
   ShapeConstruct_ProjectCurveOnSurface_Test.cxx
+  ShapeFix_EdgeConnect_Test.cxx
   ShapeFix_Face_Test.cxx
+  ShapeFix_FaceConnect_Test.cxx
   ShapeFix_Shape_Test.cxx
   ShapeUpgrade_FaceDivide_Test.cxx
+  ShapeUpgrade_ShellSewing_Test.cxx
   ShapeUpgrade_UnifySameDomain_Test.cxx
 )

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_EdgeConnect_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_EdgeConnect_Test.cxx
@@ -1,0 +1,394 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRepGProp.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <Geom_Curve.hxx>
+#include <GProp_GProps.hxx>
+#include <Precision.hxx>
+#include <ShapeFix_EdgeConnect.hxx>
+#include <TopExp.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <TopoDS_Wire.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+//=================================================================================================
+
+TopoDS_Edge makeEdge(const gp_Pnt& theFirst, const gp_Pnt& theLast)
+{
+  return BRepBuilderAPI_MakeEdge(theFirst, theLast).Edge();
+}
+
+//=================================================================================================
+
+gp_Pnt orientedFirstPoint(const TopoDS_Edge& theEdge)
+{
+  return BRep_Tool::Pnt(TopExp::FirstVertex(theEdge, true));
+}
+
+//=================================================================================================
+
+gp_Pnt orientedLastPoint(const TopoDS_Edge& theEdge)
+{
+  return BRep_Tool::Pnt(TopExp::LastVertex(theEdge, true));
+}
+
+//=================================================================================================
+
+double totalLength(const TopoDS_Shape& theShape)
+{
+  GProp_GProps aProperties;
+  BRepGProp::LinearProperties(theShape, aProperties);
+  return aProperties.Mass();
+}
+} // namespace
+
+//=================================================================================================
+
+TEST(ShapeFix_EdgeConnectTest, ConnectsPairAtBoundingBoxMidpoint)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint1 = TopExp::LastVertex(anEdge1, true);
+  const TopoDS_Vertex aJoint2 = TopExp::FirstVertex(anEdge2, true);
+  ASSERT_TRUE(aJoint1.IsSame(aJoint2));
+  EXPECT_NEAR(BRep_Tool::Pnt(aJoint1).X(), 1.1, Precision::Confusion());
+  EXPECT_NEAR(BRep_Tool::Tolerance(aJoint1), 0.10001, Precision::Confusion());
+  EXPECT_NEAR(orientedFirstPoint(anEdge1).X(), 0.0, Precision::Confusion());
+  EXPECT_NEAR(orientedLastPoint(anEdge2).X(), 2.0, Precision::Confusion());
+}
+
+TEST(ShapeFix_EdgeConnectTest, HonorsEdgeOrientation)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(2.0, 0.0, 0.0), gp_Pnt(3.0, 0.0, 0.0));
+  anEdge1.Reverse();
+  anEdge2.Reverse();
+  const gp_Pnt anExpected =
+    gp_Pnt((orientedLastPoint(anEdge1).XYZ() + orientedFirstPoint(anEdge2).XYZ()) * 0.5);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint1 = TopExp::LastVertex(anEdge1, true);
+  const TopoDS_Vertex aJoint2 = TopExp::FirstVertex(anEdge2, true);
+  ASSERT_TRUE(aJoint1.IsSame(aJoint2));
+  EXPECT_TRUE(BRep_Tool::Pnt(aJoint1).IsEqual(anExpected, Precision::Confusion()));
+}
+
+TEST(ShapeFix_EdgeConnectTest, MergesExistingConnectivityGroups)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  TopoDS_Edge anEdge3 = makeEdge(gp_Pnt(3.0, 0.0, 0.0), gp_Pnt(4.0, 0.0, 0.0));
+  TopoDS_Edge anEdge4 = makeEdge(gp_Pnt(4.1, 0.0, 0.0), gp_Pnt(5.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Add(anEdge3, anEdge4);
+  aConnector.Add(TopoDS::Edge(anEdge2.Reversed()), TopoDS::Edge(anEdge3.Reversed()));
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint = TopExp::LastVertex(anEdge1, true);
+  EXPECT_TRUE(aJoint.IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_TRUE(aJoint.IsSame(TopExp::LastVertex(anEdge3, true)));
+  EXPECT_TRUE(aJoint.IsSame(TopExp::FirstVertex(anEdge4, true)));
+  EXPECT_NEAR(BRep_Tool::Pnt(aJoint).X(), 2.55, Precision::Confusion());
+}
+
+TEST(ShapeFix_EdgeConnectTest, AddsAllConsecutiveEdgesOfOpenWire)
+{
+  TopoDS_Edge  anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge  anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  TopoDS_Edge  anEdge3 = makeEdge(gp_Pnt(2.1, 0.0, 0.0), gp_Pnt(3.0, 0.0, 0.0));
+  BRep_Builder aBuilder;
+  TopoDS_Wire  aWire;
+  aBuilder.MakeWire(aWire);
+  aBuilder.Add(aWire, anEdge1);
+  aBuilder.Add(aWire, anEdge2);
+  aBuilder.Add(aWire, anEdge3);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(aWire);
+  aConnector.Build();
+
+  EXPECT_TRUE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_TRUE(TopExp::LastVertex(anEdge2, true).IsSame(TopExp::FirstVertex(anEdge3, true)));
+  EXPECT_FALSE(TopExp::FirstVertex(anEdge1, true).IsSame(TopExp::LastVertex(anEdge3, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, ConnectsLastAndFirstEdgesOfClosedWire)
+{
+  TopoDS_Edge  anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge  anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(0.5, 1.0, 0.0));
+  TopoDS_Edge  anEdge3 = makeEdge(gp_Pnt(0.4, 1.0, 0.0), gp_Pnt(0.0, 0.1, 0.0));
+  BRep_Builder aBuilder;
+  TopoDS_Wire  aWire;
+  aBuilder.MakeWire(aWire);
+  aBuilder.Add(aWire, anEdge1);
+  aBuilder.Add(aWire, anEdge2);
+  aBuilder.Add(aWire, anEdge3);
+  aWire.Closed(true);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(aWire);
+  aConnector.Build();
+
+  EXPECT_TRUE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_TRUE(TopExp::LastVertex(anEdge2, true).IsSame(TopExp::FirstVertex(anEdge3, true)));
+  EXPECT_TRUE(TopExp::LastVertex(anEdge3, true).IsSame(TopExp::FirstVertex(anEdge1, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, RepeatedAddIsIdempotent)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  EXPECT_TRUE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_NEAR(BRep_Tool::Pnt(TopExp::LastVertex(anEdge1, true)).X(), 1.1, Precision::Confusion());
+}
+
+TEST(ShapeFix_EdgeConnectTest, ClearDiscardsPendingConnections)
+{
+  TopoDS_Edge         anEdge1     = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge         anEdge2     = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  const TopoDS_Vertex anOriginal1 = TopExp::LastVertex(anEdge1, true);
+  const TopoDS_Vertex anOriginal2 = TopExp::FirstVertex(anEdge2, true);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Clear();
+  aConnector.Build();
+
+  EXPECT_TRUE(anOriginal1.IsSame(TopExp::LastVertex(anEdge1, true)));
+  EXPECT_TRUE(anOriginal2.IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_FALSE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, BuildClearsCompletedConnections)
+{
+  TopoDS_Edge          anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge          anEdge2 = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  TopoDS_Edge anEdge3 = makeEdge(gp_Pnt(3.0, 0.0, 0.0), gp_Pnt(4.0, 0.0, 0.0));
+  TopoDS_Edge anEdge4 = makeEdge(gp_Pnt(4.2, 0.0, 0.0), gp_Pnt(5.0, 0.0, 0.0));
+  aConnector.Build();
+
+  EXPECT_FALSE(TopExp::LastVertex(anEdge3, true).IsSame(TopExp::FirstVertex(anEdge4, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, UsesConfusionAsMinimumTolerance)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.0, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint = TopExp::LastVertex(anEdge1, true);
+  ASSERT_TRUE(aJoint.IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_NEAR(BRep_Tool::Tolerance(aJoint), Precision::Confusion(), Precision::PConfusion());
+}
+
+TEST(ShapeFix_EdgeConnectTest, ComputesThreeDimensionalBoundingBoxCenter)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(-1.0, -2.0, -3.0), gp_Pnt(1.0, 2.0, 3.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(5.0, 8.0, 11.0), gp_Pnt(6.0, 9.0, 12.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint = TopExp::LastVertex(anEdge1, true);
+  const gp_Pnt        aPoint = BRep_Tool::Pnt(aJoint);
+  EXPECT_TRUE(aPoint.IsEqual(gp_Pnt(3.0, 5.0, 7.0), Precision::Confusion()));
+  EXPECT_NEAR(BRep_Tool::Tolerance(aJoint),
+              gp_Pnt(1.0, 2.0, 3.0).Distance(gp_Pnt(3.0, 5.0, 7.0)) * 1.0001,
+              Precision::Confusion());
+}
+
+TEST(ShapeFix_EdgeConnectTest, AppendsUnboundVertexToExistingGroup)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  TopoDS_Edge anEdge3 = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(3.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Add(TopoDS::Edge(anEdge2.Reversed()), anEdge3);
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint = TopExp::LastVertex(anEdge1, true);
+  EXPECT_TRUE(aJoint.IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_TRUE(aJoint.IsSame(TopExp::FirstVertex(anEdge3, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, PrependsUnboundVertexToExistingGroup)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(0.9, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.0, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  TopoDS_Edge anEdge3 = makeEdge(gp_Pnt(2.1, 0.0, 0.0), gp_Pnt(3.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge2, anEdge3);
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  const TopoDS_Vertex aJoint = TopExp::LastVertex(anEdge1, true);
+  EXPECT_TRUE(aJoint.IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_FALSE(aJoint.IsSame(TopExp::LastVertex(anEdge2, true)));
+  EXPECT_TRUE(TopExp::LastVertex(anEdge2, true).IsSame(TopExp::FirstVertex(anEdge3, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, ProcessesMultipleWiresIndependently)
+{
+  TopoDS_Edge  anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge  anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  TopoDS_Edge  anEdge3 = makeEdge(gp_Pnt(10.0, 0.0, 0.0), gp_Pnt(11.0, 0.0, 0.0));
+  TopoDS_Edge  anEdge4 = makeEdge(gp_Pnt(11.1, 0.0, 0.0), gp_Pnt(12.0, 0.0, 0.0));
+  BRep_Builder aBuilder;
+  TopoDS_Wire  aWire1;
+  TopoDS_Wire  aWire2;
+  aBuilder.MakeWire(aWire1);
+  aBuilder.MakeWire(aWire2);
+  aBuilder.Add(aWire1, anEdge1);
+  aBuilder.Add(aWire1, anEdge2);
+  aBuilder.Add(aWire2, anEdge3);
+  aBuilder.Add(aWire2, anEdge4);
+  TopoDS_Compound aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, aWire1);
+  aBuilder.Add(aCompound, aWire2);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(aCompound);
+  aConnector.Build();
+
+  EXPECT_TRUE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_TRUE(TopExp::LastVertex(anEdge3, true).IsSame(TopExp::FirstVertex(anEdge4, true)));
+  EXPECT_FALSE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge4, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, IgnoresEdgesOutsideWiresInShapeOverload)
+{
+  TopoDS_Edge     anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge     anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  BRep_Builder    aBuilder;
+  TopoDS_Compound aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, anEdge1);
+  aBuilder.Add(aCompound, anEdge2);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(aCompound);
+  aConnector.Build();
+
+  EXPECT_FALSE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, AcceptsEmptyWire)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Wire  anEmptyWire;
+  aBuilder.MakeWire(anEmptyWire);
+
+  ShapeFix_EdgeConnect aConnector;
+  EXPECT_NO_THROW(aConnector.Add(anEmptyWire));
+  EXPECT_NO_THROW(aConnector.Build());
+}
+
+TEST(ShapeFix_EdgeConnectTest, CanBeReusedAfterBuild)
+{
+  TopoDS_Edge anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge anEdge2 = makeEdge(gp_Pnt(1.1, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  TopoDS_Edge anEdge3 = makeEdge(gp_Pnt(3.0, 0.0, 0.0), gp_Pnt(4.0, 0.0, 0.0));
+  TopoDS_Edge anEdge4 = makeEdge(gp_Pnt(4.1, 0.0, 0.0), gp_Pnt(5.0, 0.0, 0.0));
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+  aConnector.Add(anEdge3, anEdge4);
+  aConnector.Build();
+
+  EXPECT_TRUE(TopExp::LastVertex(anEdge1, true).IsSame(TopExp::FirstVertex(anEdge2, true)));
+  EXPECT_TRUE(TopExp::LastVertex(anEdge3, true).IsSame(TopExp::FirstVertex(anEdge4, true)));
+}
+
+TEST(ShapeFix_EdgeConnectTest, PreservesUnderlyingCurves)
+{
+  TopoDS_Edge                   anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge                   anEdge2 = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  double                        aFirst1 = 0.0;
+  double                        aLast1  = 0.0;
+  const occ::handle<Geom_Curve> aCurve1 = BRep_Tool::Curve(anEdge1, aFirst1, aLast1);
+  double                        aFirst2 = 0.0;
+  double                        aLast2  = 0.0;
+  const occ::handle<Geom_Curve> aCurve2 = BRep_Tool::Curve(anEdge2, aFirst2, aLast2);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+
+  double aNewFirst = 0.0;
+  double aNewLast  = 0.0;
+  EXPECT_TRUE(BRep_Tool::Curve(anEdge1, aNewFirst, aNewLast) == aCurve1);
+  EXPECT_DOUBLE_EQ(aNewFirst, aFirst1);
+  EXPECT_DOUBLE_EQ(aNewLast, aLast1);
+  EXPECT_TRUE(BRep_Tool::Curve(anEdge2, aNewFirst, aNewLast) == aCurve2);
+  EXPECT_DOUBLE_EQ(aNewFirst, aFirst2);
+  EXPECT_DOUBLE_EQ(aNewLast, aLast2);
+}
+
+TEST(ShapeFix_EdgeConnectTest, PreservesTotalLengthAgainstReference)
+{
+  TopoDS_Edge     anEdge1 = makeEdge(gp_Pnt(0.0, 0.0, 0.0), gp_Pnt(1.0, 0.0, 0.0));
+  TopoDS_Edge     anEdge2 = makeEdge(gp_Pnt(1.2, 0.0, 0.0), gp_Pnt(2.0, 0.0, 0.0));
+  BRep_Builder    aBuilder;
+  TopoDS_Compound aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, anEdge1);
+  aBuilder.Add(aCompound, anEdge2);
+  const double anInputLength = totalLength(aCompound);
+
+  ShapeFix_EdgeConnect aConnector;
+  aConnector.Add(anEdge1, anEdge2);
+  aConnector.Build();
+  const double aResultLength = totalLength(aCompound);
+
+  EXPECT_NEAR(anInputLength, 1.8, Precision::Confusion());
+  EXPECT_NEAR(aResultLength, anInputLength, Precision::Confusion());
+  EXPECT_NEAR(aResultLength, 1.8, Precision::Confusion());
+}

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_FaceConnect_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_FaceConnect_Test.cxx
@@ -1,0 +1,340 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRepGProp.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <gp_Pnt.hxx>
+#include <GProp_GProps.hxx>
+#include <NCollection_Map.hxx>
+#include <ShapeFix_FaceConnect.hxx>
+#include <TopExp.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shell.hxx>
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+
+namespace
+{
+//=================================================================================================
+
+TopoDS_Face makeRectangle(const double theXMin, const double theXMax)
+{
+  BRepBuilderAPI_MakePolygon aPolygon;
+  aPolygon.Add(gp_Pnt(theXMin, 0.0, 0.0));
+  aPolygon.Add(gp_Pnt(theXMax, 0.0, 0.0));
+  aPolygon.Add(gp_Pnt(theXMax, 1.0, 0.0));
+  aPolygon.Add(gp_Pnt(theXMin, 1.0, 0.0));
+  aPolygon.Close();
+  return BRepBuilderAPI_MakeFace(aPolygon.Wire()).Face();
+}
+
+//=================================================================================================
+
+TopoDS_Shell makeShell(const TopoDS_Face& theFace1, const TopoDS_Face& theFace2)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Shell aShell;
+  aBuilder.MakeShell(aShell);
+  aBuilder.Add(aShell, theFace1);
+  aBuilder.Add(aShell, theFace2);
+  return aShell;
+}
+
+//=================================================================================================
+
+TopoDS_Shell makeShell(std::initializer_list<TopoDS_Face> theFaces)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Shell aShell;
+  aBuilder.MakeShell(aShell);
+  for (const TopoDS_Face& aFace : theFaces)
+  {
+    aBuilder.Add(aShell, aFace);
+  }
+  return aShell;
+}
+
+//=================================================================================================
+
+size_t countUniqueEdges(const TopoDS_Shape& theShape)
+{
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> anEdges;
+  for (TopExp_Explorer anEdgeExplorer(theShape, TopAbs_EDGE); anEdgeExplorer.More();
+       anEdgeExplorer.Next())
+  {
+    anEdges.Add(anEdgeExplorer.Current());
+  }
+  return anEdges.Extent();
+}
+
+//=================================================================================================
+
+double surfaceArea(const TopoDS_Shape& theShape)
+{
+  GProp_GProps aProperties;
+  BRepGProp::SurfaceProperties(theShape, aProperties);
+  return aProperties.Mass();
+}
+} // namespace
+
+//=================================================================================================
+
+TEST(ShapeFix_FaceConnectTest, RejectsNullFaces)
+{
+  ShapeFix_FaceConnect aConnector;
+  const TopoDS_Face    aFace = makeRectangle(0.0, 1.0);
+  const TopoDS_Face    aNullFace;
+
+  EXPECT_FALSE(aConnector.Add(aNullFace, aFace));
+  EXPECT_FALSE(aConnector.Add(aFace, aNullFace));
+  EXPECT_FALSE(aConnector.Add(aNullFace, aNullFace));
+}
+
+TEST(ShapeFix_FaceConnectTest, AcceptsSelfAndDuplicateConnections)
+{
+  ShapeFix_FaceConnect aConnector;
+  const TopoDS_Face    aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face    aFace2 = makeRectangle(1.0, 2.0);
+
+  EXPECT_TRUE(aConnector.Add(aFace1, aFace1));
+  EXPECT_TRUE(aConnector.Add(aFace1, aFace2));
+  EXPECT_TRUE(aConnector.Add(aFace1, aFace2));
+}
+
+TEST(ShapeFix_FaceConnectTest, NoConnectionsReturnOriginalShell)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  const TopoDS_Shell   aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_TRUE(aResult.IsSame(aShell));
+  EXPECT_EQ(countUniqueEdges(aResult), 8);
+}
+
+TEST(ShapeFix_FaceConnectTest, ConnectsCoincidentBoundaries)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const double       anInputArea = surfaceArea(aShell);
+  const TopoDS_Shell aResult     = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 7);
+  EXPECT_NEAR(anInputArea, 2.0, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), anInputArea, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), 2.0, 1.0e-12);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeFix_FaceConnectTest, ConnectsBoundariesWithinSewingTolerance)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0001, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const double       anInputArea = surfaceArea(aShell);
+  const TopoDS_Shell aResult     = aConnector.Build(aShell, 1.0e-3, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 7);
+  EXPECT_NEAR(anInputArea, 1.9999, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), anInputArea, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), 1.9999, 1.0e-12);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeFix_FaceConnectTest, LeavesBoundariesBeyondSewingToleranceSeparate)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.01, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-4, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 8);
+}
+
+TEST(ShapeFix_FaceConnectTest, ClearDiscardsConnections)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  aConnector.Clear();
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_TRUE(aResult.IsSame(aShell));
+  EXPECT_EQ(countUniqueEdges(aResult), 8);
+}
+
+TEST(ShapeFix_FaceConnectTest, CanBeReusedAfterClear)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  aConnector.Clear();
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 7);
+}
+
+TEST(ShapeFix_FaceConnectTest, EmptyShellIsReturnedUnchanged)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Shell anEmptyShell;
+  aBuilder.MakeShell(anEmptyShell);
+
+  ShapeFix_FaceConnect aConnector;
+  const TopoDS_Shell   aResult = aConnector.Build(anEmptyShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_TRUE(aResult.IsSame(anEmptyShell));
+  EXPECT_EQ(countUniqueEdges(aResult), 0);
+}
+
+TEST(ShapeFix_FaceConnectTest, SelfConnectionPreservesSingleFaceTopology)
+{
+  const TopoDS_Face aFace = makeRectangle(0.0, 1.0);
+  BRep_Builder      aBuilder;
+  TopoDS_Shell      aShell;
+  aBuilder.MakeShell(aShell);
+  aBuilder.Add(aShell, aFace);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace, aFace));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 4);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeFix_FaceConnectTest, ConnectsReversedFaces)
+{
+  TopoDS_Face aFace1 = makeRectangle(0.0, 1.0);
+  TopoDS_Face aFace2 = makeRectangle(1.0, 2.0);
+  aFace1.Reverse();
+  aFace2.Reverse();
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 7);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeFix_FaceConnectTest, ConnectsThreeFaceChain)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Face  aFace3 = makeRectangle(2.0, 3.0);
+  const TopoDS_Shell aShell = makeShell({aFace1, aFace2, aFace3});
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  ASSERT_TRUE(aConnector.Add(aFace2, aFace3));
+  const double       anInputArea = surfaceArea(aShell);
+  const TopoDS_Shell aResult     = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 10);
+  EXPECT_NEAR(anInputArea, 3.0, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), anInputArea, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), 3.0, 1.0e-12);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeFix_FaceConnectTest, LeavesUnregisteredThirdFaceSeparate)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Face  aFace3 = makeRectangle(2.0, 3.0);
+  const TopoDS_Shell aShell = makeShell({aFace1, aFace2, aFace3});
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 11);
+}
+
+TEST(ShapeFix_FaceConnectTest, ConnectsTwoIndependentFacePairs)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Face  aFace3 = makeRectangle(10.0, 11.0);
+  const TopoDS_Face  aFace4 = makeRectangle(11.0, 12.0);
+  const TopoDS_Shell aShell = makeShell({aFace1, aFace2, aFace3, aFace4});
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  ASSERT_TRUE(aConnector.Add(aFace3, aFace4));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 14);
+  // A shell with disconnected components is invalid by construction; sewing
+  // the two requested pairs must not hide that input condition.
+  EXPECT_FALSE(BRepCheck_Analyzer(aShell).IsValid());
+  EXPECT_FALSE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeFix_FaceConnectTest, DuplicateConnectionDoesNotChangeResult)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  ASSERT_TRUE(aConnector.Add(aFace2, aFace1));
+  const TopoDS_Shell aResult = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult), 7);
+}
+
+TEST(ShapeFix_FaceConnectTest, RebuildingResultIsStable)
+{
+  const TopoDS_Face  aFace1 = makeRectangle(0.0, 1.0);
+  const TopoDS_Face  aFace2 = makeRectangle(1.0, 2.0);
+  const TopoDS_Shell aShell = makeShell(aFace1, aFace2);
+
+  ShapeFix_FaceConnect aConnector;
+  ASSERT_TRUE(aConnector.Add(aFace1, aFace2));
+  const TopoDS_Shell aResult1 = aConnector.Build(aShell, 1.0e-6, 1.0e-7);
+  const TopoDS_Shell aResult2 = aConnector.Build(aResult1, 1.0e-6, 1.0e-7);
+
+  EXPECT_EQ(countUniqueEdges(aResult1), 7);
+  EXPECT_EQ(countUniqueEdges(aResult2), 7);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult2).IsValid());
+}

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_FaceConnect_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeFix_FaceConnect_Test.cxx
@@ -21,6 +21,7 @@
 #include <NCollection_Map.hxx>
 #include <ShapeFix_FaceConnect.hxx>
 #include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
 #include <TopTools_ShapeMapHasher.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Shell.hxx>

--- a/src/ModelingAlgorithms/TKShHealing/GTests/ShapeUpgrade_ShellSewing_Test.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/GTests/ShapeUpgrade_ShellSewing_Test.cxx
@@ -1,0 +1,322 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRepGProp.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <gp_Pnt.hxx>
+#include <GProp_GProps.hxx>
+#include <NCollection_Map.hxx>
+#include <ShapeUpgrade_ShellSewing.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Compound.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Solid.hxx>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+//=================================================================================================
+
+TopoDS_Face makeRectangle(const double theXMin, const double theXMax)
+{
+  BRepBuilderAPI_MakePolygon aPolygon;
+  aPolygon.Add(gp_Pnt(theXMin, 0.0, 0.0));
+  aPolygon.Add(gp_Pnt(theXMax, 0.0, 0.0));
+  aPolygon.Add(gp_Pnt(theXMax, 1.0, 0.0));
+  aPolygon.Add(gp_Pnt(theXMin, 1.0, 0.0));
+  aPolygon.Close();
+  return BRepBuilderAPI_MakeFace(aPolygon.Wire()).Face();
+}
+
+//=================================================================================================
+
+TopoDS_Shell makeShell(const TopoDS_Face& theFace1, const TopoDS_Face& theFace2)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Shell aShell;
+  aBuilder.MakeShell(aShell);
+  aBuilder.Add(aShell, theFace1);
+  aBuilder.Add(aShell, theFace2);
+  return aShell;
+}
+
+//=================================================================================================
+
+size_t countSubShapes(const TopoDS_Shape& theShape, const TopAbs_ShapeEnum theType)
+{
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aSubShapes;
+  for (TopExp_Explorer aSubShapeExplorer(theShape, theType); aSubShapeExplorer.More();
+       aSubShapeExplorer.Next())
+  {
+    aSubShapes.Add(aSubShapeExplorer.Current());
+  }
+  return aSubShapes.Extent();
+}
+
+//=================================================================================================
+
+double surfaceArea(const TopoDS_Shape& theShape)
+{
+  GProp_GProps aProperties;
+  BRepGProp::SurfaceProperties(theShape, aProperties);
+  return aProperties.Mass();
+}
+} // namespace
+
+//=================================================================================================
+
+TEST(ShapeUpgrade_ShellSewingTest, NullInputReturnsNull)
+{
+  ShapeUpgrade_ShellSewing aSewer;
+  EXPECT_TRUE(aSewer.ApplySewing(TopoDS_Shape()).IsNull());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, ShapeWithoutShellReturnsNull)
+{
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Face        aFace = makeRectangle(0.0, 1.0);
+
+  EXPECT_TRUE(aSewer.ApplySewing(aFace, 1.0e-6).IsNull());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, EmptyShellReturnsNull)
+{
+  BRep_Builder aBuilder;
+  TopoDS_Shell anEmptyShell;
+  aBuilder.MakeShell(anEmptyShell);
+
+  ShapeUpgrade_ShellSewing aSewer;
+  EXPECT_TRUE(aSewer.ApplySewing(anEmptyShell, 1.0e-6).IsNull());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, SewsOpenShellWithExplicitTolerance)
+{
+  const TopoDS_Shell aShell      = makeShell(makeRectangle(0.0, 1.0), makeRectangle(1.0001, 2.0));
+  const double       anInputArea = surfaceArea(aShell);
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aShell, 1.0e-3);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 2);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_EDGE), 7);
+  EXPECT_NEAR(anInputArea, 1.9999, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), anInputArea, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), 1.9999, 1.0e-12);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, AutomaticTolerancePreservesValidBox)
+{
+  const TopoDS_Shape aBox        = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+  const double       anInputArea = surfaceArea(aBox);
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aBox);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_SOLID), 1);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 6);
+  EXPECT_NEAR(anInputArea, 52.0, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), anInputArea, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), 52.0, 1.0e-12);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, ExplicitTolerancePreservesValidBox)
+{
+  const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aBox, 1.0e-5);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_SOLID), 1);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 6);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, ReorientsInsideOutSolid)
+{
+  TopoDS_Solid aSolid = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Solid();
+  aSolid.Reverse();
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aSolid, 1.0e-6);
+  ASSERT_FALSE(aResult.IsNull());
+  ASSERT_EQ(countSubShapes(aResult, TopAbs_SOLID), 1);
+
+  const TopoDS_Solid aResultSolid = TopoDS::Solid(TopExp_Explorer(aResult, TopAbs_SOLID).Current());
+  BRepClass3d_SolidClassifier aClassifier(aResultSolid);
+  aClassifier.PerformInfinitePoint(1.0e-6);
+  EXPECT_EQ(aClassifier.State(), TopAbs_OUT);
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, ProcessesMultipleShellsInCompound)
+{
+  const TopoDS_Shape aBox1 = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+  const TopoDS_Shape aBox2 = BRepPrimAPI_MakeBox(gp_Pnt(10.0, 0.0, 0.0), 2.0, 3.0, 4.0).Shape();
+  BRep_Builder       aBuilder;
+  TopoDS_Compound    aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, aBox1);
+  aBuilder.Add(aCompound, aBox2);
+  const double anInputArea = surfaceArea(aCompound);
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aCompound, 1.0e-6);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_SOLID), 2);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_SHELL), 2);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 12);
+  EXPECT_NEAR(anInputArea, 104.0, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), anInputArea, 1.0e-12);
+  EXPECT_NEAR(surfaceArea(aResult), 104.0, 1.0e-12);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, InstanceCanProcessSuccessiveShapes)
+{
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape aResult1 = aSewer.ApplySewing(BRepPrimAPI_MakeBox(1.0, 2.0, 3.0).Shape());
+  const TopoDS_Shape aResult2 =
+    aSewer.ApplySewing(BRepPrimAPI_MakeBox(gp_Pnt(10.0, 0.0, 0.0), 4.0, 5.0, 6.0).Shape());
+
+  ASSERT_FALSE(aResult1.IsNull());
+  ASSERT_FALSE(aResult2.IsNull());
+  EXPECT_EQ(countSubShapes(aResult2, TopAbs_SOLID), 1);
+  EXPECT_EQ(countSubShapes(aResult2, TopAbs_FACE), 6);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult2).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, SewsExactlyCoincidentOpenShell)
+{
+  const TopoDS_Shell aShell = makeShell(makeRectangle(0.0, 1.0), makeRectangle(1.0, 2.0));
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aShell, 1.0e-7);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 2);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_EDGE), 7);
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, KeepsEdgesBeyondExplicitToleranceSeparate)
+{
+  const TopoDS_Shell aShell = makeShell(makeRectangle(0.0, 1.0), makeRectangle(1.01, 2.0));
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aShell, 1.0e-4);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 2);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_EDGE), 8);
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, NegativeToleranceUsesAutomaticTolerance)
+{
+  const TopoDS_Shape aBox = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aBox, -1.0);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_SOLID), 1);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 6);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, CompoundWithoutShellReturnsNull)
+{
+  BRep_Builder    aBuilder;
+  TopoDS_Compound aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, makeRectangle(0.0, 1.0));
+  aBuilder.Add(aCompound, makeRectangle(2.0, 3.0));
+
+  ShapeUpgrade_ShellSewing aSewer;
+  EXPECT_TRUE(aSewer.ApplySewing(aCompound, 1.0e-6).IsNull());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, PreservesFaceOutsideProcessedShell)
+{
+  const TopoDS_Shell aShell          = makeShell(makeRectangle(0.0, 1.0), makeRectangle(1.0, 2.0));
+  const TopoDS_Face  aStandaloneFace = makeRectangle(10.0, 11.0);
+  BRep_Builder       aBuilder;
+  TopoDS_Compound    aCompound;
+  aBuilder.MakeCompound(aCompound);
+  aBuilder.Add(aCompound, aShell);
+  aBuilder.Add(aCompound, aStandaloneFace);
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aCompound, 1.0e-6);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 3);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_EDGE), 11);
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, HandlesReversedOpenShell)
+{
+  TopoDS_Shell aShell = makeShell(makeRectangle(0.0, 1.0), makeRectangle(1.0, 2.0));
+  aShell.Reverse();
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aShell, 1.0e-6);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 2);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_EDGE), 7);
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, ReapplyingToSewedShapeIsStable)
+{
+  const TopoDS_Shell       aShell = makeShell(makeRectangle(0.0, 1.0), makeRectangle(1.0, 2.0));
+  ShapeUpgrade_ShellSewing aSewer;
+
+  const TopoDS_Shape aResult1 = aSewer.ApplySewing(aShell, 1.0e-6);
+  ASSERT_FALSE(aResult1.IsNull());
+  const TopoDS_Shape aResult2 = aSewer.ApplySewing(aResult1, 1.0e-6);
+
+  ASSERT_FALSE(aResult2.IsNull());
+  EXPECT_EQ(countSubShapes(aResult2, TopAbs_FACE), 2);
+  EXPECT_EQ(countSubShapes(aResult2, TopAbs_EDGE), 7);
+}
+
+TEST(ShapeUpgrade_ShellSewingTest, ProcessesSingleFaceShell)
+{
+  const TopoDS_Face aFace = makeRectangle(0.0, 1.0);
+  BRep_Builder      aBuilder;
+  TopoDS_Shell      aShell;
+  aBuilder.MakeShell(aShell);
+  aBuilder.Add(aShell, aFace);
+
+  ShapeUpgrade_ShellSewing aSewer;
+  const TopoDS_Shape       aResult = aSewer.ApplySewing(aShell, 1.0e-6);
+
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_FACE), 1);
+  EXPECT_EQ(countSubShapes(aResult, TopAbs_EDGE), 4);
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/FILES.cmake
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/FILES.cmake
@@ -6,7 +6,8 @@ set(OCCT_ShapeFix_FILES
   ShapeFix.hxx
   ShapeFix_ComposeShell.cxx
   ShapeFix_ComposeShell.hxx
-
+  ShapeFix_EdgeConnect.cxx
+  ShapeFix_EdgeConnect.hxx
   ShapeFix_Edge.cxx
   ShapeFix_Edge.hxx
   ShapeFix_EdgeProjAux.cxx
@@ -14,6 +15,8 @@ set(OCCT_ShapeFix_FILES
   ShapeFix_Face.cxx
   ShapeFix_Face.hxx
   ShapeFix_Face.lxx
+  ShapeFix_FaceConnect.cxx
+  ShapeFix_FaceConnect.hxx
   ShapeFix_FixSmallFace.cxx
   ShapeFix_FixSmallFace.hxx
   ShapeFix_FixSmallSolid.cxx

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_EdgeConnect.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_EdgeConnect.cxx
@@ -1,0 +1,313 @@
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ShapeFix_EdgeConnect.hxx>
+
+#include <BRep_Builder.hxx>
+#include <BRep_GCurve.hxx>
+#include <BRep_TEdge.hxx>
+#include <gp_Pnt.hxx>
+#include <gp_XYZ.hxx>
+#include <NCollection_LinearVector.hxx>
+#include <Precision.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <TopoDS_Wire.hxx>
+
+#include <algorithm>
+#include <cstddef>
+#include <utility>
+
+namespace
+{
+//=================================================================================================
+
+struct EdgeEndUsage
+{
+  TopoDS_Vertex First;
+  TopoDS_Vertex Last;
+  bool          UsesFirst = false;
+  bool          UsesLast  = false;
+};
+
+//=================================================================================================
+
+EdgeEndUsage edgeEndUsage(const TopoDS_Edge& theEdge, const TopoDS_Vertex& theVertex)
+{
+  TopoDS_Edge aForwardEdge = theEdge;
+  aForwardEdge.Orientation(TopAbs_FORWARD);
+
+  EdgeEndUsage aUsage;
+  TopExp::Vertices(aForwardEdge, aUsage.First, aUsage.Last);
+  aUsage.UsesFirst = theVertex.IsSame(aUsage.First);
+  aUsage.UsesLast  = theVertex.IsSame(aUsage.Last);
+  return aUsage;
+}
+
+//=================================================================================================
+
+void appendCurveEndPositions(const TopoDS_Edge&                theEdge,
+                             const EdgeEndUsage&               theUsage,
+                             NCollection_LinearVector<gp_XYZ>& thePositions)
+{
+  const occ::handle<BRep_TEdge> aTEdge = occ::down_cast<BRep_TEdge>(theEdge.TShape());
+  if (aTEdge.IsNull())
+  {
+    return;
+  }
+
+  for (const occ::handle<BRep_CurveRepresentation>& aRepresentation : aTEdge->Curves())
+  {
+    const occ::handle<BRep_GCurve> aCurve = occ::down_cast<BRep_GCurve>(aRepresentation);
+    if (aCurve.IsNull())
+    {
+      continue;
+    }
+
+    double aFirstParameter = 0.0;
+    double aLastParameter  = 0.0;
+    aCurve->Range(aFirstParameter, aLastParameter);
+    gp_Pnt aPoint;
+    if (theUsage.UsesFirst)
+    {
+      aCurve->D0(aFirstParameter, aPoint);
+      thePositions.Append(aPoint.XYZ());
+    }
+    if (theUsage.UsesLast)
+    {
+      aCurve->D0(aLastParameter, aPoint);
+      thePositions.Append(aPoint.XYZ());
+    }
+  }
+}
+
+//=================================================================================================
+
+gp_XYZ positionAndTolerance(const NCollection_LinearVector<gp_XYZ>& thePositions,
+                            double&                                 theTolerance)
+{
+  gp_XYZ aPosition(0.0, 0.0, 0.0);
+  gp_XYZ aLowerBound(0.0, 0.0, 0.0);
+  gp_XYZ anUpperBound(0.0, 0.0, 0.0);
+
+  for (size_t anIndex = 0; anIndex < thePositions.Size(); ++anIndex)
+  {
+    const gp_XYZ& aCurrent = thePositions.Value(anIndex);
+    if (anIndex == 0)
+    {
+      aLowerBound  = aCurrent;
+      anUpperBound = aCurrent;
+    }
+    else
+    {
+      aLowerBound.SetX(std::min(aLowerBound.X(), aCurrent.X()));
+      aLowerBound.SetY(std::min(aLowerBound.Y(), aCurrent.Y()));
+      aLowerBound.SetZ(std::min(aLowerBound.Z(), aCurrent.Z()));
+      anUpperBound.SetX(std::max(anUpperBound.X(), aCurrent.X()));
+      anUpperBound.SetY(std::max(anUpperBound.Y(), aCurrent.Y()));
+      anUpperBound.SetZ(std::max(anUpperBound.Z(), aCurrent.Z()));
+    }
+    aPosition = aCurrent;
+  }
+
+  if (thePositions.Size() > 1)
+  {
+    aPosition = (aLowerBound + anUpperBound) * 0.5;
+  }
+
+  double aMaximumDeviation = 0.0;
+  for (size_t anIndex = 0; anIndex < thePositions.Size(); ++anIndex)
+  {
+    aMaximumDeviation =
+      std::max(aMaximumDeviation, (aPosition - thePositions.Value(anIndex)).Modulus());
+  }
+  theTolerance = std::max(aMaximumDeviation * 1.0001, Precision::Confusion());
+  return aPosition;
+}
+
+//=================================================================================================
+
+void replaceVertex(BRep_Builder&        theBuilder,
+                   TopoDS_Edge&         theEdge,
+                   const TopoDS_Vertex& theVertex,
+                   const TopoDS_Vertex& theSharedVertex)
+{
+  // BRep_Builder modifies the oriented vertex list of this stored edge copy.
+  // Keep the legacy forward normalization before removing or adding vertices.
+  theEdge.Orientation(TopAbs_FORWARD);
+  const EdgeEndUsage       aUsage          = edgeEndUsage(theEdge, theVertex);
+  const TopoDS_Vertex      anOldVertex     = aUsage.UsesFirst ? aUsage.First : aUsage.Last;
+  const TopAbs_Orientation aNewOrientation = aUsage.UsesFirst ? TopAbs_FORWARD : TopAbs_REVERSED;
+  const TopoDS_Vertex      aNewVertex = TopoDS::Vertex(theSharedVertex.Oriented(aNewOrientation));
+
+  if (anOldVertex.IsSame(aNewVertex))
+  {
+    return;
+  }
+
+  const bool wasFree = theEdge.Free();
+  theEdge.Free(true);
+  theBuilder.Remove(theEdge, anOldVertex);
+  theBuilder.Add(theEdge, aNewVertex);
+  if (aUsage.UsesFirst && aUsage.UsesLast)
+  {
+    theBuilder.Remove(theEdge, anOldVertex.Oriented(TopAbs_REVERSED));
+    theBuilder.Add(theEdge, aNewVertex.Oriented(TopAbs_REVERSED));
+  }
+  theEdge.Free(wasFree);
+}
+} // namespace
+
+//=================================================================================================
+
+ShapeFix_EdgeConnect::ShapeFix_EdgeConnect() = default;
+
+//=================================================================================================
+
+void ShapeFix_EdgeConnect::Add(const TopoDS_Edge& theFirstEdge, const TopoDS_Edge& theSecondEdge)
+{
+  const TopoDS_Vertex aFirstVertex  = TopExp::LastVertex(theFirstEdge, true);
+  const TopoDS_Vertex aSecondVertex = TopExp::FirstVertex(theSecondEdge, true);
+  const TopoDS_Shape* aFirstShared  = myVertices.Seek(aFirstVertex);
+  const TopoDS_Shape* aSecondShared = myVertices.Seek(aSecondVertex);
+
+  if (aFirstShared == nullptr && aSecondShared == nullptr)
+  {
+    myVertices.TryBind(aFirstVertex, aFirstVertex);
+    myVertices.TryBind(aSecondVertex, aFirstVertex);
+    NCollection_List<TopoDS_Shape> aNewList;
+    aNewList.Append(aFirstVertex);
+    aNewList.Append(theFirstEdge);
+    aNewList.Append(aSecondVertex);
+    aNewList.Append(theSecondEdge);
+    myLists.TryBind(aFirstVertex, std::move(aNewList));
+    return;
+  }
+
+  if (aFirstShared != nullptr && aSecondShared == nullptr)
+  {
+    const TopoDS_Shape aSharedVertex = *aFirstShared;
+    myVertices.TryBind(aSecondVertex, aSharedVertex);
+    NCollection_List<TopoDS_Shape>& aList = myLists(aSharedVertex);
+    aList.Append(aSecondVertex);
+    aList.Append(theSecondEdge);
+    return;
+  }
+
+  if (aFirstShared == nullptr)
+  {
+    const TopoDS_Shape aSharedVertex = *aSecondShared;
+    myVertices.TryBind(aFirstVertex, aSharedVertex);
+    NCollection_List<TopoDS_Shape>& aList = myLists(aSharedVertex);
+    aList.Append(aFirstVertex);
+    aList.Append(theFirstEdge);
+    return;
+  }
+
+  const TopoDS_Shape aFirstSharedVertex  = *aFirstShared;
+  const TopoDS_Shape aSecondSharedVertex = *aSecondShared;
+  if (aFirstSharedVertex.IsSame(aSecondSharedVertex))
+  {
+    return;
+  }
+
+  NCollection_List<TopoDS_Shape>& aFirstList  = myLists(aFirstSharedVertex);
+  NCollection_List<TopoDS_Shape>& aSecondList = myLists(aSecondSharedVertex);
+  for (NCollection_List<TopoDS_Shape>::Iterator anIterator(aSecondList); anIterator.More();)
+  {
+    myVertices(anIterator.Value()) = aFirstSharedVertex;
+    anIterator.Next(); // edge paired with the vertex
+    anIterator.Next();
+  }
+  aFirstList.Append(aSecondList);
+  myLists.UnBind(aSecondSharedVertex);
+}
+
+//=================================================================================================
+
+void ShapeFix_EdgeConnect::Add(const TopoDS_Shape& theShape)
+{
+  for (TopExp_Explorer aWireExplorer(theShape, TopAbs_WIRE); aWireExplorer.More();
+       aWireExplorer.Next())
+  {
+    const TopoDS_Wire aWire = TopoDS::Wire(aWireExplorer.Current());
+    TopExp_Explorer   anEdgeExplorer(aWire, TopAbs_EDGE);
+    if (!anEdgeExplorer.More())
+    {
+      continue;
+    }
+
+    TopoDS_Edge       aPreviousEdge = TopoDS::Edge(anEdgeExplorer.Current());
+    const TopoDS_Edge aFirstEdge    = aPreviousEdge;
+    for (anEdgeExplorer.Next(); anEdgeExplorer.More(); anEdgeExplorer.Next())
+    {
+      const TopoDS_Edge aCurrentEdge = TopoDS::Edge(anEdgeExplorer.Current());
+      Add(aPreviousEdge, aCurrentEdge);
+      aPreviousEdge = aCurrentEdge;
+    }
+    if (aWire.Closed())
+    {
+      Add(aPreviousEdge, aFirstEdge);
+    }
+  }
+}
+
+//=================================================================================================
+
+void ShapeFix_EdgeConnect::Build()
+{
+  NCollection_LinearVector<gp_XYZ> aPositions;
+  BRep_Builder                     aBuilder;
+
+  for (auto [aSharedShape, aList] : myLists.Items())
+  {
+    TopoDS_Vertex aSharedVertex = TopoDS::Vertex(aSharedShape);
+    aPositions.Clear();
+
+    for (NCollection_List<TopoDS_Shape>::Iterator anIterator(aList); anIterator.More();)
+    {
+      const TopoDS_Vertex aVertex = TopoDS::Vertex(anIterator.Value());
+      anIterator.Next();
+      const TopoDS_Edge& anEdge = TopoDS::Edge(anIterator.Value());
+      anIterator.Next();
+      appendCurveEndPositions(anEdge, edgeEndUsage(anEdge, aVertex), aPositions);
+    }
+
+    double       aTolerance = 0.0;
+    const gp_XYZ aPosition  = positionAndTolerance(aPositions, aTolerance);
+    aBuilder.UpdateVertex(aSharedVertex, gp_Pnt(aPosition), aTolerance);
+
+    for (NCollection_List<TopoDS_Shape>::Iterator anIterator(aList); anIterator.More();)
+    {
+      const TopoDS_Vertex aVertex = TopoDS::Vertex(anIterator.Value());
+      anIterator.Next();
+      TopoDS_Edge& anEdge = TopoDS::Edge(anIterator.ChangeValue());
+      anIterator.Next();
+      replaceVertex(aBuilder, anEdge, aVertex, aSharedVertex);
+    }
+  }
+
+  Clear();
+}
+
+//=================================================================================================
+
+void ShapeFix_EdgeConnect::Clear()
+{
+  myVertices.Clear();
+  myLists.Clear();
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_EdgeConnect.hxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_EdgeConnect.hxx
@@ -1,0 +1,65 @@
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ShapeFix_EdgeConnect_HeaderFile
+#define _ShapeFix_EdgeConnect_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <TopoDS_Shape.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <NCollection_DataMap.hxx>
+#include <NCollection_FlatDataMap.hxx>
+#include <NCollection_List.hxx>
+class TopoDS_Edge;
+class TopoDS_Shape;
+
+//! Rebuilds edge connectivity by replacing coincident end vertices with shared vertices.
+//! The connected edges must each be bounded by two vertices.
+class ShapeFix_EdgeConnect
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructs an empty edge-connectivity tool.
+  Standard_EXPORT ShapeFix_EdgeConnect();
+
+  //! Registers a connection between the oriented last vertex of the first edge and the oriented
+  //! first vertex of the second edge.
+  //! @param[in] theFirstEdge first edge in the connection
+  //! @param[in] theSecondEdge second edge in the connection
+  Standard_EXPORT void Add(const TopoDS_Edge& theFirstEdge, const TopoDS_Edge& theSecondEdge);
+
+  //! Registers consecutive edge connections for every wire in the shape.
+  //! Edges in each wire must be ordered. A closed wire must have its Closed flag set so that the
+  //! last edge is also connected to the first edge.
+  //! @param[in] theShape shape containing the wires to process
+  Standard_EXPORT void Add(const TopoDS_Shape& theShape);
+
+  //! Builds the registered connections and clears the registration data.
+  //! Each shared vertex is placed at the center of the bounding box of the connected curve ends;
+  //! its tolerance is updated to contain all those ends.
+  Standard_EXPORT void Build();
+
+  //! Clears all registered connections without modifying the edges.
+  Standard_EXPORT void Clear();
+
+private:
+  NCollection_FlatDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher> myVertices;
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    myLists;
+};
+
+#endif // _ShapeFix_EdgeConnect_HeaderFile

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_FaceConnect.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_FaceConnect.cxx
@@ -1,0 +1,684 @@
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRep_Builder.hxx>
+#include <BRep_Tool.hxx>
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <Geom2d_Curve.hxx>
+#include <gp_Pnt.hxx>
+#include <ShapeAnalysis_Edge.hxx>
+#include <ShapeAnalysis_WireOrder.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeFix_Face.hxx>
+#include <ShapeFix_FaceConnect.hxx>
+#include <ShapeFix_Wire.hxx>
+#include <Standard_ErrorHandler.hxx>
+#include <Standard_Failure.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Iterator.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <TopoDS_Wire.hxx>
+#include <TopoDS_Shape.hxx>
+#include <NCollection_Array1.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <NCollection_DataMap.hxx>
+#include <NCollection_FlatDataMap.hxx>
+#include <NCollection_List.hxx>
+
+#include <utility>
+
+namespace
+{
+//=================================================================================================
+
+void appendUniqueShape(NCollection_List<TopoDS_Shape>& theShapes, const TopoDS_Shape& theShape)
+{
+  for (const TopoDS_Shape& aStoredShape : theShapes)
+  {
+    if (aStoredShape.IsSame(theShape))
+    {
+      return;
+    }
+  }
+  theShapes.Append(theShape);
+}
+} // namespace
+
+//=================================================================================================
+
+ShapeFix_FaceConnect::ShapeFix_FaceConnect() = default;
+
+//=================================================================================================
+
+bool ShapeFix_FaceConnect::Add(const TopoDS_Face& theFirstFace, const TopoDS_Face& theSecondFace)
+{
+  if (theFirstFace.IsNull() || theSecondFace.IsNull())
+  {
+    return false;
+  }
+
+  NCollection_List<TopoDS_Shape>& aConnectedFaces =
+    myConnected.TryBound(theFirstFace, NCollection_List<TopoDS_Shape>());
+  for (const TopoDS_Shape& aConnectedFace : aConnectedFaces)
+  {
+    if (aConnectedFace.IsSame(theSecondFace))
+    {
+      return true;
+    }
+  }
+  aConnectedFaces.Append(theSecondFace);
+
+  if (!theFirstFace.IsSame(theSecondFace))
+  {
+    myConnected.TryBound(theSecondFace, NCollection_List<TopoDS_Shape>()).Append(theFirstFace);
+  }
+  return true;
+}
+
+//=================================================================================================
+
+TopoDS_Shell ShapeFix_FaceConnect::Build(const TopoDS_Shell& theShell,
+                                         const double        theSewingTolerance,
+                                         const double        theFixingTolerance)
+{
+  collectFreeEdges(theShell);
+  sewConnectedFaces(theSewingTolerance);
+  return rebuildShell(theShell, theSewingTolerance, theFixingTolerance);
+}
+
+//=================================================================================================
+
+void ShapeFix_FaceConnect::Clear()
+{
+  myConnected.Clear();
+  myOriFreeEdges.Clear();
+  myResFreeEdges.Clear();
+  myResSharEdges.Clear();
+}
+
+//=================================================================================================
+
+void ShapeFix_FaceConnect::collectFreeEdges(const TopoDS_Shell& theShell)
+{
+  // Clear maps of free and shared edges
+  myOriFreeEdges.Clear();
+  myResFreeEdges.Clear();
+  myResSharEdges.Clear();
+
+  NCollection_FlatDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher> theFreeEdges;
+  TopoDS_Shape                                                                 theEdge, theFace;
+
+  // Fill map of free edges / faces
+  for (TopoDS_Iterator itf(theShell); itf.More(); itf.Next())
+  {
+    theFace = itf.Value();
+    for (TopExp_Explorer expe(theFace, TopAbs_EDGE); expe.More(); expe.Next())
+    {
+      theEdge = expe.Current();
+      if (!theFreeEdges.TryBind(theEdge, theFace))
+      {
+        theFreeEdges.UnBind(theEdge);
+      }
+    }
+  }
+
+  // Fill maps of original and resulting edges
+  for (const auto& [aFreeEdge, aFreeFace] : theFreeEdges.Items())
+  {
+    // Get pair (face / free edge)
+    theEdge = aFreeEdge, theFace = aFreeFace;
+    // Process faces with bad connectivities only
+    if (myConnected.Seek(theFace) != nullptr && !BRep_Tool::Degenerated(TopoDS::Edge(theEdge)))
+    {
+      // Add to the map of original free edges
+      myOriFreeEdges.TryBound(theFace, NCollection_List<TopoDS_Shape>()).Append(theEdge);
+      // Add to the maps of intermediate free and resulting edges
+      NCollection_List<TopoDS_Shape> theFree;
+      theFree.Append(theEdge);
+      if (myResFreeEdges.TryBind(theEdge, std::move(theFree)))
+      {
+        myResSharEdges.TryBind(theEdge, NCollection_List<TopoDS_Shape>());
+      }
+    }
+  }
+
+  // Clear the temporary map of free edges
+  theFreeEdges.Clear();
+}
+
+//=================================================================================================
+
+void ShapeFix_FaceConnect::sewConnectedFaces(const double theSewingTolerance)
+{
+  if (myOriFreeEdges.IsEmpty())
+  {
+    return;
+  }
+
+  // Allocate array of faces to be sewed
+  TopoDS_Shape                     theFirstFace, theSecondFace;
+  NCollection_Array1<TopoDS_Shape> theFacesToSew(1, 2);
+  int                              theNumOfFacesToSew = 0;
+  bool                             skip_pair          = false;
+
+  NCollection_List<TopoDS_Shape>::Iterator theOriginalIter, theResultsIter;
+  TopoDS_Shape                             theAuxE, theOrigE, theAuxF;
+
+  BRep_Builder theBuilder;
+
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    theProcessed;
+
+  for (const auto& [aConnectedFace, aConnectedList] : myConnected.Items())
+  {
+    // Process first face only if it is in the map of faces / free edges
+    theFirstFace = aConnectedFace;
+    if (myOriFreeEdges.Seek(theFirstFace) != nullptr)
+    {
+
+      // Place first face into the array
+      theFacesToSew.SetValue(1, theFirstFace);
+      theNumOfFacesToSew = 1;
+      // Create the list of processed faces
+      NCollection_List<TopoDS_Shape> theProcessedList;
+
+      // Explore the list of connected faces
+      for (const TopoDS_Shape& aConnectedFaceCandidate : aConnectedList)
+      {
+        // Process second face only if it is in the map of faces / free edges
+        theSecondFace = aConnectedFaceCandidate;
+        if (myOriFreeEdges.Seek(theSecondFace) != nullptr)
+        {
+
+          // Place second face into the array
+          theFacesToSew.SetValue(2, theSecondFace);
+          // Add second face to the list of processed faces
+          theProcessedList.Append(theSecondFace);
+
+          // Skip the pair if already processed
+          skip_pair                                             = false;
+          const NCollection_List<TopoDS_Shape>* aProcessedFaces = theProcessed.Seek(theSecondFace);
+          if (aProcessedFaces != nullptr)
+          {
+            for (const TopoDS_Shape& aProcessedFace : *aProcessedFaces)
+            {
+              if (theFirstFace.IsSame(aProcessedFace))
+              {
+                skip_pair = true;
+                break;
+              }
+            }
+          }
+          if (!skip_pair)
+          {
+
+            // Process second face for the pair of different faces only
+            if (theFirstFace.IsSame(theSecondFace))
+            {
+            }
+            else
+            {
+              theNumOfFacesToSew = 2;
+            }
+
+            NCollection_FlatDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>
+                                  theSewerWires;
+            BRepBuilderAPI_Sewing theSewer(theSewingTolerance);
+
+            // Prepare set of faces containing free edges
+            int i = 1;
+            for (i = 1; i <= theNumOfFacesToSew; i++)
+            {
+              // Prepare empty face to fill with free edges
+              TopoDS_Shape theFaceToSew = theFacesToSew(i);
+              theAuxF                   = theFaceToSew.EmptyCopied();
+              // Fill empty face with free edges
+              for (theOriginalIter.Initialize(myOriFreeEdges(theFaceToSew)); theOriginalIter.More();
+                   theOriginalIter.Next())
+              {
+                for (theResultsIter.Initialize(myResFreeEdges(theOriginalIter.Value()));
+                     theResultsIter.More();
+                     theResultsIter.Next())
+                {
+                  // Bind free edge to wire to find results later
+                  theAuxE = theResultsIter.Value();
+                  TopoDS_Wire theAuxW;
+                  theBuilder.MakeWire(theAuxW);
+                  theBuilder.Add(theAuxW, theAuxE);
+                  theBuilder.Add(theAuxF, theAuxW);
+                  theSewerWires.Bound(theAuxE, theAuxW);
+                  theSewer.Add(theAuxW);
+                }
+              }
+              // Add constructed face to sewer
+              theSewer.Add(theAuxF);
+            }
+
+            // Perform sewing on the list of free edges
+            bool sewing_ok = true;
+            {
+              try
+              {
+                OCC_CATCH_SIGNALS
+                theSewer.Perform();
+              }
+              catch (Standard_Failure const&)
+              {
+                sewing_ok = false;
+              }
+            }
+            if (sewing_ok)
+            {
+              if (theSewer.SewedShape().IsNull())
+              {
+                sewing_ok = false;
+              }
+            }
+
+            if (sewing_ok)
+            {
+              NCollection_FlatDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>
+                theResultEdges;
+
+              // Find modified edges for the faces
+              for (i = 1; i <= theNumOfFacesToSew; i++)
+              {
+                for (theOriginalIter.Initialize(myOriFreeEdges(theFacesToSew(i)));
+                     theOriginalIter.More();
+                     theOriginalIter.Next())
+                {
+                  // Get original free edge
+                  theOrigE                                       = theOriginalIter.Value();
+                  NCollection_List<TopoDS_Shape>& theOldFreeList = myResFreeEdges(theOrigE);
+                  theResultsIter.Initialize(theOldFreeList);
+                  while (theResultsIter.More())
+                  {
+                    theAuxE = theSewerWires(theResultsIter.Value());
+                    // Process modified edges
+                    if (theSewer.IsModified(theAuxE))
+                    {
+                      // Fill map of result edges
+                      for (TopExp_Explorer expe(theSewer.Modified(theAuxE), TopAbs_EDGE);
+                           expe.More();
+                           expe.Next())
+                      {
+                        theAuxE = expe.Current();
+                        // Check edge for being shared
+                        if (theResultEdges.TryBind(theAuxE, theOrigE))
+                        {
+                          continue;
+                        }
+                        // Edge was shared - move in results list
+                        myResSharEdges(theResultEdges(theAuxE)).Append(theAuxE);
+                        myResSharEdges(theOrigE).Append(theAuxE);
+                        theResultEdges.UnBind(theAuxE);
+                      }
+                      // Remove modified free edge from the list
+                      theOldFreeList.Remove(theResultsIter);
+                    }
+                    else
+                    {
+                      theResultsIter.Next();
+                    }
+                  }
+                }
+              }
+
+              // Put free edges back to the lists of results
+              for (const auto& [aResultEdge, anOriginalEdge] : theResultEdges.Items())
+              {
+                myResFreeEdges(anOriginalEdge).Append(aResultEdge);
+              }
+            }
+          }
+        }
+      }
+
+      // Bind the list of processed faces to the processed face
+      theProcessed.TryBind(theFirstFace, std::move(theProcessedList));
+    }
+  }
+
+  // Clear the temporary map of processed faces
+  theProcessed.Clear();
+}
+
+//=================================================================================================
+
+TopoDS_Shell ShapeFix_FaceConnect::rebuildShell(const TopoDS_Shell& theShell,
+                                                const double        theSewingTolerance,
+                                                const double        theFixingTolerance)
+{
+  if (myOriFreeEdges.IsEmpty())
+  {
+    return theShell;
+  }
+
+  TopoDS_Shell                             result = theShell;
+  NCollection_List<TopoDS_Shape>::Iterator theResultsIter;
+  TopoDS_Shape                             theAuxE;
+  BRep_Builder                             theBuilder;
+
+  NCollection_FlatDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher> theRepEdges;
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+                                                                               theRepVertices;
+  NCollection_FlatDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher> theOldVertices;
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    theNewVertices;
+
+  // Replace old edges by resulting ones
+  TopoDS_Wire   theNewW;
+  TopoDS_Vertex theOldV1, theOldV2, theNewV1, theNewV2, theNewV;
+  gp_Pnt        theOldP1, theOldP2;
+  double        dist1, dist2, curdist1, curdist2;
+  for (const NCollection_List<TopoDS_Shape>& anOriginalEdges : myOriFreeEdges)
+  {
+    // Iterate on original free edges
+    for (const TopoDS_Shape& anOriginalEdge : anOriginalEdges)
+    {
+      TopoDS_Edge theOldE = TopoDS::Edge(anOriginalEdge);
+
+      // Prepare empty wire to add new edges for reshape
+      theBuilder.MakeWire(theNewW);
+
+      // Explore new edges and vertices
+      bool emptywire = true;
+      for (int i = 1; i <= 2; i++)
+      {
+        // Select list of free or shared edges
+        if (i == 1)
+        {
+          theResultsIter.Initialize(myResFreeEdges(theOldE));
+        }
+        else
+        {
+          theResultsIter.Initialize(myResSharEdges(theOldE));
+        }
+        // Iterate on new edges
+        for (; theResultsIter.More(); theResultsIter.Next())
+        {
+          theAuxE = theResultsIter.Value();
+          if (!theAuxE.IsSame(theOldE))
+          {
+            // Add new edge to the wire
+            theBuilder.Add(theNewW, theAuxE);
+            emptywire = false;
+          }
+        }
+      }
+
+      if (!emptywire)
+      {
+
+        // Get vertices on old and new edges
+        TopExp::Vertices(theOldE, theOldV1, theOldV2);
+        theOldP1 = BRep_Tool::Pnt(theOldV1);
+        theOldP2 = BRep_Tool::Pnt(theOldV2);
+
+        // Process vertices for replacing
+        dist1 = -1.;
+        dist2 = -1.;
+        for (TopExp_Explorer expv(theNewW, TopAbs_VERTEX); expv.More(); expv.Next())
+        {
+          TopoDS_Vertex theNewVtx = TopoDS::Vertex(expv.Current());
+          gp_Pnt        theNewPt  = BRep_Tool::Pnt(theNewVtx);
+          curdist1                = theOldP1.Distance(theNewPt);
+          curdist2                = theOldP2.Distance(theNewPt);
+          if (dist1 < 0 || curdist1 < dist1)
+          {
+            dist1    = curdist1;
+            theNewV1 = theNewVtx;
+          }
+          if (dist2 < 0 || curdist2 < dist2)
+          {
+            dist2    = curdist2;
+            theNewV2 = theNewVtx;
+          }
+        }
+
+        // Place results in map for replacing
+        if (!theOldV1.IsSame(theNewV1))
+        {
+          appendUniqueShape(theRepVertices.TryBound(theOldV1, NCollection_List<TopoDS_Shape>()),
+                            theNewV1);
+        }
+        if (!theOldV2.IsSame(theNewV2))
+        {
+          appendUniqueShape(theRepVertices.TryBound(theOldV2, NCollection_List<TopoDS_Shape>()),
+                            theNewV2);
+        }
+
+        // Bind edge to replace
+        theRepEdges.TryBind(theOldE, theNewW);
+      }
+    }
+  }
+
+  if (!theRepEdges.IsEmpty())
+  {
+
+    occ::handle<ShapeBuild_ReShape> theReShape = new ShapeBuild_ReShape;
+
+    // Replace edges
+    for (const auto& [anOldEdge, aNewWire] : theRepEdges.Items())
+    {
+      theReShape->Replace(anOldEdge /*.Oriented(TopAbs_FORWARD)*/,
+                          aNewWire /*.Oriented(TopAbs_FORWARD)*/);
+    }
+    // smh#8
+    TopoDS_Shape tmpReShape = theReShape->Apply(result);
+    result                  = TopoDS::Shell(tmpReShape);
+    if (theReShape->Status(ShapeExtend_OK))
+    {
+    }
+    else if (theReShape->Status(ShapeExtend_FAIL1))
+    {
+    }
+    else
+    {
+
+      occ::handle<ShapeFix_Wire>        SFW = new ShapeFix_Wire;
+      occ::handle<ShapeFix_Face>        SFF = new ShapeFix_Face;
+      ShapeAnalysis_Edge                SAE;
+      double                            f, l;
+      occ::handle<Geom2d_Curve>         c2d;
+      occ::handle<ShapeExtend_WireData> sewd;
+
+      // Perform necessary fixes on subshapes
+      // smh#8
+      TopoDS_Shape emptyCopiedShell = result.EmptyCopied();
+      TopoDS_Shell theShell         = TopoDS::Shell(emptyCopiedShell);
+      for (TopoDS_Iterator itf1(result); itf1.More(); itf1.Next())
+      {
+        TopoDS_Face newface = TopoDS::Face(itf1.Value());
+        // smh#8
+        TopoDS_Shape emptyCopiedFace = newface.EmptyCopied();
+        TopoDS_Face  EmpFace         = TopoDS::Face(emptyCopiedFace);
+        for (TopoDS_Iterator itw(newface); itw.More(); itw.Next())
+        {
+          if (itw.Value().ShapeType() != TopAbs_WIRE)
+          {
+            continue;
+          }
+          TopoDS_Wire theWire = TopoDS::Wire(itw.Value());
+
+          sewd = new ShapeExtend_WireData(theWire);
+          ShapeAnalysis_WireOrder SAWO(false, 0);
+          for (int i = 1; i <= sewd->NbEdges(); i++)
+          {
+
+            // smh#8
+            TopoDS_Shape tmpFace = EmpFace.Oriented(TopAbs_FORWARD);
+            if (!SAE.PCurve(sewd->Edge(i), TopoDS::Face(tmpFace), c2d, f, l))
+            {
+              continue;
+            }
+            SAWO.Add(c2d->Value(f).XY(), c2d->Value(l).XY());
+          }
+          SAWO.Perform();
+
+          SFW->Load(sewd);
+          SFW->FixReorder(SAWO);
+          SFW->FixReorder();
+
+          SFW->SetFace(EmpFace);
+          SFW->SetPrecision(theFixingTolerance);
+          SFW->SetMaxTolerance(theSewingTolerance);
+
+          SFW->FixEdgeCurves();
+          SFW->FixSelfIntersection();
+          theWire = SFW->Wire();
+          theBuilder.Add(EmpFace, theWire);
+        }
+        // #ifdef AIX  CKY : applies to all platforms
+        SFF->Init(EmpFace);
+        //	  SFF->Init(TopoDS::Face(EmpFace));
+
+        NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+          MapWires;
+        MapWires.Clear();
+        if (SFF->FixOrientation(MapWires))
+        {
+          EmpFace = SFF->Face();
+        }
+        theBuilder.Add(theShell, EmpFace);
+      }
+      theShell.Closed(BRep_Tool::IsClosed(theShell));
+      result = theShell;
+
+      if (!theRepVertices.IsEmpty())
+      {
+
+        // Prepare vertices to replace
+        TopoDS_Shape theOld, theNew, theRep, theAux;
+        for (const auto& [anOldVertex, aReplacementList] : theRepVertices.Items())
+        {
+          // Get the old vertex, create empty list of replaced vertices
+          theOld = anOldVertex;
+          NCollection_List<TopoDS_Shape> theNewList;
+          // Explore the list of new vertices
+          for (const TopoDS_Shape& aReplacement : aReplacementList)
+          {
+            theNew = aReplacement;
+            if (theOldVertices.TryBind(theNew, theOld))
+            {
+              theNewList.Append(theNew);
+              continue;
+            }
+
+            // Vertex has a replacing vertex in the map
+            theRep = theOldVertices(theNew);
+            if (!theRep.IsSame(theOld))
+            {
+              // Vertex is not in current list
+              theOldVertices.Bound(theRep, theOld);
+              theNewList.Append(theRep);
+              for (const TopoDS_Shape& aRelatedVertex : theNewVertices(theRep))
+              {
+                theAux                 = aRelatedVertex;
+                theOldVertices(theAux) = theOld;
+                theNewList.Append(theAux);
+              }
+              theNewVertices.UnBind(theRep);
+            }
+          }
+          theNewVertices.TryBind(theOld, std::move(theNewList));
+        }
+
+        // Update vertices positions and tolerances
+        TopoDS_Vertex theNewVert, theOldVert;
+        for (const auto& [aNewVertex, anOldVertexList] : theNewVertices.Items())
+        {
+          theNewVert = TopoDS::Vertex(aNewVertex);
+          // Calculate the vertex position
+          gp_Pnt theLBound, theRBound, thePosition;
+          theLBound = theRBound = BRep_Tool::Pnt(theNewVert);
+          for (const TopoDS_Shape& anOldVertex : anOldVertexList)
+          {
+            thePosition = BRep_Tool::Pnt(TopoDS::Vertex(anOldVertex));
+            double val  = thePosition.X();
+            if (val < theLBound.X())
+            {
+              theLBound.SetX(val);
+            }
+            else if (val > theRBound.X())
+            {
+              theRBound.SetX(val);
+            }
+            val = thePosition.Y();
+            if (val < theLBound.Y())
+            {
+              theLBound.SetY(val);
+            }
+            else if (val > theRBound.Y())
+            {
+              theRBound.SetY(val);
+            }
+            val = thePosition.Z();
+            if (val < theLBound.Z())
+            {
+              theLBound.SetZ(val);
+            }
+            else if (val > theRBound.Z())
+            {
+              theRBound.SetZ(val);
+            }
+          }
+          thePosition         = gp_Pnt((theLBound.XYZ() + theRBound.XYZ()) / 2.);
+          double theTolerance = 0., curtoler;
+          // Calculate the vertex tolerance
+          for (const TopoDS_Shape& anOldVertex : anOldVertexList)
+          {
+            theOldVert = TopoDS::Vertex(anOldVertex);
+            curtoler =
+              thePosition.Distance(BRep_Tool::Pnt(theOldVert)) + BRep_Tool::Tolerance(theOldVert);
+            if (curtoler > theTolerance)
+            {
+              theTolerance = curtoler;
+            }
+          }
+          curtoler =
+            thePosition.Distance(BRep_Tool::Pnt(theNewVert)) + BRep_Tool::Tolerance(theNewVert);
+          if (curtoler > theTolerance)
+          {
+            theTolerance = curtoler;
+          }
+          theBuilder.UpdateVertex(theNewVert, thePosition, theTolerance);
+        }
+
+        // Replace vertices
+        theReShape->Clear();
+        for (const auto& [anOldVertex, aNewVertex] : theOldVertices.Items())
+        {
+          theReShape->Replace(anOldVertex.Oriented(TopAbs_FORWARD),
+                              aNewVertex.Oriented(TopAbs_FORWARD));
+        }
+        // smh#8
+        TopoDS_Shape tmpshape = theReShape->Apply(result);
+        result                = TopoDS::Shell(tmpshape);
+
+        if (theReShape->Status(ShapeExtend_FAIL1))
+        {
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_FaceConnect.hxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_FaceConnect.hxx
@@ -1,0 +1,75 @@
+// Copyright (c) 1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ShapeFix_FaceConnect_HeaderFile
+#define _ShapeFix_FaceConnect_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <TopoDS_Shape.hxx>
+#include <NCollection_List.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+#include <NCollection_DataMap.hxx>
+class TopoDS_Face;
+class TopoDS_Shell;
+
+//! Rebuilds selected connections between faces of a shell.
+class ShapeFix_FaceConnect
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructs an empty face-connectivity tool.
+  Standard_EXPORT ShapeFix_FaceConnect();
+
+  //! Registers two faces whose free edges should be connected by Build().
+  //! Repeated registration of the same pair has no effect.
+  //! @param[in] theFirstFace first face in the connection
+  //! @param[in] theSecondFace second face in the connection
+  //! @return false if either face is null; true otherwise
+  Standard_EXPORT bool Add(const TopoDS_Face& theFirstFace, const TopoDS_Face& theSecondFace);
+
+  //! Rebuilds registered face connections in the shell.
+  //! @param[in] theShell shell containing the registered faces
+  //! @param[in] theSewingTolerance tolerance used to sew free edges
+  //! @param[in] theFixingTolerance precision used to repair rebuilt wires
+  //! @return rebuilt shell, or the input shell when no registered connection can be rebuilt
+  Standard_EXPORT TopoDS_Shell Build(const TopoDS_Shell& theShell,
+                                     const double        theSewingTolerance,
+                                     const double        theFixingTolerance);
+
+  //! Clears all registered face connections and intermediate results.
+  Standard_EXPORT void Clear();
+
+private:
+  Standard_EXPORT void collectFreeEdges(const TopoDS_Shell& theShell);
+
+  Standard_EXPORT void sewConnectedFaces(const double theSewingTolerance);
+
+  Standard_EXPORT TopoDS_Shell rebuildShell(const TopoDS_Shell& theShell,
+                                            const double        theSewingTolerance,
+                                            const double        theFixingTolerance);
+
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    myConnected;
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    myOriFreeEdges;
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    myResFreeEdges;
+  NCollection_DataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher>
+    myResSharEdges;
+};
+
+#endif // _ShapeFix_FaceConnect_HeaderFile

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/FILES.cmake
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/FILES.cmake
@@ -50,6 +50,8 @@ set(OCCT_ShapeUpgrade_FILES
   ShapeUpgrade_ShapeDivideClosedEdges.hxx
   ShapeUpgrade_ShapeDivideContinuity.cxx
   ShapeUpgrade_ShapeDivideContinuity.hxx
+  ShapeUpgrade_ShellSewing.cxx
+  ShapeUpgrade_ShellSewing.hxx
   ShapeUpgrade_SplitCurve.cxx
   ShapeUpgrade_SplitCurve.hxx
   ShapeUpgrade_SplitCurve2d.cxx

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_ShellSewing.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_ShellSewing.cxx
@@ -1,0 +1,139 @@
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <BRepBuilderAPI_Sewing.hxx>
+#include <BRepClass3d_SolidClassifier.hxx>
+#include <ShapeAnalysis_ShapeTolerance.hxx>
+#include <ShapeBuild_ReShape.hxx>
+#include <ShapeUpgrade_ShellSewing.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Shell.hxx>
+#include <TopoDS_Solid.hxx>
+
+//=================================================================================================
+
+ShapeUpgrade_ShellSewing::ShapeUpgrade_ShellSewing()
+    : myReShape(new ShapeBuild_ReShape)
+{
+}
+
+//=================================================================================================
+
+void ShapeUpgrade_ShellSewing::Init(const TopoDS_Shape& theShape)
+{
+  if (theShape.IsNull())
+  {
+    return;
+  }
+  if (theShape.ShapeType() == TopAbs_SHELL)
+  {
+    myShells.Add(theShape);
+  }
+  else
+  {
+    for (TopExp_Explorer aShellExplorer(theShape, TopAbs_SHELL); aShellExplorer.More();
+         aShellExplorer.Next())
+    {
+      myShells.Add(aShellExplorer.Current());
+    }
+  }
+}
+
+//=================================================================================================
+
+size_t ShapeUpgrade_ShellSewing::Prepare(const double theTolerance)
+{
+  size_t aSewedShellCount = 0;
+  for (const TopoDS_Shape& aShellShape : myShells)
+  {
+    const TopoDS_Shell    aShell = TopoDS::Shell(aShellShape);
+    BRepBuilderAPI_Sewing aSewer(theTolerance);
+    for (TopExp_Explorer aFaceExplorer(aShell, TopAbs_FACE); aFaceExplorer.More();
+         aFaceExplorer.Next())
+    {
+      aSewer.Add(aFaceExplorer.Current());
+    }
+    aSewer.Perform();
+    const TopoDS_Shape aSewedShape = aSewer.SewedShape();
+    if (!aSewedShape.IsNull())
+    {
+      myReShape->Replace(aShell, aSewedShape);
+      ++aSewedShellCount;
+    }
+  }
+  return aSewedShellCount;
+}
+
+//=================================================================================================
+
+TopoDS_Shape ShapeUpgrade_ShellSewing::Apply(const TopoDS_Shape& theShape,
+                                             const double        theTolerance)
+{
+  if (theShape.IsNull() || myShells.IsEmpty())
+  {
+    return theShape;
+  }
+
+  TopoDS_Shape aResult = myReShape->Apply(theShape, TopAbs_FACE, 2);
+
+  // Orient rebuilt solids so that the infinite point remains outside.
+  myReShape->Clear();
+  bool hasReversedSolid = false;
+  for (TopExp_Explorer aSolidExplorer(theShape, TopAbs_SOLID); aSolidExplorer.More();
+       aSolidExplorer.Next())
+  {
+    const TopoDS_Solid          aSolid = TopoDS::Solid(aSolidExplorer.Current());
+    BRepClass3d_SolidClassifier aClassifier(aSolid);
+    aClassifier.PerformInfinitePoint(theTolerance);
+    if (aClassifier.State() == TopAbs_IN)
+    {
+      myReShape->Replace(aSolid, aSolid.Reversed());
+      hasReversedSolid = true;
+    }
+  }
+
+  if (hasReversedSolid)
+  {
+    aResult = myReShape->Apply(aResult, TopAbs_SHELL, 2);
+  }
+
+  return aResult;
+}
+
+//=================================================================================================
+
+TopoDS_Shape ShapeUpgrade_ShellSewing::ApplySewing(const TopoDS_Shape& theShape,
+                                                   const double        theTolerance)
+{
+  if (theShape.IsNull())
+  {
+    return theShape;
+  }
+
+  double aTolerance = theTolerance;
+  if (aTolerance <= 0.0)
+  {
+    ShapeAnalysis_ShapeTolerance aToleranceAnalyzer;
+    aTolerance = aToleranceAnalyzer.Tolerance(theShape, 0);
+  }
+
+  Init(theShape);
+  if (Prepare(aTolerance) != 0)
+  {
+    return Apply(theShape, aTolerance);
+  }
+
+  return TopoDS_Shape();
+}

--- a/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_ShellSewing.hxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeUpgrade/ShapeUpgrade_ShellSewing.hxx
@@ -1,0 +1,59 @@
+// Copyright (c) 1998-1999 Matra Datavision
+// Copyright (c) 1999-2014 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ShapeUpgrade_ShellSewing_HeaderFile
+#define _ShapeUpgrade_ShellSewing_HeaderFile
+
+#include <Standard.hxx>
+#include <Standard_DefineAlloc.hxx>
+#include <Standard_Handle.hxx>
+
+#include <TopTools_ShapeMapHasher.hxx>
+#include <NCollection_OrderedMap.hxx>
+
+#include <cstddef>
+class ShapeBuild_ReShape;
+class TopoDS_Shape;
+
+//! Applies sewing independently to every shell of a shape.
+//! Sewed shells are substituted through ShapeBuild_ReShape, and rebuilt solids are oriented so
+//! that the infinite point lies outside.
+class ShapeUpgrade_ShellSewing
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructs an empty shell-sewing tool.
+  Standard_EXPORT ShapeUpgrade_ShellSewing();
+
+  //! Sews every shell in the shape and substitutes the sewing results into a rebuilt shape.
+  //! A non-positive tolerance is replaced by the mean tolerance of the input shape.
+  //! @param[in] theShape shape whose shells are to be sewed
+  //! @param[in] theTolerance sewing tolerance, or a non-positive value to compute it automatically
+  //! @return rebuilt shape, or a null shape when no shell can be sewed
+  Standard_EXPORT TopoDS_Shape ApplySewing(const TopoDS_Shape& theShape,
+                                           const double        theTolerance = 0.0);
+
+private:
+  Standard_EXPORT void Init(const TopoDS_Shape& theShape);
+
+  Standard_EXPORT size_t Prepare(const double theTolerance);
+
+  Standard_EXPORT TopoDS_Shape Apply(const TopoDS_Shape& theShape, const double theTolerance);
+
+  NCollection_OrderedMap<TopoDS_Shape, TopTools_ShapeMapHasher> myShells;
+  occ::handle<ShapeBuild_ReShape>                               myReShape;
+};
+
+#endif // _ShapeUpgrade_ShellSewing_HeaderFile


### PR DESCRIPTION
- Restore ShapeFix_EdgeConnect for rebuilding shared vertices between connected edges.
- Restore ShapeFix_FaceConnect for sewing selected face boundaries and rebuilding affected shells.
- Restore ShapeUpgrade_ShellSewing for sewing individual shells and correcting solid orientation.
- Register all restored classes in the TKShHealing source manifests.
- Add focused GTests covering connectivity, tolerances, orientation, topology, repeated use, and failure cases.
- Validate resulting edge lengths and surface areas against input properties and analytical references.
- Refactor the restored implementations into smaller, maintainable phases while preserving the original algorithms.
- Modernize NCollection containers, lookup APIs, and iteration according to ordering and storage requirements.
- Synchronize declaration and definition argument names.
- Update public API comments to the recommended OCCT Doxygen style.