### PR TITLE
Coding - Fix high-severity CodeQL multiplication warnings

### DIFF
--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib.cxx
@@ -2088,7 +2088,7 @@ void BSplCLib::InsertKnots(const int                         Degree,
   // -------------------
   // Use stack-based allocation for small arrays (MaxDegree=25, typical Dimension=4)
   NCollection_LocalArray<double, 64>  knots(2 * Degree);
-  NCollection_LocalArray<double, 256> poles((2 * Degree + 1) * Dimension);
+  NCollection_LocalArray<double, 256> poles(static_cast<size_t>(2 * Degree + 1) * Dimension);
 
   //----------------------------
   // loop on the knots to insert
@@ -2403,7 +2403,7 @@ bool BSplCLib::RemoveKnot(const int                         Index,
   // -------------------
   // Use stack-based allocation for small arrays (MaxDegree=25, typical Dimension=4)
   NCollection_LocalArray<double, 128> knots(4 * Degree);
-  NCollection_LocalArray<double, 256> poles((2 * Degree + 1) * Dimension);
+  NCollection_LocalArray<double, 256> poles(static_cast<size_t>(2 * Degree + 1) * Dimension);
 
   // ------------------------------------
   // build the knots for anti Boor Scheme
@@ -3575,7 +3575,8 @@ void BSplCLib::Eval(const double                      Parameter,
     {
       NewRequest = Degree;
     }
-    NCollection_LocalArray<double> LocalRealArray((LocalRequest + 1) * ArrayDimension);
+    NCollection_LocalArray<double> LocalRealArray(static_cast<size_t>(LocalRequest + 1)
+                                                  * ArrayDimension);
     Index   = 0;
     Inverse = 1.0e0;
 
@@ -3752,7 +3753,8 @@ void BSplCLib::Eval(const double                      Parameter,
     {
       NewRequest = Degree;
     }
-    NCollection_LocalArray<double> LocalRealArray((LocalRequest + 1) * ArrayDimension);
+    NCollection_LocalArray<double> LocalRealArray(static_cast<size_t>(LocalRequest + 1)
+                                                  * ArrayDimension);
 
     Index   = 0;
     Inverse = 1.0e0;

--- a/src/FoundationClasses/TKMath/BSplSLib/BSplSLib.cxx
+++ b/src/FoundationClasses/TKMath/BSplSLib/BSplSLib.cxx
@@ -1664,7 +1664,7 @@ void BSplSLib::Iso(const double                      Param,
     l2 = Poles.UpperRow();
   }
 
-  NCollection_LocalArray<double> locpoles((Degree + 1) * (l2 - f2 + 1) * dim);
+  NCollection_LocalArray<double> locpoles(static_cast<size_t>(Degree + 1) * (l2 - f2 + 1) * dim);
 
   double w, *pole = locpoles;
   index += f1;

--- a/src/FoundationClasses/TKMath/PLib/PLib.cxx
+++ b/src/FoundationClasses/TKMath/PLib/PLib.cxx
@@ -1163,7 +1163,8 @@ int PLib::EvalLagrange(const double Parameter,
   {
     local_request = Degree;
   }
-  NCollection_LocalArray<double> divided_differences_array((Degree + 1) * Dimension);
+  NCollection_LocalArray<double> divided_differences_array(static_cast<size_t>(Degree + 1)
+                                                           * Dimension);
   //
   //  Build the divided differences array
   //
@@ -1303,7 +1304,8 @@ int PLib::EvalCubicHermite(const double Parameter,
   {
     local_request = Degree;
   }
-  NCollection_LocalArray<double> divided_differences_array((Degree + 1) * Dimension);
+  NCollection_LocalArray<double> divided_differences_array(static_cast<size_t>(Degree + 1)
+                                                           * Dimension);
 
   for (ii = 0, jj = 0; ii < 2; ii++, jj += 2)
   {

--- a/src/ModelingAlgorithms/TKGeomAlgo/ApproxInt/ApproxInt_KnotTools.cxx
+++ b/src/ModelingAlgorithms/TKGeomAlgo/ApproxInt/ApproxInt_KnotTools.cxx
@@ -586,7 +586,7 @@ void ApproxInt_KnotTools::BuildKnots(const NCollection_Array1<gp_Pnt>&   thePnts
     return;
   }
 
-  NCollection_LocalArray<double> aCoords(thePars.Length() * aDim);
+  NCollection_LocalArray<double> aCoords(static_cast<size_t>(thePars.Length()) * aDim);
   int                            i, j;
   for (i = thePars.Lower(); i <= thePars.Upper(); ++i)
   {
@@ -758,7 +758,7 @@ Approx_ParametrizationType ApproxInt_KnotTools::DefineParType(
   }
 
   int                            aLength = theLpar - theFpar + 1;
-  NCollection_LocalArray<double> aCoords(aLength * aDim);
+  NCollection_LocalArray<double> aCoords(static_cast<size_t>(aLength) * aDim);
   for (i = theFpar; i <= theLpar; ++i)
   {
     j = (i - theFpar) * aDim;

--- a/src/ModelingData/TKG3d/GeomEval/GeomEval_AHTBezierSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomEval/GeomEval_AHTBezierSurface.cxx
@@ -1145,8 +1145,10 @@ gp_Vec GeomEval_AHTBezierSurface::EvalDN(const double U,
   const int aDimU = NbPolesU();
   const int aDimV = NbPolesV();
 
-  NCollection_LocalArray<double, 16> aBUDerivs((Nu + 1) * aDimU);
-  NCollection_LocalArray<double, 16> aBVDerivs((Nv + 1) * aDimV);
+  const size_t                       aNbUDerivs = static_cast<size_t>(Nu + 1) * aDimU;
+  const size_t                       aNbVDerivs = static_cast<size_t>(Nv + 1) * aDimV;
+  NCollection_LocalArray<double, 16> aBUDerivs(aNbUDerivs);
+  NCollection_LocalArray<double, 16> aBVDerivs(aNbVDerivs);
   evalAxisDerivs(U, Nu, myAlgDegreeU, myAlphaU, myBetaU, aDimU, aBUDerivs);
   evalAxisDerivs(V, Nv, myAlgDegreeV, myAlphaV, myBetaV, aDimV, aBVDerivs);
 
@@ -1168,9 +1170,10 @@ gp_Vec GeomEval_AHTBezierSurface::EvalDN(const double U,
     return gp_Vec(aSum);
   }
 
-  NCollection_LocalArray<gp_XYZ, 16> aNDerivs((Nu + 1) * (Nv + 1));
-  NCollection_LocalArray<double, 16> aWDerivs((Nu + 1) * (Nv + 1));
-  NCollection_LocalArray<gp_XYZ, 16> aCDerivs((Nu + 1) * (Nv + 1));
+  const size_t                       aNbDerivs = static_cast<size_t>(Nu + 1) * (Nv + 1);
+  NCollection_LocalArray<gp_XYZ, 16> aNDerivs(aNbDerivs);
+  NCollection_LocalArray<double, 16> aWDerivs(aNbDerivs);
+  NCollection_LocalArray<gp_XYZ, 16> aCDerivs(aNbDerivs);
   evalTensorDerivs(myPoles,
                    &myWeights,
                    Nu,

--- a/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_ApproxF2var.cxx
+++ b/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_ApproxF2var.cxx
@@ -7146,8 +7146,8 @@ L1000:
     i__1  = *ndimen;
     for (nd = 1; nd <= i__1; ++nd)
     {
-      iptt = ipt1 + ((nd - 1) << 1) * (ndgre / 2 + 1);
-      jptt = ipt4 + (nd - 1) * ncoeff[ncb1];
+      iptt = ipt1 + (static_cast<intptr_t>(nd - 1) << 1) * (ndgre / 2 + 1);
+      jptt = ipt4 + static_cast<intptr_t>(nd - 1) * ncoeff[ncb1];
       AdvApp2Var_MathBase::mmjacan_(iordre, &ndgre, &wrkar_off[iptt], &wrkar_off[jptt]);
       /* L400: */
     }

--- a/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_MathBase.cxx
+++ b/src/ModelingData/TKGeomBase/AdvApp2Var/AdvApp2Var_MathBase.cxx
@@ -4505,7 +4505,7 @@ int AdvApp2Var_MathBase::mmfmtb1_(int*    maxsz1,
   i__1 = *isize1;
   for (ii = 1; ii <= i__1; ++ii)
   {
-    iipt = (ii - 1) * *maxsz2 + iofst;
+    iipt = static_cast<intptr_t>(ii - 1) * *maxsz2 + iofst;
     i__2 = *jsize1;
     for (jj = 1; jj <= i__2; ++jj)
     {

--- a/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
+++ b/src/Visualization/TKOpenGl/OpenGl/OpenGl_View.cxx
@@ -541,7 +541,7 @@ bool OpenGl_View::BufferDump(Image_PixMap& theImage, const Graphic3d_BufferType&
   NCollection_LinearVector<GLfloat> aValues;
   try
   {
-    aValues.Resize(aW * aH);
+    aValues.Resize(static_cast<size_t>(aW) * aH);
   }
   catch (const Standard_OutOfMemory&)
   {
@@ -557,13 +557,14 @@ bool OpenGl_View::BufferDump(Image_PixMap& theImage, const Graphic3d_BufferType&
   aCtx->core11fwd->glBindTexture(GL_TEXTURE_RECTANGLE, 0);
   for (unsigned int aRow = 0; aRow < aH; aRow += 2)
   {
+    const size_t aRowOffset = static_cast<size_t>(aRow) * aW;
     for (unsigned int aCol = 0; aCol < aW; aCol += 3)
     {
       float* anImageValue  = theImage.ChangeValue<float[3]>((aH - aRow) / 2 - 1, aCol / 3);
-      float  aInvNbSamples = 1.f / aValues[aRow * aW + aCol + aW];
-      anImageValue[0]      = aValues[aRow * aW + aCol] * aInvNbSamples;
-      anImageValue[1]      = aValues[aRow * aW + aCol + 1] * aInvNbSamples;
-      anImageValue[2]      = aValues[aRow * aW + aCol + 1 + aW] * aInvNbSamples;
+      float  aInvNbSamples = 1.f / aValues[aRowOffset + aCol + aW];
+      anImageValue[0]      = aValues[aRowOffset + aCol] * aInvNbSamples;
+      anImageValue[1]      = aValues[aRowOffset + aCol + 1] * aInvNbSamples;
+      anImageValue[2]      = aValues[aRowOffset + aCol + 1 + aW] * aInvNbSamples;
     }
   }
 

--- a/src/Visualization/TKV3d/AIS/AIS_Manipulator.cxx
+++ b/src/Visualization/TKV3d/AIS/AIS_Manipulator.cxx
@@ -1842,8 +1842,10 @@ void AIS_Manipulator::Axis::Compute(const occ::handle<PrsMgr_PresentationManager
       {
         for (int aV = 0; aV <= aStripsNb; ++aV)
         {
-          gp_Pnt aVertex = gp_Pnt(0.0, myAxisRadius * (1.5f * aU - 0.75f), aLength * aV * aStepV)
-                             .Transformed(aTrsf);
+          const gp_Pnt aVertex = gp_Pnt(0.0,
+                                        static_cast<double>(myAxisRadius) * (1.5f * aU - 0.75f),
+                                        aLength * aV * aStepV)
+                                   .Transformed(aTrsf);
           myTriangleArray->AddVertex(aVertex, aNormal);
 
           if (aV != 0)

--- a/src/Visualization/TKV3d/Prs3d/Prs3d_ToolQuadric.cxx
+++ b/src/Visualization/TKV3d/Prs3d/Prs3d_ToolQuadric.cxx
@@ -98,8 +98,8 @@ occ::handle<Poly_Triangulation> Prs3d_ToolQuadric::CreatePolyTriangulation(
 {
   occ::handle<Poly_Triangulation> aTriangulation =
     new Poly_Triangulation(VerticesNb(), TrianglesNb(), false);
-  float aStepU = 1.0f / mySlicesNb;
-  float aStepV = 1.0f / myStacksNb;
+  const double aStepU = 1.0 / mySlicesNb;
+  const float  aStepV = 1.0f / myStacksNb;
 
   // Fill triangles
   for (int aU = 0, anIndex = 0; aU <= mySlicesNb; ++aU)


### PR DESCRIPTION
- Promote allocation-size operands to size_t before multiplication in BSplCLib, BSplSLib, PLib, ApproxInt, GeomEval, and OpenGl
- Compute AdvApp2Var workspace offsets in intptr_t to avoid intermediate integer overflow
- Evaluate quadric and manipulator coordinates in double before storing them in gp_Pnt
- Use widened OpenGl row offsets consistently for buffer allocation and indexing.
- Mark immutable geometry values and buffer sizes as const.