### PR TITLE
Modeling Data - Rework ExtremaPC and add 2D algorithms

### DIFF
--- a/src/FoundationClasses/TKMath/GTests/MathRoot_Trig_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/MathRoot_Trig_Test.cxx
@@ -659,3 +659,57 @@ TEST(MathRoot_TrigTest, InvalidFiniteOrderedInputPolicy)
     MathRoot::TrigonometricLinear(1.0, 0.0, 0.0, std::numeric_limits<double>::infinity()).Status,
     MathRoot::Status::InvalidInput);
 }
+
+TEST(MathRoot_TrigTest, PeriodicRootCountRejectsUnrepresentableSteps)
+{
+  size_t aCount = 0;
+  EXPECT_TRUE(MathRoot::Utils::ComputePeriodicRootCount(0.5,
+                                                        0.5 + 6.0 * M_PI,
+                                                        2.0 * M_PI,
+                                                        0.0,
+                                                        false,
+                                                        aCount));
+  EXPECT_EQ(aCount, 4u);
+  EXPECT_TRUE(MathRoot::Utils::ComputePeriodicRootCount(0.5,
+                                                        0.5 + 6.0 * M_PI,
+                                                        2.0 * M_PI,
+                                                        1.0e-12,
+                                                        true,
+                                                        aCount));
+  EXPECT_EQ(aCount, 3u);
+  EXPECT_TRUE(MathRoot::Utils::ComputePeriodicRootCount(0.5,
+                                                        0.5 + 6.0 * M_PI,
+                                                        2.0 * M_PI,
+                                                        0.0,
+                                                        true,
+                                                        aCount));
+  EXPECT_EQ(aCount, 3u);
+  EXPECT_TRUE(MathRoot::Utils::ComputePeriodicRootCount(0.5, 0.5, 2.0 * M_PI, 0.0, true, aCount));
+  EXPECT_EQ(aCount, 0u);
+
+  const double aFourthRoot = 0.5 + 3.0 * (2.0 * M_PI);
+  EXPECT_TRUE(
+    MathRoot::Utils::ComputePeriodicRootCount(0.5,
+                                              std::nextafter(aFourthRoot, aFourthRoot + 1.0),
+                                              2.0 * M_PI,
+                                              0.0,
+                                              true,
+                                              aCount));
+  EXPECT_EQ(aCount, 4u);
+  EXPECT_TRUE(
+    MathRoot::Utils::ComputePeriodicRootCount(0.5,
+                                              std::nextafter(aFourthRoot, aFourthRoot - 1.0),
+                                              2.0 * M_PI,
+                                              0.0,
+                                              false,
+                                              aCount));
+  EXPECT_EQ(aCount, 3u);
+
+  const double aLargeParameter = 1.0e17;
+  EXPECT_FALSE(MathRoot::Utils::ComputePeriodicRootCount(aLargeParameter,
+                                                         aLargeParameter + 100.0,
+                                                         2.0 * M_PI,
+                                                         0.0,
+                                                         false,
+                                                         aCount));
+}

--- a/src/FoundationClasses/TKMath/MathRoot/MathRoot_Trig.hxx
+++ b/src/FoundationClasses/TKMath/MathRoot/MathRoot_Trig.hxx
@@ -103,6 +103,12 @@ inline bool MapPeriodicTrigRoot(double  theRoot,
   {
     theRoot = theUpper;
   }
+  size_t aNbRepresentatives = 0;
+  if (!ComputePeriodicRootCount(theRoot, theUpper, THE_2PI, theTolerance, false, aNbRepresentatives)
+      || aNbRepresentatives == 0)
+  {
+    return false;
+  }
   theMappedRoot = theRoot;
   return true;
 }

--- a/src/FoundationClasses/TKMath/MathRoot/MathRoot_Utils.hxx
+++ b/src/FoundationClasses/TKMath/MathRoot/MathRoot_Utils.hxx
@@ -17,6 +17,7 @@
 #include <MathUtils_Config.hxx>
 
 #include <cmath>
+#include <cstddef>
 
 namespace MathRoot
 {
@@ -47,6 +48,73 @@ inline bool HaveOppositeSigns(double theFirst, double theSecond)
 inline double Midpoint(double theFirst, double theSecond)
 {
   return 0.5 * theFirst + 0.5 * theSecond;
+}
+
+//! Compute how many periodic representatives starting at theFirst lie in an upper-bounded domain.
+//! @param[in] theFirst first representative, already mapped to the domain lower bound
+//! @param[in] theUpper domain upper bound
+//! @param[in] thePeriod positive period
+//! @param[in] theTolerance tolerance applied at the upper bound
+//! @param[in] theExcludeUpperTolerance true to stop before upper-tolerance; false to include
+//! upper+tolerance
+//! @param[out] theCount number of representable periodic roots
+//! @return false if the inputs, count, or floating-point step cannot be represented safely
+inline bool ComputePeriodicRootCount(double  theFirst,
+                                     double  theUpper,
+                                     double  thePeriod,
+                                     double  theTolerance,
+                                     bool    theExcludeUpperTolerance,
+                                     size_t& theCount)
+{
+  theCount = 0;
+  if (!std::isfinite(theFirst) || !std::isfinite(theUpper) || !std::isfinite(thePeriod)
+      || thePeriod <= 0.0 || !std::isfinite(theTolerance) || theTolerance < 0.0)
+  {
+    return false;
+  }
+
+  const double aLimit =
+    theExcludeUpperTolerance ? theUpper - theTolerance : theUpper + theTolerance;
+  if (!std::isfinite(aLimit))
+  {
+    return false;
+  }
+  if (theExcludeUpperTolerance ? theFirst >= aLimit : theFirst > aLimit)
+  {
+    return true;
+  }
+
+  const long double aSpan = static_cast<long double>(aLimit) - theFirst;
+  const long double aCount =
+    theExcludeUpperTolerance ? std::ceil(aSpan / thePeriod) : std::floor(aSpan / thePeriod) + 1.0L;
+  if (aCount < 1.0L || aCount >= static_cast<long double>(static_cast<size_t>(-1)))
+  {
+    return false;
+  }
+  theCount     = static_cast<size_t>(aCount);
+  double aLast = theFirst + static_cast<double>(theCount - 1) * thePeriod;
+  if (theExcludeUpperTolerance ? aLast >= aLimit : aLast > aLimit)
+  {
+    --theCount;
+  }
+  const double aNext        = theFirst + static_cast<double>(theCount) * thePeriod;
+  const bool   isNextInside = theExcludeUpperTolerance ? aNext < aLimit : aNext <= aLimit;
+  if (theCount < static_cast<size_t>(-1) - 1 && isNextInside)
+  {
+    ++theCount;
+  }
+  if (theCount == 0)
+  {
+    return true;
+  }
+  aLast = theFirst + static_cast<double>(theCount - 1) * thePeriod;
+  if (theCount < 2 || theFirst + thePeriod <= theFirst)
+  {
+    return theCount < 2;
+  }
+
+  const double aPrevious = theFirst + static_cast<double>(theCount - 2) * thePeriod;
+  return std::isfinite(aLast) && aLast > aPrevious;
 }
 
 } // namespace Utils

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC.hxx
@@ -16,18 +16,19 @@
 
 #include <gp_Pnt.hxx>
 #include <MathUtils_Domain.hxx>
-#include <NCollection_DynamicArray.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <Precision.hxx>
 
+#include <cmath>
+#include <cstddef>
 #include <limits>
-#include <optional>
 
 //! @file ExtremaPC.hxx
 //! @brief Common types and utilities for Point-Curve extrema computation.
 //!
 //! The ExtremaPC package provides modern C++ implementation of point-curve
 //! extrema computation using std::variant for curve type dispatch and
-//! BVH-based hierarchical algorithms for numerical curves.
+//! analytical and derivative-aware numerical algorithms.
 
 namespace ExtremaPC
 {
@@ -42,6 +43,20 @@ namespace ExtremaPC
 //! Used when no explicit tolerance is provided.
 constexpr double THE_DEFAULT_TOLERANCE = Precision::Confusion();
 
+//! Returns true when a geometric tolerance is usable by extrema algorithms.
+inline bool IsValidTolerance(double theTolerance)
+{
+  return std::isfinite(theTolerance) && theTolerance > 0.0;
+}
+
+//! Returns true when all point coordinates are finite OCCT values.
+inline bool IsFinitePoint(const gp_Pnt& thePoint)
+{
+  return std::isfinite(thePoint.X()) && !Precision::IsInfinite(thePoint.X())
+         && std::isfinite(thePoint.Y()) && !Precision::IsInfinite(thePoint.Y())
+         && std::isfinite(thePoint.Z()) && !Precision::IsInfinite(thePoint.Z());
+}
+
 //! Tolerance for parameter domain comparison (cache validation).
 //! Uses PConfusion which is appropriate for parametric space.
 constexpr double THE_PARAM_TOLERANCE = Precision::PConfusion();
@@ -50,68 +65,46 @@ constexpr double THE_PARAM_TOLERANCE = Precision::PConfusion();
 //! Used to evaluate if an endpoint is a local extremum.
 constexpr double THE_NEIGHBOR_STEP_RATIO = 0.01;
 
-//! Ratio of parameter range for search interval expansion.
-//! Used in grid-based methods to expand candidate intervals.
-constexpr double THE_INTERVAL_EXPAND_RATIO = 0.05;
-
-//! Ratio of parameter range for refinement step.
-//! Used in iterative refinement algorithms.
-constexpr double THE_REFINEMENT_STEP_RATIO = 0.001;
-
-//! Multiplier for X (parameter) tolerance in Newton refinement.
-constexpr double THE_NEWTON_XTOL_FACTOR = 0.01;
-
-//! Multiplier for F (function) tolerance in Newton refinement.
-constexpr double THE_NEWTON_FTOL_FACTOR = 0.001;
-
-//! Default search radius for hint-based search (fraction of parameter range).
-constexpr double THE_HINT_SEARCH_RADIUS = 0.1;
-
-//! Factor for narrowing parameter range during refinement iterations.
-constexpr double THE_RANGE_NARROWING_FACTOR = 0.25;
-
-//! Threshold for skipping max candidates that are clearly worse.
-//! If estimated distance < best * threshold, skip candidate.
-constexpr double THE_MAX_SKIP_THRESHOLD = 0.9;
-
-//! Multiplier for near-zero F detection during grid scan.
-//! F values smaller than tolerance * this factor are considered near-zero.
-constexpr double THE_NEAR_ZERO_F_FACTOR = 10.0;
-
-//! Multiplier for fallback F tolerance when Newton fails.
-//! Used to accept grid points as approximate solutions.
-constexpr double THE_FALLBACK_F_FACTOR = 100.0;
-
-//! Maximum number of Newton iterations for refinement.
-constexpr int THE_MAX_NEWTON_ITERATIONS = 20;
-
-//! Number of samples for iterative grid refinement fallback.
-constexpr int THE_REFINEMENT_NB_SAMPLES = 20;
-
-//! Number of refinement passes when Newton fails.
-constexpr int THE_REFINEMENT_NB_PASSES = 3;
-
 //! Minimum number of samples for Bezier curves.
-constexpr int THE_BEZIER_MIN_SAMPLES = 24;
+constexpr size_t THE_BEZIER_MIN_SAMPLES = 24;
 
 //! Multiplier for degree to compute Bezier samples: samples = max(min, multiplier * (degree + 1)).
-constexpr int THE_BEZIER_DEGREE_MULTIPLIER = 3;
+constexpr size_t THE_BEZIER_DEGREE_MULTIPLIER = 3;
 
 //! Default number of samples for general (other) curves.
-constexpr int THE_OTHER_CURVE_NB_SAMPLES = 64;
+constexpr size_t THE_OTHER_CURVE_NB_SAMPLES = 64;
 
 //! Fallback number of samples for BSpline curves when curve is null.
-constexpr int THE_BSPLINE_FALLBACK_SAMPLES = 32;
+constexpr size_t THE_BSPLINE_FALLBACK_SAMPLES = 32;
 
 //! Multiplier for BSpline curve samples per knot span: samples = multiplier * (degree + 1).
 //! For a degree 3 curve: 2*4 = 8 samples per span.
 //! This is higher than the surface counterpart because curves are 1D and require
 //! finer sampling to detect extrema reliably. Surfaces use degree+2 per direction,
 //! resulting in (degree+2)^2 samples per cell, which provides adequate coverage.
-constexpr int THE_BSPLINE_SPAN_MULTIPLIER = 2;
+constexpr size_t THE_BSPLINE_SPAN_MULTIPLIER = 2;
 
 //! 1D parameter domain for curves (alias for MathUtils::Domain1D).
 using Domain1D = MathUtils::Domain1D;
+
+//! Returns true when a finite domain spans an integral number of periods.
+inline bool IsClosedPeriodicDomain(const Domain1D& theDomain, double thePeriod, double theTolerance)
+{
+  if (!theDomain.IsValid() || !std::isfinite(thePeriod) || thePeriod <= 0.0
+      || !std::isfinite(theTolerance) || theTolerance < 0.0)
+  {
+    return false;
+  }
+
+  const double aNbPeriods = std::round(theDomain.Length() / thePeriod);
+  return aNbPeriods >= 1.0 && std::abs(theDomain.Length() - aNbPeriods * thePeriod) <= theTolerance;
+}
+
+//! Returns true when a parameter can be evaluated as a finite endpoint.
+inline bool IsFiniteParameter(double theParameter)
+{
+  return std::isfinite(theParameter) && !Precision::IsInfinite(theParameter);
+}
 
 //! Status of extrema computation.
 enum class Status
@@ -120,6 +113,7 @@ enum class Status
   NotDone,           //!< Computation not performed
   InfiniteSolutions, //!< Infinite solutions exist (e.g., point at circle center)
   NoSolution,        //!< No extrema found in the given parameter range
+  InvalidInput,      //!< Invalid tolerance or parameter domain
   NumericalError     //!< Numerical issues during computation
 };
 
@@ -127,26 +121,30 @@ enum class Status
 //! Controls which extrema to find, enabling performance optimizations.
 enum class SearchMode
 {
-  MinMax, //!< Find all extrema (both minima and maxima) - default
-  Min,    //!< Find only minimum distance (enables early termination in BVH)
-  Max     //!< Find only maximum distance
+  MinMax, //!< Find all local extrema (both minima and maxima) - default
+  Min,    //!< Find local minima only
+  Max     //!< Find local maxima only
 };
 
 //! Result of a single extremum computation.
 struct ExtremumResult
 {
-  double Parameter = 0.0;       //!< Parameter value on curve
-  gp_Pnt Point;                 //!< Point on curve at parameter
-  double SquareDistance = 0.0;  //!< Square of the distance from query point to curve point
-  bool   IsMinimum      = true; //!< True if this is a local minimum, false if maximum
+  double Parameter = 0.0;        //!< Parameter value on curve
+  gp_Pnt Point;                  //!< Point on curve at parameter
+  double SquareDistance = 0.0;   //!< Square of the distance from query point to curve point
+  bool   IsMinimum      = true;  //!< True if this is a local minimum
+  bool   IsMaximum      = false; //!< True if this is a local maximum
 };
 
 //! Result of extrema computation containing all found extrema.
 //! Non-copyable to enforce use of const reference from Perform().
 struct Result
 {
+  //! Sentinel returned by index queries when no extremum exists.
+  static constexpr size_t INVALID_INDEX = static_cast<size_t>(-1);
+
   ExtremaPC::Status Status = ExtremaPC::Status::NotDone; //!< Computation status
-  NCollection_DynamicArray<ExtremumResult> Extrema{8};   //!< Collection of found extrema
+  NCollection_LinearVector<ExtremumResult> Extrema{8};   //!< Collection of found extrema
 
   //! For infinite solutions, stores the constant squared distance.
   //! Only meaningful when Status == Status::InfiniteSolutions.
@@ -167,17 +165,17 @@ struct Result
   //! Move assignment.
   Result& operator=(Result&&) = default;
 
-  //! Returns true if computation succeeded with finite number of extrema.
-  bool IsDone() const { return Status == Status::OK; }
+  //! Returns true if a finite search completed, including a search with no matching extrema.
+  bool IsDone() const { return Status == Status::OK || Status == Status::NoSolution; }
 
   //! Returns true if there are infinite solutions.
   bool IsInfinite() const { return Status == Status::InfiniteSolutions; }
 
   //! Returns number of extrema found (0 if infinite or failed).
-  int NbExt() const { return Extrema.Length(); }
+  size_t NbExt() const { return Extrema.Size(); }
 
   //! Access extremum by 0-based index.
-  const ExtremumResult& operator[](int theIndex) const { return Extrema.Value(theIndex); }
+  const ExtremumResult& operator[](size_t theIndex) const { return Extrema.Value(theIndex); }
 
   //! Returns the squared distance of the closest extremum.
   //! Returns infinity if no extrema found.
@@ -188,32 +186,32 @@ struct Result
       return std::numeric_limits<double>::infinity();
     }
     double aMinSqDist = Extrema.Value(0).SquareDistance;
-    for (int i = 1; i < Extrema.Length(); ++i)
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
     {
-      if (Extrema.Value(i).SquareDistance < aMinSqDist)
+      if (Extrema.Value(anIndex).SquareDistance < aMinSqDist)
       {
-        aMinSqDist = Extrema.Value(i).SquareDistance;
+        aMinSqDist = Extrema.Value(anIndex).SquareDistance;
       }
     }
     return aMinSqDist;
   }
 
   //! Returns the index of the closest extremum (0-based).
-  //! Returns -1 if no extrema found.
-  int MinIndex() const
+  //! Returns INVALID_INDEX if no extrema are available.
+  size_t MinIndex() const
   {
     if (Extrema.IsEmpty())
     {
-      return -1;
+      return INVALID_INDEX;
     }
-    int    aMinIdx    = 0;
+    size_t aMinIdx    = 0;
     double aMinSqDist = Extrema.Value(0).SquareDistance;
-    for (int i = 1; i < Extrema.Length(); ++i)
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
     {
-      if (Extrema.Value(i).SquareDistance < aMinSqDist)
+      if (Extrema.Value(anIndex).SquareDistance < aMinSqDist)
       {
-        aMinSqDist = Extrema.Value(i).SquareDistance;
-        aMinIdx    = i;
+        aMinSqDist = Extrema.Value(anIndex).SquareDistance;
+        aMinIdx    = anIndex;
       }
     }
     return aMinIdx;
@@ -228,32 +226,32 @@ struct Result
       return 0.0;
     }
     double aMaxSqDist = Extrema.Value(0).SquareDistance;
-    for (int i = 1; i < Extrema.Length(); ++i)
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
     {
-      if (Extrema.Value(i).SquareDistance > aMaxSqDist)
+      if (Extrema.Value(anIndex).SquareDistance > aMaxSqDist)
       {
-        aMaxSqDist = Extrema.Value(i).SquareDistance;
+        aMaxSqDist = Extrema.Value(anIndex).SquareDistance;
       }
     }
     return aMaxSqDist;
   }
 
   //! Returns the index of the farthest extremum (0-based).
-  //! Returns -1 if no extrema found.
-  int MaxIndex() const
+  //! Returns INVALID_INDEX if no extrema are available.
+  size_t MaxIndex() const
   {
     if (Extrema.IsEmpty())
     {
-      return -1;
+      return INVALID_INDEX;
     }
-    int    aMaxIdx    = 0;
+    size_t aMaxIdx    = 0;
     double aMaxSqDist = Extrema.Value(0).SquareDistance;
-    for (int i = 1; i < Extrema.Length(); ++i)
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
     {
-      if (Extrema.Value(i).SquareDistance > aMaxSqDist)
+      if (Extrema.Value(anIndex).SquareDistance > aMaxSqDist)
       {
-        aMaxSqDist = Extrema.Value(i).SquareDistance;
-        aMaxIdx    = i;
+        aMaxSqDist = Extrema.Value(anIndex).SquareDistance;
+        aMaxIdx    = anIndex;
       }
     }
     return aMaxIdx;
@@ -267,16 +265,6 @@ struct Result
     Extrema.Clear();
     InfiniteSquareDistance = 0.0;
   }
-};
-
-//! Configuration for extrema computation.
-struct Config
-{
-  double                  Tolerance = THE_DEFAULT_TOLERANCE; //!< Tolerance for root finding
-  std::optional<Domain1D> Domain;         //!< Parameter domain (nullopt = use natural/unbounded)
-  int                     NbSamples = 32; //!< Number of samples for numerical methods
-  SearchMode              Mode      = SearchMode::MinMax; //!< Search mode (MinMax, Min, or Max)
-  bool                    IncludeEndpoints = true; //!< Include endpoints as potential extrema
 };
 
 //! @brief Adds endpoint extrema to result for bounded curves.
@@ -296,37 +284,35 @@ struct Config
 //! @param theP query point
 //! @param theDomain parameter domain
 //! @param theEval curve evaluator
-//! @param theTol tolerance for duplicate detection
 //! @param theMode search mode
 template <typename CurveEvaluator>
 inline void AddEndpointExtrema(Result&               theResult,
                                const gp_Pnt&         theP,
                                const Domain1D&       theDomain,
                                const CurveEvaluator& theEval,
-                               double                theTol,
-                               SearchMode            theMode)
+                               SearchMode            theMode,
+                               bool                  theIsClosed)
 {
-  // Check for infinite bounds
-  if (!theDomain.IsFinite())
+  if (!theDomain.IsValid())
   {
     return;
   }
 
-  const double theUMin = theDomain.Min;
-  const double theUMax = theDomain.Max;
+  const double theUMin      = theDomain.Min;
+  const double theUMax      = theDomain.Max;
+  const bool   hasFiniteMin = IsFiniteParameter(theUMin);
+  const bool   hasFiniteMax = IsFiniteParameter(theUMax);
+  if (!hasFiniteMin && !hasFiniteMax)
+  {
+    return;
+  }
 
   // Helper to check if parameter or point already exists in result
-  auto isDuplicate = [&](double theU, const gp_Pnt& thePt) -> bool {
-    for (int i = 0; i < theResult.Extrema.Length(); ++i)
+  auto isDuplicate = [&](double theU) -> bool {
+    for (size_t anIndex = 0; anIndex < theResult.Extrema.Size(); ++anIndex)
     {
       // Check parameter proximity
-      if (std::abs(theResult.Extrema.Value(i).Parameter - theU) < theTol)
-      {
-        return true;
-      }
-      // Check point proximity (handles periodic curves where different params map to same point)
-      double aSqDist = theResult.Extrema.Value(i).Point.SquareDistance(thePt);
-      if (aSqDist < theTol * theTol)
+      if (std::abs(theResult.Extrema.Value(anIndex).Parameter - theU) < THE_PARAM_TOLERANCE)
       {
         return true;
       }
@@ -334,88 +320,62 @@ inline void AddEndpointExtrema(Result&               theResult,
     return false;
   };
 
-  // Evaluate endpoints
-  gp_Pnt aPtMin = theEval.Value(theUMin);
-  gp_Pnt aPtMax = theEval.Value(theUMax);
-
-  double aSqDistMin = theP.SquareDistance(aPtMin);
-  double aSqDistMax = theP.SquareDistance(aPtMax);
-
-  // Sample step for neighbor point evaluation
-  double aStep = (theUMax - theUMin) * THE_NEIGHBOR_STEP_RATIO;
-  if (aStep < theTol)
+  if (theUMin == theUMax)
   {
-    aStep = theTol;
+    if (hasFiniteMin && !isDuplicate(theUMin))
+    {
+      const gp_Pnt   aPoint = theEval.Value(theUMin);
+      ExtremumResult anExt;
+      anExt.Parameter      = theUMin;
+      anExt.Point          = aPoint;
+      anExt.SquareDistance = theP.SquareDistance(aPoint);
+      anExt.IsMinimum      = theMode != SearchMode::Max;
+      anExt.IsMaximum      = theMode != SearchMode::Min;
+      theResult.Extrema.Append(anExt);
+    }
+    return;
   }
 
-  // Check if UMin is a local extremum by comparing to neighbor
-  gp_Pnt aNeighborMin     = theEval.Value(theUMin + aStep);
-  double aNeighborDistMin = theP.SquareDistance(aNeighborMin);
-  bool   aIsMinAtUMin     = (aSqDistMin <= aNeighborDistMin);
-  bool   aIsMaxAtUMin     = (aSqDistMin >= aNeighborDistMin);
-
-  // Check if UMax is a local extremum by comparing to neighbor
-  gp_Pnt aNeighborMax     = theEval.Value(theUMax - aStep);
-  double aNeighborDistMax = theP.SquareDistance(aNeighborMax);
-  bool   aIsMinAtUMax     = (aSqDistMax <= aNeighborDistMax);
-  bool   aIsMaxAtUMax     = (aSqDistMax >= aNeighborDistMax);
-
-  // Also check if endpoints themselves are duplicates (for periodic curves)
-  bool aEndpointsAreSame = aPtMin.SquareDistance(aPtMax) < theTol * theTol;
-
-  // For periodic/closed curves, there are no true endpoints to consider
-  if (aEndpointsAreSame)
+  if (theIsClosed)
   {
     return;
   }
 
-  // Add endpoints only if they are true local extrema matching the search mode
-  if (theMode == SearchMode::Min || theMode == SearchMode::MinMax)
-  {
-    // Add UMin if it's a local minimum
-    if (aIsMinAtUMin && !isDuplicate(theUMin, aPtMin))
+  const bool hasFiniteSpan = hasFiniteMin && hasFiniteMax;
+  auto       addEndpoint   = [&](double theParameter, bool theIsLower) {
+    if (isDuplicate(theParameter))
     {
-      ExtremumResult anExt;
-      anExt.Parameter      = theUMin;
-      anExt.Point          = aPtMin;
-      anExt.SquareDistance = aSqDistMin;
-      anExt.IsMinimum      = true;
-      theResult.Extrema.Append(anExt);
+      return;
     }
-    // Add UMax if it's a local minimum (and not same point as UMin)
-    if (aIsMinAtUMax && !aEndpointsAreSame && !isDuplicate(theUMax, aPtMax))
-    {
-      ExtremumResult anExt;
-      anExt.Parameter      = theUMax;
-      anExt.Point          = aPtMax;
-      anExt.SquareDistance = aSqDistMax;
-      anExt.IsMinimum      = true;
-      theResult.Extrema.Append(anExt);
-    }
-  }
 
-  if (theMode == SearchMode::Max || theMode == SearchMode::MinMax)
+    const double aStep =
+      hasFiniteSpan
+        ? std::min((theUMax - theUMin) * THE_NEIGHBOR_STEP_RATIO, (theUMax - theUMin) * 0.5)
+        : std::max(THE_NEIGHBOR_STEP_RATIO, std::abs(theParameter) * THE_NEIGHBOR_STEP_RATIO);
+    const gp_Pnt aPoint            = theEval.Value(theParameter);
+    const gp_Pnt aNeighbor         = theEval.Value(theParameter + (theIsLower ? aStep : -aStep));
+    const double aSquareDistance   = theP.SquareDistance(aPoint);
+    const double aNeighborDistance = theP.SquareDistance(aNeighbor);
+    const bool   isMinimum         = aSquareDistance <= aNeighborDistance;
+    const bool   isMaximum         = aSquareDistance >= aNeighborDistance;
+
+    if ((theMode == SearchMode::Min || theMode == SearchMode::MinMax) && isMinimum)
+    {
+      theResult.Extrema.Append(ExtremumResult{theParameter, aPoint, aSquareDistance, true, false});
+    }
+    else if ((theMode == SearchMode::Max || theMode == SearchMode::MinMax) && isMaximum)
+    {
+      theResult.Extrema.Append(ExtremumResult{theParameter, aPoint, aSquareDistance, false, true});
+    }
+  };
+
+  if (hasFiniteMin)
   {
-    // Add UMin if it's a local maximum
-    if (aIsMaxAtUMin && !aIsMinAtUMin && !isDuplicate(theUMin, aPtMin))
-    {
-      ExtremumResult anExt;
-      anExt.Parameter      = theUMin;
-      anExt.Point          = aPtMin;
-      anExt.SquareDistance = aSqDistMin;
-      anExt.IsMinimum      = false;
-      theResult.Extrema.Append(anExt);
-    }
-    // Add UMax if it's a local maximum (and not same point as UMin)
-    if (aIsMaxAtUMax && !aIsMinAtUMax && !aEndpointsAreSame && !isDuplicate(theUMax, aPtMax))
-    {
-      ExtremumResult anExt;
-      anExt.Parameter      = theUMax;
-      anExt.Point          = aPtMax;
-      anExt.SquareDistance = aSqDistMax;
-      anExt.IsMinimum      = false;
-      theResult.Extrema.Append(anExt);
-    }
+    addEndpoint(theUMin, true);
+  }
+  if (hasFiniteMax)
+  {
+    addEndpoint(theUMax, false);
   }
 }
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC.hxx
@@ -350,10 +350,10 @@ inline void AddEndpointExtrema(Result&               theResult,
 
     const double aStep =
       hasFiniteSpan
-        ? std::min((theUMax - theUMin) * THE_NEIGHBOR_STEP_RATIO, (theUMax - theUMin) * 0.5)
-        : std::max(THE_NEIGHBOR_STEP_RATIO, std::abs(theParameter) * THE_NEIGHBOR_STEP_RATIO);
-    const gp_Pnt aPoint            = theEval.Value(theParameter);
-    const gp_Pnt aNeighbor         = theEval.Value(theParameter + (theIsLower ? aStep : -aStep));
+                ? std::min((theUMax - theUMin) * THE_NEIGHBOR_STEP_RATIO, (theUMax - theUMin) * 0.5)
+                : std::max(THE_NEIGHBOR_STEP_RATIO, std::abs(theParameter) * THE_NEIGHBOR_STEP_RATIO);
+    const gp_Pnt aPoint    = theEval.Value(theParameter);
+    const gp_Pnt aNeighbor = theEval.Value(theParameter + (theIsLower ? aStep : -aStep));
     const double aSquareDistance   = theP.SquareDistance(aPoint);
     const double aNeighborDistance = theP.SquareDistance(aNeighbor);
     const bool   isMinimum         = aSquareDistance <= aNeighborDistance;

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BSplineCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BSplineCurve.cxx
@@ -13,18 +13,31 @@
 
 #include <ExtremaPC_BSplineCurve.hxx>
 
-#include <GeomGridEval_BSplineCurve.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_BSplineCurve.hxx>
+#include <ProjLib.hxx>
+
 #include <math_Vector.hxx>
-#include <NCollection_DynamicArray.hxx>
+#include <NCollection_LocalArray.hxx>
+#include <Standard_Integer.hxx>
+#include <Standard_RangeError.hxx>
+
+#include <cmath>
 
 //==================================================================================================
 
 ExtremaPC_BSplineCurve::ExtremaPC_BSplineCurve(const occ::handle<Geom_BSplineCurve>& theCurve)
     : myCurve(theCurve),
-      myAdaptor(theCurve),
-      myDomain{theCurve->FirstParameter(), theCurve->LastParameter()}
+      myDomain{0.0, 1.0}
 {
-  buildGrid();
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myAdaptor.Load(myCurve);
+  myDomain.Min = myCurve->FirstParameter();
+  myDomain.Max = myCurve->LastParameter();
+  buildParams();
 }
 
 //==================================================================================================
@@ -32,10 +45,14 @@ ExtremaPC_BSplineCurve::ExtremaPC_BSplineCurve(const occ::handle<Geom_BSplineCur
 ExtremaPC_BSplineCurve::ExtremaPC_BSplineCurve(const occ::handle<Geom_BSplineCurve>& theCurve,
                                                const ExtremaPC::Domain1D&            theDomain)
     : myCurve(theCurve),
-      myAdaptor(theCurve),
       myDomain(theDomain)
 {
-  buildGrid();
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myAdaptor.Load(myCurve);
+  buildParams();
 }
 
 //==================================================================================================
@@ -57,44 +74,66 @@ math_Vector ExtremaPC_BSplineCurve::buildKnotAwareParams() const
   const NCollection_Array1<double>& aKnots  = myCurve->Knots();
 
   // Use multiplier*(degree+1) samples per span for accurate extrema detection.
-  const int aSamplesPerSpan = ExtremaPC::THE_BSPLINE_SPAN_MULTIPLIER * (aDegree + 1);
+  const size_t aSamplesPerSpan =
+    ExtremaPC::THE_BSPLINE_SPAN_MULTIPLIER * static_cast<size_t>(aDegree + 1);
 
-  // Single-pass algorithm using dynamic vector
-  NCollection_DynamicArray<double> aParams;
-  aParams.Append(theUMin);
-
-  for (int i = aKnots.Lower(); i < aKnots.Upper(); ++i)
+  const bool   isPeriodic      = myCurve->IsPeriodic();
+  const double aPeriod         = isPeriodic ? myCurve->Period() : 0.0;
+  const double aFirstShiftReal = isPeriodic ? std::floor((theUMin - aKnots.Last()) / aPeriod) : 0.0;
+  const double aLastShiftReal  = isPeriodic ? std::ceil((theUMax - aKnots.First()) / aPeriod) : 0.0;
+  const double aNbShifts       = aLastShiftReal - aFirstShiftReal + 1.0;
+  const double aMaxParams =
+    2.0 + aNbShifts * static_cast<double>(aKnots.Size() - 1) * aSamplesPerSpan;
+  Standard_RangeError_Raise_if(aFirstShiftReal < IntegerFirst() || aFirstShiftReal > IntegerLast()
+                                 || aLastShiftReal < IntegerFirst()
+                                 || aLastShiftReal > IntegerLast() || aNbShifts < 1.0
+                                 || aMaxParams > IntegerLast(),
+                               "ExtremaPC_BSplineCurve: parameter grid is too large");
+  const int                           aFirstShift = static_cast<int>(aFirstShiftReal);
+  const int                           aLastShift  = static_cast<int>(aLastShiftReal);
+  NCollection_LocalArray<double, 128> aParams(static_cast<size_t>(aMaxParams));
+  size_t                              aNbParams = 0;
+  aParams[aNbParams++]                          = theUMin;
+  for (int aShiftIndex = aFirstShift;; ++aShiftIndex)
   {
-    double aKnotLo = aKnots.Value(i);
-    double aKnotHi = aKnots.Value(i + 1);
-    double aSpanLo = std::max(aKnotLo, theUMin);
-    double aSpanHi = std::min(aKnotHi, theUMax);
-    if (aSpanHi <= aSpanLo)
+    const double aShift = aShiftIndex * aPeriod;
+    for (size_t aKnotIndex = 0; aKnotIndex + 1 < aKnots.Size(); ++aKnotIndex)
     {
-      continue;
-    }
-
-    double aStep = (aSpanHi - aSpanLo) / aSamplesPerSpan;
-    for (int j = 1; j < aSamplesPerSpan; ++j)
-    {
-      double aU = aSpanLo + j * aStep;
-      if (aU > theUMin && aU < theUMax)
+      const double aKnotLo = aKnots.At(aKnotIndex) + aShift;
+      const double aKnotHi = aKnots.At(aKnotIndex + 1) + aShift;
+      const double aSpanLo = std::max(aKnotLo, theUMin);
+      const double aSpanHi = std::min(aKnotHi, theUMax);
+      if (aSpanHi <= aSpanLo)
       {
-        aParams.Append(aU);
+        continue;
+      }
+
+      const double aStep = (aSpanHi - aSpanLo) / aSamplesPerSpan;
+      for (size_t aSampleIndex = 1; aSampleIndex < aSamplesPerSpan; ++aSampleIndex)
+      {
+        const double aU = aSpanLo + static_cast<double>(aSampleIndex) * aStep;
+        if (aU > theUMin && aU < theUMax)
+        {
+          aParams[aNbParams++] = aU;
+        }
+      }
+      if (aKnotHi > theUMin && aKnotHi < theUMax)
+      {
+        aParams[aNbParams++] = aKnotHi;
       }
     }
-    if (aKnotHi > theUMin && aKnotHi < theUMax)
+    if (aShiftIndex == aLastShift)
     {
-      aParams.Append(aKnotHi);
+      break;
     }
   }
-  aParams.Append(theUMax);
+  aParams[aNbParams++] = theUMax;
 
-  // Convert to math_Vector (required by BuildGrid interface)
-  math_Vector aResult(1, aParams.Length());
-  for (int i = 0; i < aParams.Length(); ++i)
+  // Convert to math_Vector for the numerical evaluator.
+  math_Vector aResult(aNbParams);
+  for (size_t anIndex = 0; anIndex < aNbParams; ++anIndex)
   {
-    aResult(i + 1) = aParams.Value(i);
+    aResult.ChangeAt(anIndex) = aParams[anIndex];
   }
 
   return aResult;
@@ -102,19 +141,17 @@ math_Vector ExtremaPC_BSplineCurve::buildKnotAwareParams() const
 
 //==================================================================================================
 
-void ExtremaPC_BSplineCurve::buildGrid()
+void ExtremaPC_BSplineCurve::buildParams()
 {
-  if (myCurve.IsNull())
+  if (myCurve.IsNull() || !myDomain.IsValid() || !myDomain.IsFinite())
   {
     return;
   }
 
-  // Build knot-aware parameter grid
+  // Build knot-aware parameter partition.
   math_Vector aParams = buildKnotAwareParams();
 
-  // Build grid using the evaluator
-  GeomGridEval_BSplineCurve aGridEval(myCurve);
-  myEvaluator.BuildGrid(aGridEval, aParams);
+  myEvaluator.SetParams(aParams);
 }
 
 //==================================================================================================
@@ -122,6 +159,30 @@ void ExtremaPC_BSplineCurve::buildGrid()
 gp_Pnt ExtremaPC_BSplineCurve::Value(double theU) const
 {
   return myCurve->Value(theU);
+}
+
+//=================================================================================================
+
+bool ExtremaPC_BSplineCurve::performPlanar(const gp_Pnt&         theP,
+                                           double                theTol,
+                                           ExtremaPC::SearchMode theMode,
+                                           bool                  theIncludeEndpoints) const
+{
+  gp_Pln                           aPlane;
+  occ::handle<Geom2d_BSplineCurve> aCurve2d;
+  if (!ExtremaPC::ProjectBSpline(myCurve, aPlane, aCurve2d))
+  {
+    return false;
+  }
+
+  ExtremaPC2d_BSplineCurve      anEvaluator2d(aCurve2d,
+                                              ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
+  const ExtremaPC2d::SearchMode aMode    = ExtremaPC::ToSearchMode2d(theMode);
+  const gp_Pnt2d                aPoint2d = ProjLib::Project(aPlane, theP);
+  const ExtremaPC2d::Result&    aResult2d =
+    theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(aPoint2d, theTol, aMode)
+                        : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
+  return ExtremaPC::ConvertPlanarResult(aResult2d, theP, aPlane, *this, myEvaluator.Result());
 }
 
 //==================================================================================================
@@ -137,6 +198,12 @@ const ExtremaPC::Result& ExtremaPC_BSplineCurve::Perform(const gp_Pnt&         t
     return myEvaluator.Result();
   }
 
+  if (ExtremaPC::IsValidTolerance(theTol) && myDomain.IsValid()
+      && performPlanar(theP, theTol, theMode, false))
+  {
+    return myEvaluator.Result();
+  }
+
   return myEvaluator.Perform(myAdaptor, theP, myDomain, theTol, theMode);
 }
 
@@ -147,14 +214,26 @@ const ExtremaPC::Result& ExtremaPC_BSplineCurve::PerformWithEndpoints(
   double                theTol,
   ExtremaPC::SearchMode theMode) const
 {
-  // Get interior extrema (populates myEvaluator's result)
-  (void)myEvaluator.Perform(myAdaptor, theP, myDomain, theTol, theMode);
+  if (myCurve.IsNull())
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC::Status::NotDone;
+    return myEvaluator.Result();
+  }
+  if (ExtremaPC::IsValidTolerance(theTol) && myDomain.IsValid()
+      && performPlanar(theP, theTol, theMode, true))
+  {
+    return myEvaluator.Result();
+  }
+
+  (void)Perform(theP, theTol, theMode);
 
   // Add endpoints to the result
   ExtremaPC::Result& aResult = myEvaluator.Result();
   if (aResult.Status == ExtremaPC::Status::OK || aResult.Status == ExtremaPC::Status::NoSolution)
   {
-    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theTol, theMode);
+    const bool isClosed = ExtremaPC_GridEvaluator::IsClosedDomain(myAdaptor, myDomain);
+    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
 
     // Update status if we found any extrema (including endpoints)
     if (!aResult.Extrema.IsEmpty())

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BSplineCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BSplineCurve.cxx
@@ -176,12 +176,12 @@ bool ExtremaPC_BSplineCurve::performPlanar(const gp_Pnt&         theP,
   }
 
   ExtremaPC2d_BSplineCurve      anEvaluator2d(aCurve2d,
-                                              ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
+                                         ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
   const ExtremaPC2d::SearchMode aMode    = ExtremaPC::ToSearchMode2d(theMode);
   const gp_Pnt2d                aPoint2d = ProjLib::Project(aPlane, theP);
   const ExtremaPC2d::Result&    aResult2d =
     theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(aPoint2d, theTol, aMode)
-                        : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
+                           : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
   return ExtremaPC::ConvertPlanarResult(aResult2d, theP, aPlane, *this, myEvaluator.Result());
 }
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BSplineCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BSplineCurve.hxx
@@ -19,23 +19,21 @@
 #include <GeomAdaptor_Curve.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <gp_Pnt.hxx>
-#include <NCollection_Array1.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
 #include <math_Vector.hxx>
 
-//! @brief Point-BSplineCurve extrema computation using grid-based approach.
+//! @brief Point-BSplineCurve extrema computation using numerical root isolation.
 //!
-//! Computes the extrema between a 3D point and a BSpline curve using
-//! a grid-based approach with Newton refinement.
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
 //!
-//! The grid is cached for efficiency when performing multiple queries
-//! with the same parameter domain.
+//! The knot-aware parameter partition is cached while geometry is evaluated for each query.
 //!
 //! The algorithm:
-//! 1. Build knot-aware grid with 2*(degree + 1) samples per knot span using GeomGridEval
-//! 2. Linear scan of grid to find candidate intervals (sign changes in F(u))
-//! 3. Newton refinement on each candidate interval
+//! 1. Build a knot-aware parameter partition
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
 //!
 //! This approach is simpler and more stable than BVH-based methods,
 //! with comparable accuracy for typical BSpline curves.
@@ -48,12 +46,12 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Constructor with BSpline curve (uses full curve domain).
-  //! Grid is built eagerly at construction time.
+  //! Parameter partition is built eagerly at construction time.
   //! @param[in] theCurve BSpline curve handle
   Standard_EXPORT explicit ExtremaPC_BSplineCurve(const occ::handle<Geom_BSplineCurve>& theCurve);
 
   //! Constructor with BSpline curve and parameter domain.
-  //! Grid is built eagerly at construction time for the specified domain.
+  //! Parameter partition is built eagerly at construction time for the specified domain.
   //! @param[in] theCurve BSpline curve handle
   //! @param[in] theDomain parameter domain (fixed for all queries)
   Standard_EXPORT ExtremaPC_BSplineCurve(const occ::handle<Geom_BSplineCurve>& theCurve,
@@ -113,14 +111,25 @@ private:
   //! @return array of parameter values for grid sampling
   math_Vector buildKnotAwareParams() const;
 
-  //! Build grid for the curve.
-  void buildGrid();
+  //! Build parameter partition for the curve.
+  void buildParams();
+
+  //! Performs through the exact 2D representation when the current curve is planar.
+  //! @param[in] theP query point
+  //! @param[in] theTol tolerance for root finding
+  //! @param[in] theMode search mode
+  //! @param[in] theIncludeEndpoints whether endpoints should be included
+  //! @return true when the 2D result was accepted
+  bool performPlanar(const gp_Pnt&         theP,
+                     double                theTol,
+                     ExtremaPC::SearchMode theMode,
+                     bool                  theIncludeEndpoints) const;
 
   occ::handle<Geom_BSplineCurve> myCurve;   //!< BSpline curve
   GeomAdaptor_Curve              myAdaptor; //!< Curve adaptor
   ExtremaPC::Domain1D            myDomain;  //!< Parameter domain (fixed)
 
-  // Grid evaluator with cached state (grid, result, temporary vectors)
+  // Numerical evaluator with cached parameter partition and result
   mutable ExtremaPC_GridEvaluator myEvaluator;
 };
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BezierCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BezierCurve.cxx
@@ -31,9 +31,9 @@ ExtremaPC_BezierCurve::ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>
   myAdaptor.Load(myCurve);
   myDomain.Min = myCurve->FirstParameter();
   myDomain.Max = myCurve->LastParameter();
-  myNbSamples = std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
-                         ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER
-                           * static_cast<size_t>(myCurve->Degree() + 1));
+  myNbSamples =
+    std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
+             ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER * static_cast<size_t>(myCurve->Degree() + 1));
   buildParams();
 }
 
@@ -50,9 +50,9 @@ ExtremaPC_BezierCurve::ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>
     return;
   }
   myAdaptor.Load(myCurve);
-  myNbSamples = std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
-                         ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER
-                           * static_cast<size_t>(myCurve->Degree() + 1));
+  myNbSamples =
+    std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
+             ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER * static_cast<size_t>(myCurve->Degree() + 1));
   buildParams();
 }
 
@@ -81,9 +81,9 @@ gp_Pnt ExtremaPC_BezierCurve::Value(double theU) const
 //=================================================================================================
 
 bool ExtremaPC_BezierCurve::performPlanar(const gp_Pnt&         theP,
-                                           double                theTol,
-                                           ExtremaPC::SearchMode theMode,
-                                           bool theIncludeEndpoints) const
+                                          double                theTol,
+                                          ExtremaPC::SearchMode theMode,
+                                          bool                  theIncludeEndpoints) const
 {
   gp_Pln                          aPlane;
   occ::handle<Geom2d_BezierCurve> aCurve2d;
@@ -92,18 +92,14 @@ bool ExtremaPC_BezierCurve::performPlanar(const gp_Pnt&         theP,
     return false;
   }
 
-  ExtremaPC2d_BezierCurve anEvaluator2d(aCurve2d,
-                                         ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
-  const ExtremaPC2d::SearchMode aMode = ExtremaPC::ToSearchMode2d(theMode);
-  const gp_Pnt2d aPoint2d = ProjLib::Project(aPlane, theP);
-  const ExtremaPC2d::Result& aResult2d =
+  ExtremaPC2d_BezierCurve       anEvaluator2d(aCurve2d,
+                                        ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
+  const ExtremaPC2d::SearchMode aMode    = ExtremaPC::ToSearchMode2d(theMode);
+  const gp_Pnt2d                aPoint2d = ProjLib::Project(aPlane, theP);
+  const ExtremaPC2d::Result&    aResult2d =
     theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(aPoint2d, theTol, aMode)
-                        : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
-  return ExtremaPC::ConvertPlanarResult(aResult2d,
-                                        theP,
-                                        aPlane,
-                                        *this,
-                                        myEvaluator.Result());
+                           : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
+  return ExtremaPC::ConvertPlanarResult(aResult2d, theP, aPlane, *this, myEvaluator.Result());
 }
 
 //==================================================================================================

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BezierCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BezierCurve.cxx
@@ -13,18 +13,28 @@
 
 #include <ExtremaPC_BezierCurve.hxx>
 
-#include <GeomGridEval_BezierCurve.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_BezierCurve.hxx>
+#include <ProjLib.hxx>
 
 //==================================================================================================
 
 ExtremaPC_BezierCurve::ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>& theCurve)
     : myCurve(theCurve),
-      myAdaptor(theCurve),
-      myDomain{theCurve->FirstParameter(), theCurve->LastParameter()},
-      myNbSamples(std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
-                           ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER * (theCurve->Degree() + 1)))
+      myDomain{0.0, 1.0},
+      myNbSamples(ExtremaPC::THE_BEZIER_MIN_SAMPLES)
 {
-  buildGrid();
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myAdaptor.Load(myCurve);
+  myDomain.Min = myCurve->FirstParameter();
+  myDomain.Max = myCurve->LastParameter();
+  myNbSamples = std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
+                         ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER
+                           * static_cast<size_t>(myCurve->Degree() + 1));
+  buildParams();
 }
 
 //==================================================================================================
@@ -32,19 +42,25 @@ ExtremaPC_BezierCurve::ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>
 ExtremaPC_BezierCurve::ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>& theCurve,
                                              const ExtremaPC::Domain1D&           theDomain)
     : myCurve(theCurve),
-      myAdaptor(theCurve),
       myDomain(theDomain),
-      myNbSamples(std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
-                           ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER * (theCurve->Degree() + 1)))
+      myNbSamples(ExtremaPC::THE_BEZIER_MIN_SAMPLES)
 {
-  buildGrid();
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myAdaptor.Load(myCurve);
+  myNbSamples = std::max(ExtremaPC::THE_BEZIER_MIN_SAMPLES,
+                         ExtremaPC::THE_BEZIER_DEGREE_MULTIPLIER
+                           * static_cast<size_t>(myCurve->Degree() + 1));
+  buildParams();
 }
 
 //==================================================================================================
 
-void ExtremaPC_BezierCurve::buildGrid()
+void ExtremaPC_BezierCurve::buildParams()
 {
-  if (myCurve.IsNull())
+  if (myCurve.IsNull() || !myDomain.IsValid() || !myDomain.IsFinite())
   {
     return;
   }
@@ -52,8 +68,7 @@ void ExtremaPC_BezierCurve::buildGrid()
   math_Vector aParams =
     ExtremaPC_GridEvaluator::BuildUniformParams(myDomain.Min, myDomain.Max, myNbSamples);
 
-  GeomGridEval_BezierCurve aGridEval(myCurve);
-  myEvaluator.BuildGrid(aGridEval, aParams);
+  myEvaluator.SetParams(aParams);
 }
 
 //==================================================================================================
@@ -61,6 +76,34 @@ void ExtremaPC_BezierCurve::buildGrid()
 gp_Pnt ExtremaPC_BezierCurve::Value(double theU) const
 {
   return myCurve->Value(theU);
+}
+
+//=================================================================================================
+
+bool ExtremaPC_BezierCurve::performPlanar(const gp_Pnt&         theP,
+                                           double                theTol,
+                                           ExtremaPC::SearchMode theMode,
+                                           bool theIncludeEndpoints) const
+{
+  gp_Pln                          aPlane;
+  occ::handle<Geom2d_BezierCurve> aCurve2d;
+  if (!ExtremaPC::ProjectBezier(myCurve, aPlane, aCurve2d))
+  {
+    return false;
+  }
+
+  ExtremaPC2d_BezierCurve anEvaluator2d(aCurve2d,
+                                         ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
+  const ExtremaPC2d::SearchMode aMode = ExtremaPC::ToSearchMode2d(theMode);
+  const gp_Pnt2d aPoint2d = ProjLib::Project(aPlane, theP);
+  const ExtremaPC2d::Result& aResult2d =
+    theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(aPoint2d, theTol, aMode)
+                        : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
+  return ExtremaPC::ConvertPlanarResult(aResult2d,
+                                        theP,
+                                        aPlane,
+                                        *this,
+                                        myEvaluator.Result());
 }
 
 //==================================================================================================
@@ -76,6 +119,12 @@ const ExtremaPC::Result& ExtremaPC_BezierCurve::Perform(const gp_Pnt&         th
     return myEvaluator.Result();
   }
 
+  if (ExtremaPC::IsValidTolerance(theTol) && myDomain.IsValid()
+      && performPlanar(theP, theTol, theMode, false))
+  {
+    return myEvaluator.Result();
+  }
+
   return myEvaluator.Perform(myAdaptor, theP, myDomain, theTol, theMode);
 }
 
@@ -86,14 +135,26 @@ const ExtremaPC::Result& ExtremaPC_BezierCurve::PerformWithEndpoints(
   double                theTol,
   ExtremaPC::SearchMode theMode) const
 {
-  // Get interior extrema (populates myEvaluator's result)
-  (void)myEvaluator.Perform(myAdaptor, theP, myDomain, theTol, theMode);
+  if (myCurve.IsNull())
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC::Status::NotDone;
+    return myEvaluator.Result();
+  }
+  if (ExtremaPC::IsValidTolerance(theTol) && myDomain.IsValid()
+      && performPlanar(theP, theTol, theMode, true))
+  {
+    return myEvaluator.Result();
+  }
+
+  (void)Perform(theP, theTol, theMode);
 
   // Add endpoints to the result
   ExtremaPC::Result& aResult = myEvaluator.Result();
   if (aResult.Status == ExtremaPC::Status::OK || aResult.Status == ExtremaPC::Status::NoSolution)
   {
-    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theTol, theMode);
+    const bool isClosed = ExtremaPC_GridEvaluator::IsClosedDomain(myAdaptor, myDomain);
+    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
 
     // Update status if we found any extrema (including endpoints)
     if (!aResult.Extrema.IsEmpty())

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BezierCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_BezierCurve.hxx
@@ -19,22 +19,21 @@
 #include <GeomAdaptor_Curve.hxx>
 #include <Geom_BezierCurve.hxx>
 #include <gp_Pnt.hxx>
-#include <NCollection_Array1.hxx>
 #include <Standard_DefineAlloc.hxx>
 #include <Standard_Handle.hxx>
 
-//! @brief Point-BezierCurve extrema computation using grid-based approach.
+//! @brief Point-BezierCurve extrema computation using numerical root isolation.
 //!
-//! Computes the extrema between a 3D point and a Bezier curve using
-//! a grid-based approach with Newton refinement.
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
 //!
-//! The grid is cached for efficiency when performing multiple queries
-//! with the same parameter domain.
+//! The parameter partition is cached while geometry is evaluated for each query,
+//! so mutations of the curve do not leave stale geometric samples.
 //!
 //! The algorithm:
-//! 1. Build grid with (3 * (degree + 1)) samples using GeomGridEval
-//! 2. Linear scan of grid to find candidate intervals (sign changes in F(u))
-//! 3. Newton refinement on each candidate interval
+//! 1. Build a parameter partition based on curve degree
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
 //!
 //! This approach is simpler and more stable than BVH-based methods,
 //! with comparable accuracy for typical Bezier curves.
@@ -47,12 +46,12 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Constructor with Bezier curve (uses full curve domain).
-  //! Grid is built eagerly at construction time.
+  //! Parameter partition is built eagerly at construction time.
   //! @param[in] theCurve Bezier curve handle
   Standard_EXPORT explicit ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>& theCurve);
 
   //! Constructor with Bezier curve and parameter domain.
-  //! Grid is built eagerly at construction time for the specified domain.
+  //! Parameter partition is built eagerly at construction time for the specified domain.
   //! @param[in] theCurve Bezier curve handle
   //! @param[in] theDomain parameter domain (fixed for all queries)
   Standard_EXPORT ExtremaPC_BezierCurve(const occ::handle<Geom_BezierCurve>& theCurve,
@@ -107,15 +106,26 @@ public:
   const occ::handle<Geom_BezierCurve>& Curve() const { return myCurve; }
 
 private:
-  //! Build grid for the curve.
-  void buildGrid();
+  //! Build parameter partition for the curve.
+  void buildParams();
+
+  //! Performs through the exact 2D representation when the current curve is planar.
+  //! @param[in] theP query point
+  //! @param[in] theTol tolerance for root finding
+  //! @param[in] theMode search mode
+  //! @param[in] theIncludeEndpoints whether endpoints should be included
+  //! @return true when the 2D result was accepted
+  bool performPlanar(const gp_Pnt&         theP,
+                     double                theTol,
+                     ExtremaPC::SearchMode theMode,
+                     bool                  theIncludeEndpoints) const;
 
   occ::handle<Geom_BezierCurve> myCurve;     //!< Bezier curve
   GeomAdaptor_Curve             myAdaptor;   //!< Curve adaptor
   ExtremaPC::Domain1D           myDomain;    //!< Parameter domain (fixed)
-  int                           myNbSamples; //!< Number of samples
+  size_t                        myNbSamples; //!< Number of samples
 
-  // Grid evaluator with cached state (grid, result, temporary vectors)
+  // Numerical evaluator with cached parameter partition and result
   mutable ExtremaPC_GridEvaluator myEvaluator;
 };
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Circle.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Circle.hxx
@@ -16,11 +16,14 @@
 
 #include <ElCLib.hxx>
 #include <ExtremaPC.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_Circle.hxx>
 #include <gp_Circ.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
 #include <Precision.hxx>
 #include <Standard_DefineAlloc.hxx>
+#include <ProjLib.hxx>
 
 #include <cmath>
 #include <optional>
@@ -62,8 +65,7 @@ public:
   //! @param[in] theDomain parameter domain in radians (fixed for all queries)
   ExtremaPC_Circle(const gp_Circ& theCircle, const ExtremaPC::Domain1D& theDomain)
       : myCircle(theCircle),
-        myDomain(theDomain.IsFullPeriod(2.0 * M_PI) ? std::nullopt
-                                                    : std::optional<ExtremaPC::Domain1D>(theDomain))
+        myDomain(theDomain)
   {
   }
 
@@ -103,6 +105,35 @@ public:
   {
     myResult.Clear();
 
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    const gp_Pln aPlane(gp_Ax3(myCircle.Position()));
+    if (ExtremaPC::PerformPlanar<ExtremaPC2d_Circle>(ProjLib::Project(aPlane, myCircle),
+                                                     myDomain,
+                                                     ProjLib::Project(aPlane, theP),
+                                                     theP,
+                                                     aPlane,
+                                                     *this,
+                                                     theTol,
+                                                     theMode,
+                                                     false,
+                                                     myResult))
+    {
+      return myResult;
+    }
+
+    if (myCircle.Radius() <= gp::Resolution())
+    {
+      myResult.Status                 = ExtremaPC::Status::InfiniteSolutions;
+      myResult.InfiniteSquareDistance = theP.SquareDistance(myCircle.Location());
+      return myResult;
+    }
+
     // Step 1: Project point P onto the circle plane
     const gp_Pnt& aCenter = myCircle.Location();
     const gp_Dir& aAxis   = myCircle.Axis().Direction();
@@ -115,7 +146,7 @@ public:
     gp_Vec aOPp(aCenter, aPp);
     double aOPpMag = aOPp.Magnitude();
 
-    if (aOPpMag < theTol)
+    if (aOPpMag <= gp::Resolution())
     {
       // Point is on the circle axis - all points on circle are equidistant
       myResult.Status                 = ExtremaPC::Status::InfiniteSolutions;
@@ -142,7 +173,7 @@ public:
     // Us2 = Us1 + PI corresponds to maximum distance (farthest point)
     double aUs2 = aUs1 + M_PI;
 
-    // Step 4: For bounded case, adjust for periodicity
+    // Step 4: For bounded case, lift each canonical solution into the requested domain.
     double aTolU = Precision::Angular();
     if (myDomain.has_value())
     {
@@ -154,38 +185,43 @@ public:
         aTolU = theTol / aRadius;
       }
 
-      // Adjust angles to be within [theUMin, theUMin + 2*PI]
-      double aUinf = theUMin;
-      ElCLib::AdjustPeriodic(theUMin, theUMin + 2.0 * M_PI, aTolU, aUinf, aUs1);
-      ElCLib::AdjustPeriodic(theUMin, theUMin + 2.0 * M_PI, aTolU, aUinf, aUs2);
-
-      // Handle boundary tolerance
-      if (std::abs(aUs1 - 2.0 * M_PI - theUMin) < aTolU)
-      {
+      const double aLiftTolerance = Precision::Angular();
+      aUs1 += std::ceil((theUMin - aUs1 - aLiftTolerance) / (2.0 * M_PI)) * (2.0 * M_PI);
+      aUs2 += std::ceil((theUMin - aUs2 - aLiftTolerance) / (2.0 * M_PI)) * (2.0 * M_PI);
+      if (std::abs(aUs1 - theUMin) <= aLiftTolerance)
         aUs1 = theUMin;
-      }
-      if (std::abs(aUs2 - 2.0 * M_PI - theUMin) < aTolU)
-      {
+      if (std::abs(aUs2 - theUMin) <= aLiftTolerance)
         aUs2 = theUMin;
-      }
     }
 
     // Step 5: Add extrema (with bounds check if domain specified)
     // Skip based on search mode: i=0 is minimum, i=1 is maximum
-    int aStart = (theMode == ExtremaPC::SearchMode::Max) ? 1 : 0;
-    int aEnd   = (theMode == ExtremaPC::SearchMode::Min) ? 1 : 2;
+    const size_t aStart = (theMode == ExtremaPC::SearchMode::Max) ? 1 : 0;
+    const size_t aEnd   = (theMode == ExtremaPC::SearchMode::Min) ? 1 : 2;
 
-    double aSolutions[2] = {aUs1, aUs2};
+    const double aSolutions[2] = {aUs1, aUs2};
 
-    for (int i = aStart; i < aEnd; ++i)
+    for (size_t anIndex = aStart; anIndex < aEnd; ++anIndex)
     {
-      double aU = aSolutions[i];
+      const double aU = aSolutions[anIndex];
 
       // Check bounds only if domain is specified
       if (myDomain.has_value())
       {
-        if (aU < myDomain->Min - aTolU || aU > myDomain->Max + aTolU)
-          continue;
+        if (aU >= myDomain->Min - aTolU && aU <= myDomain->Max + aTolU)
+        {
+          gp_Pnt aCurvePt = ElCLib::Value(aU, myCircle);
+
+          ExtremaPC::ExtremumResult anExt;
+          anExt.Parameter      = aU;
+          anExt.Point          = aCurvePt;
+          anExt.SquareDistance = theP.SquareDistance(aCurvePt);
+          anExt.IsMinimum      = (anIndex == 0);
+          anExt.IsMaximum      = (anIndex == 1);
+
+          myResult.Extrema.Append(anExt);
+        }
+        continue;
       }
 
       gp_Pnt aCurvePt = ElCLib::Value(aU, myCircle);
@@ -194,12 +230,14 @@ public:
       anExt.Parameter      = aU;
       anExt.Point          = aCurvePt;
       anExt.SquareDistance = theP.SquareDistance(aCurvePt);
-      anExt.IsMinimum      = (i == 0); // First solution is minimum, second is maximum
+      anExt.IsMinimum      = (anIndex == 0); // First solution is minimum, second is maximum
+      anExt.IsMaximum      = (anIndex == 1);
 
       myResult.Extrema.Append(anExt);
     }
 
-    myResult.Status = ExtremaPC::Status::OK;
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
     return myResult;
   }
 
@@ -215,12 +253,37 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
+      return myResult;
+    }
+
     (void)Perform(theP, theTol, theMode);
 
     // Add endpoints if interior computation succeeded and domain is bounded
-    if (myResult.Status == ExtremaPC::Status::OK && myDomain.has_value())
+    if ((myResult.Status == ExtremaPC::Status::OK
+         || myResult.Status == ExtremaPC::Status::NoSolution)
+        && myDomain.has_value())
     {
-      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theTol, theMode);
+      const bool isClosed =
+        ExtremaPC::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, isClosed);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC::Status::OK;
+      }
     }
 
     return myResult;

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Curve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Curve.cxx
@@ -41,8 +41,6 @@ static ExtremaPC::Result THE_NOT_DONE_RESULT = [] {
 void ExtremaPC_Curve::initFromAdaptor(const GeomAdaptor_Curve&   theCurve,
                                       const ExtremaPC::Domain1D& theDomain)
 {
-  myAdaptorRef = &theCurve;
-
   const GeomAbs_CurveType aCurveType = theCurve.GetType();
 
   switch (aCurveType)
@@ -76,11 +74,13 @@ void ExtremaPC_Curve::initFromAdaptor(const GeomAdaptor_Curve&   theCurve,
       break;
 
     case GeomAbs_OffsetCurve:
-      myEvaluator = ExtremaPC_OffsetCurve(theCurve, theDomain);
+      myAdaptorRef = &theCurve;
+      myEvaluator  = ExtremaPC_OffsetCurve(*myAdaptorRef, theDomain);
       break;
 
     default:
-      myEvaluator = ExtremaPC_OtherCurve(theCurve, theDomain);
+      myAdaptorRef = &theCurve;
+      myEvaluator  = ExtremaPC_OtherCurve(*myAdaptorRef, theDomain);
       break;
   }
 }
@@ -90,6 +90,10 @@ void ExtremaPC_Curve::initFromAdaptor(const GeomAdaptor_Curve&   theCurve,
 ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_Curve& theCurve)
     : myEvaluator(std::monostate{})
 {
+  if (theCurve.Curve().IsNull())
+  {
+    return;
+  }
   ExtremaPC::Domain1D aDomain(theCurve.FirstParameter(), theCurve.LastParameter());
   initFromAdaptor(theCurve, aDomain);
 }
@@ -99,6 +103,10 @@ ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_Curve& theCurve)
 ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_Curve& theCurve, double theUMin, double theUMax)
     : myEvaluator(std::monostate{})
 {
+  if (theCurve.Curve().IsNull())
+  {
+    return;
+  }
   ExtremaPC::Domain1D aDomain(theUMin, theUMax);
   initFromAdaptor(theCurve, aDomain);
 }
@@ -108,6 +116,10 @@ ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_Curve& theCurve, double theUM
 ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_TransformedCurve& theCurve)
     : myEvaluator(std::monostate{})
 {
+  if (theCurve.Is3DCurve() && theCurve.GeomCurve().IsNull())
+  {
+    return;
+  }
   initFromTransformedCurve(theCurve, std::nullopt);
 }
 
@@ -118,6 +130,10 @@ ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_TransformedCurve& theCurve,
                                  double                              theUMax)
     : myEvaluator(std::monostate{})
 {
+  if (theCurve.Is3DCurve() && theCurve.GeomCurve().IsNull())
+  {
+    return;
+  }
   ExtremaPC::Domain1D aDomain(theUMin, theUMax);
   initFromTransformedCurve(theCurve, aDomain);
 }
@@ -127,83 +143,29 @@ ExtremaPC_Curve::ExtremaPC_Curve(const GeomAdaptor_TransformedCurve& theCurve,
 void ExtremaPC_Curve::initFromTransformedCurve(const GeomAdaptor_TransformedCurve&       theCurve,
                                                const std::optional<ExtremaPC::Domain1D>& theDomain)
 {
-  // Identity transform on a 3D curve: delegate to the faster GeomAdaptor_Curve path
-  // which avoids transform overhead in evaluators.
-  // Skipped for CurveOnSurface since its myCurve member is empty.
-  if (theCurve.Is3DCurve() && theCurve.Trsf().Form() == gp_Identity)
-  {
-    const GeomAdaptor_Curve& aCurve = theCurve.Curve();
-    ExtremaPC::Domain1D      aDomain =
-      theDomain.has_value() ? theDomain.value()
-                                 : ExtremaPC::Domain1D(aCurve.FirstParameter(), aCurve.LastParameter());
-    initFromAdaptor(aCurve, aDomain);
-    return;
-  }
-
   ExtremaPC::Domain1D aDomain =
     theDomain.has_value()
       ? theDomain.value()
       : ExtremaPC::Domain1D(theCurve.FirstParameter(), theCurve.LastParameter());
 
-  const GeomAbs_CurveType aCurveType = theCurve.GetType();
-
-  switch (aCurveType)
+  if (theCurve.Is3DCurve())
   {
-    // Elementary curves: Line(), Circle() etc. return already-transformed primitives
-    case GeomAbs_Line:
-      myEvaluator = ExtremaPC_Line(theCurve.Line(), aDomain);
-      break;
+    initFromAdaptor(theCurve.Curve(), aDomain);
+    if (theCurve.Trsf().Form() != gp_Identity)
+    {
+      myTrsf = theCurve.Trsf();
+    }
+    return;
+  }
 
-    case GeomAbs_Circle:
-      myEvaluator = ExtremaPC_Circle(theCurve.Circle(), aDomain);
-      break;
-
-    case GeomAbs_Ellipse:
-      myEvaluator = ExtremaPC_Ellipse(theCurve.Ellipse(), aDomain);
-      break;
-
-    case GeomAbs_Hyperbola:
-      myEvaluator = ExtremaPC_Hyperbola(theCurve.Hyperbola(), aDomain);
-      break;
-
-    case GeomAbs_Parabola:
-      myEvaluator = ExtremaPC_Parabola(theCurve.Parabola(), aDomain);
-      break;
-
-    // BSpline/Bezier: use untransformed handle, set up inverse-transform path.
-    // For CurveOnSurface the underlying myCurve is empty, so fall through to OtherCurve.
-    case GeomAbs_BSplineCurve:
-      if (theCurve.Is3DCurve())
-      {
-        myEvaluator = ExtremaPC_BSplineCurve(theCurve.Curve().BSpline(), aDomain);
-        myTrsf      = theCurve.Trsf();
-        break;
-      }
-      myAdaptorRef = &theCurve;
-      myEvaluator  = ExtremaPC_OtherCurve(*myAdaptorRef, aDomain);
-      break;
-
-    case GeomAbs_BezierCurve:
-      if (theCurve.Is3DCurve())
-      {
-        myEvaluator = ExtremaPC_BezierCurve(theCurve.Curve().Bezier(), aDomain);
-        myTrsf      = theCurve.Trsf();
-        break;
-      }
-      myAdaptorRef = &theCurve;
-      myEvaluator  = ExtremaPC_OtherCurve(*myAdaptorRef, aDomain);
-      break;
-
-    // Offset/Other: use non-owning pointer to caller's TransformedCurve
-    case GeomAbs_OffsetCurve:
-      myAdaptorRef = &theCurve;
-      myEvaluator  = ExtremaPC_OffsetCurve(*myAdaptorRef, aDomain);
-      break;
-
-    default:
-      myAdaptorRef = &theCurve;
-      myEvaluator  = ExtremaPC_OtherCurve(*myAdaptorRef, aDomain);
-      break;
+  myAdaptorRef = &theCurve;
+  if (theCurve.GetType() == GeomAbs_OffsetCurve)
+  {
+    myEvaluator = ExtremaPC_OffsetCurve(*myAdaptorRef, aDomain);
+  }
+  else
+  {
+    myEvaluator = ExtremaPC_OtherCurve(*myAdaptorRef, aDomain);
   }
 }
 
@@ -404,22 +366,22 @@ ExtremaPC_Curve::ExtremaPC_Curve(const occ::handle<Geom_Curve>& theCurve,
 
 //=================================================================================================
 
-const ExtremaPC::Result& ExtremaPC_Curve::postProcessTransform(
-  const ExtremaPC::Result& theSrc) const
+const ExtremaPC::Result& ExtremaPC_Curve::postProcessTransform(const ExtremaPC::Result& theSrc,
+                                                               const gp_Pnt&            theP) const
 {
-  const double aSF   = myTrsf.ScaleFactor();
-  const double aSFSq = aSF * aSF;
+  const double aScale = std::abs(myTrsf->ScaleFactor());
 
   myTransformResult.Clear();
   myTransformResult.Status                 = theSrc.Status;
-  myTransformResult.InfiniteSquareDistance = theSrc.InfiniteSquareDistance * aSFSq;
-  for (int i = 0; i < theSrc.Extrema.Length(); ++i)
+  myTransformResult.InfiniteSquareDistance = theSrc.InfiniteSquareDistance * aScale * aScale;
+  for (size_t anIndex = 0; anIndex < theSrc.Extrema.Size(); ++anIndex)
   {
     ExtremaPC::ExtremumResult anExt;
-    anExt.Parameter      = theSrc[i].Parameter;
-    anExt.Point          = theSrc[i].Point.Transformed(myTrsf);
-    anExt.SquareDistance = theSrc[i].SquareDistance * aSFSq;
-    anExt.IsMinimum      = theSrc[i].IsMinimum;
+    anExt.Parameter      = theSrc[anIndex].Parameter;
+    anExt.Point          = theSrc[anIndex].Point.Transformed(*myTrsf);
+    anExt.SquareDistance = theP.SquareDistance(anExt.Point);
+    anExt.IsMinimum      = theSrc[anIndex].IsMinimum;
+    anExt.IsMaximum      = theSrc[anIndex].IsMaximum;
     myTransformResult.Extrema.Append(anExt);
   }
   return myTransformResult;
@@ -433,20 +395,34 @@ const ExtremaPC::Result& ExtremaPC_Curve::Perform(const gp_Pnt&         theP,
 {
   const ExtremaPC::Result* aResultPtr = &THE_NOT_DONE_RESULT;
 
-  if (myTrsf.Form() != gp_Identity)
+  if (myTrsf.has_value())
   {
+    if (!ExtremaPC::IsValidTolerance(theTol))
+    {
+      myTransformResult.Clear();
+      myTransformResult.Status = ExtremaPC::Status::InvalidInput;
+      return myTransformResult;
+    }
+
     // Inverse-transform query point and delegate to untransformed evaluator
-    gp_Pnt aPInv = theP.Transformed(myTrsf.Inverted());
+    const double aLocalTol = theTol / std::abs(myTrsf->ScaleFactor());
+    if (!ExtremaPC::IsValidTolerance(aLocalTol))
+    {
+      myTransformResult.Clear();
+      myTransformResult.Status = ExtremaPC::Status::NumericalError;
+      return myTransformResult;
+    }
+    gp_Pnt aPInv = theP.Transformed(myTrsf->Inverted());
     std::visit(
       [&](auto& theEval) {
         using T = std::decay_t<decltype(theEval)>;
         if constexpr (!std::is_same_v<T, std::monostate>)
         {
-          aResultPtr = &theEval.Perform(aPInv, theTol, theMode);
+          aResultPtr = &theEval.Perform(aPInv, aLocalTol, theMode);
         }
       },
       myEvaluator);
-    return postProcessTransform(*aResultPtr);
+    return postProcessTransform(*aResultPtr, theP);
   }
 
   std::visit(
@@ -469,20 +445,34 @@ const ExtremaPC::Result& ExtremaPC_Curve::PerformWithEndpoints(const gp_Pnt&    
 {
   const ExtremaPC::Result* aResultPtr = &THE_NOT_DONE_RESULT;
 
-  if (myTrsf.Form() != gp_Identity)
+  if (myTrsf.has_value())
   {
+    if (!ExtremaPC::IsValidTolerance(theTol))
+    {
+      myTransformResult.Clear();
+      myTransformResult.Status = ExtremaPC::Status::InvalidInput;
+      return myTransformResult;
+    }
+
     // Inverse-transform query point and delegate to untransformed evaluator
-    gp_Pnt aPInv = theP.Transformed(myTrsf.Inverted());
+    const double aLocalTol = theTol / std::abs(myTrsf->ScaleFactor());
+    if (!ExtremaPC::IsValidTolerance(aLocalTol))
+    {
+      myTransformResult.Clear();
+      myTransformResult.Status = ExtremaPC::Status::NumericalError;
+      return myTransformResult;
+    }
+    gp_Pnt aPInv = theP.Transformed(myTrsf->Inverted());
     std::visit(
       [&](auto& theEval) {
         using T = std::decay_t<decltype(theEval)>;
         if constexpr (!std::is_same_v<T, std::monostate>)
         {
-          aResultPtr = &theEval.PerformWithEndpoints(aPInv, theTol, theMode);
+          aResultPtr = &theEval.PerformWithEndpoints(aPInv, aLocalTol, theMode);
         }
       },
       myEvaluator);
-    return postProcessTransform(*aResultPtr);
+    return postProcessTransform(*aResultPtr, theP);
   }
 
   std::visit(

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Curve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Curve.hxx
@@ -42,7 +42,7 @@
 //! Supports all elementary curve types (analytical solutions):
 //! - Line, Circle, Ellipse, Hyperbola, Parabola
 //!
-//! And numerical curves (grid-based with Newton refinement):
+//! And numerical curves (derivative-aware multiple-root isolation):
 //! - BSpline, Bezier, Offset, and general curves
 //!
 //! @note The parameter domain is fixed at construction time for optimal performance.
@@ -55,7 +55,7 @@
 //! const ExtremaPC::Result& aResult = anExtPC.Perform(myPoint, 1.0e-9);
 //! if (aResult.IsDone())
 //! {
-//!   for (int i = 0; i < aResult.NbExt(); ++i)
+//!   for (size_t i = 0; i < aResult.NbExt(); ++i)
 //!   {
 //!     double aDist = std::sqrt(aResult[i].SquareDistance);
 //!     gp_Pnt aPtOnCurve = aResult[i].Point;
@@ -81,11 +81,13 @@ public:
 
   //! Constructor with curve adaptor.
   //! Uses the curve's natural parameter bounds as domain.
-  //! @param[in] theCurve curve adaptor
+  //! @param[in] theCurve curve adaptor; must outlive this evaluator when dispatched as an offset
+  //!                     or general curve
   Standard_EXPORT explicit ExtremaPC_Curve(const GeomAdaptor_Curve& theCurve);
 
   //! Constructor with curve adaptor and parameter range.
-  //! @param[in] theCurve curve adaptor
+  //! @param[in] theCurve curve adaptor; must outlive this evaluator when dispatched as an offset
+  //!                     or general curve
   //! @param[in] theUMin lower parameter bound
   //! @param[in] theUMax upper parameter bound
   Standard_EXPORT ExtremaPC_Curve(const GeomAdaptor_Curve& theCurve,
@@ -94,14 +96,15 @@ public:
 
   //! Constructor with transformed curve adaptor.
   //! Uses the curve's natural parameter bounds as domain.
-  //! For elementary curves, uses already-transformed primitives (analytical solver).
-  //! For BSpline/Bezier, uses inverse-transform optimization with post-processing.
-  //! For offset/other curves, delegates through Adaptor3d_Curve interface.
-  //! @param[in] theCurve transformed curve adaptor
+  //! For 3D curves, computes in the original curve space to preserve parameterization.
+  //! Curves on surfaces are evaluated through the transformed adaptor.
+  //! @param[in] theCurve transformed curve adaptor; must outlive this evaluator when it wraps a
+  //!                     curve on surface
   Standard_EXPORT explicit ExtremaPC_Curve(const GeomAdaptor_TransformedCurve& theCurve);
 
   //! Constructor with transformed curve adaptor and parameter range.
-  //! @param[in] theCurve transformed curve adaptor
+  //! @param[in] theCurve transformed curve adaptor; must outlive this evaluator when it wraps a
+  //!                     curve on surface
   //! @param[in] theUMin lower parameter bound
   //! @param[in] theUMax upper parameter bound
   Standard_EXPORT ExtremaPC_Curve(const GeomAdaptor_TransformedCurve& theCurve,
@@ -167,7 +170,7 @@ private:
                          const std::optional<ExtremaPC::Domain1D>& theDomain);
 
   //! Helper to initialize from a TransformedCurve.
-  //! Dispatches based on curve type and transform properties.
+  //! Preserves the source parameterization by dispatching the original 3D curve.
   //! @param[in] theCurve the transformed curve adaptor
   //! @param[in] theDomain optional domain to use
   void initFromTransformedCurve(const GeomAdaptor_TransformedCurve&       theCurve,
@@ -176,13 +179,15 @@ private:
   //! Post-process result from untransformed-space computation.
   //! Forward-transforms points and scales distances.
   //! @param[in] theSrc result in untransformed space
+  //! @param[in] theP query point in transformed space
   //! @return reference to myTransformResult with transformed data
-  const ExtremaPC::Result& postProcessTransform(const ExtremaPC::Result& theSrc) const;
+  const ExtremaPC::Result& postProcessTransform(const ExtremaPC::Result& theSrc,
+                                                const gp_Pnt&            theP) const;
 
   EvaluatorVariant             myEvaluator;            //!< Specialized evaluator
-  const Adaptor3d_Curve*       myAdaptorRef = nullptr; //!< Non-owning pointer to caller's adaptor
-  occ::handle<Adaptor3d_Curve> myAdaptorOwned;         //!< Owned adaptor for lifetime management
-  gp_Trsf                      myTrsf; //!< Forward transform (identity = no post-processing)
+  const Adaptor3d_Curve*       myAdaptorRef = nullptr; //!< Non-owning adaptor for numerical curves
+  occ::handle<Adaptor3d_Curve> myAdaptorOwned;         //!< Adaptor created for Geom_Curve input
+  std::optional<gp_Trsf>       myTrsf; //!< Forward transform for original-space evaluation
   mutable ExtremaPC::Result    myTransformResult; //!< Result buffer for transform post-processing
 };
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_DistanceFunction.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_DistanceFunction.hxx
@@ -17,12 +17,15 @@
 #include <Adaptor3d_Curve.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
+#include <gp.hxx>
 #include <Standard_DefineAlloc.hxx>
 
 //! @brief Distance function for point-curve extrema computation.
 //!
-//! Implements the function F(u) = (C(u) - P) . C'(u) and its derivative
-//! F'(u) = C'(u) . C'(u) + (C(u) - P) . C''(u).
+//! Implements the normalized stationarity function
+//! F(u) = (C(u) - P) . C'(u) / |C'(u)| and its derivative.
+//! Normalization gives F geometric length units and makes tolerance behavior
+//! independent of regular curve reparameterization.
 //!
 //! The roots of F(u) = 0 correspond to the extrema (local minima and maxima)
 //! of the squared distance function D(u) = ||C(u) - P||^2.
@@ -42,7 +45,7 @@ public:
   {
   }
 
-  //! Computes F(u) = (C(u) - P) . C'(u).
+  //! Computes F(u) = (C(u) - P) . C'(u) / |C'(u)|.
   //! @param theU parameter value
   //! @param theF output: function value
   //! @return true if computation succeeded
@@ -53,13 +56,20 @@ public:
     myCurve->D1(theU, aPt, aD1);
 
     gp_Vec aVec(myP, aPt);
-    theF = aVec.Dot(aD1);
+    const double aSpeed = aD1.Magnitude();
+    if (aSpeed <= gp::Resolution())
+    {
+      // The normalized function has no defined direction at a singular parameter.
+      // Its continuous one-sided signs are used later for extrema classification.
+      theF = 0.0;
+      return true;
+    }
+    theF = aVec.Dot(aD1) / aSpeed;
     return true;
   }
 
   //! Computes F(u) and F'(u).
-  //! F(u) = (C(u) - P) . C'(u)
-  //! F'(u) = C'(u) . C'(u) + (C(u) - P) . C''(u)
+  //! Computes the normalized stationarity function and its derivative.
   //! @param theU parameter value
   //! @param theF output: function value
   //! @param theDF output: derivative value
@@ -71,8 +81,17 @@ public:
     myCurve->D2(theU, aPt, aD1, aD2);
 
     gp_Vec aVec(myP, aPt);
-    theF  = aVec.Dot(aD1);
-    theDF = aD1.Dot(aD1) + aVec.Dot(aD2);
+    const double aSpeed = aD1.Magnitude();
+    if (aSpeed <= gp::Resolution())
+    {
+      theF  = 0.0;
+      theDF = 0.0;
+      return true;
+    }
+    const double aRawF = aVec.Dot(aD1);
+    theF                = aRawF / aSpeed;
+    theDF = (aD1.Dot(aD1) + aVec.Dot(aD2)) / aSpeed
+            - aRawF * aD1.Dot(aD2) / (aSpeed * aSpeed * aSpeed);
     return true;
   }
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_DistanceFunction.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_DistanceFunction.hxx
@@ -55,7 +55,7 @@ public:
     gp_Vec aD1;
     myCurve->D1(theU, aPt, aD1);
 
-    gp_Vec aVec(myP, aPt);
+    gp_Vec       aVec(myP, aPt);
     const double aSpeed = aD1.Magnitude();
     if (aSpeed <= gp::Resolution())
     {
@@ -80,7 +80,7 @@ public:
     gp_Vec aD1, aD2;
     myCurve->D2(theU, aPt, aD1, aD2);
 
-    gp_Vec aVec(myP, aPt);
+    gp_Vec       aVec(myP, aPt);
     const double aSpeed = aD1.Magnitude();
     if (aSpeed <= gp::Resolution())
     {
@@ -89,9 +89,9 @@ public:
       return true;
     }
     const double aRawF = aVec.Dot(aD1);
-    theF                = aRawF / aSpeed;
-    theDF = (aD1.Dot(aD1) + aVec.Dot(aD2)) / aSpeed
-            - aRawF * aD1.Dot(aD2) / (aSpeed * aSpeed * aSpeed);
+    theF               = aRawF / aSpeed;
+    theDF =
+      (aD1.Dot(aD1) + aVec.Dot(aD2)) / aSpeed - aRawF * aD1.Dot(aD2) / (aSpeed * aSpeed * aSpeed);
     return true;
   }
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Ellipse.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Ellipse.hxx
@@ -16,11 +16,14 @@
 
 #include <ElCLib.hxx>
 #include <ExtremaPC.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_Ellipse.hxx>
 #include <gp_Elips.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
 #include <MathRoot_Trig.hxx>
 #include <Standard_DefineAlloc.hxx>
+#include <ProjLib.hxx>
 
 #include <cmath>
 #include <optional>
@@ -61,8 +64,7 @@ public:
   //! @param[in] theDomain parameter domain in radians (fixed for all queries)
   ExtremaPC_Ellipse(const gp_Elips& theEllipse, const ExtremaPC::Domain1D& theDomain)
       : myEllipse(theEllipse),
-        myDomain(theDomain.IsFullPeriod(2.0 * M_PI) ? std::nullopt
-                                                    : std::optional<ExtremaPC::Domain1D>(theDomain))
+        myDomain(theDomain)
   {
   }
 
@@ -100,6 +102,36 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::NoSolution;
+      return myResult;
+    }
+
+    const gp_Pln aPlane(gp_Ax3(myEllipse.Position()));
+    if (ExtremaPC::PerformPlanar<ExtremaPC2d_Ellipse>(ProjLib::Project(aPlane, myEllipse),
+                                                      myDomain,
+                                                      ProjLib::Project(aPlane, theP),
+                                                      theP,
+                                                      aPlane,
+                                                      *this,
+                                                      theTol,
+                                                      theMode,
+                                                      false,
+                                                      myResult))
+    {
+      return myResult;
+    }
+
     // Use stored domain or full parameter range [0, 2*PI]
     ExtremaPC::Domain1D aDomain = myDomain.value_or(ExtremaPC::Domain1D{0.0, 2.0 * M_PI});
     performCore(theP, aDomain, theTol, theMode);
@@ -118,12 +150,37 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
+      return myResult;
+    }
+
     (void)Perform(theP, theTol, theMode);
 
     // Add endpoints if interior computation succeeded and domain is bounded
-    if (myResult.Status == ExtremaPC::Status::OK && myDomain.has_value())
+    if ((myResult.Status == ExtremaPC::Status::OK
+         || myResult.Status == ExtremaPC::Status::NoSolution)
+        && myDomain.has_value())
     {
-      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theTol, theMode);
+      const bool isClosed =
+        ExtremaPC::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, isClosed);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC::Status::OK;
+      }
     }
 
     return myResult;
@@ -141,6 +198,13 @@ private:
                    ExtremaPC::SearchMode      theMode) const
   {
     myResult.Clear();
+
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || !theDomain.IsValid())
+    {
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return;
+    }
 
     const double theUMin = theDomain.Min;
     const double theUMax = theDomain.Max;
@@ -161,9 +225,9 @@ private:
     double aOPpMag = aOPp.Magnitude();
 
     // Check for degenerate case: point at center with circular ellipse
-    if (aOPpMag < theTol)
+    if (aOPpMag <= gp::Resolution())
     {
-      if (std::abs(aA - aB) < theTol)
+      if (aA == aB)
       {
         // Point at center of a circle - infinite solutions
         myResult.Status                 = ExtremaPC::Status::InfiniteSolutions;
@@ -187,38 +251,47 @@ private:
 
     // MathRoot::Trigonometric handles all special cases including Y ~= 0
     MathRoot::TrigResult aTrigRes =
-      MathRoot::Trigonometric(0.0, aKo2, aKo3, aKo4, 0.0, theUMin, theUMax);
+      MathRoot::Trigonometric(0.0, aKo2, aKo3, aKo4, 0.0, 0.0, 2.0 * M_PI);
 
+    if (aTrigRes.InfiniteRoots)
+    {
+      myResult.Status                 = ExtremaPC::Status::InfiniteSolutions;
+      const gp_Pnt aPtOnCurve         = ElCLib::Value(0.0, myEllipse);
+      myResult.InfiniteSquareDistance = theP.SquareDistance(aPtOnCurve);
+      return;
+    }
     if (!aTrigRes.IsDone())
     {
-      if (aTrigRes.InfiniteRoots)
-      {
-        myResult.Status = ExtremaPC::Status::InfiniteSolutions;
-        // For infinite case, compute distance to any point (use U=0)
-        gp_Pnt aPtOnCurve               = ElCLib::Value(0.0, myEllipse);
-        myResult.InfiniteSquareDistance = theP.SquareDistance(aPtOnCurve);
-      }
-      else
-      {
-        myResult.Status = ExtremaPC::Status::NumericalError;
-      }
+      myResult.Status = ExtremaPC::Status::NumericalError;
       return;
     }
 
     // Step 4: Collect extrema
-    double aTol2 = theTol * theTol;
+    auto stationarity = [&](double theU) {
+      const double aCos = std::cos(theU);
+      const double aSin = std::sin(theU);
+      return (aB * aB - aA * aA) * aCos * aSin - aB * aY * aCos + aA * aX * aSin;
+    };
 
-    auto addExtremum = [&](double aU) {
+    auto addExtremum = [&](double aU, bool theIsMin) {
+      aU +=
+        std::ceil((theUMin - aU - ExtremaPC::THE_PARAM_TOLERANCE) / (2.0 * M_PI)) * (2.0 * M_PI);
+      if (std::abs(aU - theUMin) <= ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        aU = theUMin;
+      }
+      if (aU < theUMin - ExtremaPC::THE_PARAM_TOLERANCE
+          || aU > theUMax + ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        return;
+      }
+
       gp_Pnt aCurvePt = ElCLib::Value(aU, myEllipse);
 
       // Check for duplicates using parameter proximity (more robust)
-      for (int j = 0; j < myResult.Extrema.Length(); ++j)
+      for (const ExtremaPC::ExtremumResult& anExtremum : myResult.Extrema)
       {
-        if (std::abs(myResult.Extrema.Value(j).Parameter - aU) < theTol)
-        {
-          return;
-        }
-        if (aCurvePt.SquareDistance(myResult.Extrema.Value(j).Point) < aTol2)
+        if (std::abs(anExtremum.Parameter - aU) < ExtremaPC::THE_PARAM_TOLERANCE)
         {
           return;
         }
@@ -226,22 +299,12 @@ private:
 
       double aSqDist = theP.SquareDistance(aCurvePt);
 
-      // Determine if this is a minimum or maximum by checking neighboring points
-      // Use step relative to parameter range
-      double aStep      = std::max(ExtremaPC::THE_NEIGHBOR_STEP_RATIO,
-                              (theUMax - theUMin) * ExtremaPC::THE_NEIGHBOR_STEP_RATIO);
-      gp_Pnt aPtPlus    = ElCLib::Value(aU + aStep, myEllipse);
-      gp_Pnt aPtMinus   = ElCLib::Value(aU - aStep, myEllipse);
-      double aDistPlus  = theP.SquareDistance(aPtPlus);
-      double aDistMinus = theP.SquareDistance(aPtMinus);
-      bool   aIsMin     = (aSqDist <= aDistPlus) && (aSqDist <= aDistMinus);
-
       // Filter by search mode
-      if (theMode == ExtremaPC::SearchMode::Min && !aIsMin)
+      if (theMode == ExtremaPC::SearchMode::Min && !theIsMin)
       {
         return;
       }
-      if (theMode == ExtremaPC::SearchMode::Max && aIsMin)
+      if (theMode == ExtremaPC::SearchMode::Max && theIsMin)
       {
         return;
       }
@@ -250,18 +313,62 @@ private:
       anExt.Parameter      = aU;
       anExt.Point          = aCurvePt;
       anExt.SquareDistance = aSqDist;
-      anExt.IsMinimum      = aIsMin;
+      anExt.IsMinimum      = theIsMin;
+      anExt.IsMaximum      = !theIsMin;
 
       myResult.Extrema.Append(anExt);
     };
 
-    // Add solutions from solver
-    for (size_t i = 0; i < aTrigRes.NbRoots; ++i)
+    std::array<double, 4> aCanonicalRoots   = {};
+    size_t                aNbCanonicalRoots = 0;
+    for (size_t aRootIndex = 0; aRootIndex < aTrigRes.NbRoots; ++aRootIndex)
     {
-      addExtremum(aTrigRes.Roots[i]);
+      double aRoot = std::fmod(aTrigRes.Roots[aRootIndex], 2.0 * M_PI);
+      if (aRoot < 0.0)
+      {
+        aRoot += 2.0 * M_PI;
+      }
+      if (aRoot >= 2.0 * M_PI - ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        aRoot = 0.0;
+      }
+
+      bool isDuplicate = false;
+      for (size_t anIndex = 0; anIndex < aNbCanonicalRoots; ++anIndex)
+      {
+        if (std::abs(aCanonicalRoots[anIndex] - aRoot) < ExtremaPC::THE_PARAM_TOLERANCE)
+        {
+          isDuplicate = true;
+          break;
+        }
+      }
+      if (!isDuplicate)
+      {
+        aCanonicalRoots[aNbCanonicalRoots++] = aRoot;
+      }
+    }
+    std::sort(aCanonicalRoots.begin(), aCanonicalRoots.begin() + aNbCanonicalRoots);
+
+    // Classify canonical roots and lift one representative into the requested domain.
+    for (size_t i = 0; i < aNbCanonicalRoots; ++i)
+    {
+      const double aRoot = aCanonicalRoots[i];
+      const double aPrev =
+        i == 0 ? aCanonicalRoots[aNbCanonicalRoots - 1] - 2.0 * M_PI : aCanonicalRoots[i - 1];
+      const double aNext =
+        i + 1 == aNbCanonicalRoots ? aCanonicalRoots[0] + 2.0 * M_PI : aCanonicalRoots[i + 1];
+      const double aLeftValue  = stationarity((aPrev + aRoot) * 0.5);
+      const double aRightValue = stationarity((aRoot + aNext) * 0.5);
+      const bool   isMinimum   = aLeftValue < 0.0 && aRightValue > 0.0;
+      const bool   isMaximum   = aLeftValue > 0.0 && aRightValue < 0.0;
+      if (isMinimum || isMaximum)
+      {
+        addExtremum(aRoot, isMinimum);
+      }
     }
 
-    myResult.Status = ExtremaPC::Status::OK;
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
   }
 
   gp_Elips                           myEllipse; //!< Ellipse geometry

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_GridEvaluator.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_GridEvaluator.hxx
@@ -15,107 +15,56 @@
 #define _ExtremaPC_GridEvaluator_HeaderFile
 
 #include <Adaptor3d_Curve.hxx>
+#include <Extrema_CurveTool.hxx>
 #include <ExtremaPC.hxx>
 #include <ExtremaPC_DistanceFunction.hxx>
-#include <GeomGridEval.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <GeomAbs_Shape.hxx>
 #include <math_Vector.hxx>
-#include <MathRoot_Newton.hxx>
-#include <MathUtils_Config.hxx>
+#include <MathRoot_Multiple.hxx>
 #include <NCollection_Array1.hxx>
-#include <NCollection_DynamicArray.hxx>
+#include <NCollection_LinearVector.hxx>
+#include <NCollection_LocalArray.hxx>
+#include <Standard_Failure.hxx>
 
 #include <algorithm>
 #include <cmath>
-#include <limits>
-#include <utility>
+#include <optional>
 
-//! @brief Grid-based point-curve extrema computation class.
+//! @brief Numerical point-curve extrema computation over a cached parameter partition.
 //!
-//! Provides grid-based extrema finding algorithm with cached state for
-//! optimal performance on repeated queries. Used by BSpline, Bezier,
-//! Offset, and other curve evaluators.
-//!
-//! Algorithm:
-//! 1. Build grid of (parameter, point, D1) from GeomGridEval
-//! 2. Linear scan of grid to find candidate intervals (sign changes in F(u))
-//! 3. Newton refinement on each candidate
-//! 4. Optional endpoint handling
-//!
-//! All temporary vectors are stored as mutable fields and reused via Clear()
-//! to avoid repeated heap allocations.
+//! Each adjacent parameter pair is solved independently, making non-uniform knot- and
+//! curvature-aware distributions effective. C2 continuity bounds are inserted into the
+//! partition and classified separately from ordinary sampling boundaries.
 class ExtremaPC_GridEvaluator
 {
 public:
-  //! Cached grid point with pre-computed data.
-  struct GridPoint
-  {
-    double Param; //!< Parameter value
-    gp_Pnt Point; //!< Curve point C(u)
-    gp_Vec D1;    //!< First derivative C'(u)
-  };
-
-  //! Type of candidate extremum detected during grid scan.
-  enum class CandidateType
-  {
-    SignChange, //!< F(u) changes sign between grid points
-    NearZero    //!< F(u) is very small at grid point
-  };
-
-  //! Candidate interval for Newton refinement.
-  struct Candidate
-  {
-    CandidateType Type;   //!< Type of candidate
-    int           IdxLo;  //!< Lower grid index
-    int           IdxHi;  //!< Upper grid index (same as IdxLo for NearZero)
-    double        StartU; //!< Starting point for Newton
-  };
-
   //! Default constructor.
   ExtremaPC_GridEvaluator() = default;
 
-  //! @brief Build grid from GeomGridEval D1 results.
-  //!
-  //! @tparam GridEval type with EvaluateGridD1(params) method
-  //! @param theEval grid evaluator
-  //! @param theParams parameter values (math_Vector with Array1() accessor)
-  template <typename GridEval>
-  void BuildGrid(GridEval& theEval, const math_Vector& theParams)
+  //! Stores ordered parameter values defining the numerical search partition.
+  //! @param[in] theParams ordered parameter values
+  void SetParams(const math_Vector& theParams)
   {
-    // Use Array1() accessor to pass to GeomGridEval which expects NCollection_Array1
-    NCollection_Array1<GeomGridEval::CurveD1> aD1Grid = theEval.EvaluateGridD1(theParams.Array1());
-
-    const int aNbParams = theParams.Length();
-
-    // Resize grid if needed
-    if (myGrid.Length() != aNbParams)
+    const size_t aNbParams = theParams.Size();
+    if (aNbParams == 0)
     {
-      myGrid = NCollection_Array1<GridPoint>(0, aNbParams - 1);
+      myParams.Clear();
+      return;
     }
 
-    for (int i = 0; i < aNbParams; ++i)
+    myParams.Resize(aNbParams);
+    for (size_t anIndex = 0; anIndex < aNbParams; ++anIndex)
     {
-      const int aD1Idx = aD1Grid.Lower() + i;
-
-      myGrid[i].Param = theParams(theParams.Lower() + i);
-      myGrid[i].Point = aD1Grid.Value(aD1Idx).Point;
-      myGrid[i].D1    = aD1Grid.Value(aD1Idx).D1;
+      myParams[anIndex] = theParams.At(anIndex);
     }
   }
-
-  //! Returns the cached grid.
-  const NCollection_Array1<GridPoint>& Grid() const { return myGrid; }
 
   //! Returns mutable reference to the result for post-processing.
   ExtremaPC::Result& Result() const { return myResult; }
 
-  //! @brief Perform extrema computation using cached grid (interior only).
-  //!
-  //! @param theCurve curve adaptor
-  //! @param theP query point
-  //! @param theDomain parameter domain
-  //! @param theTol tolerance
-  //! @param theMode search mode
-  //! @return const reference to result with interior extrema only
+  //! Performs extrema computation using the cached parameter partition.
   [[nodiscard]] const ExtremaPC::Result& Perform(const Adaptor3d_Curve&     theCurve,
                                                  const gp_Pnt&              theP,
                                                  const ExtremaPC::Domain1D& theDomain,
@@ -123,385 +72,625 @@ public:
                                                  ExtremaPC::SearchMode      theMode) const
   {
     myResult.Clear();
-    scanGrid(theP, theTol, theMode);
-    refineCandidates(theCurve, theP, theDomain, theTol, theMode);
-
-    if (!myResult.Extrema.IsEmpty())
+    if (!theDomain.IsValid() || !ExtremaPC::IsValidTolerance(theTol)
+        || !ExtremaPC::IsFinitePoint(theP))
     {
-      myResult.Status = ExtremaPC::Status::OK;
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
     }
+    if (theDomain.Min == theDomain.Max)
+    {
+      myResult.Status = ExtremaPC::Status::NoSolution;
+      return myResult;
+    }
+    if (!validateParams(theDomain))
+    {
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    const std::optional<double> aConstantDistance =
+      constantSquareDistance(theCurve, theP, theDomain);
+    if (aConstantDistance.has_value())
+    {
+      myResult.Status                 = ExtremaPC::Status::InfiniteSolutions;
+      myResult.InfiniteSquareDistance = aConstantDistance.value();
+      return myResult;
+    }
+
+    myContinuityBounds.Clear();
+    myPartition.Clear();
+    buildPartition(theCurve, theDomain, myContinuityBounds, myPartition);
+
+    MathRoot::MultipleConfig aConfig;
+    aConfig.NbSamples     = 2;
+    aConfig.XTolerance    = ExtremaPC::THE_PARAM_TOLERANCE;
+    aConfig.FTolerance    = theTol;
+    aConfig.NullTolerance = theTol;
+
+    myRoots.Clear();
+    for (size_t anInterval = 0; anInterval + 1 < myPartition.Size(); ++anInterval)
+    {
+      const double aLower  = myPartition.Value(anInterval);
+      const double anUpper = myPartition.Value(anInterval + 1);
+      if (anUpper - aLower <= ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        continue;
+      }
+      occ::handle<Adaptor3d_Curve> aLocalCurve;
+      try
+      {
+        aLocalCurve = theCurve.Trim(aLower, anUpper, Precision::PConfusion());
+      }
+      catch (const Standard_Failure&)
+      {
+        // Some custom adaptors support evaluation but do not implement Trim().
+      }
+      const Adaptor3d_Curve&     aCurveForInterval = aLocalCurve.IsNull() ? theCurve : *aLocalCurve;
+      ExtremaPC_DistanceFunction aLocalFunction(aCurveForInterval, theP);
+      MathRoot::MultipleResult   anIntervalRoots;
+      try
+      {
+        anIntervalRoots =
+          MathRoot::FindAllRootsWithDerivative(aLocalFunction, aLower, anUpper, aConfig);
+      }
+      catch (const Standard_Failure&)
+      {
+        myResult.Status = ExtremaPC::Status::NumericalError;
+        return myResult;
+      }
+      if (!anIntervalRoots.IsDone())
+      {
+        myResult.Status = ExtremaPC::Status::NumericalError;
+        return myResult;
+      }
+      if (anIntervalRoots.IsAllNull)
+      {
+        MathRoot::MultipleConfig aRetryConfig = aConfig;
+        aRetryConfig.FTolerance               = std::min(theTol, ExtremaPC::THE_DEFAULT_TOLERANCE);
+        aRetryConfig.NullTolerance            = 0.0;
+        try
+        {
+          anIntervalRoots =
+            MathRoot::FindAllRootsWithDerivative(aLocalFunction, aLower, anUpper, aRetryConfig);
+        }
+        catch (const Standard_Failure&)
+        {
+          myResult.Status = ExtremaPC::Status::NumericalError;
+          return myResult;
+        }
+        if (!anIntervalRoots.IsDone() || anIntervalRoots.IsAllNull)
+        {
+          myResult.Status = ExtremaPC::Status::NumericalError;
+          return myResult;
+        }
+      }
+      for (size_t aRootIndex = 0; aRootIndex < anIntervalRoots.NbRoots(); ++aRootIndex)
+      {
+        appendRoot(myRoots, RootCandidate{anIntervalRoots[aRootIndex], aLower, anUpper});
+      }
+    }
+    ExtremaPC_DistanceFunction aFunction(theCurve, theP);
+    const bool                 isClosed = IsClosedDomain(theCurve, theDomain);
+    classifyRoots(theCurve,
+                  theP,
+                  theDomain,
+                  aFunction,
+                  myContinuityBounds,
+                  myRoots,
+                  theTol,
+                  theMode);
+    classifyJunctions(theCurve,
+                      theP,
+                      theDomain,
+                      aFunction,
+                      myContinuityBounds,
+                      myPartition,
+                      myRoots,
+                      isClosed,
+                      theTol,
+                      theMode);
+
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
     return myResult;
   }
 
-  //! @brief Build uniform parameter grid.
-  //! @return math_Vector with 1-based indexing
-  static math_Vector BuildUniformParams(double theUMin, double theUMax, int theNbSamples)
+  //! Builds a uniform parameter partition.
+  static math_Vector BuildUniformParams(double theUMin, double theUMax, size_t theNbSamples)
   {
-    math_Vector  aParams(1, theNbSamples);
-    const double aStep = (theUMax - theUMin) / (theNbSamples - 1);
-
-    for (int i = 1; i <= theNbSamples; ++i)
+    Standard_RangeError_Raise_if(theNbSamples < 2, "ExtremaPC_GridEvaluator::BuildUniformParams");
+    math_Vector  aParams(theNbSamples);
+    const double aStep = (theUMax - theUMin) / static_cast<double>(theNbSamples - 1);
+    for (size_t anIndex = 0; anIndex < theNbSamples; ++anIndex)
     {
-      aParams(i) = theUMin + (i - 1) * aStep;
+      aParams.ChangeAt(anIndex) = theUMin + static_cast<double>(anIndex) * aStep;
     }
-    aParams(theNbSamples) = theUMax; // Ensure exact endpoint
-
+    aParams.ChangeAt(theNbSamples - 1) = theUMax;
     return aParams;
   }
 
-private:
-  //! @brief Scan grid to find candidate intervals for extrema.
-  void scanGrid(const gp_Pnt& theP, double theTol, ExtremaPC::SearchMode theMode) const
+  //! Builds a deflection-aware partition within each C2-smooth curve interval.
+  static math_Vector BuildCurveAwareParams(const Adaptor3d_Curve&     theCurve,
+                                           const ExtremaPC::Domain1D& theDomain)
   {
-    myCandidates.Clear();
-    const int aNbGrid = myGrid.Length();
+    try
+    {
+      NCollection_LinearVector<double> aParameters;
+      insertParameter(aParameters, theDomain.Min);
+      insertParameter(aParameters, theDomain.Max);
 
-    if (aNbGrid < 2)
+      const int                          aNbIntervals = theCurve.NbIntervals(GeomAbs_C2);
+      NCollection_LocalArray<double, 32> anIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
+      NCollection_Array1<double>         anIntervals(anIntervalStorage[0], 1, aNbIntervals + 1);
+      theCurve.Intervals(anIntervals, GeomAbs_C2);
+      for (size_t anInterval = 0; anInterval + 1 < anIntervals.Size(); ++anInterval)
+      {
+        const double aLower  = theDomain.Clamp(anIntervals.At(anInterval));
+        const double anUpper = theDomain.Clamp(anIntervals.At(anInterval + 1));
+        if (anUpper - aLower <= ExtremaPC::THE_PARAM_TOLERANCE)
+        {
+          continue;
+        }
+
+        insertParameter(aParameters, aLower);
+        insertParameter(aParameters, anUpper);
+        occ::handle<Adaptor3d_Curve> aLocalCurve =
+          theCurve.Trim(aLower, anUpper, Precision::PConfusion());
+        if (aLocalCurve.IsNull())
+        {
+          continue;
+        }
+
+        const occ::handle<NCollection_HArray1<double>> aDeflectionParameters =
+          Extrema_CurveTool::DeflCurvIntervals(*aLocalCurve);
+        if (aDeflectionParameters.IsNull())
+        {
+          continue;
+        }
+        for (double aParameter : aDeflectionParameters->Array1())
+        {
+          insertParameter(aParameters, ExtremaPC::Domain1D(aLower, anUpper).Clamp(aParameter));
+        }
+      }
+
+      math_Vector aResult(aParameters.Size());
+      for (size_t anIndex = 0; anIndex < aParameters.Size(); ++anIndex)
+      {
+        aResult.ChangeAt(anIndex) = aParameters.Value(anIndex);
+      }
+      return aResult;
+    }
+    catch (const Standard_Failure&)
+    {
+      return BuildUniformParams(theDomain.Min,
+                                theDomain.Max,
+                                ExtremaPC::THE_OTHER_CURVE_NB_SAMPLES);
+    }
+  }
+
+  //! Returns true when the domain endpoints represent the same curve point.
+  static bool IsClosedDomain(const Adaptor3d_Curve& theCurve, const ExtremaPC::Domain1D& theDomain)
+  {
+    if (!theDomain.IsFinite() || theDomain.Min == theDomain.Max)
+    {
+      return false;
+    }
+    try
+    {
+      if (theCurve.IsPeriodic()
+          && ExtremaPC::IsClosedPeriodicDomain(theDomain,
+                                               theCurve.Period(),
+                                               ExtremaPC::THE_PARAM_TOLERANCE))
+      {
+        return true;
+      }
+      return theCurve.Value(theDomain.Min).SquareDistance(theCurve.Value(theDomain.Max)) == 0.0;
+    }
+    catch (const Standard_Failure&)
+    {
+      return false;
+    }
+  }
+
+private:
+  //! Root and the non-uniform cell used to isolate it.
+  struct RootCandidate
+  {
+    double Parameter;
+    double LeftBound;
+    double RightBound;
+  };
+
+  //! Validates the cached partition and its coverage of the requested domain.
+  bool validateParams(const ExtremaPC::Domain1D& theDomain) const
+  {
+    if (myParams.Size() < 2)
+    {
+      return false;
+    }
+    if (std::abs(myParams.First() - theDomain.Min) > ExtremaPC::THE_PARAM_TOLERANCE
+        || std::abs(myParams.Last() - theDomain.Max) > ExtremaPC::THE_PARAM_TOLERANCE)
+    {
+      return false;
+    }
+    for (size_t anIndex = 1; anIndex < myParams.Size(); ++anIndex)
+    {
+      if (!std::isfinite(myParams[anIndex - 1]) || !std::isfinite(myParams[anIndex])
+          || myParams[anIndex] <= myParams[anIndex - 1])
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  //! Returns a constant squared distance only when the curve geometry proves it exactly.
+  static std::optional<double> constantSquareDistance(const Adaptor3d_Curve&     theCurve,
+                                                      const gp_Pnt&              thePoint,
+                                                      const ExtremaPC::Domain1D& theDomain)
+  {
+    try
+    {
+      const GeomAbs_CurveType aType = theCurve.GetType();
+      if (aType == GeomAbs_Circle)
+      {
+        const gp_Circ aCircle = theCurve.Circle();
+        const gp_Vec  aCenterToPoint(aCircle.Location(), thePoint);
+        if (aCenterToPoint.Crossed(gp_Vec(aCircle.Axis().Direction())).SquareMagnitude() == 0.0)
+        {
+          return thePoint.SquareDistance(theCurve.Value(theDomain.Min));
+        }
+      }
+      else if (aType == GeomAbs_Ellipse)
+      {
+        const gp_Elips anEllipse = theCurve.Ellipse();
+        const gp_Vec   aCenterToPoint(anEllipse.Location(), thePoint);
+        if (anEllipse.MajorRadius() == anEllipse.MinorRadius()
+            && aCenterToPoint.Crossed(gp_Vec(anEllipse.Axis().Direction())).SquareMagnitude()
+                 == 0.0)
+        {
+          return thePoint.SquareDistance(theCurve.Value(theDomain.Min));
+        }
+      }
+
+      const occ::handle<Geom_BezierCurve> aBezier =
+        aType == GeomAbs_BezierCurve ? theCurve.Bezier() : occ::handle<Geom_BezierCurve>();
+      const occ::handle<Geom_BSplineCurve> aBSpline =
+        aType == GeomAbs_BSplineCurve ? theCurve.BSpline() : occ::handle<Geom_BSplineCurve>();
+      const size_t aNbPoles = static_cast<size_t>(
+        !aBezier.IsNull() ? aBezier->NbPoles() : (!aBSpline.IsNull() ? aBSpline->NbPoles() : 0));
+      if (aNbPoles > 0)
+      {
+        const gp_Pnt aReference = !aBezier.IsNull() ? aBezier->Pole(1) : aBSpline->Pole(1);
+        for (size_t aPoleIndex = 1; aPoleIndex < aNbPoles; ++aPoleIndex)
+        {
+          const int    aGeomIndex = static_cast<int>(aPoleIndex + 1);
+          const gp_Pnt aPole =
+            !aBezier.IsNull() ? aBezier->Pole(aGeomIndex) : aBSpline->Pole(aGeomIndex);
+          if (aPole.SquareDistance(aReference) != 0.0)
+          {
+            return std::nullopt;
+          }
+        }
+        return thePoint.SquareDistance(aReference);
+      }
+      return std::nullopt;
+    }
+    catch (const Standard_Failure&)
+    {
+      return std::nullopt;
+    }
+  }
+
+  //! Inserts a parameter in ascending order unless it is already present.
+  static void insertParameter(NCollection_LinearVector<double>& theParameters, double theParameter)
+  {
+    size_t aLower  = 0;
+    size_t anUpper = theParameters.Size();
+    while (aLower < anUpper)
+    {
+      const size_t aMiddle = aLower + (anUpper - aLower) / 2;
+      if (theParameters.Value(aMiddle) < theParameter)
+      {
+        aLower = aMiddle + 1;
+      }
+      else
+      {
+        anUpper = aMiddle;
+      }
+    }
+    if ((aLower < theParameters.Size()
+         && std::abs(theParameters.Value(aLower) - theParameter) <= ExtremaPC::THE_PARAM_TOLERANCE)
+        || (aLower > 0
+            && std::abs(theParameters.Value(aLower - 1) - theParameter)
+                 <= ExtremaPC::THE_PARAM_TOLERANCE))
     {
       return;
     }
 
-    // Resize processed array if needed
-    if (myProcessed.Length() != aNbGrid)
+    if (aLower == theParameters.Size())
     {
-      myProcessed = NCollection_Array1<bool>(0, aNbGrid - 1);
+      theParameters.Append(theParameter);
     }
-    myProcessed.Init(false);
-
-    double aPrevF     = 0.0;
-    double aPrevDist  = 0.0;
-    bool   aPrevValid = false;
-
-    for (int i = 0; i < aNbGrid; ++i)
+    else
     {
-      const GridPoint& aGP = myGrid[i];
-
-      // Compute distance function value: F(u) = (C(u) - P) . C'(u)
-      gp_Vec aVec(theP, aGP.Point);
-      double aF    = aVec.Dot(aGP.D1);
-      double aDist = aVec.SquareMagnitude();
-
-      // Check for sign change with previous point
-      if (aPrevValid && aPrevF * aF < 0.0 && !myProcessed[i - 1])
-      {
-        Candidate aCand;
-        aCand.Type  = CandidateType::SignChange;
-        aCand.IdxLo = i - 1;
-        aCand.IdxHi = i;
-        // Use linear interpolation for better starting point (secant method)
-        double aFLo  = aPrevF;
-        double aFHi  = aF;
-        double aULo  = myGrid[i - 1].Param;
-        double aUHi  = aGP.Param;
-        aCand.StartU = aULo - aFLo * (aUHi - aULo) / (aFHi - aFLo);
-        myCandidates.Append(aCand);
-        myProcessed[i - 1] = true;
-        myProcessed[i]     = true;
-      }
-
-      // Check for near-zero F (direct hit on extremum)
-      if (std::abs(aF) < theTol * ExtremaPC::THE_NEAR_ZERO_F_FACTOR && !myProcessed[i])
-      {
-        Candidate aCand;
-        aCand.Type   = CandidateType::NearZero;
-        aCand.IdxLo  = i;
-        aCand.IdxHi  = i;
-        aCand.StartU = aGP.Param;
-        myCandidates.Append(aCand);
-        myProcessed[i] = true;
-      }
-
-      // Check for local extremum by distance comparison (3-point test)
-      if (i > 0 && i < aNbGrid - 1 && !myProcessed[i])
-      {
-        double aNextDist = theP.SquareDistance(myGrid[i + 1].Point);
-
-        // Local minimum: distance decreases then increases
-        bool aIsLocalMin = (aDist <= aPrevDist && aDist <= aNextDist);
-        // Local maximum: distance increases then decreases
-        bool aIsLocalMax = (aDist >= aPrevDist && aDist >= aNextDist);
-
-        if ((theMode == ExtremaPC::SearchMode::Min || theMode == ExtremaPC::SearchMode::MinMax)
-            && aIsLocalMin)
-        {
-          Candidate aCand;
-          aCand.Type   = CandidateType::NearZero;
-          aCand.IdxLo  = i;
-          aCand.IdxHi  = i;
-          aCand.StartU = aGP.Param;
-          myCandidates.Append(aCand);
-          myProcessed[i] = true;
-        }
-        else if ((theMode == ExtremaPC::SearchMode::Max || theMode == ExtremaPC::SearchMode::MinMax)
-                 && aIsLocalMax && !aIsLocalMin)
-        {
-          Candidate aCand;
-          aCand.Type   = CandidateType::NearZero;
-          aCand.IdxLo  = i;
-          aCand.IdxHi  = i;
-          aCand.StartU = aGP.Param;
-          myCandidates.Append(aCand);
-          myProcessed[i] = true;
-        }
-      }
-
-      aPrevF     = aF;
-      aPrevDist  = aDist;
-      aPrevValid = true;
+      theParameters.InsertBefore(aLower, theParameter);
     }
   }
 
-  //! @brief Refine candidates using Newton's method.
-  void refineCandidates(const Adaptor3d_Curve&     theCurve,
-                        const gp_Pnt&              theP,
-                        const ExtremaPC::Domain1D& theDomain,
-                        double                     theTol,
-                        ExtremaPC::SearchMode      theMode) const
+  //! Combines cached sampling parameters with C2 continuity boundaries.
+  void buildPartition(const Adaptor3d_Curve&            theCurve,
+                      const ExtremaPC::Domain1D&        theDomain,
+                      NCollection_LinearVector<double>& theContinuityBounds,
+                      NCollection_LinearVector<double>& thePartition) const
   {
-    myResult.Status = ExtremaPC::Status::OK;
-    myFoundRoots.Clear();
-    mySortedIndices.Clear();
-
-    ExtremaPC_DistanceFunction aFunc(theCurve, theP);
-
-    // Newton configuration
-    MathUtils::Config aConfig;
-    aConfig.XTolerance    = theTol * ExtremaPC::THE_NEWTON_XTOL_FACTOR;
-    aConfig.FTolerance    = theTol * ExtremaPC::THE_NEWTON_FTOL_FACTOR;
-    aConfig.MaxIterations = ExtremaPC::THE_MAX_NEWTON_ITERATIONS;
-
-    // Build sorted indices by estimated distance
-    for (int c = 0; c < myCandidates.Length(); ++c)
+    thePartition.Reserve(myParams.Size());
+    for (const double aParameter : myParams)
     {
-      const Candidate& aCand     = myCandidates.Value(c);
-      double           anEstDist = theP.SquareDistance(myGrid[aCand.IdxLo].Point);
-      mySortedIndices.Append(std::make_pair(c, anEstDist));
+      thePartition.Append(aParameter);
     }
 
-    // Sort by estimated distance for Min mode (ascending), Max mode (descending)
-    if (theMode == ExtremaPC::SearchMode::Min)
+    try
     {
-      std::sort(mySortedIndices.begin(),
-                mySortedIndices.end(),
-                [](const std::pair<int, double>& a, const std::pair<int, double>& b) {
-                  return a.second < b.second;
-                });
-    }
-    else if (theMode == ExtremaPC::SearchMode::Max)
-    {
-      std::sort(mySortedIndices.begin(),
-                mySortedIndices.end(),
-                [](const std::pair<int, double>& a, const std::pair<int, double>& b) {
-                  return a.second > b.second;
-                });
-    }
-
-    // Best distance found so far (for early termination)
-    double aBestSqDist = (theMode == ExtremaPC::SearchMode::Min)
-                           ? std::numeric_limits<double>::max()
-                           : -std::numeric_limits<double>::max();
-
-    for (int s = 0; s < mySortedIndices.Length(); ++s)
-    {
-      int              c         = mySortedIndices.Value(s).first;
-      double           anEstDist = mySortedIndices.Value(s).second;
-      const Candidate& aCand     = myCandidates.Value(c);
-
-      // Early termination: skip candidates that are clearly worse than the best found.
-      // For Min mode: skip if estimated distance > best * (2.0 - threshold), i.e., ~1.1x best.
-      // For Max mode: skip if estimated distance < best * threshold, i.e., ~0.9x best.
-      constexpr double aMinSkipThreshold = 2.0 - ExtremaPC::THE_MAX_SKIP_THRESHOLD;
-      if (theMode == ExtremaPC::SearchMode::Min && anEstDist > aBestSqDist * aMinSkipThreshold)
+      const int                          aNbIntervals = theCurve.NbIntervals(GeomAbs_C2);
+      NCollection_LocalArray<double, 32> anIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
+      NCollection_Array1<double>         anIntervals(anIntervalStorage[0], 1, aNbIntervals + 1);
+      thePartition.Reserve(myParams.Size() + static_cast<size_t>(aNbIntervals + 1));
+      theContinuityBounds.Reserve(static_cast<size_t>(aNbIntervals + 1));
+      theCurve.Intervals(anIntervals, GeomAbs_C2);
+      for (size_t anIndex = 0; anIndex < anIntervals.Size(); ++anIndex)
       {
-        break;
-      }
-      if (theMode == ExtremaPC::SearchMode::Max
-          && anEstDist < aBestSqDist * ExtremaPC::THE_MAX_SKIP_THRESHOLD)
-      {
-        break;
-      }
-
-      // Skip if too close to already found root
-      bool aSkip = false;
-      for (int r = 0; r < myFoundRoots.Length(); ++r)
-      {
-        if (std::abs(aCand.StartU - myFoundRoots.Value(r)) < theTol)
+        const double aParameter = theDomain.Clamp(anIntervals.At(anIndex));
+        insertParameter(thePartition, aParameter);
+        if (aParameter > theDomain.Min + ExtremaPC::THE_PARAM_TOLERANCE
+            && aParameter < theDomain.Max - ExtremaPC::THE_PARAM_TOLERANCE)
         {
-          aSkip = true;
+          insertParameter(theContinuityBounds, aParameter);
+        }
+      }
+    }
+    catch (const Standard_Failure&)
+    {
+      // Cached sampling remains usable for adaptors without interval APIs.
+    }
+  }
+
+  //! Appends a sorted root, merging the cells of an equivalent boundary root.
+  static void appendRoot(NCollection_LinearVector<RootCandidate>& theRoots,
+                         const RootCandidate&                     theRoot)
+  {
+    if (!theRoots.IsEmpty())
+    {
+      RootCandidate& aLast = theRoots.ChangeValue(theRoots.Size() - 1);
+      if (std::abs(aLast.Parameter - theRoot.Parameter) <= ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        aLast.LeftBound  = std::min(aLast.LeftBound, theRoot.LeftBound);
+        aLast.RightBound = std::max(aLast.RightBound, theRoot.RightBound);
+        return;
+      }
+      if (aLast.Parameter < theRoot.Parameter)
+      {
+        theRoots.Append(theRoot);
+        return;
+      }
+    }
+
+    // The interval traversal and MathRoot results are ordered. Keep a defensive insertion path
+    // for custom or future solvers that violate that contract.
+    for (size_t anIndex = 0; anIndex < theRoots.Size(); ++anIndex)
+    {
+      RootCandidate& anExisting = theRoots.ChangeValue(anIndex);
+      if (std::abs(anExisting.Parameter - theRoot.Parameter) <= ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        anExisting.LeftBound  = std::min(anExisting.LeftBound, theRoot.LeftBound);
+        anExisting.RightBound = std::max(anExisting.RightBound, theRoot.RightBound);
+        return;
+      }
+      if (theRoot.Parameter < anExisting.Parameter)
+      {
+        theRoots.InsertBefore(anIndex, theRoot);
+        return;
+      }
+    }
+    theRoots.Append(theRoot);
+  }
+
+  //! Returns the stationarity sign at a probe, treating small values as unresolved.
+  static int stationaritySign(ExtremaPC_DistanceFunction& theFunction,
+                              double                      theParameter,
+                              double                      theTol)
+  {
+    double aValue = 0.0;
+    try
+    {
+      const double aSignTolerance = std::min(theTol, ExtremaPC::THE_DEFAULT_TOLERANCE);
+      if (!theFunction.Value(theParameter, aValue) || std::abs(aValue) <= aSignTolerance)
+      {
+        return 0;
+      }
+      return aValue < 0.0 ? -1 : 1;
+    }
+    catch (const Standard_Failure&)
+    {
+      return 0;
+    }
+  }
+
+  //! Adds one classified extremum if it matches the requested mode and is not duplicated.
+  void addExtremum(const Adaptor3d_Curve& theCurve,
+                   const gp_Pnt&          theP,
+                   double                 theParameter,
+                   int                    theLeftSign,
+                   int                    theRightSign,
+                   ExtremaPC::SearchMode  theMode) const
+  {
+    const bool isMinimum = theLeftSign < 0 && theRightSign > 0;
+    const bool isMaximum = theLeftSign > 0 && theRightSign < 0;
+    if ((!isMinimum && !isMaximum) || (theMode == ExtremaPC::SearchMode::Min && !isMinimum)
+        || (theMode == ExtremaPC::SearchMode::Max && !isMaximum))
+    {
+      return;
+    }
+
+    for (size_t anIndex = 0; anIndex < myResult.Extrema.Size(); ++anIndex)
+    {
+      if (std::abs(myResult.Extrema.Value(anIndex).Parameter - theParameter)
+          <= ExtremaPC::THE_PARAM_TOLERANCE)
+      {
+        return;
+      }
+    }
+
+    const gp_Pnt              aCurvePoint = theCurve.Value(theParameter);
+    ExtremaPC::ExtremumResult anExtremum;
+    anExtremum.Parameter      = theParameter;
+    anExtremum.Point          = aCurvePoint;
+    anExtremum.SquareDistance = theP.SquareDistance(aCurvePoint);
+    anExtremum.IsMinimum      = isMinimum;
+    anExtremum.IsMaximum      = isMaximum;
+    myResult.Extrema.Append(anExtremum);
+  }
+
+  //! Classifies smooth stationary roots within their isolation cells.
+  void classifyRoots(const Adaptor3d_Curve&                         theCurve,
+                     const gp_Pnt&                                  theP,
+                     const ExtremaPC::Domain1D&                     theDomain,
+                     ExtremaPC_DistanceFunction&                    theFunction,
+                     const NCollection_LinearVector<double>&        theContinuityBounds,
+                     const NCollection_LinearVector<RootCandidate>& theRoots,
+                     double                                         theTol,
+                     ExtremaPC::SearchMode                          theMode) const
+  {
+    for (size_t aRootIndex = 0; aRootIndex < theRoots.Size(); ++aRootIndex)
+    {
+      const RootCandidate& aRoot      = theRoots.Value(aRootIndex);
+      bool                 isJunction = false;
+      for (size_t aJunctionIndex = 0; aJunctionIndex < theContinuityBounds.Size(); ++aJunctionIndex)
+      {
+        if (std::abs(aRoot.Parameter - theContinuityBounds.Value(aJunctionIndex))
+            <= ExtremaPC::THE_PARAM_TOLERANCE)
+        {
+          isJunction = true;
           break;
         }
       }
-      if (aSkip)
+      if (isJunction)
       {
         continue;
       }
 
-      // Determine Newton bounds
-      double aULo, aUHi;
-      if (aCand.Type == CandidateType::SignChange)
+      const bool isAtFirst = aRoot.Parameter <= theDomain.Min + ExtremaPC::THE_PARAM_TOLERANCE;
+      const bool isAtLast  = aRoot.Parameter >= theDomain.Max - ExtremaPC::THE_PARAM_TOLERANCE;
+      if (isAtFirst || isAtLast)
       {
-        aULo = myGrid[aCand.IdxLo].Param;
-        aUHi = myGrid[aCand.IdxHi].Param;
-      }
-      else
-      {
-        double aExpand = (theDomain.Max - theDomain.Min) * ExtremaPC::THE_INTERVAL_EXPAND_RATIO;
-        aULo           = std::max(theDomain.Min, aCand.StartU - aExpand);
-        aUHi           = std::min(theDomain.Max, aCand.StartU + aExpand);
-      }
-
-      // Try Newton refinement
-      MathUtils::ScalarResult aNewtonRes =
-        MathRoot::NewtonBounded(aFunc, aCand.StartU, aULo, aUHi, aConfig);
-
-      double aRootU     = 0.0;
-      bool   aConverged = false;
-
-      if (aNewtonRes.IsDone())
-      {
-        aRootU     = std::max(theDomain.Min, std::min(theDomain.Max, *aNewtonRes.Root));
-        aConverged = true;
-      }
-      else
-      {
-        // Try iterative grid refinement as fallback
-        double aBestU    = aCand.StartU;
-        double aBestDist = std::numeric_limits<double>::max();
-        double aRefUMin  = aULo;
-        double aRefUMax  = aUHi;
-
-        for (int aPass = 0; aPass < ExtremaPC::THE_REFINEMENT_NB_PASSES; ++aPass)
-        {
-          const int    aNbSamples = ExtremaPC::THE_REFINEMENT_NB_SAMPLES;
-          const double aStep      = (aRefUMax - aRefUMin) / (aNbSamples - 1);
-
-          for (int i = 0; i < aNbSamples; ++i)
-          {
-            double aU    = aRefUMin + i * aStep;
-            gp_Pnt aPt   = theCurve.Value(aU);
-            double aDist = theP.SquareDistance(aPt);
-
-            if (aDist < aBestDist)
-            {
-              aBestDist = aDist;
-              aBestU    = aU;
-            }
-          }
-
-          // Narrow range
-          double aRangeHalf = (aRefUMax - aRefUMin) * ExtremaPC::THE_RANGE_NARROWING_FACTOR * 0.5;
-          aRefUMin          = std::max(theDomain.Min, aBestU - aRangeHalf);
-          aRefUMax          = std::min(theDomain.Max, aBestU + aRangeHalf);
-
-          // Try Newton with refined point
-          MathUtils::ScalarResult aRetryRes =
-            MathRoot::NewtonBounded(aFunc, aBestU, aRefUMin, aRefUMax, aConfig);
-          if (aRetryRes.IsDone())
-          {
-            aRootU     = std::max(theDomain.Min, std::min(theDomain.Max, *aRetryRes.Root));
-            aConverged = true;
-            break;
-          }
-        }
-
-        // Use best grid point as fallback
-        if (!aConverged)
-        {
-          gp_Pnt aPt;
-          gp_Vec aD1;
-          theCurve.D1(aBestU, aPt, aD1);
-          gp_Vec aVec(theP, aPt);
-          double aF = aVec.Dot(aD1);
-
-          if (std::abs(aF) < theTol * ExtremaPC::THE_FALLBACK_F_FACTOR)
-          {
-            aRootU     = aBestU;
-            aConverged = true;
-          }
-        }
-      }
-
-      if (!aConverged)
         continue;
+      }
 
-      // Check for duplicate
-      bool aDuplicate = false;
-      for (int r = 0; r < myFoundRoots.Length(); ++r)
+      double aLeftBound  = aRoot.LeftBound;
+      double aRightBound = aRoot.RightBound;
+      if (aRootIndex > 0)
       {
-        if (std::abs(aRootU - myFoundRoots.Value(r)) < theTol)
+        const RootCandidate& aPrevious = theRoots.Value(aRootIndex - 1);
+        aLeftBound = std::max(aLeftBound, (aPrevious.Parameter + aRoot.Parameter) * 0.5);
+      }
+      if (aRootIndex + 1 < theRoots.Size())
+      {
+        const RootCandidate& aNext = theRoots.Value(aRootIndex + 1);
+        aRightBound = std::min(aRightBound, (aRoot.Parameter + aNext.Parameter) * 0.5);
+      }
+      const int aLeftSign =
+        stationaritySign(theFunction, (aLeftBound + aRoot.Parameter) * 0.5, theTol);
+      const int aRightSign =
+        stationaritySign(theFunction, (aRoot.Parameter + aRightBound) * 0.5, theTol);
+      addExtremum(theCurve, theP, aRoot.Parameter, aLeftSign, aRightSign, theMode);
+    }
+  }
+
+  //! Classifies C2 continuity boundaries and the periodic seam from one-sided values.
+  void classifyJunctions(const Adaptor3d_Curve&                         theCurve,
+                         const gp_Pnt&                                  theP,
+                         const ExtremaPC::Domain1D&                     theDomain,
+                         ExtremaPC_DistanceFunction&                    theFunction,
+                         const NCollection_LinearVector<double>&        theContinuityBounds,
+                         const NCollection_LinearVector<double>&        thePartition,
+                         const NCollection_LinearVector<RootCandidate>& theRoots,
+                         bool                                           theIsClosed,
+                         double                                         theTol,
+                         ExtremaPC::SearchMode                          theMode) const
+  {
+    for (size_t aJunctionIndex = 0; aJunctionIndex < theContinuityBounds.Size(); ++aJunctionIndex)
+    {
+      const double aJunction   = theContinuityBounds.Value(aJunctionIndex);
+      double       aLeftBound  = theDomain.Min;
+      double       aRightBound = theDomain.Max;
+      for (size_t aParamIndex = 1; aParamIndex < thePartition.Size(); ++aParamIndex)
+      {
+        if (thePartition.Value(aParamIndex) >= aJunction)
         {
-          aDuplicate = true;
+          aLeftBound  = thePartition.Value(aParamIndex - 1);
+          aRightBound = thePartition.Value(aParamIndex);
+          if (std::abs(aRightBound - aJunction) <= ExtremaPC::THE_PARAM_TOLERANCE
+              && aParamIndex + 1 < thePartition.Size())
+          {
+            aRightBound = thePartition.Value(aParamIndex + 1);
+          }
           break;
         }
       }
-      if (aDuplicate)
-        continue;
-
-      gp_Pnt aPt     = theCurve.Value(aRootU);
-      double aSqDist = theP.SquareDistance(aPt);
-
-      // Classify as min/max using neighbor sampling
-      double aStep = (theDomain.Max - theDomain.Min) * ExtremaPC::THE_REFINEMENT_STEP_RATIO;
-      double aDistPlus =
-        theP.SquareDistance(theCurve.Value(std::min(theDomain.Max, aRootU + aStep)));
-      double aDistMinus =
-        theP.SquareDistance(theCurve.Value(std::max(theDomain.Min, aRootU - aStep)));
-      bool aIsMin = (aSqDist <= aDistPlus) && (aSqDist <= aDistMinus);
-
-      // Filter by mode
-      bool aKeep = false;
-      if (theMode == ExtremaPC::SearchMode::MinMax)
+      for (size_t aRootIndex = 0; aRootIndex < theRoots.Size(); ++aRootIndex)
       {
-        aKeep = true;
-      }
-      else if (theMode == ExtremaPC::SearchMode::Min && aIsMin)
-      {
-        aKeep = true;
-      }
-      else if (theMode == ExtremaPC::SearchMode::Max && !aIsMin)
-      {
-        aKeep = true;
-      }
-
-      if (aKeep)
-      {
-        ExtremaPC::ExtremumResult anExt;
-        anExt.Parameter      = aRootU;
-        anExt.Point          = aPt;
-        anExt.SquareDistance = aSqDist;
-        anExt.IsMinimum      = aIsMin;
-        myResult.Extrema.Append(anExt);
-
-        myFoundRoots.Append(aRootU);
-
-        // Update best distance for early termination
-        if (theMode == ExtremaPC::SearchMode::Min && aSqDist < aBestSqDist)
+        const double aRoot = theRoots.Value(aRootIndex).Parameter;
+        if (aRoot > aLeftBound + ExtremaPC::THE_PARAM_TOLERANCE
+            && aRoot < aJunction - ExtremaPC::THE_PARAM_TOLERANCE)
         {
-          aBestSqDist = aSqDist;
+          aLeftBound = aRoot;
         }
-        else if (theMode == ExtremaPC::SearchMode::Max && aSqDist > aBestSqDist)
+        else if (aRoot > aJunction + ExtremaPC::THE_PARAM_TOLERANCE
+                 && aRoot < aRightBound - ExtremaPC::THE_PARAM_TOLERANCE)
         {
-          aBestSqDist = aSqDist;
+          aRightBound = aRoot;
+          break;
         }
       }
+
+      const int aLeftSign  = stationaritySign(theFunction, (aLeftBound + aJunction) * 0.5, theTol);
+      const int aRightSign = stationaritySign(theFunction, (aJunction + aRightBound) * 0.5, theTol);
+      addExtremum(theCurve, theP, aJunction, aLeftSign, aRightSign, theMode);
     }
 
-    if (myResult.Extrema.IsEmpty() && myCandidates.IsEmpty())
+    if (theIsClosed)
     {
-      myResult.Status = ExtremaPC::Status::NoSolution;
+      double aLeftBound  = myParams[myParams.Size() - 2];
+      double aRightBound = myParams[1];
+      for (size_t aRootIndex = 0; aRootIndex < theRoots.Size(); ++aRootIndex)
+      {
+        const double aRoot = theRoots.Value(aRootIndex).Parameter;
+        if (aRoot > aLeftBound + ExtremaPC::THE_PARAM_TOLERANCE
+            && aRoot < theDomain.Max - ExtremaPC::THE_PARAM_TOLERANCE)
+        {
+          aLeftBound = aRoot;
+        }
+        if (aRoot > theDomain.Min + ExtremaPC::THE_PARAM_TOLERANCE
+            && aRoot < aRightBound - ExtremaPC::THE_PARAM_TOLERANCE)
+        {
+          aRightBound = aRoot;
+        }
+      }
+      const int aLeftSign =
+        stationaritySign(theFunction, (aLeftBound + theDomain.Max) * 0.5, theTol);
+      const int aRightSign =
+        stationaritySign(theFunction, (theDomain.Min + aRightBound) * 0.5, theTol);
+      addExtremum(theCurve, theP, theDomain.Min, aLeftSign, aRightSign, theMode);
     }
   }
 
 private:
-  NCollection_Array1<GridPoint> myGrid; //!< Cached grid
-
-  // Mutable cached temporaries (reused via Clear())
-  mutable ExtremaPC::Result                   myResult;     //!< Reusable result
-  mutable NCollection_DynamicArray<Candidate> myCandidates; //!< Candidates from grid scan
-  mutable NCollection_DynamicArray<double>    myFoundRoots; //!< Found roots for dedup
-  mutable NCollection_DynamicArray<std::pair<int, double>>
-                                   mySortedIndices; //!< Sorted candidate indices
-  mutable NCollection_Array1<bool> myProcessed;     //!< Processed flags for grid scan
+  NCollection_LinearVector<double>                myParams; //!< Cached parameter partition
+  mutable NCollection_LinearVector<double>        myContinuityBounds; //!< Reusable C2 bounds
+  mutable NCollection_LinearVector<double>        myPartition;        //!< Reusable merged partition
+  mutable NCollection_LinearVector<RootCandidate> myRoots;            //!< Reusable root candidates
+  mutable ExtremaPC::Result                       myResult;           //!< Reusable result
 };
 
 #endif // _ExtremaPC_GridEvaluator_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Hyperbola.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Hyperbola.hxx
@@ -16,12 +16,15 @@
 
 #include <ElCLib.hxx>
 #include <ExtremaPC.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_Hyperbola.hxx>
 #include <gp_Hypr.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
 #include <MathPoly_Quartic.hxx>
 #include <Precision.hxx>
 #include <Standard_DefineAlloc.hxx>
+#include <ProjLib.hxx>
 
 #include <cmath>
 #include <optional>
@@ -61,8 +64,7 @@ public:
   //! @param[in] theDomain parameter domain (fixed for all queries)
   ExtremaPC_Hyperbola(const gp_Hypr& theHyperbola, const ExtremaPC::Domain1D& theDomain)
       : myHyperbola(theHyperbola),
-        myDomain(theDomain.IsFinite() ? std::optional<ExtremaPC::Domain1D>(theDomain)
-                                      : std::nullopt)
+        myDomain(theDomain)
   {
     cacheGeometry();
   }
@@ -111,6 +113,22 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    const gp_Pln aPlane(gp_Ax3(myHyperbola.Position()));
+    if (ExtremaPC::IsValidTolerance(theTol) && ExtremaPC::IsFinitePoint(theP)
+        && (!myDomain.has_value() || myDomain->IsValid())
+        && ExtremaPC::PerformPlanar<ExtremaPC2d_Hyperbola>(ProjLib::Project(aPlane, myHyperbola),
+                                                           myDomain,
+                                                           ProjLib::Project(aPlane, theP),
+                                                           theP,
+                                                           aPlane,
+                                                           *this,
+                                                           theTol,
+                                                           theMode,
+                                                           false,
+                                                           myResult))
+    {
+      return myResult;
+    }
     performCore(theP, myDomain, theTol, theMode);
     return myResult;
   }
@@ -126,12 +144,35 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
+      return myResult;
+    }
+
     (void)Perform(theP, theTol, theMode);
 
     // Add endpoints if interior computation succeeded and domain is bounded
-    if (myResult.Status == ExtremaPC::Status::OK && myDomain.has_value())
+    if ((myResult.Status == ExtremaPC::Status::OK
+         || myResult.Status == ExtremaPC::Status::NoSolution)
+        && myDomain.has_value())
     {
-      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theTol, theMode);
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC::Status::OK;
+      }
     }
 
     return myResult;
@@ -218,6 +259,13 @@ private:
   {
     myResult.Clear();
 
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (theDomain.has_value() && !theDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return;
+    }
+
     MathPoly::PolyResult aPolyRes = solveQuartic(theP);
 
     if (!aPolyRes.IsDone())
@@ -235,8 +283,6 @@ private:
       return;
     }
 
-    double aTol2 = theTol * theTol;
-
     // Process all positive roots (v > 0 required for u = ln(v))
     for (size_t i = 0; i < aPolyRes.NbRoots; ++i)
     {
@@ -249,17 +295,20 @@ private:
       // Check bounds if domain is specified
       if (theDomain.has_value())
       {
-        if (aU < theDomain->Min || aU > theDomain->Max)
+        if (!theDomain->Contains(aU, ExtremaPC::THE_PARAM_TOLERANCE))
+        {
           continue;
+        }
+        aU = theDomain->Clamp(aU);
       }
 
       gp_Pnt aCurvePt = Value(aU);
 
       // Check for duplicates
       bool aDuplicate = false;
-      for (int j = 0; j < myResult.Extrema.Length(); ++j)
+      for (const ExtremaPC::ExtremumResult& anExtremum : myResult.Extrema)
       {
-        if (aCurvePt.SquareDistance(myResult.Extrema.Value(j).Point) < aTol2)
+        if (std::abs(aU - anExtremum.Parameter) < ExtremaPC::THE_PARAM_TOLERANCE)
         {
           aDuplicate = true;
           break;
@@ -268,23 +317,25 @@ private:
       if (aDuplicate)
         continue;
 
-      // Determine if minimum or maximum using neighbor comparison
-      double aSqDist = theP.SquareDistance(aCurvePt);
-      double aNeighborU;
-      if (theDomain.has_value())
+      const size_t aMultiplicity = aPolyRes.Multiplicities[i];
+      if (aMultiplicity % 2 == 0)
       {
-        // For bounded case, choose neighbor direction based on position in domain
-        aNeighborU = aU + (aU < (theDomain->Min + theDomain->Max) * 0.5 ? 1.0 : -1.0);
-        aNeighborU = std::max(theDomain->Min, std::min(theDomain->Max, aNeighborU));
+        continue;
       }
-      else
+
+      // The quartic is v^2 times the stationary function and has a positive leading
+      // coefficient. Since v = exp(u) is increasing, odd roots that follow determine whether
+      // the stationary function crosses from negative to positive at this root.
+      double aSqDist          = theP.SquareDistance(aCurvePt);
+      size_t aNbOddRootsAfter = 0;
+      for (size_t aNext = i + 1; aNext < aPolyRes.NbRoots; ++aNext)
       {
-        // For unbounded case, just use +1.0
-        aNeighborU = aU + 1.0;
+        if (aPolyRes.Roots[aNext] > 0.0)
+        {
+          aNbOddRootsAfter += aPolyRes.Multiplicities[aNext] % 2;
+        }
       }
-      gp_Pnt aNeighborPt   = Value(aNeighborU);
-      double aNeighborDist = theP.SquareDistance(aNeighborPt);
-      bool   aIsMin        = aSqDist < aNeighborDist;
+      const bool aIsMin = aNbOddRootsAfter % 2 == 0;
 
       // Filter by search mode
       if (theMode == ExtremaPC::SearchMode::Min && !aIsMin)
@@ -297,11 +348,13 @@ private:
       anExt.Point          = aCurvePt;
       anExt.SquareDistance = aSqDist;
       anExt.IsMinimum      = aIsMin;
+      anExt.IsMaximum      = !aIsMin;
 
       myResult.Extrema.Append(anExt);
     }
 
-    myResult.Status = ExtremaPC::Status::OK;
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
   }
 
   gp_Hypr                            myHyperbola; //!< Hyperbola geometry

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Line.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Line.hxx
@@ -15,9 +15,12 @@
 #define _ExtremaPC_Line_HeaderFile
 
 #include <ExtremaPC.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_Line.hxx>
 #include <gp_Lin.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
+#include <ProjLib.hxx>
 #include <Standard_DefineAlloc.hxx>
 
 #include <algorithm>
@@ -53,8 +56,7 @@ public:
   //! @param[in] theDomain parameter domain (fixed for all queries)
   ExtremaPC_Line(const gp_Lin& theLine, const ExtremaPC::Domain1D& theDomain)
       : myLine(theLine),
-        myDomain(theDomain.IsFinite() ? std::optional<ExtremaPC::Domain1D>(theDomain)
-                                      : std::nullopt)
+        myDomain(theDomain)
   {
   }
 
@@ -88,16 +90,42 @@ public:
   //! Uses domain specified at construction time.
   //! @param theP query point
   //! @param theTol tolerance for parameter comparison
-  //! @param theMode search mode (unused for lines - always returns minimum)
+  //! @param theMode search mode (Max returns no interior extremum)
   //! @return const reference to result containing the extremum
   [[nodiscard]] const ExtremaPC::Result& Perform(
     const gp_Pnt&         theP,
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
-    (void)theMode; // Lines always have exactly one extremum (minimum)
-
     myResult.Clear();
+
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    const gp_Pln aPlane = ExtremaPC::LinePlane(myLine);
+    if (ExtremaPC::PerformPlanar<ExtremaPC2d_Line>(ProjLib::Project(aPlane, myLine),
+                                                   myDomain,
+                                                   ProjLib::Project(aPlane, theP),
+                                                   theP,
+                                                   aPlane,
+                                                   *this,
+                                                   theTol,
+                                                   theMode,
+                                                   false,
+                                                   myResult))
+    {
+      return myResult;
+    }
+
+    if (theMode == ExtremaPC::SearchMode::Max)
+    {
+      myResult.Status = ExtremaPC::Status::NoSolution;
+      return myResult;
+    }
 
     // Compute projection parameter: u = (P - O) . Direction
     const gp_Dir& aDir    = myLine.Direction();
@@ -111,7 +139,7 @@ public:
       if (aU < myDomain->Min - theTol || aU > myDomain->Max + theTol)
       {
         // Projection is outside bounds - no interior extremum
-        myResult.Status = ExtremaPC::Status::OK;
+        myResult.Status = ExtremaPC::Status::NoSolution;
         return myResult;
       }
       // Clamp to bounds
@@ -127,6 +155,7 @@ public:
     anExt.Point          = aPtOnLine;
     anExt.SquareDistance = theP.SquareDistance(aPtOnLine);
     anExt.IsMinimum      = true;
+    anExt.IsMaximum      = false;
 
     myResult.Extrema.Append(anExt);
     myResult.Status = ExtremaPC::Status::OK;
@@ -144,11 +173,34 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
+      return myResult;
+    }
+
     (void)Perform(theP, theTol, theMode);
 
-    if (myResult.Status == ExtremaPC::Status::OK && myDomain.has_value())
+    if ((myResult.Status == ExtremaPC::Status::OK
+         || myResult.Status == ExtremaPC::Status::NoSolution)
+        && myDomain.has_value())
     {
-      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theTol, theMode);
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC::Status::OK;
+      }
     }
 
     return myResult;

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OffsetCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OffsetCurve.cxx
@@ -65,9 +65,9 @@ gp_Pnt ExtremaPC_OffsetCurve::Value(double theU) const
 //=================================================================================================
 
 bool ExtremaPC_OffsetCurve::performPlanar(const gp_Pnt&         theP,
-                                           double                theTol,
-                                           ExtremaPC::SearchMode theMode,
-                                           bool theIncludeEndpoints) const
+                                          double                theTol,
+                                          ExtremaPC::SearchMode theMode,
+                                          bool                  theIncludeEndpoints) const
 {
   gp_Pln                          aPlane;
   occ::handle<Geom2d_OffsetCurve> anOffset2d;
@@ -91,19 +91,15 @@ bool ExtremaPC_OffsetCurve::performPlanar(const gp_Pnt&         theP,
     return false;
   }
 
-  Geom2dAdaptor_Curve anAdaptor2d(anOffset2d, myDomain.Min, myDomain.Max);
-  ExtremaPC2d_OffsetCurve anEvaluator2d(anAdaptor2d,
-                                         ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
-  const ExtremaPC2d::SearchMode aMode = ExtremaPC::ToSearchMode2d(theMode);
-  const gp_Pnt2d aPoint2d = ProjLib::Project(aPlane, theP);
-  const ExtremaPC2d::Result& aResult2d =
+  Geom2dAdaptor_Curve           anAdaptor2d(anOffset2d, myDomain.Min, myDomain.Max);
+  ExtremaPC2d_OffsetCurve       anEvaluator2d(anAdaptor2d,
+                                        ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
+  const ExtremaPC2d::SearchMode aMode    = ExtremaPC::ToSearchMode2d(theMode);
+  const gp_Pnt2d                aPoint2d = ProjLib::Project(aPlane, theP);
+  const ExtremaPC2d::Result&    aResult2d =
     theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(aPoint2d, theTol, aMode)
-                        : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
-  return ExtremaPC::ConvertPlanarResult(aResult2d,
-                                        theP,
-                                        aPlane,
-                                        *this,
-                                        myEvaluator.Result());
+                           : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
+  return ExtremaPC::ConvertPlanarResult(aResult2d, theP, aPlane, *this, myEvaluator.Result());
 }
 
 //==================================================================================================

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OffsetCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OffsetCurve.cxx
@@ -14,7 +14,13 @@
 #include <ExtremaPC_OffsetCurve.hxx>
 
 #include <ExtremaPC_GridEvaluator.hxx>
-#include <GeomGridEval_OtherCurve.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_OffsetCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <GeomAdaptor_Curve.hxx>
+#include <ProjLib.hxx>
+#include <Standard_ErrorHandler.hxx>
+#include <Standard_Failure.hxx>
 
 //==================================================================================================
 
@@ -22,7 +28,7 @@ ExtremaPC_OffsetCurve::ExtremaPC_OffsetCurve(const Adaptor3d_Curve& theCurve)
     : myCurve(&theCurve),
       myDomain{theCurve.FirstParameter(), theCurve.LastParameter()}
 {
-  buildGrid();
+  buildParams();
 }
 
 //==================================================================================================
@@ -32,26 +38,21 @@ ExtremaPC_OffsetCurve::ExtremaPC_OffsetCurve(const Adaptor3d_Curve&     theCurve
     : myCurve(&theCurve),
       myDomain(theDomain)
 {
-  buildGrid();
+  buildParams();
 }
 
 //==================================================================================================
 
-void ExtremaPC_OffsetCurve::buildGrid()
+void ExtremaPC_OffsetCurve::buildParams()
 {
-  if (myCurve == nullptr)
+  if (myCurve == nullptr || !myDomain.IsValid() || !myDomain.IsFinite())
   {
     return;
   }
 
-  // Use higher number of samples for offset curves (they can be complex)
-  constexpr int aNbSamples = 64;
+  math_Vector aParams = ExtremaPC_GridEvaluator::BuildCurveAwareParams(*myCurve, myDomain);
 
-  math_Vector aParams =
-    ExtremaPC_GridEvaluator::BuildUniformParams(myDomain.Min, myDomain.Max, aNbSamples);
-
-  GeomGridEval_OtherCurve aGridEval(*myCurve);
-  myEvaluator.BuildGrid(aGridEval, aParams);
+  myEvaluator.SetParams(aParams);
 }
 
 //==================================================================================================
@@ -59,6 +60,50 @@ void ExtremaPC_OffsetCurve::buildGrid()
 gp_Pnt ExtremaPC_OffsetCurve::Value(double theU) const
 {
   return myCurve->Value(theU);
+}
+
+//=================================================================================================
+
+bool ExtremaPC_OffsetCurve::performPlanar(const gp_Pnt&         theP,
+                                           double                theTol,
+                                           ExtremaPC::SearchMode theMode,
+                                           bool theIncludeEndpoints) const
+{
+  gp_Pln                          aPlane;
+  occ::handle<Geom2d_OffsetCurve> anOffset2d;
+  try
+  {
+    OCC_CATCH_SIGNALS
+    const GeomAdaptor_Curve* aGeomAdaptor = dynamic_cast<const GeomAdaptor_Curve*>(myCurve);
+    if (aGeomAdaptor == nullptr)
+    {
+      return false;
+    }
+    const occ::handle<Geom_OffsetCurve> anOffset =
+      occ::down_cast<Geom_OffsetCurve>(aGeomAdaptor->Curve());
+    if (!ExtremaPC::ProjectOffset(anOffset, aPlane, anOffset2d))
+    {
+      return false;
+    }
+  }
+  catch (const Standard_Failure&)
+  {
+    return false;
+  }
+
+  Geom2dAdaptor_Curve anAdaptor2d(anOffset2d, myDomain.Min, myDomain.Max);
+  ExtremaPC2d_OffsetCurve anEvaluator2d(anAdaptor2d,
+                                         ExtremaPC2d::Domain1D(myDomain.Min, myDomain.Max));
+  const ExtremaPC2d::SearchMode aMode = ExtremaPC::ToSearchMode2d(theMode);
+  const gp_Pnt2d aPoint2d = ProjLib::Project(aPlane, theP);
+  const ExtremaPC2d::Result& aResult2d =
+    theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(aPoint2d, theTol, aMode)
+                        : anEvaluator2d.Perform(aPoint2d, theTol, aMode);
+  return ExtremaPC::ConvertPlanarResult(aResult2d,
+                                        theP,
+                                        aPlane,
+                                        *this,
+                                        myEvaluator.Result());
 }
 
 //==================================================================================================
@@ -74,6 +119,12 @@ const ExtremaPC::Result& ExtremaPC_OffsetCurve::Perform(const gp_Pnt&         th
     return myEvaluator.Result();
   }
 
+  if (ExtremaPC::IsValidTolerance(theTol) && myDomain.IsValid()
+      && performPlanar(theP, theTol, theMode, false))
+  {
+    return myEvaluator.Result();
+  }
+
   return myEvaluator.Perform(*myCurve, theP, myDomain, theTol, theMode);
 }
 
@@ -84,6 +135,19 @@ const ExtremaPC::Result& ExtremaPC_OffsetCurve::PerformWithEndpoints(
   double                theTol,
   ExtremaPC::SearchMode theMode) const
 {
+  if (myCurve == nullptr)
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  if (ExtremaPC::IsValidTolerance(theTol) && myDomain.IsValid()
+      && performPlanar(theP, theTol, theMode, true))
+  {
+    return myEvaluator.Result();
+  }
+
   // Get interior extrema (populates myEvaluator's result)
   (void)myEvaluator.Perform(*myCurve, theP, myDomain, theTol, theMode);
 
@@ -91,7 +155,8 @@ const ExtremaPC::Result& ExtremaPC_OffsetCurve::PerformWithEndpoints(
   ExtremaPC::Result& aResult = myEvaluator.Result();
   if (aResult.Status == ExtremaPC::Status::OK || aResult.Status == ExtremaPC::Status::NoSolution)
   {
-    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theTol, theMode);
+    const bool isClosed = ExtremaPC_GridEvaluator::IsClosedDomain(*myCurve, myDomain);
+    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
 
     // Update status if we found any extrema (including endpoints)
     if (!aResult.Extrema.IsEmpty())

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OffsetCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OffsetCurve.hxx
@@ -18,21 +18,20 @@
 #include <ExtremaPC.hxx>
 #include <ExtremaPC_GridEvaluator.hxx>
 #include <gp_Pnt.hxx>
-#include <NCollection_Array1.hxx>
 #include <Standard_DefineAlloc.hxx>
 
-//! @brief Point-OffsetCurve extrema computation using grid-based approach.
+//! @brief Point-OffsetCurve extrema computation using numerical root isolation.
 //!
-//! Computes the extrema between a 3D point and an offset curve using
-//! a grid-based approach with Newton refinement.
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
 //!
 //! The grid is cached for efficiency when performing multiple queries
 //! with the same parameter domain.
 //!
 //! The algorithm:
-//! 1. Build uniform grid using GeomGridEval
-//! 2. Linear scan of grid to find candidate intervals (sign changes in F(u))
-//! 3. Newton refinement on each candidate interval
+//! 1. Build a uniform parameter partition
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
 //!
 //! Offset curves are handled through the Adaptor3d_Curve interface,
 //! which provides uniform access to the offset geometry.
@@ -45,12 +44,12 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Constructor with curve adaptor (uses full curve domain).
-  //! Grid is built eagerly at construction time.
+  //! Parameter partition is built eagerly at construction time.
   //! @param[in] theCurve curve adaptor for offset curve (must remain valid)
   Standard_EXPORT explicit ExtremaPC_OffsetCurve(const Adaptor3d_Curve& theCurve);
 
   //! Constructor with curve adaptor and parameter domain.
-  //! Grid is built eagerly at construction time for the specified domain.
+  //! Parameter partition is built eagerly at construction time for the specified domain.
   //! @param[in] theCurve curve adaptor for offset curve (must remain valid)
   //! @param[in] theDomain parameter domain (fixed for all queries)
   Standard_EXPORT ExtremaPC_OffsetCurve(const Adaptor3d_Curve&     theCurve,
@@ -74,7 +73,7 @@ public:
   Standard_EXPORT gp_Pnt Value(double theU) const;
 
   //! Returns true if domain is bounded.
-  bool IsBounded() const { return true; } // Offset curves are always bounded
+  bool IsBounded() const { return myDomain.IsFinite(); }
 
   //! Returns the domain.
   const ExtremaPC::Domain1D& Domain() const { return myDomain; }
@@ -102,13 +101,24 @@ public:
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const;
 
 private:
-  //! Build grid for the curve.
-  void buildGrid();
+  //! Build parameter partition for the curve.
+  void buildParams();
+
+  //! Performs through the exact 2D representation when the current offset is planar.
+  //! @param[in] theP query point
+  //! @param[in] theTol tolerance for root finding
+  //! @param[in] theMode search mode
+  //! @param[in] theIncludeEndpoints whether endpoints should be included
+  //! @return true when the 2D result was accepted
+  bool performPlanar(const gp_Pnt&         theP,
+                     double                theTol,
+                     ExtremaPC::SearchMode theMode,
+                     bool                  theIncludeEndpoints) const;
 
   const Adaptor3d_Curve* myCurve;  //!< Curve adaptor (not owned)
   ExtremaPC::Domain1D    myDomain; //!< Parameter domain (fixed)
 
-  //! Grid evaluator with cached state (grid, result, temporary vectors).
+  //! Numerical evaluator with cached parameter partition and result.
   mutable ExtremaPC_GridEvaluator myEvaluator;
 };
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OtherCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OtherCurve.cxx
@@ -14,7 +14,6 @@
 #include <ExtremaPC_OtherCurve.hxx>
 
 #include <ExtremaPC_GridEvaluator.hxx>
-#include <GeomGridEval_OtherCurve.hxx>
 
 //==================================================================================================
 
@@ -22,7 +21,7 @@ ExtremaPC_OtherCurve::ExtremaPC_OtherCurve(const Adaptor3d_Curve& theCurve)
     : myCurve(&theCurve),
       myDomain{theCurve.FirstParameter(), theCurve.LastParameter()}
 {
-  buildGrid();
+  buildParams();
 }
 
 //==================================================================================================
@@ -32,26 +31,21 @@ ExtremaPC_OtherCurve::ExtremaPC_OtherCurve(const Adaptor3d_Curve&     theCurve,
     : myCurve(&theCurve),
       myDomain(theDomain)
 {
-  buildGrid();
+  buildParams();
 }
 
 //==================================================================================================
 
-void ExtremaPC_OtherCurve::buildGrid()
+void ExtremaPC_OtherCurve::buildParams()
 {
-  if (myCurve == nullptr)
+  if (myCurve == nullptr || !myDomain.IsValid() || !myDomain.IsFinite())
   {
     return;
   }
 
-  // Use higher number of samples for general curves
-  math_Vector aParams =
-    ExtremaPC_GridEvaluator::BuildUniformParams(myDomain.Min,
-                                                myDomain.Max,
-                                                ExtremaPC::THE_OTHER_CURVE_NB_SAMPLES);
+  math_Vector aParams = ExtremaPC_GridEvaluator::BuildCurveAwareParams(*myCurve, myDomain);
 
-  GeomGridEval_OtherCurve aGridEval(*myCurve);
-  myEvaluator.BuildGrid(aGridEval, aParams);
+  myEvaluator.SetParams(aParams);
 }
 
 //==================================================================================================
@@ -84,6 +78,13 @@ const ExtremaPC::Result& ExtremaPC_OtherCurve::PerformWithEndpoints(
   double                theTol,
   ExtremaPC::SearchMode theMode) const
 {
+  if (myCurve == nullptr)
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
   // Get interior extrema (populates myEvaluator's result)
   (void)myEvaluator.Perform(*myCurve, theP, myDomain, theTol, theMode);
 
@@ -91,7 +92,8 @@ const ExtremaPC::Result& ExtremaPC_OtherCurve::PerformWithEndpoints(
   ExtremaPC::Result& aResult = myEvaluator.Result();
   if (aResult.Status == ExtremaPC::Status::OK || aResult.Status == ExtremaPC::Status::NoSolution)
   {
-    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theTol, theMode);
+    const bool isClosed = ExtremaPC_GridEvaluator::IsClosedDomain(*myCurve, myDomain);
+    ExtremaPC::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
 
     // Update status if we found any extrema (including endpoints)
     if (!aResult.Extrema.IsEmpty())

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OtherCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_OtherCurve.hxx
@@ -18,21 +18,20 @@
 #include <ExtremaPC.hxx>
 #include <ExtremaPC_GridEvaluator.hxx>
 #include <gp_Pnt.hxx>
-#include <NCollection_Array1.hxx>
 #include <Standard_DefineAlloc.hxx>
 
-//! @brief Point-Curve extrema computation for general curves using grid-based approach.
+//! @brief Point-Curve extrema computation for general curves using numerical root isolation.
 //!
-//! Computes the extrema between a 3D point and a general curve using
-//! a grid-based approach with Newton refinement.
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
 //!
 //! The grid is cached for efficiency when performing multiple queries
 //! with the same parameter domain.
 //!
 //! The algorithm:
-//! 1. Build uniform grid using GeomGridEval
-//! 2. Linear scan of grid to find candidate intervals (sign changes in F(u))
-//! 3. Newton refinement on each candidate interval
+//! 1. Build a uniform parameter partition
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
 //!
 //! This is a fallback implementation that works with any curve type
 //! through the Adaptor3d_Curve interface.
@@ -45,12 +44,12 @@ public:
   DEFINE_STANDARD_ALLOC
 
   //! Constructor with curve adaptor (uses full curve domain).
-  //! Grid is built eagerly at construction time.
+  //! Parameter partition is built eagerly at construction time.
   //! @param[in] theCurve curve adaptor (must remain valid)
   Standard_EXPORT explicit ExtremaPC_OtherCurve(const Adaptor3d_Curve& theCurve);
 
   //! Constructor with curve adaptor and parameter domain.
-  //! Grid is built eagerly at construction time for the specified domain.
+  //! Parameter partition is built eagerly at construction time for the specified domain.
   //! @param[in] theCurve curve adaptor (must remain valid)
   //! @param[in] theDomain parameter domain (fixed for all queries)
   Standard_EXPORT ExtremaPC_OtherCurve(const Adaptor3d_Curve&     theCurve,
@@ -74,7 +73,7 @@ public:
   Standard_EXPORT gp_Pnt Value(double theU) const;
 
   //! Returns true if domain is bounded.
-  bool IsBounded() const { return true; }
+  bool IsBounded() const { return myDomain.IsFinite(); }
 
   //! Returns the domain.
   const ExtremaPC::Domain1D& Domain() const { return myDomain; }
@@ -102,13 +101,13 @@ public:
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const;
 
 private:
-  //! Build grid for the curve.
-  void buildGrid();
+  //! Build parameter partition for the curve.
+  void buildParams();
 
   const Adaptor3d_Curve* myCurve;  //!< Curve adaptor (not owned)
   ExtremaPC::Domain1D    myDomain; //!< Parameter domain (fixed)
 
-  //! Grid evaluator with cached state (grid, result, temporary vectors).
+  //! Numerical evaluator with cached parameter partition and result.
   mutable ExtremaPC_GridEvaluator myEvaluator;
 };
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Parabola.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Parabola.hxx
@@ -16,12 +16,15 @@
 
 #include <ElCLib.hxx>
 #include <ExtremaPC.hxx>
+#include <ExtremaPC_Planar.hxx>
+#include <ExtremaPC2d_Parabola.hxx>
 #include <gp_Parab.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
 #include <MathPoly_Cubic.hxx>
 #include <Precision.hxx>
 #include <Standard_DefineAlloc.hxx>
+#include <ProjLib.hxx>
 
 #include <cmath>
 #include <optional>
@@ -60,8 +63,7 @@ public:
   //! @param[in] theDomain parameter domain (fixed for all queries)
   ExtremaPC_Parabola(const gp_Parab& theParabola, const ExtremaPC::Domain1D& theDomain)
       : myParabola(theParabola),
-        myDomain(theDomain.IsFinite() ? std::optional<ExtremaPC::Domain1D>(theDomain)
-                                      : std::nullopt)
+        myDomain(theDomain)
   {
     cacheGeometry();
   }
@@ -83,6 +85,11 @@ public:
   //! @return point on parabola
   gp_Pnt Value(double theU) const
   {
+    if (myFocal <= gp::Resolution())
+    {
+      return myParabola.Location().Translated(theU * gp_Vec(myParabola.XAxis().Direction()));
+    }
+
     // Parabola: P(u) = Vertex + (u^2/4F)*XDir + u*YDir
     const double aX = theU * theU * my1Over4F;
     return gp_Pnt(myVertexX + aX * myXDirX + theU * myYDirX,
@@ -107,6 +114,22 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    const gp_Pln aPlane(gp_Ax3(myParabola.Position()));
+    if (ExtremaPC::IsValidTolerance(theTol) && ExtremaPC::IsFinitePoint(theP)
+        && (!myDomain.has_value() || myDomain->IsValid())
+        && ExtremaPC::PerformPlanar<ExtremaPC2d_Parabola>(ProjLib::Project(aPlane, myParabola),
+                                                          myDomain,
+                                                          ProjLib::Project(aPlane, theP),
+                                                          theP,
+                                                          aPlane,
+                                                          *this,
+                                                          theTol,
+                                                          theMode,
+                                                          false,
+                                                          myResult))
+    {
+      return myResult;
+    }
     performCore(theP, myDomain, theTol, theMode);
     return myResult;
   }
@@ -122,12 +145,35 @@ public:
     double                theTol,
     ExtremaPC::SearchMode theMode = ExtremaPC::SearchMode::MinMax) const
   {
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
+      return myResult;
+    }
+
     (void)Perform(theP, theTol, theMode);
 
     // Add endpoints if interior computation succeeded and domain is bounded
-    if (myResult.Status == ExtremaPC::Status::OK && myDomain.has_value())
+    if ((myResult.Status == ExtremaPC::Status::OK
+         || myResult.Status == ExtremaPC::Status::NoSolution)
+        && myDomain.has_value())
     {
-      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theTol, theMode);
+      ExtremaPC::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC::Status::OK;
+      }
     }
 
     return myResult;
@@ -161,7 +207,7 @@ private:
     myAxisZ             = aAxis.Z();
 
     myFocal   = myParabola.Focal();
-    my1Over4F = 1.0 / (4.0 * myFocal);
+    my1Over4F = myFocal > gp::Resolution() ? 1.0 / (4.0 * myFocal) : 0.0;
     my2F      = 2.0 * myFocal;
   }
 
@@ -206,9 +252,47 @@ private:
                    double                                    theTol,
                    ExtremaPC::SearchMode                     theMode) const
   {
-    (void)theTol; // Tolerance used for endpoint detection
-
     myResult.Clear();
+
+    if (!ExtremaPC::IsValidTolerance(theTol) || !ExtremaPC::IsFinitePoint(theP)
+        || (theDomain.has_value() && !theDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC::Status::InvalidInput;
+      return;
+    }
+
+    if (myFocal <= gp::Resolution())
+    {
+      if (theMode == ExtremaPC::SearchMode::Max)
+      {
+        myResult.Status = ExtremaPC::Status::NoSolution;
+        return;
+      }
+
+      const gp_Pnt& aVertex = myParabola.Location();
+      const gp_Vec  aDirection(myParabola.XAxis().Direction());
+      double        aU = gp_Vec(aVertex, theP).Dot(aDirection);
+      if (theDomain.has_value() && !theDomain->Contains(aU, theTol))
+      {
+        myResult.Status = ExtremaPC::Status::NoSolution;
+        return;
+      }
+      if (theDomain.has_value())
+      {
+        aU = theDomain->Clamp(aU);
+      }
+
+      const gp_Pnt              aCurvePt = Value(aU);
+      ExtremaPC::ExtremumResult anExt;
+      anExt.Parameter      = aU;
+      anExt.Point          = aCurvePt;
+      anExt.SquareDistance = theP.SquareDistance(aCurvePt);
+      anExt.IsMinimum      = true;
+      anExt.IsMaximum      = false;
+      myResult.Extrema.Append(anExt);
+      myResult.Status = ExtremaPC::Status::OK;
+      return;
+    }
 
     MathPoly::PolyResult aPolyRes = solveCubic(theP);
 
@@ -227,8 +311,6 @@ private:
       return;
     }
 
-    double aTol2 = Precision::SquareConfusion();
-
     // Process all roots
     for (size_t i = 0; i < aPolyRes.NbRoots; ++i)
     {
@@ -237,17 +319,20 @@ private:
       // Check bounds if domain is specified
       if (theDomain.has_value())
       {
-        if (aU < theDomain->Min || aU > theDomain->Max)
+        if (!theDomain->Contains(aU, ExtremaPC::THE_PARAM_TOLERANCE))
+        {
           continue;
+        }
+        aU = theDomain->Clamp(aU);
       }
 
       gp_Pnt aCurvePt = Value(aU);
 
       // Check for duplicates
       bool aDuplicate = false;
-      for (int j = 0; j < myResult.Extrema.Length(); ++j)
+      for (const ExtremaPC::ExtremumResult& anExtremum : myResult.Extrema)
       {
-        if (aCurvePt.SquareDistance(myResult.Extrema.Value(j).Point) < aTol2)
+        if (std::abs(aU - anExtremum.Parameter) < ExtremaPC::THE_PARAM_TOLERANCE)
         {
           aDuplicate = true;
           break;
@@ -256,23 +341,21 @@ private:
       if (aDuplicate)
         continue;
 
-      // Determine if minimum or maximum using neighbor comparison
-      double aSqDist = theP.SquareDistance(aCurvePt);
-      double aNeighborU;
-      if (theDomain.has_value())
+      const size_t aMultiplicity = aPolyRes.Multiplicities[i];
+      if (aMultiplicity % 2 == 0)
       {
-        // For bounded case, choose neighbor direction based on position in domain
-        aNeighborU = aU + (aU < (theDomain->Min + theDomain->Max) * 0.5 ? 1.0 : -1.0);
-        aNeighborU = std::max(theDomain->Min, std::min(theDomain->Max, aNeighborU));
+        continue;
       }
-      else
+
+      // The stationary polynomial has a positive leading coefficient. Its sign to the right
+      // of this root is determined by the odd-multiplicity roots that follow it.
+      double aSqDist          = theP.SquareDistance(aCurvePt);
+      size_t aNbOddRootsAfter = 0;
+      for (size_t aNext = i + 1; aNext < aPolyRes.NbRoots; ++aNext)
       {
-        // For unbounded case, just use +1.0
-        aNeighborU = aU + 1.0;
+        aNbOddRootsAfter += aPolyRes.Multiplicities[aNext] % 2;
       }
-      gp_Pnt aNeighborPt   = Value(aNeighborU);
-      double aNeighborDist = theP.SquareDistance(aNeighborPt);
-      bool   aIsMin        = aSqDist <= aNeighborDist;
+      const bool aIsMin = aNbOddRootsAfter % 2 == 0;
 
       // Filter by search mode
       if (theMode == ExtremaPC::SearchMode::Min && !aIsMin)
@@ -285,11 +368,13 @@ private:
       anExt.Point          = aCurvePt;
       anExt.SquareDistance = aSqDist;
       anExt.IsMinimum      = aIsMin;
+      anExt.IsMaximum      = !aIsMin;
 
       myResult.Extrema.Append(anExt);
     }
 
-    myResult.Status = ExtremaPC::Status::OK;
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC::Status::NoSolution : ExtremaPC::Status::OK;
   }
 
   gp_Parab                           myParabola; //!< Parabola geometry

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.cxx
@@ -1,0 +1,314 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ExtremaPC_Planar.hxx>
+
+#include <gp_Ax3.hxx>
+#include <gp_Circ2d.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Elips2d.hxx>
+#include <gp_Hypr2d.hxx>
+#include <gp_Parab2d.hxx>
+#include <gp_Vec.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_Hyperbola.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom2d_Parabola.hxx>
+#include <Geom2d_TrimmedCurve.hxx>
+#include <Geom_Circle.hxx>
+#include <Geom_Ellipse.hxx>
+#include <Geom_Hyperbola.hxx>
+#include <Geom_Line.hxx>
+#include <Geom_Parabola.hxx>
+#include <Geom_TrimmedCurve.hxx>
+#include <NCollection_Array1.hxx>
+#include <NCollection_LocalArray.hxx>
+#include <ProjLib.hxx>
+#include <ElSLib.hxx>
+
+#include <cmath>
+
+namespace
+{
+bool findExactPolePlane(const NCollection_Array1<gp_Pnt>& thePoles, gp_Pln& thePlane)
+{
+  if (thePoles.IsEmpty())
+  {
+    return false;
+  }
+
+  const gp_Pnt& anOrigin = thePoles.First();
+  gp_Vec        aBase;
+  for (const gp_Pnt& aPole : thePoles)
+  {
+    aBase = gp_Vec(anOrigin, aPole);
+    if (aBase.SquareMagnitude() > 0.0)
+    {
+      break;
+    }
+  }
+
+  if (aBase.SquareMagnitude() == 0.0)
+  {
+    thePlane = gp_Pln(gp_Ax3(anOrigin, gp::DZ(), gp::DX()));
+    return true;
+  }
+
+  gp_Vec aSecond;
+  gp_Vec aNormal;
+  for (const gp_Pnt& aPole : thePoles)
+  {
+    aSecond = gp_Vec(anOrigin, aPole);
+    aNormal = aBase.Crossed(aSecond);
+    if (aNormal.SquareMagnitude() > 0.0)
+    {
+      break;
+    }
+  }
+
+  const gp_Dir anXDirection(aBase);
+  if (aNormal.SquareMagnitude() == 0.0)
+  {
+    const gp_Dir aReference = std::abs(anXDirection.Z()) < 0.9 ? gp::DZ() : gp::DY();
+    aNormal                 = gp_Vec(anXDirection).Crossed(gp_Vec(aReference));
+    thePlane                = gp_Pln(gp_Ax3(anOrigin, gp_Dir(aNormal), anXDirection));
+    return true;
+  }
+
+  for (const gp_Pnt& aPole : thePoles)
+  {
+    const gp_Vec      aVector(anOrigin, aPole);
+    const long double aTriple = static_cast<long double>(aBase.X())
+                                  * (static_cast<long double>(aSecond.Y()) * aVector.Z()
+                                     - static_cast<long double>(aSecond.Z()) * aVector.Y())
+                                - static_cast<long double>(aBase.Y())
+                                    * (static_cast<long double>(aSecond.X()) * aVector.Z()
+                                       - static_cast<long double>(aSecond.Z()) * aVector.X())
+                                + static_cast<long double>(aBase.Z())
+                                    * (static_cast<long double>(aSecond.X()) * aVector.Y()
+                                       - static_cast<long double>(aSecond.Y()) * aVector.X());
+    if (aTriple != 0.0L)
+    {
+      return false;
+    }
+  }
+
+  thePlane = gp_Pln(gp_Ax3(anOrigin, gp_Dir(aNormal), anXDirection));
+  return true;
+}
+
+bool isParallel(const gp_Dir& theFirst, const gp_Dir& theSecond)
+{
+  return gp_Vec(theFirst).Crossed(gp_Vec(theSecond)).SquareMagnitude() == 0.0;
+}
+
+bool projectBasisCurve(const occ::handle<Geom_Curve>& theCurve,
+                       const gp_Dir&                  theNormal,
+                       gp_Pln&                        thePlane,
+                       occ::handle<Geom2d_Curve>&     theCurve2d)
+{
+  theCurve2d.Nullify();
+  if (theCurve.IsNull())
+  {
+    return false;
+  }
+
+  const occ::handle<Geom_TrimmedCurve> aTrimmed = occ::down_cast<Geom_TrimmedCurve>(theCurve);
+  if (!aTrimmed.IsNull())
+  {
+    occ::handle<Geom2d_Curve> aBasis2d;
+    if (!projectBasisCurve(aTrimmed->BasisCurve(), theNormal, thePlane, aBasis2d))
+    {
+      return false;
+    }
+    theCurve2d =
+      new Geom2d_TrimmedCurve(aBasis2d, aTrimmed->FirstParameter(), aTrimmed->LastParameter());
+    return true;
+  }
+
+  const occ::handle<Geom_Line> aLine = occ::down_cast<Geom_Line>(theCurve);
+  if (!aLine.IsNull())
+  {
+    if (gp_Vec(aLine->Lin().Direction()).Dot(gp_Vec(theNormal)) != 0.0)
+    {
+      return false;
+    }
+    thePlane   = gp_Pln(gp_Ax3(aLine->Lin().Location(), theNormal, aLine->Lin().Direction()));
+    theCurve2d = new Geom2d_Line(ProjLib::Project(thePlane, aLine->Lin()));
+    return true;
+  }
+
+  const occ::handle<Geom_Circle> aCircle = occ::down_cast<Geom_Circle>(theCurve);
+  if (!aCircle.IsNull() && isParallel(aCircle->Circ().Axis().Direction(), theNormal))
+  {
+    thePlane   = gp_Pln(gp_Ax3(aCircle->Circ().Position()));
+    theCurve2d = new Geom2d_Circle(ProjLib::Project(thePlane, aCircle->Circ()));
+    return true;
+  }
+
+  const occ::handle<Geom_Ellipse> anEllipse = occ::down_cast<Geom_Ellipse>(theCurve);
+  if (!anEllipse.IsNull() && isParallel(anEllipse->Elips().Axis().Direction(), theNormal))
+  {
+    thePlane   = gp_Pln(gp_Ax3(anEllipse->Elips().Position()));
+    theCurve2d = new Geom2d_Ellipse(ProjLib::Project(thePlane, anEllipse->Elips()));
+    return true;
+  }
+
+  const occ::handle<Geom_Hyperbola> aHyperbola = occ::down_cast<Geom_Hyperbola>(theCurve);
+  if (!aHyperbola.IsNull() && isParallel(aHyperbola->Hypr().Axis().Direction(), theNormal))
+  {
+    thePlane   = gp_Pln(gp_Ax3(aHyperbola->Hypr().Position()));
+    theCurve2d = new Geom2d_Hyperbola(ProjLib::Project(thePlane, aHyperbola->Hypr()));
+    return true;
+  }
+
+  const occ::handle<Geom_Parabola> aParabola = occ::down_cast<Geom_Parabola>(theCurve);
+  if (!aParabola.IsNull() && isParallel(aParabola->Parab().Axis().Direction(), theNormal))
+  {
+    thePlane   = gp_Pln(gp_Ax3(aParabola->Parab().Position()));
+    theCurve2d = new Geom2d_Parabola(ProjLib::Project(thePlane, aParabola->Parab()));
+    return true;
+  }
+
+  const occ::handle<Geom_BezierCurve> aBezier = occ::down_cast<Geom_BezierCurve>(theCurve);
+  occ::handle<Geom2d_BezierCurve>     aBezier2d;
+  if (!aBezier.IsNull() && ExtremaPC::ProjectBezier(aBezier, thePlane, aBezier2d)
+      && isParallel(thePlane.Axis().Direction(), theNormal))
+  {
+    theCurve2d = aBezier2d;
+    return true;
+  }
+
+  const occ::handle<Geom_BSplineCurve> aBSpline = occ::down_cast<Geom_BSplineCurve>(theCurve);
+  occ::handle<Geom2d_BSplineCurve>     aBSpline2d;
+  if (!aBSpline.IsNull() && ExtremaPC::ProjectBSpline(aBSpline, thePlane, aBSpline2d)
+      && isParallel(thePlane.Axis().Direction(), theNormal))
+  {
+    theCurve2d = aBSpline2d;
+    return true;
+  }
+  return false;
+}
+} // namespace
+
+//=================================================================================================
+
+gp_Pln ExtremaPC::LinePlane(const gp_Lin& theLine)
+{
+  const gp_Dir& aLineDirection = theLine.Direction();
+  const gp_Dir  aReference     = std::abs(aLineDirection.Z()) < 0.9 ? gp::DZ() : gp::DY();
+  const gp_Dir  aNormal(gp_Vec(aLineDirection).Crossed(gp_Vec(aReference)));
+  return gp_Pln(gp_Ax3(theLine.Location(), aNormal, aLineDirection));
+}
+
+//=================================================================================================
+
+bool ExtremaPC::ProjectBezier(const occ::handle<Geom_BezierCurve>& theCurve,
+                              gp_Pln&                              thePlane,
+                              occ::handle<Geom2d_BezierCurve>&     theCurve2d)
+{
+  theCurve2d.Nullify();
+  if (theCurve.IsNull() || theCurve->HasEvalRepresentation()
+      || !findExactPolePlane(theCurve->Poles(), thePlane))
+  {
+    return false;
+  }
+
+  NCollection_LocalArray<gp_Pnt2d, 32> aPoleStorage(theCurve->Poles().Size());
+  NCollection_Array1<gp_Pnt2d>         aPoles(aPoleStorage[0],
+                                              theCurve->Poles().Lower(),
+                                              theCurve->Poles().Upper());
+  for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
+  {
+    aPoles.ChangeAt(anIndex) = ProjLib::Project(thePlane, theCurve->Poles().At(anIndex));
+  }
+  theCurve2d = theCurve->IsRational() ? new Geom2d_BezierCurve(aPoles, theCurve->WeightsArray())
+                                      : new Geom2d_BezierCurve(aPoles);
+  return theCurve2d->IsRational() == theCurve->IsRational();
+}
+
+//=================================================================================================
+
+bool ExtremaPC::ProjectBSpline(const occ::handle<Geom_BSplineCurve>& theCurve,
+                               gp_Pln&                               thePlane,
+                               occ::handle<Geom2d_BSplineCurve>&     theCurve2d)
+{
+  theCurve2d.Nullify();
+  if (theCurve.IsNull() || theCurve->HasEvalRepresentation()
+      || !findExactPolePlane(theCurve->Poles(), thePlane))
+  {
+    return false;
+  }
+
+  NCollection_LocalArray<gp_Pnt2d, 64> aPoleStorage(theCurve->Poles().Size());
+  NCollection_Array1<gp_Pnt2d>         aPoles(aPoleStorage[0],
+                                              theCurve->Poles().Lower(),
+                                              theCurve->Poles().Upper());
+  for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
+  {
+    aPoles.ChangeAt(anIndex) = ProjLib::Project(thePlane, theCurve->Poles().At(anIndex));
+  }
+  theCurve2d = theCurve->IsRational() ? new Geom2d_BSplineCurve(aPoles,
+                                                                theCurve->WeightsArray(),
+                                                                theCurve->Knots(),
+                                                                theCurve->Multiplicities(),
+                                                                theCurve->Degree(),
+                                                                theCurve->IsPeriodic())
+                                      : new Geom2d_BSplineCurve(aPoles,
+                                                                theCurve->Knots(),
+                                                                theCurve->Multiplicities(),
+                                                                theCurve->Degree(),
+                                                                theCurve->IsPeriodic());
+  return theCurve2d->IsRational() == theCurve->IsRational();
+}
+
+//=================================================================================================
+
+bool ExtremaPC::ProjectOffset(const occ::handle<Geom_OffsetCurve>& theCurve,
+                              gp_Pln&                              thePlane,
+                              occ::handle<Geom2d_OffsetCurve>&     theCurve2d)
+{
+  theCurve2d.Nullify();
+  if (theCurve.IsNull() || theCurve->HasEvalRepresentation())
+  {
+    return false;
+  }
+
+  occ::handle<Geom2d_Curve> aBasis2d;
+  if (!projectBasisCurve(theCurve->BasisCurve(), theCurve->Direction(), thePlane, aBasis2d))
+  {
+    return false;
+  }
+
+  const double aProbe = (theCurve->FirstParameter() + theCurve->LastParameter()) * 0.5;
+  if (!std::isfinite(aProbe))
+  {
+    return false;
+  }
+
+  for (const double aSign : {-1.0, 1.0})
+  {
+    occ::handle<Geom2d_OffsetCurve> aCandidate =
+      new Geom2d_OffsetCurve(aBasis2d, aSign * theCurve->Offset());
+    const gp_Pnt2d aPoint2d = aCandidate->Value(aProbe);
+    const gp_Pnt   aPoint3d = ElSLib::Value(aPoint2d.X(), aPoint2d.Y(), thePlane);
+    if (aPoint3d.SquareDistance(theCurve->Value(aProbe)) == 0.0)
+    {
+      theCurve2d = aCandidate;
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.cxx
@@ -228,8 +228,8 @@ bool ExtremaPC::ProjectBezier(const occ::handle<Geom_BezierCurve>& theCurve,
 
   NCollection_LocalArray<gp_Pnt2d, 32> aPoleStorage(theCurve->Poles().Size());
   NCollection_Array1<gp_Pnt2d>         aPoles(aPoleStorage[0],
-                                              theCurve->Poles().Lower(),
-                                              theCurve->Poles().Upper());
+                                      theCurve->Poles().Lower(),
+                                      theCurve->Poles().Upper());
   for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
   {
     aPoles.ChangeAt(anIndex) = ProjLib::Project(thePlane, theCurve->Poles().At(anIndex));
@@ -254,8 +254,8 @@ bool ExtremaPC::ProjectBSpline(const occ::handle<Geom_BSplineCurve>& theCurve,
 
   NCollection_LocalArray<gp_Pnt2d, 64> aPoleStorage(theCurve->Poles().Size());
   NCollection_Array1<gp_Pnt2d>         aPoles(aPoleStorage[0],
-                                              theCurve->Poles().Lower(),
-                                              theCurve->Poles().Upper());
+                                      theCurve->Poles().Lower(),
+                                      theCurve->Poles().Upper());
   for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
   {
     aPoles.ChangeAt(anIndex) = ProjLib::Project(thePlane, theCurve->Poles().At(anIndex));

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.cxx
@@ -18,6 +18,7 @@
 #include <gp_Dir.hxx>
 #include <gp_Elips2d.hxx>
 #include <gp_Hypr2d.hxx>
+#include <gp_Lin2d.hxx>
 #include <gp_Parab2d.hxx>
 #include <gp_Vec.hxx>
 #include <Geom2d_Circle.hxx>

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.hxx
@@ -1,0 +1,197 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC_Planar_HeaderFile
+#define _ExtremaPC_Planar_HeaderFile
+
+#include <ExtremaPC.hxx>
+#include <ExtremaPC2d.hxx>
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom_BezierCurve.hxx>
+#include <Geom_BSplineCurve.hxx>
+#include <Geom_OffsetCurve.hxx>
+#include <gp_Lin.hxx>
+#include <gp_Pln.hxx>
+
+#include <optional>
+
+namespace ExtremaPC
+{
+
+//! Converts the 3D search mode to its 2D counterpart without relying on enum ordinals.
+//! @param[in] theMode 3D search mode
+//! @return corresponding 2D search mode; MinMax for an invalid enumeration value
+constexpr ExtremaPC2d::SearchMode ToSearchMode2d(ExtremaPC::SearchMode theMode)
+{
+  switch (theMode)
+  {
+    case ExtremaPC::SearchMode::Min:
+      return ExtremaPC2d::SearchMode::Min;
+    case ExtremaPC::SearchMode::Max:
+      return ExtremaPC2d::SearchMode::Max;
+    case ExtremaPC::SearchMode::MinMax:
+      return ExtremaPC2d::SearchMode::MinMax;
+  }
+  return ExtremaPC2d::SearchMode::MinMax;
+}
+
+//! Builds a deterministic plane containing the line.
+//! The plane X direction is the line direction, preserving the line parameter.
+//! @param[in] theLine source line
+//! @return containing plane
+Standard_EXPORT gp_Pln LinePlane(const gp_Lin& theLine);
+
+//! Projects a planar Bezier curve to 2D without changing its parameterization.
+//! Curves with evaluation representations and non-planar control polygons are rejected.
+//! @param[in] theCurve source curve
+//! @param[out] thePlane plane used as the 2D coordinate system
+//! @param[out] theCurve2d projected curve
+//! @return true if an exact supported projection was built
+Standard_EXPORT bool ProjectBezier(const occ::handle<Geom_BezierCurve>& theCurve,
+                                   gp_Pln&                               thePlane,
+                                   occ::handle<Geom2d_BezierCurve>&      theCurve2d);
+
+//! Projects a planar BSpline curve to 2D without changing its parameterization.
+//! Curves with evaluation representations, non-planar control polygons, or a rational
+//! representation that cannot be retained by Geom2d_BSplineCurve are rejected.
+//! @param[in] theCurve source curve
+//! @param[out] thePlane plane used as the 2D coordinate system
+//! @param[out] theCurve2d projected curve
+//! @return true if an exact supported projection was built
+Standard_EXPORT bool ProjectBSpline(const occ::handle<Geom_BSplineCurve>& theCurve,
+                                    gp_Pln&                                thePlane,
+                                    occ::handle<Geom2d_BSplineCurve>&      theCurve2d);
+
+//! Projects a planar 3D offset curve to its parameter-preserving 2D representation.
+//! The basis curve must have an exact supported projection and the offset direction
+//! must be normal to that plane.
+//! @param[in] theCurve source offset curve
+//! @param[out] thePlane plane used as the 2D coordinate system
+//! @param[out] theCurve2d projected offset curve
+//! @return true if an exact supported projection was built
+Standard_EXPORT bool ProjectOffset(const occ::handle<Geom_OffsetCurve>& theCurve,
+                                   gp_Pln&                               thePlane,
+                                   occ::handle<Geom2d_OffsetCurve>&      theCurve2d);
+
+//! Converts a 2D result to the corresponding 3D result.
+//! Points and distances are evaluated on the original 3D evaluator at unchanged parameters.
+//! @tparam CurveEvaluator type providing Value(double)
+//! @param[in] theResult2d source 2D result
+//! @param[in] theQuery original 3D query point
+//! @param[in] thePlane projection plane
+//! @param[in] theEvaluator original 3D evaluator
+//! @param[out] theResult converted result
+//! @return false when the 2D result should be ignored in favor of the 3D implementation
+template <typename CurveEvaluator>
+bool ConvertPlanarResult(const ExtremaPC2d::Result& theResult2d,
+                         const gp_Pnt&              theQuery,
+                         const gp_Pln&              thePlane,
+                         const CurveEvaluator&      theEvaluator,
+                         ExtremaPC::Result&          theResult)
+{
+  if (theResult2d.Status == ExtremaPC2d::Status::NotDone
+      || theResult2d.Status == ExtremaPC2d::Status::NumericalError)
+  {
+    return false;
+  }
+
+  theResult.Clear();
+  switch (theResult2d.Status)
+  {
+    case ExtremaPC2d::Status::OK:
+      theResult.Status = ExtremaPC::Status::OK;
+      break;
+    case ExtremaPC2d::Status::InfiniteSolutions:
+      theResult.Status = ExtremaPC::Status::InfiniteSolutions;
+      break;
+    case ExtremaPC2d::Status::NoSolution:
+      theResult.Status = ExtremaPC::Status::NoSolution;
+      break;
+    case ExtremaPC2d::Status::InvalidInput:
+      theResult.Status = ExtremaPC::Status::InvalidInput;
+      break;
+    case ExtremaPC2d::Status::NotDone:
+    case ExtremaPC2d::Status::NumericalError:
+      return false;
+  }
+
+  if (theResult2d.IsInfinite())
+  {
+    const double aHeight = thePlane.Distance(theQuery);
+    theResult.InfiniteSquareDistance =
+      theResult2d.InfiniteSquareDistance + aHeight * aHeight;
+    return true;
+  }
+
+  for (size_t anIndex = 0; anIndex < theResult2d.NbExt(); ++anIndex)
+  {
+    const double aParameter = theResult2d[anIndex].Parameter;
+    const gp_Pnt aCurvePoint = theEvaluator.Value(aParameter);
+    theResult.Extrema.Append(ExtremaPC::ExtremumResult{aParameter,
+                                                       aCurvePoint,
+                                                       theQuery.SquareDistance(aCurvePoint),
+                                                       theResult2d[anIndex].IsMinimum,
+                                                       theResult2d[anIndex].IsMaximum});
+  }
+  return true;
+}
+
+//! Runs a parameter-preserving 2D evaluator and converts its result to 3D.
+//! @tparam Evaluator2d 2D extrema evaluator type
+//! @tparam Geometry2d 2D geometry type accepted by Evaluator2d
+//! @tparam CurveEvaluator original 3D evaluator type
+//! @param[in] theGeometry projected 2D geometry
+//! @param[in] theDomain optional parameter domain
+//! @param[in] theQuery2d projected query point
+//! @param[in] theQuery3d original query point
+//! @param[in] thePlane projection plane
+//! @param[in] theEvaluator original 3D evaluator
+//! @param[in] theTolerance geometric tolerance
+//! @param[in] theMode search mode
+//! @param[in] theIncludeEndpoints whether endpoints should be included
+//! @param[out] theResult converted result
+//! @return false when the 3D implementation should be used instead
+template <typename Evaluator2d, typename Geometry2d, typename CurveEvaluator>
+bool PerformPlanar(const Geometry2d&                    theGeometry,
+                   const std::optional<ExtremaPC::Domain1D>& theDomain,
+                   const gp_Pnt2d&                      theQuery2d,
+                   const gp_Pnt&                        theQuery3d,
+                   const gp_Pln&                        thePlane,
+                   const CurveEvaluator&                theEvaluator,
+                   double                               theTolerance,
+                   ExtremaPC::SearchMode                theMode,
+                   bool                                 theIncludeEndpoints,
+                   ExtremaPC::Result&                   theResult)
+{
+  const ExtremaPC2d::SearchMode aMode = ExtremaPC::ToSearchMode2d(theMode);
+  if (theDomain.has_value())
+  {
+    Evaluator2d anEvaluator2d(theGeometry, theDomain.value());
+    const ExtremaPC2d::Result& aResult2d =
+      theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(theQuery2d, theTolerance, aMode)
+                          : anEvaluator2d.Perform(theQuery2d, theTolerance, aMode);
+    return ConvertPlanarResult(aResult2d, theQuery3d, thePlane, theEvaluator, theResult);
+  }
+
+  Evaluator2d anEvaluator2d(theGeometry);
+  const ExtremaPC2d::Result& aResult2d =
+    theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(theQuery2d, theTolerance, aMode)
+                        : anEvaluator2d.Perform(theQuery2d, theTolerance, aMode);
+  return ConvertPlanarResult(aResult2d, theQuery3d, thePlane, theEvaluator, theResult);
+}
+
+} // namespace ExtremaPC
+
+#endif // _ExtremaPC_Planar_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/ExtremaPC_Planar.hxx
@@ -60,8 +60,8 @@ Standard_EXPORT gp_Pln LinePlane(const gp_Lin& theLine);
 //! @param[out] theCurve2d projected curve
 //! @return true if an exact supported projection was built
 Standard_EXPORT bool ProjectBezier(const occ::handle<Geom_BezierCurve>& theCurve,
-                                   gp_Pln&                               thePlane,
-                                   occ::handle<Geom2d_BezierCurve>&      theCurve2d);
+                                   gp_Pln&                              thePlane,
+                                   occ::handle<Geom2d_BezierCurve>&     theCurve2d);
 
 //! Projects a planar BSpline curve to 2D without changing its parameterization.
 //! Curves with evaluation representations, non-planar control polygons, or a rational
@@ -71,8 +71,8 @@ Standard_EXPORT bool ProjectBezier(const occ::handle<Geom_BezierCurve>& theCurve
 //! @param[out] theCurve2d projected curve
 //! @return true if an exact supported projection was built
 Standard_EXPORT bool ProjectBSpline(const occ::handle<Geom_BSplineCurve>& theCurve,
-                                    gp_Pln&                                thePlane,
-                                    occ::handle<Geom2d_BSplineCurve>&      theCurve2d);
+                                    gp_Pln&                               thePlane,
+                                    occ::handle<Geom2d_BSplineCurve>&     theCurve2d);
 
 //! Projects a planar 3D offset curve to its parameter-preserving 2D representation.
 //! The basis curve must have an exact supported projection and the offset direction
@@ -82,8 +82,8 @@ Standard_EXPORT bool ProjectBSpline(const occ::handle<Geom_BSplineCurve>& theCur
 //! @param[out] theCurve2d projected offset curve
 //! @return true if an exact supported projection was built
 Standard_EXPORT bool ProjectOffset(const occ::handle<Geom_OffsetCurve>& theCurve,
-                                   gp_Pln&                               thePlane,
-                                   occ::handle<Geom2d_OffsetCurve>&      theCurve2d);
+                                   gp_Pln&                              thePlane,
+                                   occ::handle<Geom2d_OffsetCurve>&     theCurve2d);
 
 //! Converts a 2D result to the corresponding 3D result.
 //! Points and distances are evaluated on the original 3D evaluator at unchanged parameters.
@@ -99,7 +99,7 @@ bool ConvertPlanarResult(const ExtremaPC2d::Result& theResult2d,
                          const gp_Pnt&              theQuery,
                          const gp_Pln&              thePlane,
                          const CurveEvaluator&      theEvaluator,
-                         ExtremaPC::Result&          theResult)
+                         ExtremaPC::Result&         theResult)
 {
   if (theResult2d.Status == ExtremaPC2d::Status::NotDone
       || theResult2d.Status == ExtremaPC2d::Status::NumericalError)
@@ -129,15 +129,14 @@ bool ConvertPlanarResult(const ExtremaPC2d::Result& theResult2d,
 
   if (theResult2d.IsInfinite())
   {
-    const double aHeight = thePlane.Distance(theQuery);
-    theResult.InfiniteSquareDistance =
-      theResult2d.InfiniteSquareDistance + aHeight * aHeight;
+    const double aHeight             = thePlane.Distance(theQuery);
+    theResult.InfiniteSquareDistance = theResult2d.InfiniteSquareDistance + aHeight * aHeight;
     return true;
   }
 
   for (size_t anIndex = 0; anIndex < theResult2d.NbExt(); ++anIndex)
   {
-    const double aParameter = theResult2d[anIndex].Parameter;
+    const double aParameter  = theResult2d[anIndex].Parameter;
     const gp_Pnt aCurvePoint = theEvaluator.Value(aParameter);
     theResult.Extrema.Append(ExtremaPC::ExtremumResult{aParameter,
                                                        aCurvePoint,
@@ -164,28 +163,28 @@ bool ConvertPlanarResult(const ExtremaPC2d::Result& theResult2d,
 //! @param[out] theResult converted result
 //! @return false when the 3D implementation should be used instead
 template <typename Evaluator2d, typename Geometry2d, typename CurveEvaluator>
-bool PerformPlanar(const Geometry2d&                    theGeometry,
+bool PerformPlanar(const Geometry2d&                         theGeometry,
                    const std::optional<ExtremaPC::Domain1D>& theDomain,
-                   const gp_Pnt2d&                      theQuery2d,
-                   const gp_Pnt&                        theQuery3d,
-                   const gp_Pln&                        thePlane,
-                   const CurveEvaluator&                theEvaluator,
-                   double                               theTolerance,
-                   ExtremaPC::SearchMode                theMode,
-                   bool                                 theIncludeEndpoints,
-                   ExtremaPC::Result&                   theResult)
+                   const gp_Pnt2d&                           theQuery2d,
+                   const gp_Pnt&                             theQuery3d,
+                   const gp_Pln&                             thePlane,
+                   const CurveEvaluator&                     theEvaluator,
+                   double                                    theTolerance,
+                   ExtremaPC::SearchMode                     theMode,
+                   bool                                      theIncludeEndpoints,
+                   ExtremaPC::Result&                        theResult)
 {
   const ExtremaPC2d::SearchMode aMode = ExtremaPC::ToSearchMode2d(theMode);
   if (theDomain.has_value())
   {
-    Evaluator2d anEvaluator2d(theGeometry, theDomain.value());
+    Evaluator2d                anEvaluator2d(theGeometry, theDomain.value());
     const ExtremaPC2d::Result& aResult2d =
       theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(theQuery2d, theTolerance, aMode)
                           : anEvaluator2d.Perform(theQuery2d, theTolerance, aMode);
     return ConvertPlanarResult(aResult2d, theQuery3d, thePlane, theEvaluator, theResult);
   }
 
-  Evaluator2d anEvaluator2d(theGeometry);
+  Evaluator2d                anEvaluator2d(theGeometry);
   const ExtremaPC2d::Result& aResult2d =
     theIncludeEndpoints ? anEvaluator2d.PerformWithEndpoints(theQuery2d, theTolerance, aMode)
                         : anEvaluator2d.Perform(theQuery2d, theTolerance, aMode);

--- a/src/ModelingData/TKGeomBase/ExtremaPC/FILES.cmake
+++ b/src/ModelingData/TKGeomBase/ExtremaPC/FILES.cmake
@@ -4,6 +4,8 @@ set(OCCT_ExtremaPC_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 set(OCCT_ExtremaPC_FILES
   # Core types
   ExtremaPC.hxx
+  ExtremaPC_Planar.hxx
+  ExtremaPC_Planar.cxx
 
   # Elementary curves (header-only, analytical solutions)
   ExtremaPC_Line.hxx

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d.hxx
@@ -1,0 +1,378 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_HeaderFile
+#define _ExtremaPC2d_HeaderFile
+
+#include <gp_Pnt2d.hxx>
+#include <MathUtils_Domain.hxx>
+#include <NCollection_LinearVector.hxx>
+#include <Precision.hxx>
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+//! @file ExtremaPC2d.hxx
+//! @brief Common types and utilities for Point-Curve extrema computation.
+//!
+//! The ExtremaPC2d package provides modern C++ implementation of point-curve
+//! extrema computation using std::variant for curve type dispatch and
+//! analytical and derivative-aware numerical algorithms.
+
+namespace ExtremaPC2d
+{
+
+//! Default tolerance for root finding and distance comparison.
+//! Used when no explicit tolerance is provided.
+constexpr double THE_DEFAULT_TOLERANCE = Precision::Confusion();
+
+//! Returns true when a geometric tolerance is usable by extrema algorithms.
+inline bool IsValidTolerance(double theTolerance)
+{
+  return std::isfinite(theTolerance) && theTolerance > 0.0;
+}
+
+//! Returns true when both point coordinates are finite.
+inline bool IsFinitePoint(const gp_Pnt2d& thePoint)
+{
+  return std::isfinite(thePoint.X()) && !Precision::IsInfinite(thePoint.X())
+         && std::isfinite(thePoint.Y()) && !Precision::IsInfinite(thePoint.Y());
+}
+
+//! Tolerance for parameter domain comparison (cache validation).
+//! Uses PConfusion which is appropriate for parametric space.
+constexpr double THE_PARAM_TOLERANCE = Precision::PConfusion();
+
+//! Maximum ratio of parameter range for one-sided endpoint classification.
+constexpr double THE_NEIGHBOR_STEP_RATIO = 1.0e-6;
+
+//! Minimum number of samples for Bezier curves.
+constexpr size_t THE_BEZIER_MIN_SAMPLES = 24;
+
+//! Multiplier for degree to compute Bezier samples: samples = max(min, multiplier * (degree + 1)).
+constexpr size_t THE_BEZIER_DEGREE_MULTIPLIER = 3;
+
+//! Default number of samples for general (other) curves.
+constexpr size_t THE_OTHER_CURVE_NB_SAMPLES = 64;
+
+//! Fallback number of samples for BSpline curves when curve is null.
+constexpr size_t THE_BSPLINE_FALLBACK_SAMPLES = 32;
+
+//! Multiplier for BSpline curve samples per knot span: samples = multiplier * (degree + 1).
+//! For a degree 3 curve: 2*4 = 8 samples per span.
+//! This is higher than the surface counterpart because curves are 1D and require
+//! finer sampling to detect extrema reliably. Surfaces use degree+2 per direction,
+//! resulting in (degree+2)^2 samples per cell, which provides adequate coverage.
+constexpr size_t THE_BSPLINE_SPAN_MULTIPLIER = 2;
+
+//! 1D parameter domain for curves (alias for MathUtils::Domain1D).
+using Domain1D = MathUtils::Domain1D;
+
+//! Returns true when a finite domain spans an integral number of periods.
+inline bool IsClosedPeriodicDomain(const Domain1D& theDomain, double thePeriod, double theTolerance)
+{
+  if (!theDomain.IsValid() || !std::isfinite(thePeriod) || thePeriod <= 0.0
+      || !std::isfinite(theTolerance) || theTolerance < 0.0)
+  {
+    return false;
+  }
+
+  const double aNbPeriods = std::round(theDomain.Length() / thePeriod);
+  return aNbPeriods >= 1.0 && std::abs(theDomain.Length() - aNbPeriods * thePeriod) <= theTolerance;
+}
+
+//! Returns true when a parameter can be evaluated as a finite endpoint.
+inline bool IsFiniteParameter(double theParameter)
+{
+  return std::isfinite(theParameter) && !Precision::IsInfinite(theParameter);
+}
+
+//! Status of extrema computation.
+enum class Status
+{
+  OK,                //!< Computation succeeded, finite number of extrema found
+  NotDone,           //!< Computation not performed
+  InfiniteSolutions, //!< Infinite solutions exist (e.g., point at circle center)
+  NoSolution,        //!< No extrema found in the given parameter range
+  InvalidInput,      //!< Invalid tolerance or parameter domain
+  NumericalError     //!< Numerical issues during computation
+};
+
+//! Search mode for extrema computation.
+//! Controls which extrema to find, enabling performance optimizations.
+enum class SearchMode
+{
+  MinMax, //!< Find all local extrema (both minima and maxima) - default
+  Min,    //!< Find local minima only
+  Max     //!< Find local maxima only
+};
+
+//! Result of a single extremum computation.
+struct ExtremumResult
+{
+  double   Parameter = 0.0;        //!< Parameter value on curve
+  gp_Pnt2d Point;                  //!< Point on curve at parameter
+  double   SquareDistance = 0.0;   //!< Square of the distance from query point to curve point
+  bool     IsMinimum      = true;  //!< True if this is a local minimum
+  bool     IsMaximum      = false; //!< True if this is a local maximum
+};
+
+//! Result of extrema computation containing all found extrema.
+//! Non-copyable to enforce use of const reference from Perform().
+struct Result
+{
+  //! Sentinel returned by index queries when no extremum exists.
+  static constexpr size_t INVALID_INDEX = static_cast<size_t>(-1);
+
+  ExtremaPC2d::Status Status = ExtremaPC2d::Status::NotDone; //!< Computation status
+  NCollection_LinearVector<ExtremumResult> Extrema{8};       //!< Collection of found extrema
+
+  //! For infinite solutions, stores the constant squared distance.
+  //! Only meaningful when Status == Status::InfiniteSolutions.
+  double InfiniteSquareDistance = 0.0;
+
+  //! Default constructor.
+  Result() = default;
+
+  //! Copy constructor is deleted.
+  Result(const Result&) = delete;
+
+  //! Copy assignment is deleted.
+  Result& operator=(const Result&) = delete;
+
+  //! Move constructor.
+  Result(Result&&) = default;
+
+  //! Move assignment.
+  Result& operator=(Result&&) = default;
+
+  //! Returns true if a finite search completed, including a search with no matching extrema.
+  bool IsDone() const { return Status == Status::OK || Status == Status::NoSolution; }
+
+  //! Returns true if there are infinite solutions.
+  bool IsInfinite() const { return Status == Status::InfiniteSolutions; }
+
+  //! Returns number of extrema found (0 if infinite or failed).
+  size_t NbExt() const { return Extrema.Size(); }
+
+  //! Access extremum by 0-based index.
+  const ExtremumResult& operator[](size_t theIndex) const { return Extrema.Value(theIndex); }
+
+  //! Returns the squared distance of the closest extremum.
+  //! Returns infinity if no extrema found.
+  double MinSquareDistance() const
+  {
+    if (Extrema.IsEmpty())
+    {
+      return std::numeric_limits<double>::infinity();
+    }
+    double aMinSqDist = Extrema.Value(0).SquareDistance;
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
+    {
+      if (Extrema.Value(anIndex).SquareDistance < aMinSqDist)
+      {
+        aMinSqDist = Extrema.Value(anIndex).SquareDistance;
+      }
+    }
+    return aMinSqDist;
+  }
+
+  //! Returns the index of the closest extremum (0-based).
+  //! Returns INVALID_INDEX if no extrema are available.
+  size_t MinIndex() const
+  {
+    if (Extrema.IsEmpty())
+    {
+      return INVALID_INDEX;
+    }
+    size_t aMinIdx    = 0;
+    double aMinSqDist = Extrema.Value(0).SquareDistance;
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
+    {
+      if (Extrema.Value(anIndex).SquareDistance < aMinSqDist)
+      {
+        aMinSqDist = Extrema.Value(anIndex).SquareDistance;
+        aMinIdx    = anIndex;
+      }
+    }
+    return aMinIdx;
+  }
+
+  //! Returns the squared distance of the farthest extremum.
+  //! Returns 0 if no extrema found.
+  double MaxSquareDistance() const
+  {
+    if (Extrema.IsEmpty())
+    {
+      return 0.0;
+    }
+    double aMaxSqDist = Extrema.Value(0).SquareDistance;
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
+    {
+      if (Extrema.Value(anIndex).SquareDistance > aMaxSqDist)
+      {
+        aMaxSqDist = Extrema.Value(anIndex).SquareDistance;
+      }
+    }
+    return aMaxSqDist;
+  }
+
+  //! Returns the index of the farthest extremum (0-based).
+  //! Returns INVALID_INDEX if no extrema are available.
+  size_t MaxIndex() const
+  {
+    if (Extrema.IsEmpty())
+    {
+      return INVALID_INDEX;
+    }
+    size_t aMaxIdx    = 0;
+    double aMaxSqDist = Extrema.Value(0).SquareDistance;
+    for (size_t anIndex = 1; anIndex < Extrema.Size(); ++anIndex)
+    {
+      if (Extrema.Value(anIndex).SquareDistance > aMaxSqDist)
+      {
+        aMaxSqDist = Extrema.Value(anIndex).SquareDistance;
+        aMaxIdx    = anIndex;
+      }
+    }
+    return aMaxIdx;
+  }
+
+  //! Clear the result for reuse.
+  //! Preserves allocated memory in Extrema vector.
+  void Clear()
+  {
+    Status = Status::NotDone;
+    Extrema.Clear();
+    InfiniteSquareDistance = 0.0;
+  }
+};
+
+//! @brief Adds endpoint extrema to result for bounded curves.
+//!
+//! This function adds the curve endpoints as extrema when:
+//! - The parameter bounds are finite
+//! - The endpoint is a true local extremum (checked via neighbor distance)
+//! - The endpoint doesn't duplicate an existing extremum
+//!
+//! An endpoint is considered a local minimum if the distance to a neighboring
+//! point on the curve is greater than the distance to the endpoint.
+//! An endpoint is considered a local maximum if the distance to a neighboring
+//! point is less than the distance to the endpoint.
+//!
+//! @tparam CurveEvaluator Type with Value(double) method returning gp_Pnt2d
+//! @param theResult result to add endpoints to
+//! @param theP query point
+//! @param theDomain parameter domain
+//! @param theEval curve evaluator
+//! @param theMode search mode
+template <typename CurveEvaluator>
+inline void AddEndpointExtrema(Result&               theResult,
+                               const gp_Pnt2d&       theP,
+                               const Domain1D&       theDomain,
+                               const CurveEvaluator& theEval,
+                               SearchMode            theMode,
+                               bool                  theIsClosed)
+{
+  if (!theDomain.IsValid())
+  {
+    return;
+  }
+
+  const double theUMin      = theDomain.Min;
+  const double theUMax      = theDomain.Max;
+  const bool   hasFiniteMin = IsFiniteParameter(theUMin);
+  const bool   hasFiniteMax = IsFiniteParameter(theUMax);
+  if (!hasFiniteMin && !hasFiniteMax)
+  {
+    return;
+  }
+
+  // Helper to check if parameter or point already exists in result
+  auto isDuplicate = [&](double theU) -> bool {
+    for (size_t anIndex = 0; anIndex < theResult.Extrema.Size(); ++anIndex)
+    {
+      // Check parameter proximity
+      if (std::abs(theResult.Extrema.Value(anIndex).Parameter - theU) < THE_PARAM_TOLERANCE)
+      {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  if (theUMin == theUMax)
+  {
+    if (hasFiniteMin && !isDuplicate(theUMin))
+    {
+      const gp_Pnt2d aPoint = theEval.Value(theUMin);
+      ExtremumResult anExt;
+      anExt.Parameter      = theUMin;
+      anExt.Point          = aPoint;
+      anExt.SquareDistance = theP.SquareDistance(aPoint);
+      anExt.IsMinimum      = theMode != SearchMode::Max;
+      anExt.IsMaximum      = theMode != SearchMode::Min;
+      theResult.Extrema.Append(anExt);
+    }
+    return;
+  }
+
+  if (theIsClosed)
+  {
+    return;
+  }
+
+  const bool hasFiniteSpan = hasFiniteMin && hasFiniteMax;
+  auto       addEndpoint   = [&](double theParameter, bool theIsLower) {
+    if (isDuplicate(theParameter))
+    {
+      return;
+    }
+
+    const double aParameterResolution = Precision::PConfusion();
+    const double aStep =
+      hasFiniteSpan
+        ? std::min((theUMax - theUMin) * 0.5,
+                   std::max((theUMax - theUMin) * THE_NEIGHBOR_STEP_RATIO, aParameterResolution))
+        : aParameterResolution;
+    const gp_Pnt2d aPoint            = theEval.Value(theParameter);
+    const gp_Pnt2d aNeighbor         = theEval.Value(theParameter + (theIsLower ? aStep : -aStep));
+    const double   aSquareDistance   = theP.SquareDistance(aPoint);
+    const double   aNeighborDistance = theP.SquareDistance(aNeighbor);
+    const bool     isMinimum         = aSquareDistance <= aNeighborDistance;
+    const bool     isMaximum         = aSquareDistance >= aNeighborDistance;
+
+    if ((theMode == SearchMode::Min || theMode == SearchMode::MinMax) && isMinimum)
+    {
+      theResult.Extrema.Append(ExtremumResult{theParameter, aPoint, aSquareDistance, true, false});
+    }
+    else if ((theMode == SearchMode::Max || theMode == SearchMode::MinMax) && isMaximum)
+    {
+      theResult.Extrema.Append(ExtremumResult{theParameter, aPoint, aSquareDistance, false, true});
+    }
+  };
+
+  if (hasFiniteMin)
+  {
+    addEndpoint(theUMin, true);
+  }
+  if (hasFiniteMax)
+  {
+    addEndpoint(theUMax, false);
+  }
+}
+
+} // namespace ExtremaPC2d
+
+#endif // _ExtremaPC2d_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d.hxx
@@ -343,11 +343,11 @@ inline void AddEndpointExtrema(Result&               theResult,
     const double aParameterResolution = Precision::PConfusion();
     const double aStep =
       hasFiniteSpan
-        ? std::min((theUMax - theUMin) * 0.5,
+                ? std::min((theUMax - theUMin) * 0.5,
                    std::max((theUMax - theUMin) * THE_NEIGHBOR_STEP_RATIO, aParameterResolution))
-        : aParameterResolution;
-    const gp_Pnt2d aPoint            = theEval.Value(theParameter);
-    const gp_Pnt2d aNeighbor         = theEval.Value(theParameter + (theIsLower ? aStep : -aStep));
+                : aParameterResolution;
+    const gp_Pnt2d aPoint    = theEval.Value(theParameter);
+    const gp_Pnt2d aNeighbor = theEval.Value(theParameter + (theIsLower ? aStep : -aStep));
     const double   aSquareDistance   = theP.SquareDistance(aPoint);
     const double   aNeighborDistance = theP.SquareDistance(aNeighbor);
     const bool     isMinimum         = aSquareDistance <= aNeighborDistance;

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BSplineCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BSplineCurve.cxx
@@ -1,0 +1,198 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ExtremaPC2d_BSplineCurve.hxx>
+
+#include <math_Vector.hxx>
+#include <NCollection_LocalArray.hxx>
+#include <Standard_Integer.hxx>
+#include <Standard_RangeError.hxx>
+
+//==================================================================================================
+
+ExtremaPC2d_BSplineCurve::ExtremaPC2d_BSplineCurve(const occ::handle<Geom2d_BSplineCurve>& theCurve)
+    : myCurve(theCurve),
+      myDomain{0.0, 1.0}
+{
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myDomain.Min = myCurve->FirstParameter();
+  myDomain.Max = myCurve->LastParameter();
+}
+
+//==================================================================================================
+
+ExtremaPC2d_BSplineCurve::ExtremaPC2d_BSplineCurve(const occ::handle<Geom2d_BSplineCurve>& theCurve,
+                                                   const ExtremaPC2d::Domain1D& theDomain)
+    : myCurve(theCurve),
+      myDomain(theDomain)
+{
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+}
+
+//==================================================================================================
+
+math_Vector ExtremaPC2d_BSplineCurve::buildKnotAwareParams() const
+{
+  if (myCurve.IsNull())
+  {
+    // Fallback to uniform sampling
+    return ExtremaPC2d_GridEvaluator::BuildUniformParams(myDomain.Min,
+                                                         myDomain.Max,
+                                                         ExtremaPC2d::THE_BSPLINE_FALLBACK_SAMPLES);
+  }
+
+  const double theUMin = myDomain.Min;
+  const double theUMax = myDomain.Max;
+
+  const int                         aDegree = myCurve->Degree();
+  const NCollection_Array1<double>& aKnots  = myCurve->Knots();
+
+  // Use multiplier*(degree+1) samples per span for accurate extrema detection.
+  const size_t aSamplesPerSpan =
+    ExtremaPC2d::THE_BSPLINE_SPAN_MULTIPLIER * static_cast<size_t>(aDegree + 1);
+
+  const bool   isPeriodic      = myCurve->IsPeriodic();
+  const double aPeriod         = isPeriodic ? myCurve->Period() : 0.0;
+  const double aFirstShiftReal = isPeriodic ? std::floor((theUMin - aKnots.Last()) / aPeriod) : 0.0;
+  const double aLastShiftReal  = isPeriodic ? std::ceil((theUMax - aKnots.First()) / aPeriod) : 0.0;
+  const double aNbShifts       = aLastShiftReal - aFirstShiftReal + 1.0;
+  const double aMaxParams =
+    2.0 + aNbShifts * static_cast<double>(aKnots.Size() - 1) * aSamplesPerSpan;
+  Standard_RangeError_Raise_if(aFirstShiftReal < IntegerFirst() || aFirstShiftReal > IntegerLast()
+                                 || aLastShiftReal < IntegerFirst()
+                                 || aLastShiftReal > IntegerLast() || aNbShifts < 1.0
+                                 || aMaxParams > IntegerLast(),
+                               "ExtremaPC2d_BSplineCurve: parameter grid is too large");
+  const int                           aFirstShift = static_cast<int>(aFirstShiftReal);
+  const int                           aLastShift  = static_cast<int>(aLastShiftReal);
+  NCollection_LocalArray<double, 128> aParams(static_cast<size_t>(aMaxParams));
+  size_t                              aNbParams = 0;
+  aParams[aNbParams++]                          = theUMin;
+  for (int aShiftIndex = aFirstShift;; ++aShiftIndex)
+  {
+    const double aShift = aShiftIndex * aPeriod;
+    for (size_t aKnotIndex = 0; aKnotIndex + 1 < aKnots.Size(); ++aKnotIndex)
+    {
+      const double aKnotLo = aKnots.At(aKnotIndex) + aShift;
+      const double aKnotHi = aKnots.At(aKnotIndex + 1) + aShift;
+      const double aSpanLo = std::max(aKnotLo, theUMin);
+      const double aSpanHi = std::min(aKnotHi, theUMax);
+      if (aSpanHi <= aSpanLo)
+      {
+        continue;
+      }
+
+      const double aStep = (aSpanHi - aSpanLo) / aSamplesPerSpan;
+      for (size_t aSampleIndex = 1; aSampleIndex < aSamplesPerSpan; ++aSampleIndex)
+      {
+        const double aU = aSpanLo + static_cast<double>(aSampleIndex) * aStep;
+        if (aU > theUMin && aU < theUMax)
+        {
+          aParams[aNbParams++] = aU;
+        }
+      }
+      if (aKnotHi > theUMin && aKnotHi < theUMax)
+      {
+        aParams[aNbParams++] = aKnotHi;
+      }
+    }
+    if (aShiftIndex == aLastShift)
+    {
+      break;
+    }
+  }
+  aParams[aNbParams++] = theUMax;
+
+  // Convert to math_Vector for the numerical evaluator.
+  math_Vector aResult(aNbParams);
+  for (size_t anIndex = 0; anIndex < aNbParams; ++anIndex)
+  {
+    aResult.ChangeAt(anIndex) = aParams[anIndex];
+  }
+
+  return aResult;
+}
+
+//==================================================================================================
+
+void ExtremaPC2d_BSplineCurve::buildParams() const
+{
+  if (myCurve.IsNull() || !myDomain.IsValid() || !myDomain.IsFinite())
+  {
+    return;
+  }
+
+  // Build knot-aware parameter partition.
+  math_Vector aParams = buildKnotAwareParams();
+
+  myEvaluator.SetParams(aParams);
+}
+
+//==================================================================================================
+
+gp_Pnt2d ExtremaPC2d_BSplineCurve::Value(double theU) const
+{
+  return myCurve->Value(theU);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_BSplineCurve::Perform(const gp_Pnt2d&         theP,
+                                                             double                  theTol,
+                                                             ExtremaPC2d::SearchMode theMode) const
+{
+  if (myCurve.IsNull())
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC2d::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  buildParams();
+  Geom2dAdaptor_Curve anAdaptor(myCurve);
+  return myEvaluator.Perform(anAdaptor, theP, myDomain, theTol, theMode);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_BSplineCurve::PerformWithEndpoints(
+  const gp_Pnt2d&         theP,
+  double                  theTol,
+  ExtremaPC2d::SearchMode theMode) const
+{
+  (void)Perform(theP, theTol, theMode);
+
+  // Add endpoints to the result
+  ExtremaPC2d::Result& aResult = myEvaluator.Result();
+  if (aResult.Status == ExtremaPC2d::Status::OK
+      || aResult.Status == ExtremaPC2d::Status::NoSolution)
+  {
+    Geom2dAdaptor_Curve anAdaptor(myCurve);
+    const bool          isClosed = ExtremaPC2d_GridEvaluator::IsClosedDomain(anAdaptor, myDomain);
+    ExtremaPC2d::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
+
+    // Update status if we found any extrema (including endpoints)
+    if (!aResult.Extrema.IsEmpty())
+    {
+      aResult.Status = ExtremaPC2d::Status::OK;
+    }
+  }
+
+  return aResult;
+}

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BSplineCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BSplineCurve.hxx
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_BSplineCurve_HeaderFile
+#define _ExtremaPC2d_BSplineCurve_HeaderFile
+
+#include <ExtremaPC2d.hxx>
+#include <ExtremaPC2d_GridEvaluator.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <gp_Pnt2d.hxx>
+#include <Standard_DefineAlloc.hxx>
+#include <Standard_Handle.hxx>
+#include <math_Vector.hxx>
+
+//! @brief Point-BSplineCurve extrema computation using numerical root isolation.
+//!
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
+//!
+//! The knot-aware parameter partition is cached while geometry is evaluated for each query.
+//!
+//! The algorithm:
+//! 1. Build a knot-aware parameter partition
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
+//!
+//! This approach is simpler and more stable than BVH-based methods,
+//! with comparable accuracy for typical BSpline curves.
+//!
+//! The domain is fixed at construction time. The parameter partition is refreshed
+//! on each query so changes to the referenced curve are observed.
+class ExtremaPC2d_BSplineCurve
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with BSpline curve (uses full curve domain).
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve BSpline curve handle
+  Standard_EXPORT explicit ExtremaPC2d_BSplineCurve(
+    const occ::handle<Geom2d_BSplineCurve>& theCurve);
+
+  //! Constructor with BSpline curve and parameter domain.
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve BSpline curve handle
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  Standard_EXPORT ExtremaPC2d_BSplineCurve(const occ::handle<Geom2d_BSplineCurve>& theCurve,
+                                           const ExtremaPC2d::Domain1D&            theDomain);
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_BSplineCurve(const ExtremaPC2d_BSplineCurve&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_BSplineCurve& operator=(const ExtremaPC2d_BSplineCurve&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_BSplineCurve(ExtremaPC2d_BSplineCurve&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_BSplineCurve& operator=(ExtremaPC2d_BSplineCurve&&) = default;
+
+  //! Evaluates point on curve at parameter.
+  //! @param theU parameter
+  //! @return point on curve
+  Standard_EXPORT gp_Pnt2d Value(double theU) const;
+
+  //! Returns true if domain is bounded (subset of curve domain).
+  bool IsBounded() const { return true; } // BSpline curves are always bounded
+
+  //! Returns the domain.
+  const ExtremaPC2d::Domain1D& Domain() const { return myDomain; }
+
+  //! Compute extrema between point P and the curve.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Compute extrema between point P and the curve including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Returns the BSpline curve.
+  const occ::handle<Geom2d_BSplineCurve>& Curve() const { return myCurve; }
+
+private:
+  //! Build knot-aware parameter array for grid sampling.
+  //! Places samples at knots and (degree + 1) intermediate points per span.
+  //! @return array of parameter values for grid sampling
+  math_Vector buildKnotAwareParams() const;
+
+  //! Build parameter partition for the curve.
+  void buildParams() const;
+
+  occ::handle<Geom2d_BSplineCurve> myCurve;  //!< BSpline curve
+  ExtremaPC2d::Domain1D            myDomain; //!< Parameter domain (fixed)
+
+  // Numerical evaluator with cached parameter partition and result
+  mutable ExtremaPC2d_GridEvaluator myEvaluator;
+};
+
+#endif // _ExtremaPC2d_BSplineCurve_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BezierCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BezierCurve.cxx
@@ -1,0 +1,121 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ExtremaPC2d_BezierCurve.hxx>
+
+//==================================================================================================
+
+ExtremaPC2d_BezierCurve::ExtremaPC2d_BezierCurve(const occ::handle<Geom2d_BezierCurve>& theCurve)
+    : myCurve(theCurve),
+      myDomain{0.0, 1.0},
+      myNbSamples(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES)
+{
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myDomain.Min = myCurve->FirstParameter();
+  myDomain.Max = myCurve->LastParameter();
+  myNbSamples = std::max(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES,
+                         ExtremaPC2d::THE_BEZIER_DEGREE_MULTIPLIER
+                           * static_cast<size_t>(myCurve->Degree() + 1));
+}
+
+//==================================================================================================
+
+ExtremaPC2d_BezierCurve::ExtremaPC2d_BezierCurve(const occ::handle<Geom2d_BezierCurve>& theCurve,
+                                                 const ExtremaPC2d::Domain1D&           theDomain)
+    : myCurve(theCurve),
+      myDomain(theDomain),
+      myNbSamples(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES)
+{
+  if (myCurve.IsNull())
+  {
+    return;
+  }
+  myNbSamples = std::max(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES,
+                         ExtremaPC2d::THE_BEZIER_DEGREE_MULTIPLIER
+                           * static_cast<size_t>(myCurve->Degree() + 1));
+}
+
+//==================================================================================================
+
+void ExtremaPC2d_BezierCurve::buildParams() const
+{
+  if (myCurve.IsNull() || !myDomain.IsValid() || !myDomain.IsFinite())
+  {
+    return;
+  }
+
+  myNbSamples = std::max(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES,
+                         ExtremaPC2d::THE_BEZIER_DEGREE_MULTIPLIER
+                           * static_cast<size_t>(myCurve->Degree() + 1));
+
+  math_Vector aParams =
+    ExtremaPC2d_GridEvaluator::BuildUniformParams(myDomain.Min, myDomain.Max, myNbSamples);
+
+  myEvaluator.SetParams(aParams);
+}
+
+//==================================================================================================
+
+gp_Pnt2d ExtremaPC2d_BezierCurve::Value(double theU) const
+{
+  return myCurve->Value(theU);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_BezierCurve::Perform(const gp_Pnt2d&         theP,
+                                                            double                  theTol,
+                                                            ExtremaPC2d::SearchMode theMode) const
+{
+  if (myCurve.IsNull())
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC2d::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  buildParams();
+  Geom2dAdaptor_Curve anAdaptor(myCurve);
+  return myEvaluator.Perform(anAdaptor, theP, myDomain, theTol, theMode);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_BezierCurve::PerformWithEndpoints(
+  const gp_Pnt2d&         theP,
+  double                  theTol,
+  ExtremaPC2d::SearchMode theMode) const
+{
+  (void)Perform(theP, theTol, theMode);
+
+  // Add endpoints to the result
+  ExtremaPC2d::Result& aResult = myEvaluator.Result();
+  if (aResult.Status == ExtremaPC2d::Status::OK
+      || aResult.Status == ExtremaPC2d::Status::NoSolution)
+  {
+    Geom2dAdaptor_Curve anAdaptor(myCurve);
+    const bool          isClosed = ExtremaPC2d_GridEvaluator::IsClosedDomain(anAdaptor, myDomain);
+    ExtremaPC2d::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
+
+    // Update status if we found any extrema (including endpoints)
+    if (!aResult.Extrema.IsEmpty())
+    {
+      aResult.Status = ExtremaPC2d::Status::OK;
+    }
+  }
+
+  return aResult;
+}

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BezierCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BezierCurve.cxx
@@ -26,7 +26,7 @@ ExtremaPC2d_BezierCurve::ExtremaPC2d_BezierCurve(const occ::handle<Geom2d_Bezier
   }
   myDomain.Min = myCurve->FirstParameter();
   myDomain.Max = myCurve->LastParameter();
-  myNbSamples = std::max(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES,
+  myNbSamples  = std::max(ExtremaPC2d::THE_BEZIER_MIN_SAMPLES,
                          ExtremaPC2d::THE_BEZIER_DEGREE_MULTIPLIER
                            * static_cast<size_t>(myCurve->Degree() + 1));
 }

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BezierCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_BezierCurve.hxx
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_BezierCurve_HeaderFile
+#define _ExtremaPC2d_BezierCurve_HeaderFile
+
+#include <ExtremaPC2d.hxx>
+#include <ExtremaPC2d_GridEvaluator.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <Geom2d_BezierCurve.hxx>
+#include <gp_Pnt2d.hxx>
+#include <Standard_DefineAlloc.hxx>
+#include <Standard_Handle.hxx>
+
+//! @brief Point-BezierCurve extrema computation using numerical root isolation.
+//!
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
+//!
+//! The parameter partition is cached while geometry is evaluated for each query,
+//! so mutations of the curve do not leave stale geometric samples.
+//!
+//! The algorithm:
+//! 1. Build a parameter partition based on curve degree
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
+//!
+//! This approach is simpler and more stable than BVH-based methods,
+//! with comparable accuracy for typical Bezier curves.
+//!
+//! The domain is fixed at construction time. The parameter partition is refreshed
+//! on each query so changes to the referenced curve are observed.
+class ExtremaPC2d_BezierCurve
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with Bezier curve (uses full curve domain).
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve Bezier curve handle
+  Standard_EXPORT explicit ExtremaPC2d_BezierCurve(const occ::handle<Geom2d_BezierCurve>& theCurve);
+
+  //! Constructor with Bezier curve and parameter domain.
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve Bezier curve handle
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  Standard_EXPORT ExtremaPC2d_BezierCurve(const occ::handle<Geom2d_BezierCurve>& theCurve,
+                                          const ExtremaPC2d::Domain1D&           theDomain);
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_BezierCurve(const ExtremaPC2d_BezierCurve&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_BezierCurve& operator=(const ExtremaPC2d_BezierCurve&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_BezierCurve(ExtremaPC2d_BezierCurve&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_BezierCurve& operator=(ExtremaPC2d_BezierCurve&&) = default;
+
+  //! Evaluates point on curve at parameter.
+  //! @param theU parameter
+  //! @return point on curve
+  Standard_EXPORT gp_Pnt2d Value(double theU) const;
+
+  //! Returns true if domain is bounded (subset of curve domain).
+  bool IsBounded() const { return true; } // Bezier curves are always bounded
+
+  //! Returns the domain.
+  const ExtremaPC2d::Domain1D& Domain() const { return myDomain; }
+
+  //! Compute extrema between point P and the curve.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Compute extrema between point P and the curve including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Returns the Bezier curve.
+  const occ::handle<Geom2d_BezierCurve>& Curve() const { return myCurve; }
+
+private:
+  //! Build parameter partition for the curve.
+  void buildParams() const;
+
+  occ::handle<Geom2d_BezierCurve> myCurve;     //!< Bezier curve
+  ExtremaPC2d::Domain1D           myDomain;    //!< Parameter domain (fixed)
+  mutable size_t                  myNbSamples; //!< Number of samples
+
+  // Numerical evaluator with cached parameter partition and result
+  mutable ExtremaPC2d_GridEvaluator myEvaluator;
+};
+
+#endif // _ExtremaPC2d_BezierCurve_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Circle.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Circle.hxx
@@ -97,7 +97,7 @@ public:
   //! @return const reference to result containing extrema or InfiniteSolutions status
   [[nodiscard]] const ExtremaPC2d::Result& Perform(
     const gp_Pnt2d&         theP,
-    double                theTol,
+    double                  theTol,
     ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
   {
     myResult.Clear();
@@ -123,8 +123,8 @@ public:
     }
 
     const gp_Pnt2d& aCenter = myCircle.Location();
-    const gp_Vec2d aOPp(aCenter, theP);
-    double aOPpMag = aOPp.Magnitude();
+    const gp_Vec2d  aOPp(aCenter, theP);
+    double          aOPpMag = aOPp.Magnitude();
 
     if (aOPpMag <= gp::Resolution())
     {
@@ -135,7 +135,7 @@ public:
     }
 
     const gp_Ax22d& aPosition = myCircle.Axis();
-    double aUs1 = std::atan2(aOPp.Dot(gp_Vec2d(aPosition.YDirection())),
+    double          aUs1      = std::atan2(aOPp.Dot(gp_Vec2d(aPosition.YDirection())),
                              aOPp.Dot(gp_Vec2d(aPosition.XDirection())));
 
     // Handle angle boundaries
@@ -156,7 +156,7 @@ public:
     const double aTolU = ExtremaPC2d::THE_PARAM_TOLERANCE;
     if (myDomain.has_value())
     {
-      const double theUMin = myDomain->Min;
+      const double theUMin        = myDomain->Min;
       const double aLiftTolerance = Precision::Angular();
       aUs1 += std::ceil((theUMin - aUs1 - aLiftTolerance) / (2.0 * M_PI)) * (2.0 * M_PI);
       aUs2 += std::ceil((theUMin - aUs2 - aLiftTolerance) / (2.0 * M_PI)) * (2.0 * M_PI);
@@ -172,10 +172,9 @@ public:
     const size_t aEnd   = (theMode == ExtremaPC2d::SearchMode::Min) ? 1 : 2;
 
     const double aSolutions[2] = {aUs1, aUs2};
-    const bool isClosedDomain = myDomain.has_value()
-                                && ExtremaPC2d::IsClosedPeriodicDomain(*myDomain,
-                                                                       2.0 * M_PI,
-                                                                       Precision::Angular());
+    const bool   isClosedDomain =
+      myDomain.has_value()
+      && ExtremaPC2d::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
 
     for (size_t anIndex = aStart; anIndex < aEnd; ++anIndex)
     {
@@ -196,8 +195,7 @@ public:
       double aPreviousParameter = 0.0;
       for (size_t aPeriodIndex = 0; aPeriodIndex < aNbRepresentatives; ++aPeriodIndex)
       {
-        const double aU = aSolutions[anIndex]
-                          + static_cast<double>(aPeriodIndex) * (2.0 * M_PI);
+        const double aU = aSolutions[anIndex] + static_cast<double>(aPeriodIndex) * (2.0 * M_PI);
         if (aPeriodIndex > 0 && aU <= aPreviousParameter)
         {
           myResult.Clear();
@@ -219,8 +217,8 @@ public:
       }
     }
 
-    myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
-                                                 : ExtremaPC2d::Status::OK;
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
     return myResult;
   }
 
@@ -233,7 +231,7 @@ public:
   //! status
   [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
     const gp_Pnt2d&         theP,
-    double                theTol,
+    double                  theTol,
     ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
   {
     if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
@@ -248,8 +246,8 @@ public:
     {
       myResult.Clear();
       ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
-      myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
-                                                   : ExtremaPC2d::Status::OK;
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
       return myResult;
     }
 
@@ -262,12 +260,7 @@ public:
     {
       const bool isClosed =
         ExtremaPC2d::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
-      ExtremaPC2d::AddEndpointExtrema(myResult,
-                                    theP,
-                                    *myDomain,
-                                    *this,
-                                    theMode,
-                                    isClosed);
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, isClosed);
       if (!myResult.Extrema.IsEmpty())
       {
         myResult.Status = ExtremaPC2d::Status::OK;

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Circle.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Circle.hxx
@@ -1,0 +1,289 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_Circle_HeaderFile
+#define _ExtremaPC2d_Circle_HeaderFile
+
+#include <ElCLib.hxx>
+#include <ExtremaPC2d.hxx>
+#include <gp_Circ2d.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <MathRoot_Utils.hxx>
+#include <Precision.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <cmath>
+#include <optional>
+
+//! @brief Point-Circle extrema computation.
+//!
+//! Computes the extrema between a 2D point and a circle.
+//! Uses an analytical solution in the circle coordinate system.
+//!
+//! For a circle with center O and radius R, the algorithm:
+//! Computes the local angle of the center-to-point vector to find the
+//! closest and farthest points.
+//!
+//! The domain is fixed at construction time for optimal performance.
+//! For full circle, construct without domain or with nullopt.
+//!
+//! @note Degenerate case: When P projects to the circle center,
+//!       all points on the circle are equidistant (infinite solutions).
+//!       Returns Status::InfiniteSolutions with InfiniteSquareDistance = R^2.
+//!
+//! @note A circle always has exactly 2 extrema: one minimum (closest)
+//!       and one maximum (farthest), at opposite points on the circle.
+class ExtremaPC2d_Circle
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with circle geometry (full circle).
+  //! @param[in] theCircle the circle to compute extrema for
+  explicit ExtremaPC2d_Circle(const gp_Circ2d& theCircle)
+      : myCircle(theCircle),
+        myDomain(std::nullopt)
+  {
+  }
+
+  //! Constructor with circle geometry and parameter domain.
+  //! @param[in] theCircle the circle to compute extrema for
+  //! @param[in] theDomain parameter domain in radians (fixed for all queries)
+  ExtremaPC2d_Circle(const gp_Circ2d& theCircle, const ExtremaPC2d::Domain1D& theDomain)
+      : myCircle(theCircle),
+        myDomain(theDomain)
+  {
+  }
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_Circle(const ExtremaPC2d_Circle&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_Circle& operator=(const ExtremaPC2d_Circle&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_Circle(ExtremaPC2d_Circle&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_Circle& operator=(ExtremaPC2d_Circle&&) = default;
+
+  //! Evaluates point on circle at parameter.
+  //! @param theU parameter (radians)
+  //! @return point on circle
+  gp_Pnt2d Value(double theU) const { return ElCLib::Value(theU, myCircle); }
+
+  //! Returns true if domain is bounded (partial arc).
+  bool IsBounded() const { return myDomain.has_value(); }
+
+  //! Returns the domain (only valid if IsBounded() is true).
+  const ExtremaPC2d::Domain1D& Domain() const { return *myDomain; }
+
+  //! Compute extrema between point P and the circle.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for degenerate case detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema or InfiniteSolutions status
+  [[nodiscard]] const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    myResult.Clear();
+
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Status = ExtremaPC2d::Status::NoSolution;
+      return myResult;
+    }
+
+    if (myCircle.Radius() <= gp::Resolution())
+    {
+      myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+      myResult.InfiniteSquareDistance = theP.SquareDistance(myCircle.Location());
+      return myResult;
+    }
+
+    const gp_Pnt2d& aCenter = myCircle.Location();
+    const gp_Vec2d aOPp(aCenter, theP);
+    double aOPpMag = aOPp.Magnitude();
+
+    if (aOPpMag <= gp::Resolution())
+    {
+      myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+      double aRadius                  = myCircle.Radius();
+      myResult.InfiniteSquareDistance = aRadius * aRadius;
+      return myResult;
+    }
+
+    const gp_Ax22d& aPosition = myCircle.Axis();
+    double aUs1 = std::atan2(aOPp.Dot(gp_Vec2d(aPosition.YDirection())),
+                             aOPp.Dot(gp_Vec2d(aPosition.XDirection())));
+
+    // Handle angle boundaries
+    constexpr double aAngTol = Precision::Angular();
+    if (aUs1 + M_PI < aAngTol)
+    {
+      aUs1 = -M_PI;
+    }
+    else if (aUs1 - M_PI > -aAngTol)
+    {
+      aUs1 = M_PI;
+    }
+
+    // Us2 = Us1 + PI corresponds to maximum distance (farthest point)
+    double aUs2 = aUs1 + M_PI;
+
+    // Step 4: For bounded case, lift each canonical solution into the requested domain.
+    const double aTolU = ExtremaPC2d::THE_PARAM_TOLERANCE;
+    if (myDomain.has_value())
+    {
+      const double theUMin = myDomain->Min;
+      const double aLiftTolerance = Precision::Angular();
+      aUs1 += std::ceil((theUMin - aUs1 - aLiftTolerance) / (2.0 * M_PI)) * (2.0 * M_PI);
+      aUs2 += std::ceil((theUMin - aUs2 - aLiftTolerance) / (2.0 * M_PI)) * (2.0 * M_PI);
+      if (std::abs(aUs1 - theUMin) <= aLiftTolerance)
+        aUs1 = theUMin;
+      if (std::abs(aUs2 - theUMin) <= aLiftTolerance)
+        aUs2 = theUMin;
+    }
+
+    // Step 5: Add extrema (with bounds check if domain specified)
+    // Skip based on search mode: i=0 is minimum, i=1 is maximum
+    const size_t aStart = (theMode == ExtremaPC2d::SearchMode::Max) ? 1 : 0;
+    const size_t aEnd   = (theMode == ExtremaPC2d::SearchMode::Min) ? 1 : 2;
+
+    const double aSolutions[2] = {aUs1, aUs2};
+    const bool isClosedDomain = myDomain.has_value()
+                                && ExtremaPC2d::IsClosedPeriodicDomain(*myDomain,
+                                                                       2.0 * M_PI,
+                                                                       Precision::Angular());
+
+    for (size_t anIndex = aStart; anIndex < aEnd; ++anIndex)
+    {
+      size_t aNbRepresentatives = 1;
+      if (myDomain.has_value()
+          && !MathRoot::Utils::ComputePeriodicRootCount(aSolutions[anIndex],
+                                                        myDomain->Max,
+                                                        2.0 * M_PI,
+                                                        aTolU,
+                                                        isClosedDomain,
+                                                        aNbRepresentatives))
+      {
+        myResult.Clear();
+        myResult.Status = ExtremaPC2d::Status::NumericalError;
+        return myResult;
+      }
+
+      double aPreviousParameter = 0.0;
+      for (size_t aPeriodIndex = 0; aPeriodIndex < aNbRepresentatives; ++aPeriodIndex)
+      {
+        const double aU = aSolutions[anIndex]
+                          + static_cast<double>(aPeriodIndex) * (2.0 * M_PI);
+        if (aPeriodIndex > 0 && aU <= aPreviousParameter)
+        {
+          myResult.Clear();
+          myResult.Status = ExtremaPC2d::Status::NumericalError;
+          return myResult;
+        }
+        aPreviousParameter = aU;
+
+        const gp_Pnt2d aCurvePt = ElCLib::Value(aU, myCircle);
+
+        ExtremaPC2d::ExtremumResult anExt;
+        anExt.Parameter      = aU;
+        anExt.Point          = aCurvePt;
+        anExt.SquareDistance = theP.SquareDistance(aCurvePt);
+        anExt.IsMinimum      = (anIndex == 0);
+        anExt.IsMaximum      = (anIndex == 1);
+
+        myResult.Extrema.Append(anExt);
+      }
+    }
+
+    myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
+                                                 : ExtremaPC2d::Status::OK;
+    return myResult;
+  }
+
+  //! Compute extrema between point P and the circle arc including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for degenerate case detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema or InfiniteSolutions
+  //! status
+  [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
+                                                   : ExtremaPC2d::Status::OK;
+      return myResult;
+    }
+
+    (void)Perform(theP, theTol, theMode);
+
+    // Add endpoints if interior computation succeeded and domain is bounded
+    if ((myResult.Status == ExtremaPC2d::Status::OK
+         || myResult.Status == ExtremaPC2d::Status::NoSolution)
+        && myDomain.has_value())
+    {
+      const bool isClosed =
+        ExtremaPC2d::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
+      ExtremaPC2d::AddEndpointExtrema(myResult,
+                                    theP,
+                                    *myDomain,
+                                    *this,
+                                    theMode,
+                                    isClosed);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC2d::Status::OK;
+      }
+    }
+
+    return myResult;
+  }
+
+  //! Returns the circle geometry.
+  const gp_Circ2d& Circle() const { return myCircle; }
+
+private:
+  gp_Circ2d                            myCircle; //!< Circle geometry
+  std::optional<ExtremaPC2d::Domain1D> myDomain; //!< Parameter domain (nullopt for full circle)
+  mutable ExtremaPC2d::Result          myResult; //!< Reusable result storage
+};
+
+#endif // _ExtremaPC2d_Circle_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Curve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Curve.cxx
@@ -1,0 +1,341 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ExtremaPC2d_Curve.hxx>
+
+#include <algorithm>
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_Hyperbola.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom2d_Parabola.hxx>
+#include <Geom2d_TrimmedCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+
+namespace
+{
+//! Static result for uninitialized evaluator case
+static ExtremaPC2d::Result THE_NOT_DONE_RESULT = [] {
+  ExtremaPC2d::Result aResult;
+  aResult.Status = ExtremaPC2d::Status::NotDone;
+  return aResult;
+}();
+} // namespace
+
+//=================================================================================================
+
+void ExtremaPC2d_Curve::initFromAdaptor(const Adaptor2d_Curve2d&     theCurve,
+                                        const ExtremaPC2d::Domain1D& theDomain)
+{
+  const GeomAbs_CurveType aCurveType = theCurve.GetType();
+
+  switch (aCurveType)
+  {
+    case GeomAbs_Line:
+      myEvaluator = ExtremaPC2d_Line(theCurve.Line(), theDomain);
+      break;
+
+    case GeomAbs_Circle:
+      myEvaluator = ExtremaPC2d_Circle(theCurve.Circle(), theDomain);
+      break;
+
+    case GeomAbs_Ellipse:
+      myEvaluator = ExtremaPC2d_Ellipse(theCurve.Ellipse(), theDomain);
+      break;
+
+    case GeomAbs_Hyperbola:
+      myEvaluator = ExtremaPC2d_Hyperbola(theCurve.Hyperbola(), theDomain);
+      break;
+
+    case GeomAbs_Parabola:
+      myEvaluator = ExtremaPC2d_Parabola(theCurve.Parabola(), theDomain);
+      break;
+
+    case GeomAbs_BezierCurve:
+      myEvaluator = ExtremaPC2d_BezierCurve(theCurve.Bezier(), theDomain);
+      break;
+
+    case GeomAbs_BSplineCurve:
+      myEvaluator = ExtremaPC2d_BSplineCurve(theCurve.BSpline(), theDomain);
+      break;
+
+    case GeomAbs_OffsetCurve:
+      myAdaptorRef = &theCurve;
+      myEvaluator  = ExtremaPC2d_OffsetCurve(*myAdaptorRef, theDomain);
+      break;
+
+    default:
+      myAdaptorRef = &theCurve;
+      myEvaluator  = ExtremaPC2d_OtherCurve(*myAdaptorRef, theDomain);
+      break;
+  }
+}
+
+//=================================================================================================
+
+ExtremaPC2d_Curve::ExtremaPC2d_Curve(const Adaptor2d_Curve2d& theCurve)
+    : myEvaluator(std::monostate{})
+{
+  ExtremaPC2d::Domain1D aDomain(theCurve.FirstParameter(), theCurve.LastParameter());
+  initFromAdaptor(theCurve, aDomain);
+}
+
+//=================================================================================================
+
+ExtremaPC2d_Curve::ExtremaPC2d_Curve(const Adaptor2d_Curve2d& theCurve,
+                                     double                   theUMin,
+                                     double                   theUMax)
+    : myEvaluator(std::monostate{})
+{
+  ExtremaPC2d::Domain1D aDomain(theUMin, theUMax);
+  initFromAdaptor(theCurve, aDomain);
+}
+
+//=================================================================================================
+
+void ExtremaPC2d_Curve::initFromGeomCurve(const occ::handle<Geom2d_Curve>&            theCurve,
+                                          const std::optional<ExtremaPC2d::Domain1D>& theDomain)
+{
+  // Try specific curve types for direct initialization
+  occ::handle<Geom2d_Line> aLine = occ::down_cast<Geom2d_Line>(theCurve);
+  if (!aLine.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_Line(aLine->Lin2d(), theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_Line(aLine->Lin2d());
+    }
+    return;
+  }
+
+  occ::handle<Geom2d_Circle> aCircle = occ::down_cast<Geom2d_Circle>(theCurve);
+  if (!aCircle.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_Circle(aCircle->Circ2d(), theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_Circle(aCircle->Circ2d());
+    }
+    return;
+  }
+
+  occ::handle<Geom2d_Ellipse> anEllipse = occ::down_cast<Geom2d_Ellipse>(theCurve);
+  if (!anEllipse.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_Ellipse(anEllipse->Elips2d(), theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_Ellipse(anEllipse->Elips2d());
+    }
+    return;
+  }
+
+  occ::handle<Geom2d_Hyperbola> aHyperbola = occ::down_cast<Geom2d_Hyperbola>(theCurve);
+  if (!aHyperbola.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_Hyperbola(aHyperbola->Hypr2d(), theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_Hyperbola(aHyperbola->Hypr2d());
+    }
+    return;
+  }
+
+  occ::handle<Geom2d_Parabola> aParabola = occ::down_cast<Geom2d_Parabola>(theCurve);
+  if (!aParabola.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_Parabola(aParabola->Parab2d(), theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_Parabola(aParabola->Parab2d());
+    }
+    return;
+  }
+
+  occ::handle<Geom2d_BezierCurve> aBezier = occ::down_cast<Geom2d_BezierCurve>(theCurve);
+  if (!aBezier.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_BezierCurve(aBezier, theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_BezierCurve(aBezier);
+    }
+    return;
+  }
+
+  occ::handle<Geom2d_BSplineCurve> aBSpline = occ::down_cast<Geom2d_BSplineCurve>(theCurve);
+  if (!aBSpline.IsNull())
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_BSplineCurve(aBSpline, theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_BSplineCurve(aBSpline);
+    }
+    return;
+  }
+
+  // For offset and other curves, store adaptor and use it
+  // Use domain bounds if set, otherwise use natural curve bounds
+  if (theDomain.has_value())
+  {
+    myAdaptorOwned = new Geom2dAdaptor_Curve(theCurve, theDomain->Min, theDomain->Max);
+  }
+  else
+  {
+    myAdaptorOwned = new Geom2dAdaptor_Curve(theCurve);
+  }
+  const GeomAbs_CurveType aCurveType = myAdaptorOwned->GetType();
+
+  if (aCurveType == GeomAbs_OffsetCurve)
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_OffsetCurve(*myAdaptorOwned, theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_OffsetCurve(*myAdaptorOwned);
+    }
+  }
+  else
+  {
+    if (theDomain.has_value())
+    {
+      myEvaluator = ExtremaPC2d_OtherCurve(*myAdaptorOwned, theDomain.value());
+    }
+    else
+    {
+      myEvaluator = ExtremaPC2d_OtherCurve(*myAdaptorOwned);
+    }
+  }
+}
+
+//=================================================================================================
+
+ExtremaPC2d_Curve::ExtremaPC2d_Curve(const occ::handle<Geom2d_Curve>& theCurve)
+    : myEvaluator(std::monostate{})
+{
+  if (theCurve.IsNull())
+  {
+    return;
+  }
+
+  // Check for trimmed curve - if so, use bounds
+  occ::handle<Geom2d_TrimmedCurve> aTrimmed = occ::down_cast<Geom2d_TrimmedCurve>(theCurve);
+  if (!aTrimmed.IsNull())
+  {
+    ExtremaPC2d::Domain1D aDomain(aTrimmed->FirstParameter(), aTrimmed->LastParameter());
+    initFromGeomCurve(aTrimmed->BasisCurve(), aDomain);
+    return;
+  }
+
+  // Initialize based on curve type - without setting domain (unbounded)
+  initFromGeomCurve(theCurve, std::nullopt);
+}
+
+//=================================================================================================
+
+ExtremaPC2d_Curve::ExtremaPC2d_Curve(const occ::handle<Geom2d_Curve>& theCurve,
+                                     double                           theUMin,
+                                     double                           theUMax)
+    : myEvaluator(std::monostate{})
+{
+  if (theCurve.IsNull())
+  {
+    return;
+  }
+
+  // Get base curve and effective bounds
+  occ::handle<Geom2d_Curve> aBaseCurve     = theCurve;
+  double                    aEffectiveUMin = theUMin;
+  double                    aEffectiveUMax = theUMax;
+
+  // For trimmed curve, intersect input bounds with trimmed bounds
+  occ::handle<Geom2d_TrimmedCurve> aTrimmed = occ::down_cast<Geom2d_TrimmedCurve>(theCurve);
+  if (!aTrimmed.IsNull())
+  {
+    aBaseCurve = aTrimmed->BasisCurve();
+    // Intersect bounds: take max of mins, min of maxs
+    aEffectiveUMin = std::max(theUMin, aTrimmed->FirstParameter());
+    aEffectiveUMax = std::min(theUMax, aTrimmed->LastParameter());
+  }
+
+  // Use common helper for curve type detection and evaluator creation
+  ExtremaPC2d::Domain1D aDomain(aEffectiveUMin, aEffectiveUMax);
+  initFromGeomCurve(aBaseCurve, aDomain);
+}
+
+//=================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_Curve::Perform(const gp_Pnt2d&         theP,
+                                                      double                  theTol,
+                                                      ExtremaPC2d::SearchMode theMode) const
+{
+  const ExtremaPC2d::Result* aResultPtr = &THE_NOT_DONE_RESULT;
+
+  std::visit(
+    [&](auto& theEval) {
+      using T = std::decay_t<decltype(theEval)>;
+      if constexpr (!std::is_same_v<T, std::monostate>)
+      {
+        aResultPtr = &theEval.Perform(theP, theTol, theMode);
+      }
+    },
+    myEvaluator);
+  return *aResultPtr;
+}
+
+//=================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_Curve::PerformWithEndpoints(
+  const gp_Pnt2d&         theP,
+  double                  theTol,
+  ExtremaPC2d::SearchMode theMode) const
+{
+  const ExtremaPC2d::Result* aResultPtr = &THE_NOT_DONE_RESULT;
+
+  std::visit(
+    [&](auto& theEval) {
+      using T = std::decay_t<decltype(theEval)>;
+      if constexpr (!std::is_same_v<T, std::monostate>)
+      {
+        aResultPtr = &theEval.PerformWithEndpoints(theP, theTol, theMode);
+      }
+    },
+    myEvaluator);
+  return *aResultPtr;
+}

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Curve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Curve.hxx
@@ -1,0 +1,158 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_Curve_HeaderFile
+#define _ExtremaPC2d_Curve_HeaderFile
+
+#include <ExtremaPC2d.hxx>
+#include <ExtremaPC2d_BezierCurve.hxx>
+#include <ExtremaPC2d_BSplineCurve.hxx>
+#include <ExtremaPC2d_Circle.hxx>
+#include <ExtremaPC2d_Ellipse.hxx>
+#include <ExtremaPC2d_Hyperbola.hxx>
+#include <ExtremaPC2d_Line.hxx>
+#include <ExtremaPC2d_OffsetCurve.hxx>
+#include <ExtremaPC2d_OtherCurve.hxx>
+#include <ExtremaPC2d_Parabola.hxx>
+#include <Geom2d_Curve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <gp_Pnt2d.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <variant>
+
+//! @brief Main aggregator for Point-Curve extrema computation.
+//!
+//! Provides a unified interface for computing extrema between a 2D point
+//! and any type of curve. Uses std::variant with std::visit for efficient
+//! curve type dispatch at runtime.
+//!
+//! Supports all elementary curve types (analytical solutions):
+//! - Line, Circle, Ellipse, Hyperbola, Parabola
+//!
+//! And numerical curves (derivative-aware multiple-root isolation):
+//! - BSpline, Bezier, Offset, and general curves
+//!
+//! @note The parameter domain is fixed at construction time. Numerical evaluators refresh their
+//!       parameter partition on Perform() so mutations of referenced geometry are observed.
+//!
+//! Usage example:
+//! @code
+//! ExtremaPC2d_Curve anExtPC(myAdaptorCurve);
+//! const ExtremaPC2d::Result& aResult = anExtPC.Perform(myPoint, 1.0e-9);
+//! if (aResult.IsDone())
+//! {
+//!   for (size_t i = 0; i < aResult.NbExt(); ++i)
+//!   {
+//!     double aDist = std::sqrt(aResult[i].SquareDistance);
+//!     gp_Pnt2d aPtOnCurve = aResult[i].Point;
+//!   }
+//! }
+//! @endcode
+class ExtremaPC2d_Curve
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Variant type holding all specialized evaluators.
+  using EvaluatorVariant = std::variant<std::monostate,
+                                        ExtremaPC2d_Line,
+                                        ExtremaPC2d_Circle,
+                                        ExtremaPC2d_Ellipse,
+                                        ExtremaPC2d_Hyperbola,
+                                        ExtremaPC2d_Parabola,
+                                        ExtremaPC2d_BezierCurve,
+                                        ExtremaPC2d_BSplineCurve,
+                                        ExtremaPC2d_OffsetCurve,
+                                        ExtremaPC2d_OtherCurve>;
+
+  //! Constructor with curve adaptor.
+  //! Uses the curve's natural parameter bounds as domain.
+  //! @param[in] theCurve curve adaptor; must outlive this evaluator when dispatched as an offset
+  //!                     or general curve
+  Standard_EXPORT explicit ExtremaPC2d_Curve(const Adaptor2d_Curve2d& theCurve);
+
+  //! Constructor with curve adaptor and parameter range.
+  //! @param[in] theCurve curve adaptor; must outlive this evaluator when dispatched as an offset
+  //!                     or general curve
+  //! @param[in] theUMin lower parameter bound
+  //! @param[in] theUMax upper parameter bound
+  Standard_EXPORT ExtremaPC2d_Curve(const Adaptor2d_Curve2d& theCurve,
+                                    double                   theUMin,
+                                    double                   theUMax);
+
+  //! Constructor with Geom2d_Curve.
+  //! For non-trimmed curves, uses the natural domain. Numerical offset and general
+  //! curves require this domain to be finite; otherwise Perform() returns InvalidInput.
+  //! For trimmed curves, uses the trimmed bounds as domain.
+  //! @param[in] theCurve geometric curve handle
+  Standard_EXPORT explicit ExtremaPC2d_Curve(const occ::handle<Geom2d_Curve>& theCurve);
+
+  //! Constructor with Geom2d_Curve and parameter range.
+  //! For trimmed curves, intersects input bounds with trimmed bounds.
+  //! @param[in] theCurve geometric curve handle
+  //! @param[in] theUMin lower parameter bound
+  //! @param[in] theUMax upper parameter bound
+  Standard_EXPORT ExtremaPC2d_Curve(const occ::handle<Geom2d_Curve>& theCurve,
+                                    double                           theUMin,
+                                    double                           theUMax);
+
+  ExtremaPC2d_Curve(const ExtremaPC2d_Curve&)            = delete;
+  ExtremaPC2d_Curve& operator=(const ExtremaPC2d_Curve&) = delete;
+  ExtremaPC2d_Curve(ExtremaPC2d_Curve&&)                 = delete;
+  ExtremaPC2d_Curve& operator=(ExtremaPC2d_Curve&&)      = delete;
+
+  //! Computes extrema between point P and the curve.
+  //! Uses domain specified at construction time.
+  //! @param[in] theP query point
+  //! @param[in] theTol tolerance for extrema computation
+  //! @param[in] theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing all found extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Computes extrema between point P and the curve, including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param[in] theP query point
+  //! @param[in] theTol tolerance for extrema computation
+  //! @param[in] theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Returns true if the evaluator is properly initialized.
+  bool IsInitialized() const { return !std::holds_alternative<std::monostate>(myEvaluator); }
+
+private:
+  //! Helper to initialize evaluator from an adaptor curve with curve-type switch.
+  //! @param[in] theCurve the adaptor curve
+  //! @param[in] theDomain parameter domain
+  void initFromAdaptor(const Adaptor2d_Curve2d& theCurve, const ExtremaPC2d::Domain1D& theDomain);
+
+  //! Helper method to initialize evaluator from a Geom2d_Curve.
+  //! Handles all curve type detection and evaluator creation.
+  //! @param[in] theCurve the curve to initialize from (must not be null)
+  //! @param[in] theDomain optional domain to use
+  void initFromGeomCurve(const occ::handle<Geom2d_Curve>&            theCurve,
+                         const std::optional<ExtremaPC2d::Domain1D>& theDomain);
+
+  EvaluatorVariant               myEvaluator;            //!< Specialized evaluator
+  const Adaptor2d_Curve2d*       myAdaptorRef = nullptr; //!< Non-owning numerical adaptor
+  occ::handle<Adaptor2d_Curve2d> myAdaptorOwned;         //!< Adaptor for Geom2d_Curve input
+};
+
+#endif // _ExtremaPC2d_Curve_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_DistanceFunction.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_DistanceFunction.hxx
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_DistanceFunction_HeaderFile
+#define _ExtremaPC2d_DistanceFunction_HeaderFile
+
+#include <Adaptor2d_Curve2d.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <gp.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+//! @brief Distance function for point-curve extrema computation.
+//!
+//! Implements the normalized stationarity function
+//! F(u) = (C(u) - P) . C'(u) / |C'(u)| and its derivative.
+//! Normalization gives F geometric length units and makes tolerance behavior
+//! independent of regular curve reparameterization.
+//!
+//! The roots of F(u) = 0 correspond to the extrema (local minima and maxima)
+//! of the squared distance function D(u) = ||C(u) - P||^2.
+//!
+//! This class provides the interface required by MathRoot::FindAllRootsWithDerivative.
+class ExtremaPC2d_DistanceFunction
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor.
+  //! @param theCurve the curve adaptor
+  //! @param theP the query point
+  ExtremaPC2d_DistanceFunction(const Adaptor2d_Curve2d& theCurve, const gp_Pnt2d& theP)
+      : myCurve(&theCurve),
+        myP(theP)
+  {
+  }
+
+  //! Computes F(u) = (C(u) - P) . C'(u) / |C'(u)|.
+  //! @param theU parameter value
+  //! @param theF output: function value
+  //! @return true if computation succeeded
+  bool Value(double theU, double& theF) const
+  {
+    gp_Pnt2d aPt;
+    gp_Vec2d aD1;
+    myCurve->D1(theU, aPt, aD1);
+
+    gp_Vec2d aVec(myP, aPt);
+    const double aSpeed = aD1.Magnitude();
+    if (aSpeed <= gp::Resolution())
+    {
+      // The normalized function has no defined direction at a singular parameter.
+      // Its continuous one-sided signs are used later for extrema classification.
+      theF = 0.0;
+      return true;
+    }
+    theF = aVec.Dot(aD1) / aSpeed;
+    return true;
+  }
+
+  //! Computes F(u) and F'(u).
+  //! Computes the normalized stationarity function and its derivative.
+  //! @param theU parameter value
+  //! @param theF output: function value
+  //! @param theDF output: derivative value
+  //! @return true if computation succeeded
+  bool Values(double theU, double& theF, double& theDF) const
+  {
+    gp_Pnt2d aPt;
+    gp_Vec2d aD1, aD2;
+    myCurve->D2(theU, aPt, aD1, aD2);
+
+    gp_Vec2d aVec(myP, aPt);
+    const double aSpeed = aD1.Magnitude();
+    if (aSpeed <= gp::Resolution())
+    {
+      theF  = 0.0;
+      theDF = 0.0;
+      return true;
+    }
+    const double aRawF = aVec.Dot(aD1);
+    theF                = aRawF / aSpeed;
+    theDF = (aD1.Dot(aD1) + aVec.Dot(aD2)) / aSpeed
+            - aRawF * aD1.Dot(aD2) / (aSpeed * aSpeed * aSpeed);
+    return true;
+  }
+
+  //! Computes the derivative F'(u).
+  //! @param theU parameter value
+  //! @param theDF output: derivative value
+  //! @return true if computation succeeded
+  bool Derivative(double theU, double& theDF) const
+  {
+    double aF;
+    return Values(theU, aF, theDF);
+  }
+
+  //! Returns the first parameter of the curve.
+  double FirstParameter() const { return myCurve->FirstParameter(); }
+
+  //! Returns the last parameter of the curve.
+  double LastParameter() const { return myCurve->LastParameter(); }
+
+  //! Returns the query point.
+  const gp_Pnt2d& Point() const { return myP; }
+
+  //! Returns the curve.
+  const Adaptor2d_Curve2d& Curve() const { return *myCurve; }
+
+private:
+  const Adaptor2d_Curve2d* myCurve; //!< Curve adaptor (not owned)
+  gp_Pnt2d                 myP;     //!< Query point
+};
+
+#endif // _ExtremaPC2d_DistanceFunction_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_DistanceFunction.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_DistanceFunction.hxx
@@ -55,7 +55,7 @@ public:
     gp_Vec2d aD1;
     myCurve->D1(theU, aPt, aD1);
 
-    gp_Vec2d aVec(myP, aPt);
+    gp_Vec2d     aVec(myP, aPt);
     const double aSpeed = aD1.Magnitude();
     if (aSpeed <= gp::Resolution())
     {
@@ -80,7 +80,7 @@ public:
     gp_Vec2d aD1, aD2;
     myCurve->D2(theU, aPt, aD1, aD2);
 
-    gp_Vec2d aVec(myP, aPt);
+    gp_Vec2d     aVec(myP, aPt);
     const double aSpeed = aD1.Magnitude();
     if (aSpeed <= gp::Resolution())
     {
@@ -89,9 +89,9 @@ public:
       return true;
     }
     const double aRawF = aVec.Dot(aD1);
-    theF                = aRawF / aSpeed;
-    theDF = (aD1.Dot(aD1) + aVec.Dot(aD2)) / aSpeed
-            - aRawF * aD1.Dot(aD2) / (aSpeed * aSpeed * aSpeed);
+    theF               = aRawF / aSpeed;
+    theDF =
+      (aD1.Dot(aD1) + aVec.Dot(aD2)) / aSpeed - aRawF * aD1.Dot(aD2) / (aSpeed * aSpeed * aSpeed);
     return true;
   }
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Ellipse.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Ellipse.hxx
@@ -95,7 +95,7 @@ public:
   //! @return const reference to result containing extrema or InfiniteSolutions status
   [[nodiscard]] const ExtremaPC2d::Result& Perform(
     const gp_Pnt2d&         theP,
-    double                theTol,
+    double                  theTol,
     ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
   {
     if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
@@ -128,7 +128,7 @@ public:
   //! status
   [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
     const gp_Pnt2d&         theP,
-    double                theTol,
+    double                  theTol,
     ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
   {
     if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
@@ -143,8 +143,8 @@ public:
     {
       myResult.Clear();
       ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
-      myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
-                                                   : ExtremaPC2d::Status::OK;
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
       return myResult;
     }
 
@@ -157,12 +157,7 @@ public:
     {
       const bool isClosed =
         ExtremaPC2d::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
-      ExtremaPC2d::AddEndpointExtrema(myResult,
-                                    theP,
-                                    *myDomain,
-                                    *this,
-                                    theMode,
-                                    isClosed);
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, isClosed);
       if (!myResult.Extrema.IsEmpty())
       {
         myResult.Status = ExtremaPC2d::Status::OK;
@@ -180,7 +175,7 @@ private:
   //! Stores results in myResult.
   void performCore(const gp_Pnt2d&              theP,
                    const ExtremaPC2d::Domain1D& theDomain,
-                   double                     theTol,
+                   double                       theTol,
                    ExtremaPC2d::SearchMode      theMode) const
   {
     myResult.Clear();
@@ -196,11 +191,11 @@ private:
     const double theUMax = theDomain.Max;
 
     const gp_Pnt2d& aCenter = myEllipse.Location();
-    const double aA = myEllipse.MajorRadius();
-    const double aB = myEllipse.MinorRadius();
+    const double    aA      = myEllipse.MajorRadius();
+    const double    aB      = myEllipse.MinorRadius();
 
     const gp_Vec2d aOPp(aCenter, theP);
-    const double aOPpMag = aOPp.Magnitude();
+    const double   aOPpMag = aOPp.Magnitude();
 
     // Check for degenerate case: point at center with circular ellipse
     if (aOPpMag <= gp::Resolution())
@@ -234,7 +229,7 @@ private:
     if (aTrigRes.InfiniteRoots)
     {
       myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
-      const gp_Pnt2d aPtOnCurve         = ElCLib::Value(0.0, myEllipse);
+      const gp_Pnt2d aPtOnCurve       = ElCLib::Value(0.0, myEllipse);
       myResult.InfiniteSquareDistance = theP.SquareDistance(aPtOnCurve);
       return;
     }
@@ -254,9 +249,9 @@ private:
     const bool isClosedDomain =
       ExtremaPC2d::IsClosedPeriodicDomain(theDomain, 2.0 * M_PI, Precision::Angular());
     bool hasEnumerationError = false;
-    auto addExtremum = [&](double aU, bool theIsMin) {
-      aU += std::ceil((theUMin - aU - ExtremaPC2d::THE_PARAM_TOLERANCE) / (2.0 * M_PI))
-            * (2.0 * M_PI);
+    auto addExtremum         = [&](double aU, bool theIsMin) {
+      aU +=
+        std::ceil((theUMin - aU - ExtremaPC2d::THE_PARAM_TOLERANCE) / (2.0 * M_PI)) * (2.0 * M_PI);
       if (std::abs(aU - theUMin) <= ExtremaPC2d::THE_PARAM_TOLERANCE)
       {
         aU = theUMin;
@@ -291,8 +286,8 @@ private:
           hasEnumerationError = true;
           return;
         }
-        aPreviousParameter = aParameter;
-        const gp_Pnt2d aCurvePt = ElCLib::Value(aParameter, myEllipse);
+        aPreviousParameter                   = aParameter;
+        const gp_Pnt2d              aCurvePt = ElCLib::Value(aParameter, myEllipse);
         ExtremaPC2d::ExtremumResult anExt;
         anExt.Parameter      = aParameter;
         anExt.Point          = aCurvePt;
@@ -303,7 +298,7 @@ private:
       }
     };
 
-    std::array<double, 4> aCanonicalRoots = {};
+    std::array<double, 4> aCanonicalRoots   = {};
     size_t                aNbCanonicalRoots = 0;
     for (size_t aRootIndex = 0; aRootIndex < aTrigRes.NbRoots; ++aRootIndex)
     {
@@ -337,10 +332,10 @@ private:
     for (size_t i = 0; i < aNbCanonicalRoots; ++i)
     {
       const double aRoot = aCanonicalRoots[i];
-      const double aPrev = i == 0 ? aCanonicalRoots[aNbCanonicalRoots - 1] - 2.0 * M_PI
-                                  : aCanonicalRoots[i - 1];
-      const double aNext = i + 1 == aNbCanonicalRoots ? aCanonicalRoots[0] + 2.0 * M_PI
-                                                      : aCanonicalRoots[i + 1];
+      const double aPrev =
+        i == 0 ? aCanonicalRoots[aNbCanonicalRoots - 1] - 2.0 * M_PI : aCanonicalRoots[i - 1];
+      const double aNext =
+        i + 1 == aNbCanonicalRoots ? aCanonicalRoots[0] + 2.0 * M_PI : aCanonicalRoots[i + 1];
       const double aLeftValue  = stationarity((aPrev + aRoot) * 0.5);
       const double aRightValue = stationarity((aRoot + aNext) * 0.5);
       const bool   isMinimum   = aLeftValue < 0.0 && aRightValue > 0.0;
@@ -357,8 +352,8 @@ private:
       }
     }
 
-    myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
-                                                 : ExtremaPC2d::Status::OK;
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
   }
 
   gp_Elips2d                           myEllipse; //!< Ellipse geometry

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Ellipse.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Ellipse.hxx
@@ -1,0 +1,369 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_Ellipse_HeaderFile
+#define _ExtremaPC2d_Ellipse_HeaderFile
+
+#include <ElCLib.hxx>
+#include <ExtremaPC2d.hxx>
+#include <gp_Elips2d.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <MathRoot_Trig.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <cmath>
+#include <optional>
+
+//! @brief Point-Ellipse extrema computation.
+//!
+//! Computes the extrema between a 2D point and an ellipse.
+//! Uses trigonometric equation solving via MathRoot::Trigonometric.
+//!
+//! The algorithm:
+//! Solves: (B^2 - A^2)*cos(u)*sin(u) - B*Y*cos(u) + A*X*sin(u) = 0
+//!    where A = major radius, B = minor radius, and (X,Y) are coordinates
+//!    of Pp in the ellipse local coordinate system.
+//!
+//! @note Degenerate case: When P projects to the ellipse center and A = B
+//!       (i.e., the ellipse is a circle), returns Status::InfiniteSolutions.
+//!
+//! @note An ellipse can have up to 4 extrema.
+//!
+//! The domain is fixed at construction time for optimal performance.
+//! For full ellipse, construct without domain or with nullopt.
+class ExtremaPC2d_Ellipse
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with ellipse geometry (full ellipse).
+  //! @param[in] theEllipse the ellipse to compute extrema for
+  explicit ExtremaPC2d_Ellipse(const gp_Elips2d& theEllipse)
+      : myEllipse(theEllipse),
+        myDomain(std::nullopt)
+  {
+  }
+
+  //! Constructor with ellipse geometry and parameter domain.
+  //! @param[in] theEllipse the ellipse to compute extrema for
+  //! @param[in] theDomain parameter domain in radians (fixed for all queries)
+  ExtremaPC2d_Ellipse(const gp_Elips2d& theEllipse, const ExtremaPC2d::Domain1D& theDomain)
+      : myEllipse(theEllipse),
+        myDomain(theDomain)
+  {
+  }
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_Ellipse(const ExtremaPC2d_Ellipse&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_Ellipse& operator=(const ExtremaPC2d_Ellipse&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_Ellipse(ExtremaPC2d_Ellipse&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_Ellipse& operator=(ExtremaPC2d_Ellipse&&) = default;
+
+  //! Evaluates point on ellipse at parameter.
+  //! @param theU parameter (radians)
+  //! @return point on ellipse
+  gp_Pnt2d Value(double theU) const { return ElCLib::Value(theU, myEllipse); }
+
+  //! Returns true if domain is bounded (partial arc).
+  bool IsBounded() const { return myDomain.has_value(); }
+
+  //! Returns the domain (only valid if IsBounded() is true).
+  const ExtremaPC2d::Domain1D& Domain() const { return *myDomain; }
+
+  //! Compute extrema between point P and the ellipse.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for degenerate case detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema or InfiniteSolutions status
+  [[nodiscard]] const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::NoSolution;
+      return myResult;
+    }
+
+    // Use stored domain or full parameter range [0, 2*PI]
+    ExtremaPC2d::Domain1D aDomain = myDomain.value_or(ExtremaPC2d::Domain1D{0.0, 2.0 * M_PI});
+    performCore(theP, aDomain, theTol, theMode);
+    return myResult;
+  }
+
+  //! Compute extrema between point P and the ellipse arc including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for degenerate case detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema or InfiniteSolutions
+  //! status
+  [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
+                                                   : ExtremaPC2d::Status::OK;
+      return myResult;
+    }
+
+    (void)Perform(theP, theTol, theMode);
+
+    // Add endpoints if interior computation succeeded and domain is bounded
+    if ((myResult.Status == ExtremaPC2d::Status::OK
+         || myResult.Status == ExtremaPC2d::Status::NoSolution)
+        && myDomain.has_value())
+    {
+      const bool isClosed =
+        ExtremaPC2d::IsClosedPeriodicDomain(*myDomain, 2.0 * M_PI, Precision::Angular());
+      ExtremaPC2d::AddEndpointExtrema(myResult,
+                                    theP,
+                                    *myDomain,
+                                    *this,
+                                    theMode,
+                                    isClosed);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC2d::Status::OK;
+      }
+    }
+
+    return myResult;
+  }
+
+  //! Returns the ellipse geometry.
+  const gp_Elips2d& Ellipse() const { return myEllipse; }
+
+private:
+  //! Core algorithm - finds extrema with bounds checking.
+  //! Stores results in myResult.
+  void performCore(const gp_Pnt2d&              theP,
+                   const ExtremaPC2d::Domain1D& theDomain,
+                   double                     theTol,
+                   ExtremaPC2d::SearchMode      theMode) const
+  {
+    myResult.Clear();
+
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || !theDomain.IsValid())
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return;
+    }
+
+    const double theUMin = theDomain.Min;
+    const double theUMax = theDomain.Max;
+
+    const gp_Pnt2d& aCenter = myEllipse.Location();
+    const double aA = myEllipse.MajorRadius();
+    const double aB = myEllipse.MinorRadius();
+
+    const gp_Vec2d aOPp(aCenter, theP);
+    const double aOPpMag = aOPp.Magnitude();
+
+    // Check for degenerate case: point at center with circular ellipse
+    if (aOPpMag <= gp::Resolution())
+    {
+      if (aA == aB)
+      {
+        // Point at center of a circle - infinite solutions
+        myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+        myResult.InfiniteSquareDistance = aA * aA;
+        return;
+      }
+      // For non-circular ellipse at center, we still get valid extrema at semi-axes
+    }
+
+    // Local coordinates
+    const double aX = aOPp.Dot(gp_Vec2d(myEllipse.Axis().XDirection()));
+    const double aY = aOPp.Dot(gp_Vec2d(myEllipse.Axis().YDirection()));
+
+    // Step 3: Solve trigonometric equation
+    // (B^2 - A^2)*cos*sin - B*Y*cos + A*X*sin = 0
+    // In MathRoot::Trigonometric form: a*cos^2 + 2*b*cos*sin + c*cos + d*sin + e = 0
+    // a = 0, 2*b = (B^2 - A^2), c = -B*Y, d = A*X, e = 0
+    double aKo2 = (aB * aB - aA * aA) / 2.0;
+    double aKo3 = -aB * aY;
+    double aKo4 = aA * aX;
+
+    // MathRoot::Trigonometric handles all special cases including Y ~= 0
+    MathRoot::TrigResult aTrigRes =
+      MathRoot::Trigonometric(0.0, aKo2, aKo3, aKo4, 0.0, 0.0, 2.0 * M_PI);
+
+    if (aTrigRes.InfiniteRoots)
+    {
+      myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+      const gp_Pnt2d aPtOnCurve         = ElCLib::Value(0.0, myEllipse);
+      myResult.InfiniteSquareDistance = theP.SquareDistance(aPtOnCurve);
+      return;
+    }
+    if (!aTrigRes.IsDone())
+    {
+      myResult.Status = ExtremaPC2d::Status::NumericalError;
+      return;
+    }
+
+    // Step 4: Collect extrema
+    auto stationarity = [&](double theU) {
+      const double aCos = std::cos(theU);
+      const double aSin = std::sin(theU);
+      return (aB * aB - aA * aA) * aCos * aSin - aB * aY * aCos + aA * aX * aSin;
+    };
+
+    const bool isClosedDomain =
+      ExtremaPC2d::IsClosedPeriodicDomain(theDomain, 2.0 * M_PI, Precision::Angular());
+    bool hasEnumerationError = false;
+    auto addExtremum = [&](double aU, bool theIsMin) {
+      aU += std::ceil((theUMin - aU - ExtremaPC2d::THE_PARAM_TOLERANCE) / (2.0 * M_PI))
+            * (2.0 * M_PI);
+      if (std::abs(aU - theUMin) <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+      {
+        aU = theUMin;
+      }
+      // Filter by search mode
+      if (theMode == ExtremaPC2d::SearchMode::Min && !theIsMin)
+      {
+        return;
+      }
+      if (theMode == ExtremaPC2d::SearchMode::Max && theIsMin)
+      {
+        return;
+      }
+
+      size_t aNbRepresentatives = 0;
+      if (!MathRoot::Utils::ComputePeriodicRootCount(aU,
+                                                     theUMax,
+                                                     2.0 * M_PI,
+                                                     ExtremaPC2d::THE_PARAM_TOLERANCE,
+                                                     isClosedDomain,
+                                                     aNbRepresentatives))
+      {
+        hasEnumerationError = true;
+        return;
+      }
+      double aPreviousParameter = 0.0;
+      for (size_t aPeriodIndex = 0; aPeriodIndex < aNbRepresentatives; ++aPeriodIndex)
+      {
+        const double aParameter = aU + static_cast<double>(aPeriodIndex) * (2.0 * M_PI);
+        if (aPeriodIndex > 0 && aParameter <= aPreviousParameter)
+        {
+          hasEnumerationError = true;
+          return;
+        }
+        aPreviousParameter = aParameter;
+        const gp_Pnt2d aCurvePt = ElCLib::Value(aParameter, myEllipse);
+        ExtremaPC2d::ExtremumResult anExt;
+        anExt.Parameter      = aParameter;
+        anExt.Point          = aCurvePt;
+        anExt.SquareDistance = theP.SquareDistance(aCurvePt);
+        anExt.IsMinimum      = theIsMin;
+        anExt.IsMaximum      = !theIsMin;
+        myResult.Extrema.Append(anExt);
+      }
+    };
+
+    std::array<double, 4> aCanonicalRoots = {};
+    size_t                aNbCanonicalRoots = 0;
+    for (size_t aRootIndex = 0; aRootIndex < aTrigRes.NbRoots; ++aRootIndex)
+    {
+      double aRoot = std::fmod(aTrigRes.Roots[aRootIndex], 2.0 * M_PI);
+      if (aRoot < 0.0)
+      {
+        aRoot += 2.0 * M_PI;
+      }
+      if (aRoot >= 2.0 * M_PI - ExtremaPC2d::THE_PARAM_TOLERANCE)
+      {
+        aRoot = 0.0;
+      }
+
+      bool isDuplicate = false;
+      for (size_t anIndex = 0; anIndex < aNbCanonicalRoots; ++anIndex)
+      {
+        if (std::abs(aCanonicalRoots[anIndex] - aRoot) < ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          isDuplicate = true;
+          break;
+        }
+      }
+      if (!isDuplicate)
+      {
+        aCanonicalRoots[aNbCanonicalRoots++] = aRoot;
+      }
+    }
+    std::sort(aCanonicalRoots.begin(), aCanonicalRoots.begin() + aNbCanonicalRoots);
+
+    // Classify canonical roots and lift one representative into the requested domain.
+    for (size_t i = 0; i < aNbCanonicalRoots; ++i)
+    {
+      const double aRoot = aCanonicalRoots[i];
+      const double aPrev = i == 0 ? aCanonicalRoots[aNbCanonicalRoots - 1] - 2.0 * M_PI
+                                  : aCanonicalRoots[i - 1];
+      const double aNext = i + 1 == aNbCanonicalRoots ? aCanonicalRoots[0] + 2.0 * M_PI
+                                                      : aCanonicalRoots[i + 1];
+      const double aLeftValue  = stationarity((aPrev + aRoot) * 0.5);
+      const double aRightValue = stationarity((aRoot + aNext) * 0.5);
+      const bool   isMinimum   = aLeftValue < 0.0 && aRightValue > 0.0;
+      const bool   isMaximum   = aLeftValue > 0.0 && aRightValue < 0.0;
+      if (isMinimum || isMaximum)
+      {
+        addExtremum(aRoot, isMinimum);
+        if (hasEnumerationError)
+        {
+          myResult.Clear();
+          myResult.Status = ExtremaPC2d::Status::NumericalError;
+          return;
+        }
+      }
+    }
+
+    myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
+                                                 : ExtremaPC2d::Status::OK;
+  }
+
+  gp_Elips2d                           myEllipse; //!< Ellipse geometry
+  std::optional<ExtremaPC2d::Domain1D> myDomain;  //!< Parameter domain (nullopt for full ellipse)
+  mutable ExtremaPC2d::Result          myResult;  //!< Reusable result storage
+};
+
+#endif // _ExtremaPC2d_Ellipse_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_GridEvaluator.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_GridEvaluator.hxx
@@ -368,7 +368,7 @@ private:
       {
         const size_t      aSecondIndex = aResultIndex - anIndex;
         const long double aFactor      = aDegreeBinomial[anIndex] * aDegreeBinomial[aSecondIndex]
-                                         / aDoubleDegreeBinomial[aResultIndex];
+                                    / aDoubleDegreeBinomial[aResultIndex];
         aDistance +=
           aFactor * (aQx[anIndex] * aQx[aSecondIndex] + aQy[anIndex] * aQy[aSecondIndex]);
         aWeight += aFactor * aWeights[anIndex] * aWeights[aSecondIndex];

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_GridEvaluator.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_GridEvaluator.hxx
@@ -1,0 +1,820 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_GridEvaluator_HeaderFile
+#define _ExtremaPC2d_GridEvaluator_HeaderFile
+
+#include <Adaptor2d_Curve2d.hxx>
+#include <Extrema_Curve2dTool.hxx>
+#include <ExtremaPC2d.hxx>
+#include <ExtremaPC2d_DistanceFunction.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <GeomAbs_Shape.hxx>
+#include <math_Vector.hxx>
+#include <MathRoot_Multiple.hxx>
+#include <NCollection_Array1.hxx>
+#include <NCollection_LinearVector.hxx>
+#include <NCollection_LocalArray.hxx>
+#include <Standard_Failure.hxx>
+#include <Standard_ErrorHandler.hxx>
+
+#include <algorithm>
+#include <cmath>
+#include <optional>
+
+//! @brief Numerical point-curve extrema computation over a cached parameter partition.
+//!
+//! Each adjacent parameter pair is solved independently, making non-uniform knot- and
+//! curvature-aware distributions effective. C2 continuity bounds are inserted into the
+//! partition and classified separately from ordinary sampling boundaries.
+class ExtremaPC2d_GridEvaluator
+{
+public:
+  //! Default constructor.
+  ExtremaPC2d_GridEvaluator() = default;
+
+  //! Stores ordered parameter values defining the numerical search partition.
+  //! @param[in] theParams ordered parameter values
+  void SetParams(const math_Vector& theParams)
+  {
+    const size_t aNbParams = theParams.Size();
+    if (aNbParams == 0)
+    {
+      myParams.Clear();
+      return;
+    }
+
+    myParams.Resize(aNbParams);
+    for (size_t anIndex = 0; anIndex < aNbParams; ++anIndex)
+    {
+      myParams[anIndex] = theParams.At(anIndex);
+    }
+  }
+
+  //! Returns mutable reference to the result for post-processing.
+  ExtremaPC2d::Result& Result() const { return myResult; }
+
+  //! Performs extrema computation using the cached parameter partition.
+  [[nodiscard]] const ExtremaPC2d::Result& Perform(const Adaptor2d_Curve2d&     theCurve,
+                                                   const gp_Pnt2d&              theP,
+                                                   const ExtremaPC2d::Domain1D& theDomain,
+                                                   double                       theTol,
+                                                   ExtremaPC2d::SearchMode      theMode) const
+  {
+    myResult.Clear();
+    if (!theDomain.IsValid() || !ExtremaPC2d::IsValidTolerance(theTol)
+        || !ExtremaPC2d::IsFinitePoint(theP))
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+    if (theDomain.Min == theDomain.Max)
+    {
+      myResult.Status = ExtremaPC2d::Status::NoSolution;
+      return myResult;
+    }
+    if (!validateParams(theDomain))
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    const std::optional<double> aConstantDistance =
+      constantSquareDistance(theCurve, theP, theDomain);
+    if (aConstantDistance.has_value())
+    {
+      myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+      myResult.InfiniteSquareDistance = aConstantDistance.value();
+      return myResult;
+    }
+
+    myContinuityBounds.Clear();
+    myPartition.Clear();
+    buildPartition(theCurve, theDomain, myContinuityBounds, myPartition);
+
+    MathRoot::MultipleConfig aConfig;
+    aConfig.NbSamples     = 2;
+    aConfig.XTolerance    = ExtremaPC2d::THE_PARAM_TOLERANCE;
+    aConfig.FTolerance    = theTol;
+    aConfig.NullTolerance = theTol;
+
+    myRoots.Clear();
+    for (size_t anInterval = 0; anInterval + 1 < myPartition.Size(); ++anInterval)
+    {
+      const double aLower  = myPartition.Value(anInterval);
+      const double anUpper = myPartition.Value(anInterval + 1);
+      if (anUpper - aLower <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+      {
+        continue;
+      }
+      occ::handle<Adaptor2d_Curve2d> aLocalCurve;
+      try
+      {
+        OCC_CATCH_SIGNALS
+        aLocalCurve = theCurve.Trim(aLower, anUpper, Precision::PConfusion());
+      }
+      catch (const Standard_Failure&)
+      {
+        // Some custom adaptors support evaluation but do not implement Trim().
+      }
+      const Adaptor2d_Curve2d& aCurveForInterval = aLocalCurve.IsNull() ? theCurve : *aLocalCurve;
+      ExtremaPC2d_DistanceFunction aLocalFunction(aCurveForInterval, theP);
+      MathRoot::MultipleResult     anIntervalRoots;
+      try
+      {
+        OCC_CATCH_SIGNALS
+        anIntervalRoots =
+          MathRoot::FindAllRootsWithDerivative(aLocalFunction, aLower, anUpper, aConfig);
+      }
+      catch (const Standard_Failure&)
+      {
+        myResult.Status = ExtremaPC2d::Status::NumericalError;
+        return myResult;
+      }
+      if (!anIntervalRoots.IsDone())
+      {
+        myResult.Status = ExtremaPC2d::Status::NumericalError;
+        return myResult;
+      }
+      if (anIntervalRoots.IsAllNull)
+      {
+        MathRoot::MultipleConfig aRetryConfig = aConfig;
+        aRetryConfig.FTolerance    = std::min(theTol, ExtremaPC2d::THE_DEFAULT_TOLERANCE);
+        aRetryConfig.NullTolerance = 0.0;
+        try
+        {
+          OCC_CATCH_SIGNALS
+          anIntervalRoots =
+            MathRoot::FindAllRootsWithDerivative(aLocalFunction, aLower, anUpper, aRetryConfig);
+        }
+        catch (const Standard_Failure&)
+        {
+          myResult.Status = ExtremaPC2d::Status::NumericalError;
+          return myResult;
+        }
+        if (!anIntervalRoots.IsDone() || anIntervalRoots.IsAllNull)
+        {
+          myResult.Status = ExtremaPC2d::Status::NumericalError;
+          return myResult;
+        }
+      }
+      for (size_t aRootIndex = 0; aRootIndex < anIntervalRoots.NbRoots(); ++aRootIndex)
+      {
+        appendRoot(myRoots, RootCandidate{anIntervalRoots[aRootIndex], aLower, anUpper});
+      }
+    }
+    ExtremaPC2d_DistanceFunction aFunction(theCurve, theP);
+    const bool                   isClosed = IsClosedDomain(theCurve, theDomain);
+    try
+    {
+      OCC_CATCH_SIGNALS
+      classifyRoots(theCurve,
+                    theP,
+                    theDomain,
+                    aFunction,
+                    myContinuityBounds,
+                    myRoots,
+                    theTol,
+                    theMode);
+      classifyJunctions(theCurve,
+                        theP,
+                        theDomain,
+                        aFunction,
+                        myContinuityBounds,
+                        myPartition,
+                        myRoots,
+                        isClosed,
+                        theTol,
+                        theMode);
+    }
+    catch (const Standard_Failure&)
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::NumericalError;
+      return myResult;
+    }
+
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
+    return myResult;
+  }
+
+  //! Builds a uniform parameter partition.
+  static math_Vector BuildUniformParams(double theUMin, double theUMax, size_t theNbSamples)
+  {
+    Standard_RangeError_Raise_if(theNbSamples < 2, "ExtremaPC2d_GridEvaluator::BuildUniformParams");
+    math_Vector  aParams(theNbSamples);
+    const double aStep = (theUMax - theUMin) / static_cast<double>(theNbSamples - 1);
+    for (size_t anIndex = 0; anIndex < theNbSamples; ++anIndex)
+    {
+      aParams.ChangeAt(anIndex) = theUMin + static_cast<double>(anIndex) * aStep;
+    }
+    aParams.ChangeAt(theNbSamples - 1) = theUMax;
+    return aParams;
+  }
+
+  //! Builds a deflection-aware partition within each C2-smooth curve interval.
+  static math_Vector BuildCurveAwareParams(const Adaptor2d_Curve2d&     theCurve,
+                                           const ExtremaPC2d::Domain1D& theDomain)
+  {
+    try
+    {
+      OCC_CATCH_SIGNALS
+      NCollection_LinearVector<double> aParameters;
+      insertParameter(aParameters, theDomain.Min);
+      insertParameter(aParameters, theDomain.Max);
+
+      const int                          aNbIntervals = theCurve.NbIntervals(GeomAbs_C2);
+      NCollection_LocalArray<double, 32> anIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
+      NCollection_Array1<double>         anIntervals(anIntervalStorage[0], 1, aNbIntervals + 1);
+      theCurve.Intervals(anIntervals, GeomAbs_C2);
+      for (size_t anInterval = 0; anInterval + 1 < anIntervals.Size(); ++anInterval)
+      {
+        const double aLower  = theDomain.Clamp(anIntervals.At(anInterval));
+        const double anUpper = theDomain.Clamp(anIntervals.At(anInterval + 1));
+        if (anUpper - aLower <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          continue;
+        }
+
+        insertParameter(aParameters, aLower);
+        insertParameter(aParameters, anUpper);
+        occ::handle<Adaptor2d_Curve2d> aLocalCurve =
+          theCurve.Trim(aLower, anUpper, Precision::PConfusion());
+        if (aLocalCurve.IsNull())
+        {
+          continue;
+        }
+
+        const occ::handle<NCollection_HArray1<double>> aDeflectionParameters =
+          Extrema_Curve2dTool::DeflCurvIntervals(*aLocalCurve);
+        if (aDeflectionParameters.IsNull())
+        {
+          continue;
+        }
+        for (double aParameter : aDeflectionParameters->Array1())
+        {
+          insertParameter(aParameters, ExtremaPC2d::Domain1D(aLower, anUpper).Clamp(aParameter));
+        }
+      }
+
+      math_Vector aResult(aParameters.Size());
+      for (size_t anIndex = 0; anIndex < aParameters.Size(); ++anIndex)
+      {
+        aResult.ChangeAt(anIndex) = aParameters.Value(anIndex);
+      }
+      return aResult;
+    }
+    catch (const Standard_Failure&)
+    {
+      return BuildUniformParams(theDomain.Min,
+                                theDomain.Max,
+                                ExtremaPC2d::THE_OTHER_CURVE_NB_SAMPLES);
+    }
+  }
+
+  //! Returns true when the domain endpoints represent the same curve point.
+  static bool IsClosedDomain(const Adaptor2d_Curve2d&     theCurve,
+                             const ExtremaPC2d::Domain1D& theDomain)
+  {
+    if (!theDomain.IsFinite() || theDomain.Min == theDomain.Max)
+    {
+      return false;
+    }
+    try
+    {
+      OCC_CATCH_SIGNALS
+      if (theCurve.IsPeriodic()
+          && ExtremaPC2d::IsClosedPeriodicDomain(theDomain,
+                                                 theCurve.Period(),
+                                                 ExtremaPC2d::THE_PARAM_TOLERANCE))
+      {
+        return true;
+      }
+      return theCurve.Value(theDomain.Min).SquareDistance(theCurve.Value(theDomain.Max)) == 0.0;
+    }
+    catch (const Standard_Failure&)
+    {
+      return false;
+    }
+  }
+
+private:
+  //! Builds one complete binomial row in extended precision.
+  static void fillBinomialRow(size_t theDegree, long double* theCoefficients)
+  {
+    theCoefficients[0] = 1.0L;
+    for (size_t anIndex = 1; anIndex <= theDegree; ++anIndex)
+    {
+      theCoefficients[anIndex] =
+        theCoefficients[anIndex - 1] * static_cast<long double>(theDegree - anIndex + 1) / anIndex;
+    }
+  }
+
+  //! Certifies constant distance for a rational Bezier from its homogeneous polynomial.
+  static std::optional<double> rationalBezierSquareDistance(
+    const occ::handle<Geom2d_BezierCurve>& theCurve,
+    const gp_Pnt2d&                        thePoint)
+  {
+    if (theCurve.IsNull() || !theCurve->IsRational())
+    {
+      return std::nullopt;
+    }
+
+    const size_t aDegree = static_cast<size_t>(theCurve->Degree());
+    // Geom2d_BezierCurve is limited to degree 25, so these workspaces stay on the stack.
+    NCollection_LocalArray<long double, 32> aQx(aDegree + 1);
+    NCollection_LocalArray<long double, 32> aQy(aDegree + 1);
+    NCollection_LocalArray<long double, 32> aWeights(aDegree + 1);
+    for (size_t anIndex = 0; anIndex <= aDegree; ++anIndex)
+    {
+      const int       aPoleIndex = static_cast<int>(anIndex + 1);
+      const double    aWeight    = theCurve->Weight(aPoleIndex);
+      const gp_Pnt2d& aPole      = theCurve->Pole(aPoleIndex);
+      aWeights[anIndex]          = aWeight;
+      aQx[anIndex]               = aWeight * (aPole.X() - thePoint.X());
+      aQy[anIndex]               = aWeight * (aPole.Y() - thePoint.Y());
+    }
+
+    const size_t                            aDoubleDegree = 2 * aDegree;
+    NCollection_LocalArray<long double, 64> aDistanceCoefficients(aDoubleDegree + 1);
+    NCollection_LocalArray<long double, 64> aWeightCoefficients(aDoubleDegree + 1);
+    NCollection_LocalArray<long double, 32> aDegreeBinomial(aDegree + 1);
+    NCollection_LocalArray<long double, 64> aDoubleDegreeBinomial(aDoubleDegree + 1);
+    fillBinomialRow(aDegree, aDegreeBinomial.begin());
+    fillBinomialRow(aDoubleDegree, aDoubleDegreeBinomial.begin());
+    for (size_t aResultIndex = 0; aResultIndex <= aDoubleDegree; ++aResultIndex)
+    {
+      long double  aDistance = 0.0L;
+      long double  aWeight   = 0.0L;
+      const size_t aFirst    = aResultIndex > aDegree ? aResultIndex - aDegree : 0;
+      const size_t aLast     = std::min(aDegree, aResultIndex);
+      for (size_t anIndex = aFirst; anIndex <= aLast; ++anIndex)
+      {
+        const size_t      aSecondIndex = aResultIndex - anIndex;
+        const long double aFactor      = aDegreeBinomial[anIndex] * aDegreeBinomial[aSecondIndex]
+                                         / aDoubleDegreeBinomial[aResultIndex];
+        aDistance +=
+          aFactor * (aQx[anIndex] * aQx[aSecondIndex] + aQy[anIndex] * aQy[aSecondIndex]);
+        aWeight += aFactor * aWeights[anIndex] * aWeights[aSecondIndex];
+      }
+      aDistanceCoefficients[aResultIndex] = aDistance;
+      aWeightCoefficients[aResultIndex]   = aWeight;
+    }
+
+    const long double aReferenceWeight = aWeightCoefficients[0];
+    if (aReferenceWeight == 0.0L)
+    {
+      return std::nullopt;
+    }
+    const long double aSquareDistance = aDistanceCoefficients[0] / aReferenceWeight;
+    for (size_t anIndex = 0; anIndex <= aDoubleDegree; ++anIndex)
+    {
+      const long double aResidual =
+        aDistanceCoefficients[anIndex] - aSquareDistance * aWeightCoefficients[anIndex];
+      const long double aScale = std::max(1.0L, std::abs(aDistanceCoefficients[anIndex]));
+      if (std::abs(aResidual) > Precision::SquareConfusion() * aScale)
+      {
+        return std::nullopt;
+      }
+    }
+    return static_cast<double>(aSquareDistance);
+  }
+
+  //! Root and the non-uniform cell used to isolate it.
+  struct RootCandidate
+  {
+    double Parameter;
+    double LeftBound;
+    double RightBound;
+  };
+
+  //! Validates the cached partition and its coverage of the requested domain.
+  bool validateParams(const ExtremaPC2d::Domain1D& theDomain) const
+  {
+    if (myParams.Size() < 2)
+    {
+      return false;
+    }
+    if (std::abs(myParams.First() - theDomain.Min) > ExtremaPC2d::THE_PARAM_TOLERANCE
+        || std::abs(myParams.Last() - theDomain.Max) > ExtremaPC2d::THE_PARAM_TOLERANCE)
+    {
+      return false;
+    }
+    for (size_t anIndex = 1; anIndex < myParams.Size(); ++anIndex)
+    {
+      if (!std::isfinite(myParams[anIndex - 1]) || !std::isfinite(myParams[anIndex])
+          || myParams[anIndex] <= myParams[anIndex - 1])
+      {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  //! Returns a constant squared distance only when the curve geometry proves it exactly.
+  static std::optional<double> constantSquareDistance(const Adaptor2d_Curve2d&     theCurve,
+                                                      const gp_Pnt2d&              thePoint,
+                                                      const ExtremaPC2d::Domain1D& theDomain)
+  {
+    try
+    {
+      OCC_CATCH_SIGNALS
+      const GeomAbs_CurveType aType = theCurve.GetType();
+      if (aType == GeomAbs_Circle)
+      {
+        const gp_Circ2d aCircle = theCurve.Circle();
+        if (thePoint.SquareDistance(aCircle.Location()) == 0.0)
+        {
+          return aCircle.Radius() * aCircle.Radius();
+        }
+      }
+      else if (aType == GeomAbs_Ellipse)
+      {
+        const gp_Elips2d anEllipse = theCurve.Ellipse();
+        if (anEllipse.MajorRadius() == anEllipse.MinorRadius()
+            && thePoint.SquareDistance(anEllipse.Location()) == 0.0)
+        {
+          return anEllipse.MajorRadius() * anEllipse.MajorRadius();
+        }
+      }
+
+      const Geom2dAdaptor_Curve* aGeomAdaptor = dynamic_cast<const Geom2dAdaptor_Curve*>(&theCurve);
+      if (aGeomAdaptor == nullptr || aGeomAdaptor->Curve().IsNull())
+      {
+        return std::nullopt;
+      }
+
+      occ::handle<Geom2d_Curve>             aCurve   = aGeomAdaptor->Curve();
+      const occ::handle<Geom2d_OffsetCurve> anOffset = occ::down_cast<Geom2d_OffsetCurve>(aCurve);
+      const bool                            isOffset = !anOffset.IsNull();
+      if (!anOffset.IsNull())
+      {
+        aCurve = anOffset->BasisCurve();
+      }
+
+      const occ::handle<Geom2d_Circle> aCircle = occ::down_cast<Geom2d_Circle>(aCurve);
+      if (!aCircle.IsNull() && thePoint.SquareDistance(aCircle->Location()) == 0.0)
+      {
+        return thePoint.SquareDistance(theCurve.Value(theDomain.Min));
+      }
+
+      const occ::handle<Geom2d_BezierCurve>  aBezier  = occ::down_cast<Geom2d_BezierCurve>(aCurve);
+      const occ::handle<Geom2d_BSplineCurve> aBSpline = occ::down_cast<Geom2d_BSplineCurve>(aCurve);
+      if (!aBezier.IsNull())
+      {
+        const std::optional<double> aRationalDistance =
+          rationalBezierSquareDistance(aBezier, thePoint);
+        if (aRationalDistance.has_value())
+        {
+          return isOffset ? thePoint.SquareDistance(theCurve.Value(theDomain.Min))
+                          : aRationalDistance;
+        }
+      }
+      const size_t aNbPoles = static_cast<size_t>(
+        !aBezier.IsNull() ? aBezier->NbPoles() : (!aBSpline.IsNull() ? aBSpline->NbPoles() : 0));
+      if (aNbPoles > 0)
+      {
+        const gp_Pnt2d aReference = !aBezier.IsNull() ? aBezier->Pole(1) : aBSpline->Pole(1);
+        for (size_t aPoleIndex = 1; aPoleIndex < aNbPoles; ++aPoleIndex)
+        {
+          const int      aGeomIndex = static_cast<int>(aPoleIndex + 1);
+          const gp_Pnt2d aPole =
+            !aBezier.IsNull() ? aBezier->Pole(aGeomIndex) : aBSpline->Pole(aGeomIndex);
+          if (aPole.SquareDistance(aReference) != 0.0)
+          {
+            return std::nullopt;
+          }
+        }
+        return isOffset ? thePoint.SquareDistance(theCurve.Value(theDomain.Min))
+                        : thePoint.SquareDistance(aReference);
+      }
+      return std::nullopt;
+    }
+    catch (const Standard_Failure&)
+    {
+      return std::nullopt;
+    }
+  }
+
+  //! Inserts a parameter in ascending order unless it is already present.
+  static void insertParameter(NCollection_LinearVector<double>& theParameters, double theParameter)
+  {
+    size_t aLower  = 0;
+    size_t anUpper = theParameters.Size();
+    while (aLower < anUpper)
+    {
+      const size_t aMiddle = aLower + (anUpper - aLower) / 2;
+      if (theParameters.Value(aMiddle) < theParameter)
+      {
+        aLower = aMiddle + 1;
+      }
+      else
+      {
+        anUpper = aMiddle;
+      }
+    }
+    if ((aLower < theParameters.Size()
+         && std::abs(theParameters.Value(aLower) - theParameter)
+              <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+        || (aLower > 0
+            && std::abs(theParameters.Value(aLower - 1) - theParameter)
+                 <= ExtremaPC2d::THE_PARAM_TOLERANCE))
+    {
+      return;
+    }
+
+    if (aLower == theParameters.Size())
+    {
+      theParameters.Append(theParameter);
+    }
+    else
+    {
+      theParameters.InsertBefore(aLower, theParameter);
+    }
+  }
+
+  //! Combines cached sampling parameters with C2 continuity boundaries.
+  void buildPartition(const Adaptor2d_Curve2d&          theCurve,
+                      const ExtremaPC2d::Domain1D&      theDomain,
+                      NCollection_LinearVector<double>& theContinuityBounds,
+                      NCollection_LinearVector<double>& thePartition) const
+  {
+    thePartition.Reserve(myParams.Size());
+    for (const double aParameter : myParams)
+    {
+      thePartition.Append(aParameter);
+    }
+
+    try
+    {
+      OCC_CATCH_SIGNALS
+      const int                          aNbIntervals = theCurve.NbIntervals(GeomAbs_C2);
+      NCollection_LocalArray<double, 32> anIntervalStorage(static_cast<size_t>(aNbIntervals + 1));
+      NCollection_Array1<double>         anIntervals(anIntervalStorage[0], 1, aNbIntervals + 1);
+      thePartition.Reserve(myParams.Size() + static_cast<size_t>(aNbIntervals + 1));
+      theContinuityBounds.Reserve(static_cast<size_t>(aNbIntervals + 1));
+      theCurve.Intervals(anIntervals, GeomAbs_C2);
+      for (size_t anIndex = 0; anIndex < anIntervals.Size(); ++anIndex)
+      {
+        const double aParameter = theDomain.Clamp(anIntervals.At(anIndex));
+        insertParameter(thePartition, aParameter);
+        if (aParameter > theDomain.Min + ExtremaPC2d::THE_PARAM_TOLERANCE
+            && aParameter < theDomain.Max - ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          insertParameter(theContinuityBounds, aParameter);
+        }
+      }
+    }
+    catch (const Standard_Failure&)
+    {
+      // Cached sampling remains usable for adaptors without interval APIs.
+    }
+  }
+
+  //! Appends a sorted root, merging the cells of an equivalent boundary root.
+  static void appendRoot(NCollection_LinearVector<RootCandidate>& theRoots,
+                         const RootCandidate&                     theRoot)
+  {
+    if (!theRoots.IsEmpty())
+    {
+      RootCandidate& aLast = theRoots.ChangeValue(theRoots.Size() - 1);
+      if (std::abs(aLast.Parameter - theRoot.Parameter) <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+      {
+        aLast.LeftBound  = std::min(aLast.LeftBound, theRoot.LeftBound);
+        aLast.RightBound = std::max(aLast.RightBound, theRoot.RightBound);
+        return;
+      }
+      if (aLast.Parameter < theRoot.Parameter)
+      {
+        theRoots.Append(theRoot);
+        return;
+      }
+    }
+
+    // The interval traversal and MathRoot results are ordered. Keep a defensive insertion path
+    // for custom or future solvers that violate that contract.
+    for (size_t anIndex = 0; anIndex < theRoots.Size(); ++anIndex)
+    {
+      RootCandidate& anExisting = theRoots.ChangeValue(anIndex);
+      if (std::abs(anExisting.Parameter - theRoot.Parameter) <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+      {
+        anExisting.LeftBound  = std::min(anExisting.LeftBound, theRoot.LeftBound);
+        anExisting.RightBound = std::max(anExisting.RightBound, theRoot.RightBound);
+        return;
+      }
+      if (theRoot.Parameter < anExisting.Parameter)
+      {
+        theRoots.InsertBefore(anIndex, theRoot);
+        return;
+      }
+    }
+    theRoots.Append(theRoot);
+  }
+
+  //! Returns the stationarity sign at a probe, treating small values as unresolved.
+  static int stationaritySign(ExtremaPC2d_DistanceFunction& theFunction,
+                              double                        theParameter,
+                              double                        theTol)
+  {
+    double       aValue         = 0.0;
+    const double aSignTolerance = std::min(theTol, ExtremaPC2d::THE_DEFAULT_TOLERANCE);
+    if (!theFunction.Value(theParameter, aValue) || std::abs(aValue) <= aSignTolerance)
+    {
+      return 0;
+    }
+    return aValue < 0.0 ? -1 : 1;
+  }
+
+  //! Adds one classified extremum if it matches the requested mode and is not duplicated.
+  void addExtremum(const Adaptor2d_Curve2d& theCurve,
+                   const gp_Pnt2d&          theP,
+                   double                   theParameter,
+                   int                      theLeftSign,
+                   int                      theRightSign,
+                   ExtremaPC2d::SearchMode  theMode) const
+  {
+    const bool isMinimum = theLeftSign < 0 && theRightSign > 0;
+    const bool isMaximum = theLeftSign > 0 && theRightSign < 0;
+    if ((!isMinimum && !isMaximum) || (theMode == ExtremaPC2d::SearchMode::Min && !isMinimum)
+        || (theMode == ExtremaPC2d::SearchMode::Max && !isMaximum))
+    {
+      return;
+    }
+
+    for (size_t anIndex = 0; anIndex < myResult.Extrema.Size(); ++anIndex)
+    {
+      if (std::abs(myResult.Extrema.Value(anIndex).Parameter - theParameter)
+          <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+      {
+        return;
+      }
+    }
+
+    const gp_Pnt2d              aCurvePoint = theCurve.Value(theParameter);
+    ExtremaPC2d::ExtremumResult anExtremum;
+    anExtremum.Parameter      = theParameter;
+    anExtremum.Point          = aCurvePoint;
+    anExtremum.SquareDistance = theP.SquareDistance(aCurvePoint);
+    anExtremum.IsMinimum      = isMinimum;
+    anExtremum.IsMaximum      = isMaximum;
+    myResult.Extrema.Append(anExtremum);
+  }
+
+  //! Classifies smooth stationary roots within their isolation cells.
+  void classifyRoots(const Adaptor2d_Curve2d&                       theCurve,
+                     const gp_Pnt2d&                                theP,
+                     const ExtremaPC2d::Domain1D&                   theDomain,
+                     ExtremaPC2d_DistanceFunction&                  theFunction,
+                     const NCollection_LinearVector<double>&        theContinuityBounds,
+                     const NCollection_LinearVector<RootCandidate>& theRoots,
+                     double                                         theTol,
+                     ExtremaPC2d::SearchMode                        theMode) const
+  {
+    for (size_t aRootIndex = 0; aRootIndex < theRoots.Size(); ++aRootIndex)
+    {
+      const RootCandidate& aRoot      = theRoots.Value(aRootIndex);
+      bool                 isJunction = false;
+      for (size_t aJunctionIndex = 0; aJunctionIndex < theContinuityBounds.Size(); ++aJunctionIndex)
+      {
+        if (std::abs(aRoot.Parameter - theContinuityBounds.Value(aJunctionIndex))
+            <= ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          isJunction = true;
+          break;
+        }
+      }
+      if (isJunction)
+      {
+        continue;
+      }
+
+      const bool isAtFirst = aRoot.Parameter <= theDomain.Min + ExtremaPC2d::THE_PARAM_TOLERANCE;
+      const bool isAtLast  = aRoot.Parameter >= theDomain.Max - ExtremaPC2d::THE_PARAM_TOLERANCE;
+      if (isAtFirst || isAtLast)
+      {
+        continue;
+      }
+
+      double aLeftBound  = aRoot.LeftBound;
+      double aRightBound = aRoot.RightBound;
+      if (aRootIndex > 0)
+      {
+        const RootCandidate& aPrevious = theRoots.Value(aRootIndex - 1);
+        aLeftBound = std::max(aLeftBound, (aPrevious.Parameter + aRoot.Parameter) * 0.5);
+      }
+      if (aRootIndex + 1 < theRoots.Size())
+      {
+        const RootCandidate& aNext = theRoots.Value(aRootIndex + 1);
+        aRightBound = std::min(aRightBound, (aRoot.Parameter + aNext.Parameter) * 0.5);
+      }
+      const int aLeftSign =
+        stationaritySign(theFunction, (aLeftBound + aRoot.Parameter) * 0.5, theTol);
+      const int aRightSign =
+        stationaritySign(theFunction, (aRoot.Parameter + aRightBound) * 0.5, theTol);
+      addExtremum(theCurve, theP, aRoot.Parameter, aLeftSign, aRightSign, theMode);
+    }
+  }
+
+  //! Classifies C2 continuity boundaries and the periodic seam from one-sided values.
+  void classifyJunctions(const Adaptor2d_Curve2d&                       theCurve,
+                         const gp_Pnt2d&                                theP,
+                         const ExtremaPC2d::Domain1D&                   theDomain,
+                         ExtremaPC2d_DistanceFunction&                  theFunction,
+                         const NCollection_LinearVector<double>&        theContinuityBounds,
+                         const NCollection_LinearVector<double>&        thePartition,
+                         const NCollection_LinearVector<RootCandidate>& theRoots,
+                         bool                                           theIsClosed,
+                         double                                         theTol,
+                         ExtremaPC2d::SearchMode                        theMode) const
+  {
+    for (size_t aJunctionIndex = 0; aJunctionIndex < theContinuityBounds.Size(); ++aJunctionIndex)
+    {
+      const double aJunction   = theContinuityBounds.Value(aJunctionIndex);
+      double       aLeftBound  = theDomain.Min;
+      double       aRightBound = theDomain.Max;
+      for (size_t aParamIndex = 1; aParamIndex < thePartition.Size(); ++aParamIndex)
+      {
+        if (thePartition.Value(aParamIndex) >= aJunction)
+        {
+          aLeftBound  = thePartition.Value(aParamIndex - 1);
+          aRightBound = thePartition.Value(aParamIndex);
+          if (std::abs(aRightBound - aJunction) <= ExtremaPC2d::THE_PARAM_TOLERANCE
+              && aParamIndex + 1 < thePartition.Size())
+          {
+            aRightBound = thePartition.Value(aParamIndex + 1);
+          }
+          break;
+        }
+      }
+      for (size_t aRootIndex = 0; aRootIndex < theRoots.Size(); ++aRootIndex)
+      {
+        const double aRoot = theRoots.Value(aRootIndex).Parameter;
+        if (aRoot > aLeftBound + ExtremaPC2d::THE_PARAM_TOLERANCE
+            && aRoot < aJunction - ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          aLeftBound = aRoot;
+        }
+        else if (aRoot > aJunction + ExtremaPC2d::THE_PARAM_TOLERANCE
+                 && aRoot < aRightBound - ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          aRightBound = aRoot;
+          break;
+        }
+      }
+
+      const int aLeftSign  = stationaritySign(theFunction, (aLeftBound + aJunction) * 0.5, theTol);
+      const int aRightSign = stationaritySign(theFunction, (aJunction + aRightBound) * 0.5, theTol);
+      addExtremum(theCurve, theP, aJunction, aLeftSign, aRightSign, theMode);
+    }
+
+    if (theIsClosed)
+    {
+      double aLeftBound  = myParams[myParams.Size() - 2];
+      double aRightBound = myParams[1];
+      for (size_t aRootIndex = 0; aRootIndex < theRoots.Size(); ++aRootIndex)
+      {
+        const double aRoot = theRoots.Value(aRootIndex).Parameter;
+        if (aRoot > aLeftBound + ExtremaPC2d::THE_PARAM_TOLERANCE
+            && aRoot < theDomain.Max - ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          aLeftBound = aRoot;
+        }
+        if (aRoot > theDomain.Min + ExtremaPC2d::THE_PARAM_TOLERANCE
+            && aRoot < aRightBound - ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          aRightBound = aRoot;
+        }
+      }
+      const int aLeftSign =
+        stationaritySign(theFunction, (aLeftBound + theDomain.Max) * 0.5, theTol);
+      const int aRightSign =
+        stationaritySign(theFunction, (theDomain.Min + aRightBound) * 0.5, theTol);
+      addExtremum(theCurve, theP, theDomain.Min, aLeftSign, aRightSign, theMode);
+    }
+  }
+
+private:
+  NCollection_LinearVector<double>                myParams; //!< Cached parameter partition
+  mutable NCollection_LinearVector<double>        myContinuityBounds; //!< Reusable C2 bounds
+  mutable NCollection_LinearVector<double>        myPartition;        //!< Reusable merged partition
+  mutable NCollection_LinearVector<RootCandidate> myRoots;            //!< Reusable root candidates
+  mutable ExtremaPC2d::Result                     myResult;           //!< Reusable result
+};
+
+#endif // _ExtremaPC2d_GridEvaluator_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Hyperbola.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Hyperbola.hxx
@@ -1,0 +1,328 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_Hyperbola_HeaderFile
+#define _ExtremaPC2d_Hyperbola_HeaderFile
+
+#include <ElCLib.hxx>
+#include <ExtremaPC2d.hxx>
+#include <gp_Hypr2d.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <MathPoly_Quartic.hxx>
+#include <Precision.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <cmath>
+#include <optional>
+
+//! @brief Point-Hyperbola extrema computation.
+//!
+//! Computes the extrema between a 2D point and a hyperbola.
+//! Uses quartic polynomial solving via MathPoly::Quartic with substitution.
+//!
+//! The algorithm:
+//! For hyperbola C(u) = (R*cosh(u), r*sinh(u)) with major radius R and minor radius r,
+//!    substitutes v = e^u to convert the transcendental equation to a polynomial:
+//!    ((R^2 + r^2)/4) * v^4 - ((X*R + Y*r)/2) * v^3 + ((X*R - Y*r)/2) * v - ((R^2 + r^2)/4) = 0
+//! 3. Filters positive roots (v > 0) and converts back via u = ln(v)
+//!
+//! @note A hyperbola can have up to 4 extrema.
+//!
+//! The domain is fixed at construction time for optimal performance.
+//! For infinite hyperbola, construct without domain or with nullopt.
+class ExtremaPC2d_Hyperbola
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with hyperbola geometry (infinite).
+  //! @param[in] theHyperbola the hyperbola to compute extrema for
+  explicit ExtremaPC2d_Hyperbola(const gp_Hypr2d& theHyperbola)
+      : myHyperbola(theHyperbola),
+        myDomain(std::nullopt)
+  {
+    cacheGeometry();
+  }
+
+  //! Constructor with hyperbola geometry and parameter domain.
+  //! @param[in] theHyperbola the hyperbola to compute extrema for
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  ExtremaPC2d_Hyperbola(const gp_Hypr2d& theHyperbola, const ExtremaPC2d::Domain1D& theDomain)
+      : myHyperbola(theHyperbola),
+        myDomain(theDomain)
+  {
+    cacheGeometry();
+  }
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_Hyperbola(const ExtremaPC2d_Hyperbola&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_Hyperbola& operator=(const ExtremaPC2d_Hyperbola&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_Hyperbola(ExtremaPC2d_Hyperbola&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_Hyperbola& operator=(ExtremaPC2d_Hyperbola&&) = default;
+
+  //! Evaluates point on hyperbola at parameter using cached geometry.
+  //! @param theU parameter
+  //! @return point on hyperbola
+  gp_Pnt2d Value(double theU) const
+  {
+    // Hyperbola: P(u) = Center + R*cosh(u)*XDir + r*sinh(u)*YDir
+    const double aCosh  = std::cosh(theU);
+    const double aSinh  = std::sinh(theU);
+    const double aRCosh = myMajorR * aCosh;
+    const double arSinh = myMinorR * aSinh;
+    return gp_Pnt2d(myCenterX + aRCosh * myXDirX + arSinh * myYDirX,
+                    myCenterY + aRCosh * myXDirY + arSinh * myYDirY);
+  }
+
+  //! Returns true if domain is bounded.
+  bool IsBounded() const { return myDomain.has_value(); }
+
+  //! Returns the domain (only valid if IsBounded() is true).
+  const ExtremaPC2d::Domain1D& Domain() const { return *myDomain; }
+
+  //! Compute extrema between point P and the hyperbola.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for duplicate detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema
+  [[nodiscard]] const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    performCore(theP, myDomain, theTol, theMode);
+    return myResult;
+  }
+
+  //! Compute extrema between point P and the hyperbola arc including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for duplicate detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
+      return myResult;
+    }
+
+    (void)Perform(theP, theTol, theMode);
+
+    // Add endpoints if interior computation succeeded and domain is bounded
+    if ((myResult.Status == ExtremaPC2d::Status::OK
+         || myResult.Status == ExtremaPC2d::Status::NoSolution)
+        && myDomain.has_value())
+    {
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC2d::Status::OK;
+      }
+    }
+
+    return myResult;
+  }
+
+  //! Returns the hyperbola geometry.
+  const gp_Hypr2d& Hyperbola() const { return myHyperbola; }
+
+private:
+  //! Cache geometry components for fast computation.
+  void cacheGeometry()
+  {
+    const gp_Pnt2d& aCenter = myHyperbola.Location();
+    myCenterX               = aCenter.X();
+    myCenterY               = aCenter.Y();
+    const gp_Dir2d& aXDir   = myHyperbola.Axis().XDirection();
+    myXDirX                 = aXDir.X();
+    myXDirY                 = aXDir.Y();
+
+    const gp_Dir2d& aYDir = myHyperbola.Axis().YDirection();
+    myYDirX               = aYDir.X();
+    myYDirY               = aYDir.Y();
+
+    myMajorR        = myHyperbola.MajorRadius();
+    myMinorR        = myHyperbola.MinorRadius();
+    myR2PlusR2Over4 = (myMajorR * myMajorR + myMinorR * myMinorR) / 4.0;
+  }
+
+  //! Solve the quartic equation and return polynomial result using cached geometry.
+  MathPoly::PolyResult solveQuartic(const gp_Pnt2d& theP) const
+  {
+    // Vector from center to point
+    const double aDx = theP.X() - myCenterX;
+    const double aDy = theP.Y() - myCenterY;
+
+    // Local coordinates in hyperbola frame
+    const double aX = aDx * myXDirX + aDy * myXDirY;
+    const double aY = aDx * myYDirX + aDy * myYDirY;
+
+    // Solve quartic equation in v = e^u
+    const double aC1 = myR2PlusR2Over4;
+    const double aC2 = -(aX * myMajorR + aY * myMinorR) / 2.0;
+    const double aC3 = 0.0;
+    const double aC4 = (aX * myMajorR - aY * myMinorR) / 2.0;
+    const double aC5 = -myR2PlusR2Over4;
+
+    return MathPoly::Quartic(aC1, aC2, aC3, aC4, aC5);
+  }
+
+  //! Core algorithm - finds extrema with optional bounds checking.
+  //! Stores results in myResult.
+  //! @param theP query point
+  //! @param theDomain optional parameter domain (nullopt for unbounded)
+  //! @param theTol tolerance for duplicate detection
+  //! @param theMode search mode
+  void performCore(const gp_Pnt2d&                             theP,
+                   const std::optional<ExtremaPC2d::Domain1D>& theDomain,
+                   double                                      theTol,
+                   ExtremaPC2d::SearchMode                     theMode) const
+  {
+    myResult.Clear();
+
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (theDomain.has_value() && !theDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return;
+    }
+
+    MathPoly::PolyResult aPolyRes = solveQuartic(theP);
+
+    if (!aPolyRes.IsDone())
+    {
+      if (aPolyRes.Status == MathUtils::Status::InfiniteSolutions)
+      {
+        myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+        gp_Pnt2d aPtOnCurve             = Value(0.0);
+        myResult.InfiniteSquareDistance = theP.SquareDistance(aPtOnCurve);
+      }
+      else
+      {
+        myResult.Status = ExtremaPC2d::Status::NumericalError;
+      }
+      return;
+    }
+
+    // Process all positive roots (v > 0 required for u = ln(v))
+    for (size_t i = 0; i < aPolyRes.NbRoots; ++i)
+    {
+      double aV = aPolyRes.Roots[i];
+      if (aV <= 0.0)
+        continue;
+
+      double aU = std::log(aV);
+
+      // Check bounds if domain is specified
+      if (theDomain.has_value())
+      {
+        if (!theDomain->Contains(aU, ExtremaPC2d::THE_PARAM_TOLERANCE))
+        {
+          continue;
+        }
+        aU = theDomain->Clamp(aU);
+      }
+
+      gp_Pnt2d aCurvePt = Value(aU);
+
+      // Check for duplicates
+      bool aDuplicate = false;
+      for (const ExtremaPC2d::ExtremumResult& anExtremum : myResult.Extrema)
+      {
+        if (std::abs(aU - anExtremum.Parameter) < ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          aDuplicate = true;
+          break;
+        }
+      }
+      if (aDuplicate)
+        continue;
+
+      const size_t aMultiplicity = aPolyRes.Multiplicities[i];
+      if (aMultiplicity % 2 == 0)
+      {
+        continue;
+      }
+
+      // The quartic is v^2 times the stationary function and has a positive leading
+      // coefficient. Since v = exp(u) is increasing, odd roots that follow determine whether
+      // the stationary function crosses from negative to positive at this root.
+      double aSqDist          = theP.SquareDistance(aCurvePt);
+      size_t aNbOddRootsAfter = 0;
+      for (size_t aNext = i + 1; aNext < aPolyRes.NbRoots; ++aNext)
+      {
+        if (aPolyRes.Roots[aNext] > 0.0)
+        {
+          aNbOddRootsAfter += aPolyRes.Multiplicities[aNext] % 2;
+        }
+      }
+      const bool aIsMin = aNbOddRootsAfter % 2 == 0;
+
+      // Filter by search mode
+      if (theMode == ExtremaPC2d::SearchMode::Min && !aIsMin)
+        continue;
+      if (theMode == ExtremaPC2d::SearchMode::Max && aIsMin)
+        continue;
+
+      ExtremaPC2d::ExtremumResult anExt;
+      anExt.Parameter      = aU;
+      anExt.Point          = aCurvePt;
+      anExt.SquareDistance = aSqDist;
+      anExt.IsMinimum      = aIsMin;
+      anExt.IsMaximum      = !aIsMin;
+
+      myResult.Extrema.Append(anExt);
+    }
+
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
+  }
+
+  gp_Hypr2d                            myHyperbola; //!< Hyperbola geometry
+  std::optional<ExtremaPC2d::Domain1D> myDomain;    //!< Parameter domain (nullopt for infinite)
+  mutable ExtremaPC2d::Result          myResult;    //!< Reusable result storage
+
+  // Cached geometry components for fast computation
+  double myCenterX, myCenterY; //!< Center location
+  double myXDirX, myXDirY;     //!< X-axis direction
+  double myYDirX, myYDirY;     //!< Y-axis direction
+  double myMajorR;             //!< Major radius
+  double myMinorR;             //!< Minor radius
+  double myR2PlusR2Over4;      //!< Precomputed (R^2 + r^2)/4
+};
+
+#endif // _ExtremaPC2d_Hyperbola_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Line.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Line.hxx
@@ -1,0 +1,200 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_Line_HeaderFile
+#define _ExtremaPC2d_Line_HeaderFile
+
+#include <ExtremaPC2d.hxx>
+#include <gp_Lin2d.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <algorithm>
+#include <optional>
+
+//! @brief Point-Line extrema computation.
+//!
+//! Computes the extremum (closest point) between a 2D point and a line.
+//! Uses direct analytical projection via dot product.
+//!
+//! For a line defined by origin O and direction D, the closest point
+//! to P is at parameter u = (P - O) . D, which gives the minimum distance.
+//!
+//! The domain is fixed at construction time for optimal performance.
+//! For unbounded line, construct without domain or with nullopt.
+//!
+//! @note Lines always have exactly one extremum (minimum) if within bounds.
+class ExtremaPC2d_Line
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with line geometry (unbounded).
+  //! @param[in] theLine the line to compute extrema for
+  explicit ExtremaPC2d_Line(const gp_Lin2d& theLine)
+      : myLine(theLine),
+        myDomain(std::nullopt)
+  {
+  }
+
+  //! Constructor with line geometry and parameter domain.
+  //! @param[in] theLine the line to compute extrema for
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  ExtremaPC2d_Line(const gp_Lin2d& theLine, const ExtremaPC2d::Domain1D& theDomain)
+      : myLine(theLine),
+        myDomain(theDomain)
+  {
+  }
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_Line(const ExtremaPC2d_Line&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_Line& operator=(const ExtremaPC2d_Line&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_Line(ExtremaPC2d_Line&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_Line& operator=(ExtremaPC2d_Line&&) = default;
+
+  //! Evaluates point on line at parameter.
+  //! @param theU parameter
+  //! @return point on line
+  gp_Pnt2d Value(double theU) const
+  {
+    return myLine.Location().Translated(theU * gp_Vec2d(myLine.Direction()));
+  }
+
+  //! Returns true if domain is bounded.
+  bool IsBounded() const { return myDomain.has_value(); }
+
+  //! Returns the domain (only valid if IsBounded() is true).
+  const ExtremaPC2d::Domain1D& Domain() const { return *myDomain; }
+
+  //! Compute extrema between point P and the line.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for parameter comparison
+  //! @param theMode search mode (Max returns no interior extremum)
+  //! @return const reference to result containing the extremum
+  [[nodiscard]] const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    myResult.Clear();
+
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (theMode == ExtremaPC2d::SearchMode::Max)
+    {
+      myResult.Status = ExtremaPC2d::Status::NoSolution;
+      return myResult;
+    }
+
+    // Compute projection parameter: u = (P - O) . Direction
+    const gp_Dir2d& aDir    = myLine.Direction();
+    const gp_Pnt2d& aOrigin = myLine.Location();
+    gp_Vec2d        aVec(aOrigin, theP);
+    double        aU = aVec.Dot(gp_Vec2d(aDir));
+
+    // Check bounds if domain is specified
+    if (myDomain.has_value())
+    {
+      if (aU < myDomain->Min - theTol || aU > myDomain->Max + theTol)
+      {
+        // Projection is outside bounds - no interior extremum
+        myResult.Status = ExtremaPC2d::Status::NoSolution;
+        return myResult;
+      }
+      // Clamp to bounds
+      aU = std::clamp(aU, myDomain->Min, myDomain->Max);
+    }
+
+    // Compute point on line at projected parameter
+    gp_Pnt2d aPtOnLine = aOrigin.Translated(aU * gp_Vec2d(aDir));
+
+    // Store result
+    ExtremaPC2d::ExtremumResult anExt;
+    anExt.Parameter      = aU;
+    anExt.Point          = aPtOnLine;
+    anExt.SquareDistance = theP.SquareDistance(aPtOnLine);
+    anExt.IsMinimum      = true;
+    anExt.IsMaximum      = false;
+
+    myResult.Extrema.Append(anExt);
+    myResult.Status = ExtremaPC2d::Status::OK;
+    return myResult;
+  }
+
+  //! Compute extrema between point P and the line segment including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for parameter comparison
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
+                                                   : ExtremaPC2d::Status::OK;
+      return myResult;
+    }
+
+    (void)Perform(theP, theTol, theMode);
+
+    if ((myResult.Status == ExtremaPC2d::Status::OK
+         || myResult.Status == ExtremaPC2d::Status::NoSolution)
+        && myDomain.has_value())
+    {
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC2d::Status::OK;
+      }
+    }
+
+    return myResult;
+  }
+
+  //! Returns the line geometry.
+  const gp_Lin2d& Line() const { return myLine; }
+
+private:
+  gp_Lin2d                             myLine;   //!< Line geometry
+  std::optional<ExtremaPC2d::Domain1D> myDomain; //!< Parameter domain (nullopt for unbounded)
+  mutable ExtremaPC2d::Result          myResult; //!< Reusable result storage
+};
+
+#endif // _ExtremaPC2d_Line_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Line.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Line.hxx
@@ -91,7 +91,7 @@ public:
   //! @return const reference to result containing the extremum
   [[nodiscard]] const ExtremaPC2d::Result& Perform(
     const gp_Pnt2d&         theP,
-    double                theTol,
+    double                  theTol,
     ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
   {
     myResult.Clear();
@@ -113,7 +113,7 @@ public:
     const gp_Dir2d& aDir    = myLine.Direction();
     const gp_Pnt2d& aOrigin = myLine.Location();
     gp_Vec2d        aVec(aOrigin, theP);
-    double        aU = aVec.Dot(gp_Vec2d(aDir));
+    double          aU = aVec.Dot(gp_Vec2d(aDir));
 
     // Check bounds if domain is specified
     if (myDomain.has_value())
@@ -152,7 +152,7 @@ public:
   //! @return const reference to result containing interior + endpoint extrema
   [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
     const gp_Pnt2d&         theP,
-    double                theTol,
+    double                  theTol,
     ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
   {
     if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
@@ -167,8 +167,8 @@ public:
     {
       myResult.Clear();
       ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
-      myResult.Status = myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution
-                                                   : ExtremaPC2d::Status::OK;
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
       return myResult;
     }
 

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OffsetCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OffsetCurve.cxx
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ExtremaPC2d_OffsetCurve.hxx>
+
+#include <ExtremaPC2d_GridEvaluator.hxx>
+
+//==================================================================================================
+
+ExtremaPC2d_OffsetCurve::ExtremaPC2d_OffsetCurve(const Adaptor2d_Curve2d& theCurve)
+    : myCurve(&theCurve),
+      myDomain{theCurve.FirstParameter(), theCurve.LastParameter()}
+{
+}
+
+//==================================================================================================
+
+ExtremaPC2d_OffsetCurve::ExtremaPC2d_OffsetCurve(const Adaptor2d_Curve2d&     theCurve,
+                                                 const ExtremaPC2d::Domain1D& theDomain)
+    : myCurve(&theCurve),
+      myDomain(theDomain)
+{
+}
+
+//==================================================================================================
+
+void ExtremaPC2d_OffsetCurve::buildParams() const
+{
+  if (myCurve == nullptr || !myDomain.IsValid() || !myDomain.IsFinite())
+  {
+    return;
+  }
+
+  math_Vector aParams = ExtremaPC2d_GridEvaluator::BuildCurveAwareParams(*myCurve, myDomain);
+
+  myEvaluator.SetParams(aParams);
+}
+
+//==================================================================================================
+
+gp_Pnt2d ExtremaPC2d_OffsetCurve::Value(double theU) const
+{
+  return myCurve->Value(theU);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_OffsetCurve::Perform(const gp_Pnt2d&         theP,
+                                                            double                  theTol,
+                                                            ExtremaPC2d::SearchMode theMode) const
+{
+  if (myCurve == nullptr)
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC2d::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  buildParams();
+  return myEvaluator.Perform(*myCurve, theP, myDomain, theTol, theMode);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_OffsetCurve::PerformWithEndpoints(
+  const gp_Pnt2d&         theP,
+  double                  theTol,
+  ExtremaPC2d::SearchMode theMode) const
+{
+  if (myCurve == nullptr)
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC2d::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  // Refresh the curve-aware partition and compute interior extrema.
+  (void)Perform(theP, theTol, theMode);
+
+  // Add endpoints to the result
+  ExtremaPC2d::Result& aResult = myEvaluator.Result();
+  if (aResult.Status == ExtremaPC2d::Status::OK
+      || aResult.Status == ExtremaPC2d::Status::NoSolution)
+  {
+    const bool isClosed = ExtremaPC2d_GridEvaluator::IsClosedDomain(*myCurve, myDomain);
+    ExtremaPC2d::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
+
+    // Update status if we found any extrema (including endpoints)
+    if (!aResult.Extrema.IsEmpty())
+    {
+      aResult.Status = ExtremaPC2d::Status::OK;
+    }
+  }
+
+  return aResult;
+}

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OffsetCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OffsetCurve.hxx
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_OffsetCurve_HeaderFile
+#define _ExtremaPC2d_OffsetCurve_HeaderFile
+
+#include <Adaptor2d_Curve2d.hxx>
+#include <ExtremaPC2d.hxx>
+#include <ExtremaPC2d_GridEvaluator.hxx>
+#include <gp_Pnt2d.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+//! @brief Point-OffsetCurve extrema computation using numerical root isolation.
+//!
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
+//!
+//! The parameter partition is refreshed for each query so referenced-adaptor mutations are seen.
+//!
+//! The algorithm:
+//! 1. Build a uniform parameter partition
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
+//!
+//! Offset curves are handled through the Adaptor2d_Curve2d interface,
+//! which provides uniform access to the offset geometry.
+//!
+//! The domain is fixed at construction time and the adaptor must remain valid.
+class ExtremaPC2d_OffsetCurve
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with curve adaptor (uses full curve domain).
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve curve adaptor for offset curve (must remain valid)
+  Standard_EXPORT explicit ExtremaPC2d_OffsetCurve(const Adaptor2d_Curve2d& theCurve);
+
+  //! Constructor with curve adaptor and parameter domain.
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve curve adaptor for offset curve (must remain valid)
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  Standard_EXPORT ExtremaPC2d_OffsetCurve(const Adaptor2d_Curve2d&     theCurve,
+                                          const ExtremaPC2d::Domain1D& theDomain);
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_OffsetCurve(const ExtremaPC2d_OffsetCurve&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_OffsetCurve& operator=(const ExtremaPC2d_OffsetCurve&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_OffsetCurve(ExtremaPC2d_OffsetCurve&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_OffsetCurve& operator=(ExtremaPC2d_OffsetCurve&&) = default;
+
+  //! Evaluates point on curve at parameter.
+  //! @param theU parameter
+  //! @return point on curve
+  Standard_EXPORT gp_Pnt2d Value(double theU) const;
+
+  //! Returns true if domain is bounded.
+  bool IsBounded() const { return myDomain.IsFinite(); }
+
+  //! Returns the domain.
+  const ExtremaPC2d::Domain1D& Domain() const { return myDomain; }
+
+  //! Compute extrema between point P and the curve.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Compute extrema between point P and the curve including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+private:
+  //! Build parameter partition for the current adaptor state.
+  void buildParams() const;
+
+  const Adaptor2d_Curve2d* myCurve;  //!< Curve adaptor (not owned)
+  ExtremaPC2d::Domain1D    myDomain; //!< Parameter domain (fixed)
+
+  //! Numerical evaluator with cached parameter partition and result.
+  mutable ExtremaPC2d_GridEvaluator myEvaluator;
+};
+
+#endif // _ExtremaPC2d_OffsetCurve_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OtherCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OtherCurve.cxx
@@ -1,0 +1,106 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <ExtremaPC2d_OtherCurve.hxx>
+
+#include <ExtremaPC2d_GridEvaluator.hxx>
+
+//==================================================================================================
+
+ExtremaPC2d_OtherCurve::ExtremaPC2d_OtherCurve(const Adaptor2d_Curve2d& theCurve)
+    : myCurve(&theCurve),
+      myDomain{theCurve.FirstParameter(), theCurve.LastParameter()}
+{
+}
+
+//==================================================================================================
+
+ExtremaPC2d_OtherCurve::ExtremaPC2d_OtherCurve(const Adaptor2d_Curve2d&     theCurve,
+                                               const ExtremaPC2d::Domain1D& theDomain)
+    : myCurve(&theCurve),
+      myDomain(theDomain)
+{
+}
+
+//==================================================================================================
+
+void ExtremaPC2d_OtherCurve::buildParams() const
+{
+  if (myCurve == nullptr || !myDomain.IsValid() || !myDomain.IsFinite())
+  {
+    return;
+  }
+
+  math_Vector aParams = ExtremaPC2d_GridEvaluator::BuildCurveAwareParams(*myCurve, myDomain);
+
+  myEvaluator.SetParams(aParams);
+}
+
+//==================================================================================================
+
+gp_Pnt2d ExtremaPC2d_OtherCurve::Value(double theU) const
+{
+  return myCurve->Value(theU);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_OtherCurve::Perform(const gp_Pnt2d&         theP,
+                                                           double                  theTol,
+                                                           ExtremaPC2d::SearchMode theMode) const
+{
+  if (myCurve == nullptr)
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC2d::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  buildParams();
+  return myEvaluator.Perform(*myCurve, theP, myDomain, theTol, theMode);
+}
+
+//==================================================================================================
+
+const ExtremaPC2d::Result& ExtremaPC2d_OtherCurve::PerformWithEndpoints(
+  const gp_Pnt2d&         theP,
+  double                  theTol,
+  ExtremaPC2d::SearchMode theMode) const
+{
+  if (myCurve == nullptr)
+  {
+    myEvaluator.Result().Clear();
+    myEvaluator.Result().Status = ExtremaPC2d::Status::NotDone;
+    return myEvaluator.Result();
+  }
+
+  // Refresh the curve-aware partition and compute interior extrema.
+  (void)Perform(theP, theTol, theMode);
+
+  // Add endpoints to the result
+  ExtremaPC2d::Result& aResult = myEvaluator.Result();
+  if (aResult.Status == ExtremaPC2d::Status::OK
+      || aResult.Status == ExtremaPC2d::Status::NoSolution)
+  {
+    const bool isClosed = ExtremaPC2d_GridEvaluator::IsClosedDomain(*myCurve, myDomain);
+    ExtremaPC2d::AddEndpointExtrema(aResult, theP, myDomain, *this, theMode, isClosed);
+
+    // Update status if we found any extrema (including endpoints)
+    if (!aResult.Extrema.IsEmpty())
+    {
+      aResult.Status = ExtremaPC2d::Status::OK;
+    }
+  }
+
+  return aResult;
+}

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OtherCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_OtherCurve.hxx
@@ -1,0 +1,112 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_OtherCurve_HeaderFile
+#define _ExtremaPC2d_OtherCurve_HeaderFile
+
+#include <Adaptor2d_Curve2d.hxx>
+#include <ExtremaPC2d.hxx>
+#include <ExtremaPC2d_GridEvaluator.hxx>
+#include <gp_Pnt2d.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+//! @brief Point-Curve extrema computation for general curves using numerical root isolation.
+//!
+//! Computes roots of the normalized point-curve stationarity function with a
+//! derivative-aware multiple-root solver.
+//!
+//! The parameter partition is refreshed for each query so referenced-adaptor mutations are seen.
+//!
+//! The algorithm:
+//! 1. Build a uniform parameter partition
+//! 2. Isolate all roots of the stationarity function, including tangential roots
+//! 3. Classify roots from the stationarity sign on both sides
+//!
+//! This is a fallback implementation that works with any curve type
+//! through the Adaptor2d_Curve2d interface.
+//!
+//! The domain is fixed at construction time and the adaptor must remain valid.
+class ExtremaPC2d_OtherCurve
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with curve adaptor (uses full curve domain).
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve curve adaptor (must remain valid)
+  Standard_EXPORT explicit ExtremaPC2d_OtherCurve(const Adaptor2d_Curve2d& theCurve);
+
+  //! Constructor with curve adaptor and parameter domain.
+  //! Parameter partition is built on demand by Perform().
+  //! @param[in] theCurve curve adaptor (must remain valid)
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  Standard_EXPORT ExtremaPC2d_OtherCurve(const Adaptor2d_Curve2d&     theCurve,
+                                         const ExtremaPC2d::Domain1D& theDomain);
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_OtherCurve(const ExtremaPC2d_OtherCurve&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_OtherCurve& operator=(const ExtremaPC2d_OtherCurve&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_OtherCurve(ExtremaPC2d_OtherCurve&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_OtherCurve& operator=(ExtremaPC2d_OtherCurve&&) = default;
+
+  //! Evaluates point on curve at parameter.
+  //! @param theU parameter
+  //! @return point on curve
+  Standard_EXPORT gp_Pnt2d Value(double theU) const;
+
+  //! Returns true if domain is bounded.
+  bool IsBounded() const { return myDomain.IsFinite(); }
+
+  //! Returns the domain.
+  const ExtremaPC2d::Domain1D& Domain() const { return myDomain; }
+
+  //! Compute extrema between point P and the curve.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+  //! Compute extrema between point P and the curve including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for root finding
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] Standard_EXPORT const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const;
+
+private:
+  //! Build parameter partition for the current adaptor state.
+  void buildParams() const;
+
+  const Adaptor2d_Curve2d* myCurve;  //!< Curve adaptor (not owned)
+  ExtremaPC2d::Domain1D    myDomain; //!< Parameter domain (fixed)
+
+  //! Numerical evaluator with cached parameter partition and result.
+  mutable ExtremaPC2d_GridEvaluator myEvaluator;
+};
+
+#endif // _ExtremaPC2d_OtherCurve_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Parabola.hxx
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/ExtremaPC2d_Parabola.hxx
@@ -1,0 +1,348 @@
+// Copyright (c) 2025 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#ifndef _ExtremaPC2d_Parabola_HeaderFile
+#define _ExtremaPC2d_Parabola_HeaderFile
+
+#include <ElCLib.hxx>
+#include <ExtremaPC2d.hxx>
+#include <gp_Parab2d.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+#include <MathPoly_Cubic.hxx>
+#include <Precision.hxx>
+#include <Standard_DefineAlloc.hxx>
+
+#include <cmath>
+#include <optional>
+
+//! @brief Point-Parabola extrema computation.
+//!
+//! Computes the extrema between a 2D point and a parabola.
+//! Uses cubic polynomial solving via MathPoly::Cubic.
+//!
+//! The algorithm:
+//! For parabola C(u) = ((u^2)/(4F), u) with focal length F,
+//!    solves: (1/(4F)) * u^3 + (2F - X) * u - 2F*Y = 0
+//!    where (X, Y) are coordinates of Pp in parabola local frame.
+//!
+//! @note A parabola can have up to 3 extrema.
+//!
+//! The domain is fixed at construction time for optimal performance.
+//! For infinite parabola, construct without domain or with nullopt.
+class ExtremaPC2d_Parabola
+{
+public:
+  DEFINE_STANDARD_ALLOC
+
+  //! Constructor with parabola geometry (infinite).
+  //! @param[in] theParabola the parabola to compute extrema for
+  explicit ExtremaPC2d_Parabola(const gp_Parab2d& theParabola)
+      : myParabola(theParabola),
+        myDomain(std::nullopt)
+  {
+    cacheGeometry();
+  }
+
+  //! Constructor with parabola geometry and parameter domain.
+  //! @param[in] theParabola the parabola to compute extrema for
+  //! @param[in] theDomain parameter domain (fixed for all queries)
+  ExtremaPC2d_Parabola(const gp_Parab2d& theParabola, const ExtremaPC2d::Domain1D& theDomain)
+      : myParabola(theParabola),
+        myDomain(theDomain)
+  {
+    cacheGeometry();
+  }
+
+  //! Copy constructor is deleted.
+  ExtremaPC2d_Parabola(const ExtremaPC2d_Parabola&) = delete;
+
+  //! Copy assignment operator is deleted.
+  ExtremaPC2d_Parabola& operator=(const ExtremaPC2d_Parabola&) = delete;
+
+  //! Move constructor.
+  ExtremaPC2d_Parabola(ExtremaPC2d_Parabola&&) = default;
+
+  //! Move assignment operator.
+  ExtremaPC2d_Parabola& operator=(ExtremaPC2d_Parabola&&) = default;
+
+  //! Evaluates point on parabola at parameter using cached geometry.
+  //! @param theU parameter
+  //! @return point on parabola
+  gp_Pnt2d Value(double theU) const
+  {
+    if (myFocal <= gp::Resolution())
+    {
+      return myParabola.Location().Translated(theU * gp_Vec2d(myParabola.MirrorAxis().Direction()));
+    }
+
+    // Parabola: P(u) = Vertex + (u^2/4F)*XDir + u*YDir
+    const double aX = theU * theU * my1Over4F;
+    return gp_Pnt2d(myVertexX + aX * myXDirX + theU * myYDirX,
+                    myVertexY + aX * myXDirY + theU * myYDirY);
+  }
+
+  //! Returns true if domain is bounded.
+  bool IsBounded() const { return myDomain.has_value(); }
+
+  //! Returns the domain (only valid if IsBounded() is true).
+  const ExtremaPC2d::Domain1D& Domain() const { return *myDomain; }
+
+  //! Compute extrema between point P and the parabola.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for duplicate detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing extrema
+  [[nodiscard]] const ExtremaPC2d::Result& Perform(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    performCore(theP, myDomain, theTol, theMode);
+    return myResult;
+  }
+
+  //! Compute extrema between point P and the parabola arc including endpoints.
+  //! Uses domain specified at construction time.
+  //! @param theP query point
+  //! @param theTol tolerance for duplicate detection
+  //! @param theMode search mode (MinMax, Min, or Max)
+  //! @return const reference to result containing interior + endpoint extrema
+  [[nodiscard]] const ExtremaPC2d::Result& PerformWithEndpoints(
+    const gp_Pnt2d&         theP,
+    double                  theTol,
+    ExtremaPC2d::SearchMode theMode = ExtremaPC2d::SearchMode::MinMax) const
+  {
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (myDomain.has_value() && !myDomain->IsValid()))
+    {
+      myResult.Clear();
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return myResult;
+    }
+
+    if (myDomain.has_value() && myDomain->IsValid() && myDomain->Min == myDomain->Max)
+    {
+      myResult.Clear();
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      myResult.Status =
+        myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
+      return myResult;
+    }
+
+    (void)Perform(theP, theTol, theMode);
+
+    // Add endpoints if interior computation succeeded and domain is bounded
+    if ((myResult.Status == ExtremaPC2d::Status::OK
+         || myResult.Status == ExtremaPC2d::Status::NoSolution)
+        && myDomain.has_value())
+    {
+      ExtremaPC2d::AddEndpointExtrema(myResult, theP, *myDomain, *this, theMode, false);
+      if (!myResult.Extrema.IsEmpty())
+      {
+        myResult.Status = ExtremaPC2d::Status::OK;
+      }
+    }
+
+    return myResult;
+  }
+
+  //! Returns the parabola geometry.
+  const gp_Parab2d& Parabola() const { return myParabola; }
+
+private:
+  //! Cache geometry components for fast computation.
+  void cacheGeometry()
+  {
+    const gp_Pnt2d& aVertex = myParabola.Location();
+    myVertexX               = aVertex.X();
+    myVertexY               = aVertex.Y();
+    const gp_Dir2d& aXDir   = myParabola.Axis().XDirection();
+    myXDirX                 = aXDir.X();
+    myXDirY                 = aXDir.Y();
+
+    const gp_Dir2d& aYDir = myParabola.Axis().YDirection();
+    myYDirX               = aYDir.X();
+    myYDirY               = aYDir.Y();
+
+    myFocal   = myParabola.Focal();
+    my1Over4F = myFocal > gp::Resolution() ? 1.0 / (4.0 * myFocal) : 0.0;
+    my2F      = 2.0 * myFocal;
+  }
+
+  //! Solve the cubic equation and return polynomial result using cached geometry.
+  MathPoly::PolyResult solveCubic(const gp_Pnt2d& theP) const
+  {
+    // Vector from vertex to point
+    const double aDx = theP.X() - myVertexX;
+    const double aDy = theP.Y() - myVertexY;
+
+    // Local coordinates in parabola frame
+    const double aX = aDx * myXDirX + aDy * myXDirY;
+    const double aY = aDx * myYDirX + aDy * myYDirY;
+
+    // Solve cubic equation: (1/(4F)) * u^3 + (2F - X) * u - 2F*Y = 0
+    return MathPoly::Cubic(my1Over4F, 0.0, my2F - aX, -my2F * aY);
+  }
+
+  //! Core algorithm - finds extrema with optional bounds checking.
+  //! Stores results in myResult.
+  //! @param theP query point
+  //! @param theDomain optional parameter domain (nullopt for unbounded)
+  //! @param theTol tolerance for duplicate detection
+  //! @param theMode search mode
+  void performCore(const gp_Pnt2d&                             theP,
+                   const std::optional<ExtremaPC2d::Domain1D>& theDomain,
+                   double                                      theTol,
+                   ExtremaPC2d::SearchMode                     theMode) const
+  {
+    myResult.Clear();
+
+    if (!ExtremaPC2d::IsValidTolerance(theTol) || !ExtremaPC2d::IsFinitePoint(theP)
+        || (theDomain.has_value() && !theDomain->IsValid()))
+    {
+      myResult.Status = ExtremaPC2d::Status::InvalidInput;
+      return;
+    }
+
+    if (myFocal <= gp::Resolution())
+    {
+      if (theMode == ExtremaPC2d::SearchMode::Max)
+      {
+        myResult.Status = ExtremaPC2d::Status::NoSolution;
+        return;
+      }
+
+      const gp_Pnt2d& aVertex = myParabola.Location();
+      const gp_Vec2d  aDirection(myParabola.MirrorAxis().Direction());
+      double          aU = gp_Vec2d(aVertex, theP).Dot(aDirection);
+      if (theDomain.has_value() && !theDomain->Contains(aU, theTol))
+      {
+        myResult.Status = ExtremaPC2d::Status::NoSolution;
+        return;
+      }
+      if (theDomain.has_value())
+      {
+        aU = theDomain->Clamp(aU);
+      }
+
+      const gp_Pnt2d              aCurvePt = Value(aU);
+      ExtremaPC2d::ExtremumResult anExt;
+      anExt.Parameter      = aU;
+      anExt.Point          = aCurvePt;
+      anExt.SquareDistance = theP.SquareDistance(aCurvePt);
+      anExt.IsMinimum      = true;
+      anExt.IsMaximum      = false;
+      myResult.Extrema.Append(anExt);
+      myResult.Status = ExtremaPC2d::Status::OK;
+      return;
+    }
+
+    MathPoly::PolyResult aPolyRes = solveCubic(theP);
+
+    if (!aPolyRes.IsDone())
+    {
+      if (aPolyRes.Status == MathUtils::Status::InfiniteSolutions)
+      {
+        myResult.Status                 = ExtremaPC2d::Status::InfiniteSolutions;
+        gp_Pnt2d aPtOnCurve             = Value(0.0);
+        myResult.InfiniteSquareDistance = theP.SquareDistance(aPtOnCurve);
+      }
+      else
+      {
+        myResult.Status = ExtremaPC2d::Status::NumericalError;
+      }
+      return;
+    }
+
+    // Process all roots
+    for (size_t i = 0; i < aPolyRes.NbRoots; ++i)
+    {
+      double aU = aPolyRes.Roots[i];
+
+      // Check bounds if domain is specified
+      if (theDomain.has_value())
+      {
+        if (!theDomain->Contains(aU, ExtremaPC2d::THE_PARAM_TOLERANCE))
+        {
+          continue;
+        }
+        aU = theDomain->Clamp(aU);
+      }
+
+      gp_Pnt2d aCurvePt = Value(aU);
+
+      // Check for duplicates
+      bool aDuplicate = false;
+      for (const ExtremaPC2d::ExtremumResult& anExtremum : myResult.Extrema)
+      {
+        if (std::abs(aU - anExtremum.Parameter) < ExtremaPC2d::THE_PARAM_TOLERANCE)
+        {
+          aDuplicate = true;
+          break;
+        }
+      }
+      if (aDuplicate)
+        continue;
+
+      const size_t aMultiplicity = aPolyRes.Multiplicities[i];
+      if (aMultiplicity % 2 == 0)
+      {
+        continue;
+      }
+
+      // The stationary polynomial has a positive leading coefficient. Its sign to the right
+      // of this root is determined by the odd-multiplicity roots that follow it.
+      double aSqDist          = theP.SquareDistance(aCurvePt);
+      size_t aNbOddRootsAfter = 0;
+      for (size_t aNext = i + 1; aNext < aPolyRes.NbRoots; ++aNext)
+      {
+        aNbOddRootsAfter += aPolyRes.Multiplicities[aNext] % 2;
+      }
+      const bool aIsMin = aNbOddRootsAfter % 2 == 0;
+
+      // Filter by search mode
+      if (theMode == ExtremaPC2d::SearchMode::Min && !aIsMin)
+        continue;
+      if (theMode == ExtremaPC2d::SearchMode::Max && aIsMin)
+        continue;
+
+      ExtremaPC2d::ExtremumResult anExt;
+      anExt.Parameter      = aU;
+      anExt.Point          = aCurvePt;
+      anExt.SquareDistance = aSqDist;
+      anExt.IsMinimum      = aIsMin;
+      anExt.IsMaximum      = !aIsMin;
+
+      myResult.Extrema.Append(anExt);
+    }
+
+    myResult.Status =
+      myResult.Extrema.IsEmpty() ? ExtremaPC2d::Status::NoSolution : ExtremaPC2d::Status::OK;
+  }
+
+  gp_Parab2d                           myParabola; //!< Parabola geometry
+  std::optional<ExtremaPC2d::Domain1D> myDomain;   //!< Parameter domain (nullopt for infinite)
+  mutable ExtremaPC2d::Result          myResult;   //!< Reusable result storage
+
+  // Cached geometry components for fast computation
+  double myVertexX, myVertexY; //!< Vertex location
+  double myXDirX, myXDirY;     //!< X-axis direction
+  double myYDirX, myYDirY;     //!< Y-axis direction
+  double myFocal;              //!< Focal length
+  double my1Over4F;            //!< Precomputed 1/(4*F)
+  double my2F;                 //!< Precomputed 2*F
+};
+
+#endif // _ExtremaPC2d_Parabola_HeaderFile

--- a/src/ModelingData/TKGeomBase/ExtremaPC2d/FILES.cmake
+++ b/src/ModelingData/TKGeomBase/ExtremaPC2d/FILES.cmake
@@ -1,0 +1,23 @@
+# Auto-generated list of source files for ExtremaPC2d package
+set(OCCT_ExtremaPC2d_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
+
+set(OCCT_ExtremaPC2d_FILES
+  ExtremaPC2d.hxx
+  ExtremaPC2d_Line.hxx
+  ExtremaPC2d_Circle.hxx
+  ExtremaPC2d_Ellipse.hxx
+  ExtremaPC2d_Hyperbola.hxx
+  ExtremaPC2d_Parabola.hxx
+  ExtremaPC2d_DistanceFunction.hxx
+  ExtremaPC2d_GridEvaluator.hxx
+  ExtremaPC2d_BezierCurve.hxx
+  ExtremaPC2d_BezierCurve.cxx
+  ExtremaPC2d_BSplineCurve.hxx
+  ExtremaPC2d_BSplineCurve.cxx
+  ExtremaPC2d_OffsetCurve.hxx
+  ExtremaPC2d_OffsetCurve.cxx
+  ExtremaPC2d_OtherCurve.hxx
+  ExtremaPC2d_OtherCurve.cxx
+  ExtremaPC2d_Curve.hxx
+  ExtremaPC2d_Curve.cxx
+)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BSplineCurve_Test.cxx
@@ -104,9 +104,10 @@ TEST(ExtremaPC2d_BSplineCurveTest, PoleMutationIsObserved)
   const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL);
   ASSERT_TRUE(anAfter.IsDone());
   EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
-  EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
-              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
-            0.0);
+  EXPECT_NEAR(anAfter[anAfter.MinIndex()].Point.Distance(
+                aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+              0.0,
+              THE_TOL);
 }
 
 TEST(ExtremaPC2d_BSplineCurveTest, SearchModesFilterExtrema)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BSplineCurve_Test.cxx
@@ -1,0 +1,134 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_BSplineCurve.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+
+occ::handle<Geom2d_BSplineCurve> makeLinear()
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 2);
+  aPoles(1) = gp_Pnt2d(0.0, 0.0);
+  aPoles(2) = gp_Pnt2d(10.0, 0.0);
+  NCollection_Array1<double> aKnots(1, 2);
+  aKnots(1) = 0.0;
+  aKnots(2) = 1.0;
+  NCollection_Array1<int> aMults(1, 2);
+  aMults(1) = 2;
+  aMults(2) = 2;
+  return new Geom2d_BSplineCurve(aPoles, aKnots, aMults, 1);
+}
+
+occ::handle<Geom2d_BSplineCurve> makeC1Curve()
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 4);
+  aPoles(1) = gp_Pnt2d(0.0, 0.0);
+  aPoles(2) = gp_Pnt2d(1.0, 1.0);
+  aPoles(3) = gp_Pnt2d(2.0, 1.0);
+  aPoles(4) = gp_Pnt2d(3.0, 0.0);
+  NCollection_Array1<double> aKnots(1, 3);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.5;
+  aKnots(3) = 1.0;
+  NCollection_Array1<int> aMults(1, 3);
+  aMults(1) = 3;
+  aMults(2) = 1;
+  aMults(3) = 3;
+  return new Geom2d_BSplineCurve(aPoles, aKnots, aMults, 2);
+}
+} // namespace
+
+TEST(ExtremaPC2d_BSplineCurveTest, LinearProjectionIsExact)
+{
+  ExtremaPC2d_BSplineCurve anEvaluator(makeLinear());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(6.0, 4.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.6, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 16.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BSplineCurveTest, PartialDomainUsesEndpointWhenRequested)
+{
+  ExtremaPC2d_BSplineCurve anEvaluator(makeLinear(), {0.0, 0.5});
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL).NbExt(), 0);
+  const ExtremaPC2d::Result& aResult = anEvaluator.PerformWithEndpoints(
+    gp_Pnt2d(8.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.5, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BSplineCurveTest, C1JunctionPointIsFound)
+{
+  occ::handle<Geom2d_BSplineCurve> aCurve = makeC1Curve();
+  ExtremaPC2d_BSplineCurve anEvaluator(aCurve);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(aCurve->Value(0.5), THE_TOL,
+                                                           ExtremaPC2d::SearchMode::Min);
+  ASSERT_GE(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.5, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BSplineCurveTest, DegenerateCurveHasInfiniteSolutions)
+{
+  occ::handle<Geom2d_BSplineCurve> aCurve = makeLinear();
+  aCurve->SetPole(1, gp_Pnt2d(2.0, -1.0));
+  aCurve->SetPole(2, gp_Pnt2d(2.0, -1.0));
+  ExtremaPC2d_BSplineCurve anEvaluator(aCurve);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(5.0, 3.0), THE_TOL);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BSplineCurveTest, PoleMutationIsObserved)
+{
+  occ::handle<Geom2d_BSplineCurve> aCurve = makeC1Curve();
+  ExtremaPC2d_BSplineCurve anEvaluator(aCurve);
+  const double aBefore = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL).MinSquareDistance();
+  aCurve->SetPole(2, gp_Pnt2d(1.0, -3.0));
+  const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL);
+  ASSERT_TRUE(anAfter.IsDone());
+  EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
+  EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
+              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)), 0.0);
+}
+
+TEST(ExtremaPC2d_BSplineCurveTest, SearchModesFilterExtrema)
+{
+  ExtremaPC2d_BSplineCurve anEvaluator(makeC1Curve());
+  const ExtremaPC2d::Result& aMin = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Min);
+  for (size_t anIndex = 0; anIndex < aMin.NbExt(); ++anIndex)
+  {
+    EXPECT_TRUE(aMin[anIndex].IsMinimum);
+  }
+  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Max);
+  for (size_t anIndex = 0; anIndex < aMax.NbExt(); ++anIndex)
+  {
+    EXPECT_TRUE(aMax[anIndex].IsMaximum);
+  }
+}
+
+TEST(ExtremaPC2d_BSplineCurveTest, SingletonInvalidNullAndOwnership)
+{
+  ExtremaPC2d_BSplineCurve aSingleton(makeLinear(), {0.4, 0.4});
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
+  EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
+  ExtremaPC2d_BSplineCurve anInvalid(makeLinear(), {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::InvalidInput);
+  occ::handle<Geom2d_BSplineCurve> aNull;
+  ExtremaPC2d_BSplineCurve aNullEvaluator(aNull);
+  EXPECT_EQ(aNullEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::NotDone);
+  occ::handle<Geom2d_BSplineCurve> aCurve = makeLinear();
+  ExtremaPC2d_BSplineCurve anOwned(aCurve);
+  aCurve.Nullify();
+  EXPECT_FALSE(anOwned.Curve().IsNull());
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BSplineCurve_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_BSplineCurve.hxx>
 
@@ -46,7 +56,7 @@ occ::handle<Geom2d_BSplineCurve> makeC1Curve()
 
 TEST(ExtremaPC2d_BSplineCurveTest, LinearProjectionIsExact)
 {
-  ExtremaPC2d_BSplineCurve anEvaluator(makeLinear());
+  ExtremaPC2d_BSplineCurve   anEvaluator(makeLinear());
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(6.0, 4.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult[0].Parameter, 0.6, THE_TOL);
@@ -57,8 +67,8 @@ TEST(ExtremaPC2d_BSplineCurveTest, PartialDomainUsesEndpointWhenRequested)
 {
   ExtremaPC2d_BSplineCurve anEvaluator(makeLinear(), {0.0, 0.5});
   EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL).NbExt(), 0);
-  const ExtremaPC2d::Result& aResult = anEvaluator.PerformWithEndpoints(
-    gp_Pnt2d(8.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(8.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult[0].Parameter, 0.5, THE_TOL);
 }
@@ -66,9 +76,9 @@ TEST(ExtremaPC2d_BSplineCurveTest, PartialDomainUsesEndpointWhenRequested)
 TEST(ExtremaPC2d_BSplineCurveTest, C1JunctionPointIsFound)
 {
   occ::handle<Geom2d_BSplineCurve> aCurve = makeC1Curve();
-  ExtremaPC2d_BSplineCurve anEvaluator(aCurve);
-  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(aCurve->Value(0.5), THE_TOL,
-                                                           ExtremaPC2d::SearchMode::Min);
+  ExtremaPC2d_BSplineCurve         anEvaluator(aCurve);
+  const ExtremaPC2d::Result&       aResult =
+    anEvaluator.Perform(aCurve->Value(0.5), THE_TOL, ExtremaPC2d::SearchMode::Min);
   ASSERT_GE(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.5, THE_TOL);
@@ -79,7 +89,7 @@ TEST(ExtremaPC2d_BSplineCurveTest, DegenerateCurveHasInfiniteSolutions)
   occ::handle<Geom2d_BSplineCurve> aCurve = makeLinear();
   aCurve->SetPole(1, gp_Pnt2d(2.0, -1.0));
   aCurve->SetPole(2, gp_Pnt2d(2.0, -1.0));
-  ExtremaPC2d_BSplineCurve anEvaluator(aCurve);
+  ExtremaPC2d_BSplineCurve   anEvaluator(aCurve);
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(5.0, 3.0), THE_TOL);
   EXPECT_TRUE(aResult.IsInfinite());
   EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, THE_TOL);
@@ -88,27 +98,28 @@ TEST(ExtremaPC2d_BSplineCurveTest, DegenerateCurveHasInfiniteSolutions)
 TEST(ExtremaPC2d_BSplineCurveTest, PoleMutationIsObserved)
 {
   occ::handle<Geom2d_BSplineCurve> aCurve = makeC1Curve();
-  ExtremaPC2d_BSplineCurve anEvaluator(aCurve);
+  ExtremaPC2d_BSplineCurve         anEvaluator(aCurve);
   const double aBefore = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL).MinSquareDistance();
   aCurve->SetPole(2, gp_Pnt2d(1.0, -3.0));
   const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL);
   ASSERT_TRUE(anAfter.IsDone());
   EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
   EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
-              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)), 0.0);
+              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+            0.0);
 }
 
 TEST(ExtremaPC2d_BSplineCurveTest, SearchModesFilterExtrema)
 {
-  ExtremaPC2d_BSplineCurve anEvaluator(makeC1Curve());
-  const ExtremaPC2d::Result& aMin = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Min);
+  ExtremaPC2d_BSplineCurve   anEvaluator(makeC1Curve());
+  const ExtremaPC2d::Result& aMin =
+    anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
   for (size_t anIndex = 0; anIndex < aMin.NbExt(); ++anIndex)
   {
     EXPECT_TRUE(aMin[anIndex].IsMinimum);
   }
-  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Max);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.Perform(gp_Pnt2d(1.5, 2.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
   for (size_t anIndex = 0; anIndex < aMax.NbExt(); ++anIndex)
   {
     EXPECT_TRUE(aMax[anIndex].IsMaximum);
@@ -121,14 +132,12 @@ TEST(ExtremaPC2d_BSplineCurveTest, SingletonInvalidNullAndOwnership)
   EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
   EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
   ExtremaPC2d_BSplineCurve anInvalid(makeLinear(), {1.0, 0.0});
-  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
   occ::handle<Geom2d_BSplineCurve> aNull;
-  ExtremaPC2d_BSplineCurve aNullEvaluator(aNull);
-  EXPECT_EQ(aNullEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::NotDone);
+  ExtremaPC2d_BSplineCurve         aNullEvaluator(aNull);
+  EXPECT_EQ(aNullEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::NotDone);
   occ::handle<Geom2d_BSplineCurve> aCurve = makeLinear();
-  ExtremaPC2d_BSplineCurve anOwned(aCurve);
+  ExtremaPC2d_BSplineCurve         anOwned(aCurve);
   aCurve.Nullify();
   EXPECT_FALSE(anOwned.Curve().IsNull());
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BezierCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BezierCurve_Test.cxx
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_BezierCurve.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+
+occ::handle<Geom2d_BezierCurve> makeLinear()
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 2);
+  aPoles(1) = gp_Pnt2d(0.0, 0.0);
+  aPoles(2) = gp_Pnt2d(10.0, 0.0);
+  return new Geom2d_BezierCurve(aPoles);
+}
+
+occ::handle<Geom2d_BezierCurve> makeQuadratic()
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles(1) = gp_Pnt2d(-2.0, 0.0);
+  aPoles(2) = gp_Pnt2d(0.0, 2.0);
+  aPoles(3) = gp_Pnt2d(2.0, 0.0);
+  return new Geom2d_BezierCurve(aPoles);
+}
+} // namespace
+
+TEST(ExtremaPC2d_BezierCurveTest, LinearProjectionIsExact)
+{
+  ExtremaPC2d_BezierCurve    anEvaluator(makeLinear());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.4, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 9.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, SearchModesAndEndpoints)
+{
+  ExtremaPC2d_BezierCurve anEvaluator(makeLinear());
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Max).NbExt(),
+            0);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(-2.0, 0.0), THE_TOL).NbExt(), 0);
+  const ExtremaPC2d::Result& aMin =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(-2.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aMin.NbExt(), 1);
+  EXPECT_NEAR(aMin[0].Parameter, 0.0, THE_TOL);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(-2.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_NEAR(aMax[0].Parameter, 1.0, THE_TOL);
+  EXPECT_NEAR(aMax[0].SquareDistance, 144.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, SymmetricQuadraticHasCentralMinimum)
+{
+  ExtremaPC2d_BezierCurve    anEvaluator(makeQuadratic());
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.Perform(gp_Pnt2d(), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.5, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 1.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, RationalArcHasConstantDistance)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles(1) = gp_Pnt2d(1.0, 0.0);
+  aPoles(2) = gp_Pnt2d(1.0, 1.0);
+  aPoles(3) = gp_Pnt2d(0.0, 1.0);
+  NCollection_Array1<double> aWeights(1, 3);
+  aWeights(1) = 1.0;
+  aWeights(2) = M_SQRT1_2;
+  aWeights(3) = 1.0;
+  ExtremaPC2d_BezierCurve    anEvaluator(new Geom2d_BezierCurve(aPoles, aWeights));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 1.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, DegenerateCurveHasInfiniteSolutions)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles.Init(gp_Pnt2d(2.0, -1.0));
+  ExtremaPC2d_BezierCurve    anEvaluator(new Geom2d_BezierCurve(aPoles));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(5.0, 3.0), THE_TOL);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, MaxDegreeRationalWorkspaceHandlesConstantCurve)
+{
+  const int                    aNbPoles = Geom2d_BezierCurve::MaxDegree() + 1;
+  NCollection_Array1<gp_Pnt2d> aPoles(1, aNbPoles);
+  NCollection_Array1<double>   aWeights(1, aNbPoles);
+  for (size_t aPoleIndex = 0; aPoleIndex < aPoles.Size(); ++aPoleIndex)
+  {
+    aPoles.ChangeAt(aPoleIndex)   = gp_Pnt2d(2.0, -1.0);
+    aWeights.ChangeAt(aPoleIndex) = 1.0 + 0.01 * static_cast<double>(aPoleIndex + 1);
+  }
+
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles, aWeights);
+  ExtremaPC2d_BezierCurve         anExtrema(aCurve);
+  const ExtremaPC2d::Result&      aResult = anExtrema.Perform(gp_Pnt2d(5.0, 3.0), THE_TOL);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, MutationIsObserved)
+{
+  occ::handle<Geom2d_BezierCurve> aCurve = makeQuadratic();
+  ExtremaPC2d_BezierCurve         anEvaluator(aCurve);
+  const double aBefore = anEvaluator.Perform(gp_Pnt2d(0.0, 1.5), THE_TOL).MinSquareDistance();
+  aCurve->SetPole(2, gp_Pnt2d(3.0, -4.0));
+  const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(0.0, 1.5), THE_TOL);
+  ASSERT_TRUE(anAfter.IsDone());
+  EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
+  EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
+              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+            0.0);
+}
+
+TEST(ExtremaPC2d_BezierCurveTest, SingletonInvalidNullAndOwnership)
+{
+  ExtremaPC2d_BezierCurve aSingleton(makeLinear(), {0.4, 0.4});
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
+  EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
+  ExtremaPC2d_BezierCurve anInvalid(makeLinear(), {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  occ::handle<Geom2d_BezierCurve> aNull;
+  ExtremaPC2d_BezierCurve         aNullEvaluator(aNull);
+  EXPECT_EQ(aNullEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::NotDone);
+
+  occ::handle<Geom2d_BezierCurve> aCurve = makeLinear();
+  ExtremaPC2d_BezierCurve         anOwned(aCurve);
+  aCurve.Nullify();
+  EXPECT_FALSE(anOwned.Curve().IsNull());
+  EXPECT_TRUE(anOwned.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL).IsDone());
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BezierCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BezierCurve_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_BezierCurve.hxx>
 

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BezierCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_BezierCurve_Test.cxx
@@ -128,9 +128,10 @@ TEST(ExtremaPC2d_BezierCurveTest, MutationIsObserved)
   const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(0.0, 1.5), THE_TOL);
   ASSERT_TRUE(anAfter.IsDone());
   EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
-  EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
-              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
-            0.0);
+  EXPECT_NEAR(anAfter[anAfter.MinIndex()].Point.Distance(
+                aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+              0.0,
+              THE_TOL);
 }
 
 TEST(ExtremaPC2d_BezierCurveTest, SingletonInvalidNullAndOwnership)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Circle_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Circle_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_Circle.hxx>
 
@@ -10,6 +20,7 @@
 namespace
 {
 constexpr double THE_TOL = 1.0e-9;
+
 gp_Circ2d makeCircle(double theRadius = 5.0)
 {
   return gp_Circ2d(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), theRadius);
@@ -18,7 +29,7 @@ gp_Circ2d makeCircle(double theRadius = 5.0)
 
 TEST(ExtremaPC2d_CircleTest, OutsideAndInsidePointsHaveOppositeExtrema)
 {
-  ExtremaPC2d_Circle anEvaluator(makeCircle());
+  ExtremaPC2d_Circle         anEvaluator(makeCircle());
   const ExtremaPC2d::Result& anOutside = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL);
   ASSERT_EQ(anOutside.NbExt(), 2);
   EXPECT_NEAR(anOutside[anOutside.MinIndex()].Parameter, 0.0, THE_TOL);
@@ -32,13 +43,13 @@ TEST(ExtremaPC2d_CircleTest, OutsideAndInsidePointsHaveOppositeExtrema)
 
 TEST(ExtremaPC2d_CircleTest, SearchModesReturnExactSubsets)
 {
-  ExtremaPC2d_Circle anEvaluator(makeCircle());
-  const ExtremaPC2d::Result& aMin = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Min);
+  ExtremaPC2d_Circle         anEvaluator(makeCircle());
+  const ExtremaPC2d::Result& aMin =
+    anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
   ASSERT_EQ(aMin.NbExt(), 1);
   EXPECT_TRUE(aMin[0].IsMinimum);
-  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Max);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
   ASSERT_EQ(aMax.NbExt(), 1);
   EXPECT_TRUE(aMax[0].IsMaximum);
   EXPECT_NEAR(aMax[0].Parameter, M_PI, THE_TOL);
@@ -46,13 +57,14 @@ TEST(ExtremaPC2d_CircleTest, SearchModesReturnExactSubsets)
 
 TEST(ExtremaPC2d_CircleTest, IndirectOrientationPreservesSense)
 {
-  const gp_Ax22d aPosition(gp_Pnt2d(2.0, -1.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
+  const gp_Ax22d  aPosition(gp_Pnt2d(2.0, -1.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
   const gp_Circ2d aCircle(aPosition, 4.0);
-  const double anAngle = 0.7;
-  const gp_Pnt2d aQuery = aCircle.Location().Translated(
-    7.0 * (std::cos(anAngle) * gp_Vec2d(aPosition.XDirection())
-           + std::sin(anAngle) * gp_Vec2d(aPosition.YDirection())));
-  ExtremaPC2d_Circle anEvaluator(aCircle);
+  const double    anAngle = 0.7;
+  const gp_Pnt2d  aQuery =
+    aCircle.Location().Translated(7.0
+                                  * (std::cos(anAngle) * gp_Vec2d(aPosition.XDirection())
+                                     + std::sin(anAngle) * gp_Vec2d(aPosition.YDirection())));
+  ExtremaPC2d_Circle         anEvaluator(aCircle);
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(aQuery, THE_TOL);
   EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, anAngle, THE_TOL);
   EXPECT_NEAR(aResult.MinSquareDistance(), 9.0, THE_TOL);
@@ -60,12 +72,12 @@ TEST(ExtremaPC2d_CircleTest, IndirectOrientationPreservesSense)
 
 TEST(ExtremaPC2d_CircleTest, CenterAndZeroRadiusHaveInfiniteSolutions)
 {
-  ExtremaPC2d_Circle aCircle(makeCircle());
+  ExtremaPC2d_Circle         aCircle(makeCircle());
   const ExtremaPC2d::Result& aCenter = aCircle.Perform(gp_Pnt2d(), THE_TOL);
   EXPECT_TRUE(aCenter.IsInfinite());
   EXPECT_NEAR(aCenter.InfiniteSquareDistance, 25.0, THE_TOL);
 
-  ExtremaPC2d_Circle aPointCircle(makeCircle(0.0));
+  ExtremaPC2d_Circle         aPointCircle(makeCircle(0.0));
   const ExtremaPC2d::Result& aPointResult = aPointCircle.Perform(gp_Pnt2d(3.0, 4.0), THE_TOL);
   EXPECT_TRUE(aPointResult.IsInfinite());
   EXPECT_NEAR(aPointResult.InfiniteSquareDistance, 25.0, THE_TOL);
@@ -73,9 +85,9 @@ TEST(ExtremaPC2d_CircleTest, CenterAndZeroRadiusHaveInfiniteSolutions)
 
 TEST(ExtremaPC2d_CircleTest, ShiftedFullPeriodHasUniqueRepresentatives)
 {
-  ExtremaPC2d_Circle anEvaluator(makeCircle(), {7.0, 7.0 + 2.0 * M_PI});
-  const ExtremaPC2d::Result& aResult = anEvaluator.PerformWithEndpoints(gp_Pnt2d(13.0, 0.0),
-                                                                        THE_TOL);
+  ExtremaPC2d_Circle         anEvaluator(makeCircle(), {7.0, 7.0 + 2.0 * M_PI});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(13.0, 0.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 2);
   EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 4.0 * M_PI, THE_TOL);
   EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 3.0 * M_PI, THE_TOL);
@@ -83,7 +95,7 @@ TEST(ExtremaPC2d_CircleTest, ShiftedFullPeriodHasUniqueRepresentatives)
 
 TEST(ExtremaPC2d_CircleTest, MultiplePeriodsReturnAllParameterExtrema)
 {
-  ExtremaPC2d_Circle anEvaluator(makeCircle(), {0.0, 4.0 * M_PI});
+  ExtremaPC2d_Circle         anEvaluator(makeCircle(), {0.0, 4.0 * M_PI});
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 4);
   EXPECT_NEAR(aResult[0].Parameter, 0.0, THE_TOL);
@@ -94,7 +106,7 @@ TEST(ExtremaPC2d_CircleTest, MultiplePeriodsReturnAllParameterExtrema)
 
 TEST(ExtremaPC2d_CircleTest, HalfCircleClassifiesInteriorAndEndpoints)
 {
-  ExtremaPC2d_Circle anEvaluator(makeCircle(), {M_PI_2, 3.0 * M_PI_2});
+  ExtremaPC2d_Circle         anEvaluator(makeCircle(), {M_PI_2, 3.0 * M_PI_2});
   const ExtremaPC2d::Result& aResult =
     anEvaluator.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 3);
@@ -111,19 +123,16 @@ TEST(ExtremaPC2d_CircleTest, SingletonAndInvalidInput)
 {
   ExtremaPC2d_Circle aSingleton(makeCircle(), {0.4, 0.4});
   EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL).NbExt(), 0);
-  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::NoSolution);
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::NoSolution);
   EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(8.0, 0.0), THE_TOL).NbExt(), 1);
   ExtremaPC2d_Circle anInvalid(makeCircle(), {1.0, 0.0});
-  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::InvalidInput);
-  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), 0.0).Status,
-            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), 0.0).Status, ExtremaPC2d::Status::InvalidInput);
 }
 
 TEST(ExtremaPC2d_CircleTest, LargeToleranceDoesNotExpandDomain)
 {
-  ExtremaPC2d_Circle anEvaluator(makeCircle(1.0), {1.0, 2.0});
+  ExtremaPC2d_Circle         anEvaluator(makeCircle(1.0), {1.0, 2.0});
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(2.0, 0.0), 2.0);
   EXPECT_EQ(aResult.Status, ExtremaPC2d::Status::NoSolution);
   EXPECT_EQ(aResult.NbExt(), 0);
@@ -132,14 +141,13 @@ TEST(ExtremaPC2d_CircleTest, LargeToleranceDoesNotExpandDomain)
 TEST(ExtremaPC2d_CircleTest, NonFiniteQueryIsRejected)
 {
   ExtremaPC2d_Circle anEvaluator(makeCircle());
-  const gp_Pnt2d aQuery(Precision::Infinite(), 0.0);
-  EXPECT_EQ(anEvaluator.Perform(aQuery, THE_TOL).Status,
-            ExtremaPC2d::Status::InvalidInput);
+  const gp_Pnt2d     aQuery(Precision::Infinite(), 0.0);
+  EXPECT_EQ(anEvaluator.Perform(aQuery, THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
 }
 
 TEST(ExtremaPC2d_CircleTest, UnrepresentablePeriodicStepReportsNumericalError)
 {
-  const double aFirst = 1.0e17;
+  const double       aFirst = 1.0e17;
   ExtremaPC2d_Circle anEvaluator(makeCircle(), {aFirst, aFirst + 100.0});
   EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(12.0, 0.0), THE_TOL).Status,
             ExtremaPC2d::Status::NumericalError);
@@ -147,7 +155,7 @@ TEST(ExtremaPC2d_CircleTest, UnrepresentablePeriodicStepReportsNumericalError)
 
 TEST(ExtremaPC2d_CircleTest, AccessorsAndValueMatchGeometry)
 {
-  const gp_Circ2d aCircle(gp_Ax22d(gp_Pnt2d(2.0, 3.0), gp_Dir2d(0.0, 1.0), false), 4.0);
+  const gp_Circ2d    aCircle(gp_Ax22d(gp_Pnt2d(2.0, 3.0), gp_Dir2d(0.0, 1.0), false), 4.0);
   ExtremaPC2d_Circle anEvaluator(aCircle, {-1.0, 2.0});
   EXPECT_TRUE(anEvaluator.IsBounded());
   EXPECT_NEAR(anEvaluator.Domain().Min, -1.0, THE_TOL);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Circle_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Circle_Test.cxx
@@ -1,0 +1,155 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_Circle.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-9;
+gp_Circ2d makeCircle(double theRadius = 5.0)
+{
+  return gp_Circ2d(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), theRadius);
+}
+} // namespace
+
+TEST(ExtremaPC2d_CircleTest, OutsideAndInsidePointsHaveOppositeExtrema)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle());
+  const ExtremaPC2d::Result& anOutside = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL);
+  ASSERT_EQ(anOutside.NbExt(), 2);
+  EXPECT_NEAR(anOutside[anOutside.MinIndex()].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(anOutside.MinSquareDistance(), 64.0, THE_TOL);
+  EXPECT_NEAR(anOutside.MaxSquareDistance(), 324.0, THE_TOL);
+
+  const ExtremaPC2d::Result& anInside = anEvaluator.Perform(gp_Pnt2d(2.0, 0.0), THE_TOL);
+  EXPECT_NEAR(anInside.MinSquareDistance(), 9.0, THE_TOL);
+  EXPECT_NEAR(anInside.MaxSquareDistance(), 49.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CircleTest, SearchModesReturnExactSubsets)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle());
+  const ExtremaPC2d::Result& aMin = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aMin.NbExt(), 1);
+  EXPECT_TRUE(aMin[0].IsMinimum);
+  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_TRUE(aMax[0].IsMaximum);
+  EXPECT_NEAR(aMax[0].Parameter, M_PI, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CircleTest, IndirectOrientationPreservesSense)
+{
+  const gp_Ax22d aPosition(gp_Pnt2d(2.0, -1.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
+  const gp_Circ2d aCircle(aPosition, 4.0);
+  const double anAngle = 0.7;
+  const gp_Pnt2d aQuery = aCircle.Location().Translated(
+    7.0 * (std::cos(anAngle) * gp_Vec2d(aPosition.XDirection())
+           + std::sin(anAngle) * gp_Vec2d(aPosition.YDirection())));
+  ExtremaPC2d_Circle anEvaluator(aCircle);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(aQuery, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, anAngle, THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 9.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CircleTest, CenterAndZeroRadiusHaveInfiniteSolutions)
+{
+  ExtremaPC2d_Circle aCircle(makeCircle());
+  const ExtremaPC2d::Result& aCenter = aCircle.Perform(gp_Pnt2d(), THE_TOL);
+  EXPECT_TRUE(aCenter.IsInfinite());
+  EXPECT_NEAR(aCenter.InfiniteSquareDistance, 25.0, THE_TOL);
+
+  ExtremaPC2d_Circle aPointCircle(makeCircle(0.0));
+  const ExtremaPC2d::Result& aPointResult = aPointCircle.Perform(gp_Pnt2d(3.0, 4.0), THE_TOL);
+  EXPECT_TRUE(aPointResult.IsInfinite());
+  EXPECT_NEAR(aPointResult.InfiniteSquareDistance, 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CircleTest, ShiftedFullPeriodHasUniqueRepresentatives)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle(), {7.0, 7.0 + 2.0 * M_PI});
+  const ExtremaPC2d::Result& aResult = anEvaluator.PerformWithEndpoints(gp_Pnt2d(13.0, 0.0),
+                                                                        THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 4.0 * M_PI, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 3.0 * M_PI, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CircleTest, MultiplePeriodsReturnAllParameterExtrema)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle(), {0.0, 4.0 * M_PI});
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(13.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 4);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[1].Parameter, 2.0 * M_PI, THE_TOL);
+  EXPECT_NEAR(aResult[2].Parameter, M_PI, THE_TOL);
+  EXPECT_NEAR(aResult[3].Parameter, 3.0 * M_PI, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CircleTest, HalfCircleClassifiesInteriorAndEndpoints)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle(), {M_PI_2, 3.0 * M_PI_2});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, M_PI, THE_TOL);
+  int aMinimumCount = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    aMinimumCount += aResult[anIndex].IsMinimum ? 1 : 0;
+  }
+  EXPECT_EQ(aMinimumCount, 2);
+}
+
+TEST(ExtremaPC2d_CircleTest, SingletonAndInvalidInput)
+{
+  ExtremaPC2d_Circle aSingleton(makeCircle(), {0.4, 0.4});
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL).NbExt(), 0);
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::NoSolution);
+  EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(8.0, 0.0), THE_TOL).NbExt(), 1);
+  ExtremaPC2d_Circle anInvalid(makeCircle(), {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), 0.0).Status,
+            ExtremaPC2d::Status::InvalidInput);
+}
+
+TEST(ExtremaPC2d_CircleTest, LargeToleranceDoesNotExpandDomain)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle(1.0), {1.0, 2.0});
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(2.0, 0.0), 2.0);
+  EXPECT_EQ(aResult.Status, ExtremaPC2d::Status::NoSolution);
+  EXPECT_EQ(aResult.NbExt(), 0);
+}
+
+TEST(ExtremaPC2d_CircleTest, NonFiniteQueryIsRejected)
+{
+  ExtremaPC2d_Circle anEvaluator(makeCircle());
+  const gp_Pnt2d aQuery(Precision::Infinite(), 0.0);
+  EXPECT_EQ(anEvaluator.Perform(aQuery, THE_TOL).Status,
+            ExtremaPC2d::Status::InvalidInput);
+}
+
+TEST(ExtremaPC2d_CircleTest, UnrepresentablePeriodicStepReportsNumericalError)
+{
+  const double aFirst = 1.0e17;
+  ExtremaPC2d_Circle anEvaluator(makeCircle(), {aFirst, aFirst + 100.0});
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(12.0, 0.0), THE_TOL).Status,
+            ExtremaPC2d::Status::NumericalError);
+}
+
+TEST(ExtremaPC2d_CircleTest, AccessorsAndValueMatchGeometry)
+{
+  const gp_Circ2d aCircle(gp_Ax22d(gp_Pnt2d(2.0, 3.0), gp_Dir2d(0.0, 1.0), false), 4.0);
+  ExtremaPC2d_Circle anEvaluator(aCircle, {-1.0, 2.0});
+  EXPECT_TRUE(anEvaluator.IsBounded());
+  EXPECT_NEAR(anEvaluator.Domain().Min, -1.0, THE_TOL);
+  EXPECT_EQ(anEvaluator.Value(0.3).Distance(ElCLib::Value(0.3, aCircle)), 0.0);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Curve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Curve_Test.cxx
@@ -203,9 +203,10 @@ TEST(ExtremaPC2d_CurveTest, BezierMutationFlowsThroughAggregator)
   aCurve->SetPole(2, gp_Pnt2d(3.5, -4.0));
   const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(2.0, 2.0), THE_TOL);
   EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
-  EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
-              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
-            0.0);
+  EXPECT_NEAR(anAfter[anAfter.MinIndex()].Point.Distance(
+                aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+              0.0,
+              THE_TOL);
 }
 
 TEST(ExtremaPC2d_CurveTest, AnalyticalDispatchCopiesPrimitiveGeometry)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Curve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Curve_Test.cxx
@@ -1,0 +1,235 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_Curve.hxx>
+
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_BSplineCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_Hyperbola.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom2d_Parabola.hxx>
+#include <Geom2d_TrimmedCurve.hxx>
+#include <Geom2dEval_SineWaveCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <NCollection_Array1.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+
+void compareResults(const ExtremaPC2d::Result& theFirst, const ExtremaPC2d::Result& theSecond)
+{
+  ASSERT_EQ(theFirst.Status, theSecond.Status);
+  ASSERT_EQ(theFirst.NbExt(), theSecond.NbExt());
+  for (size_t anIndex = 0; anIndex < theFirst.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(theFirst[anIndex].Parameter, theSecond[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(theFirst[anIndex].SquareDistance, theSecond[anIndex].SquareDistance, THE_TOL);
+    EXPECT_EQ(theFirst[anIndex].IsMinimum, theSecond[anIndex].IsMinimum);
+    EXPECT_EQ(theFirst[anIndex].IsMaximum, theSecond[anIndex].IsMaximum);
+  }
+}
+
+occ::handle<Geom2d_BezierCurve> makeBezier()
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles(1) = gp_Pnt2d(0.0, 0.0);
+  aPoles(2) = gp_Pnt2d(2.0, 3.0);
+  aPoles(3) = gp_Pnt2d(4.0, 0.0);
+  return new Geom2d_BezierCurve(aPoles);
+}
+
+occ::handle<Geom2d_BSplineCurve> makeBSpline()
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 4);
+  aPoles(1) = gp_Pnt2d(0.0, 0.0);
+  aPoles(2) = gp_Pnt2d(1.0, 2.0);
+  aPoles(3) = gp_Pnt2d(3.0, -1.0);
+  aPoles(4) = gp_Pnt2d(4.0, 0.0);
+  NCollection_Array1<double> aKnots(1, 2);
+  aKnots(1) = 0.0;
+  aKnots(2) = 1.0;
+  NCollection_Array1<int> aMults(1, 2);
+  aMults(1) = 4;
+  aMults(2) = 4;
+  return new Geom2d_BSplineCurve(aPoles, aKnots, aMults, 3);
+}
+} // namespace
+
+TEST(ExtremaPC2d_CurveTest, NullCurveIsUninitializedAndNotDone)
+{
+  occ::handle<Geom2d_Curve> aNull;
+  ExtremaPC2d_Curve anEvaluator(aNull);
+  EXPECT_FALSE(anEvaluator.IsInitialized());
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::NotDone);
+  EXPECT_EQ(anEvaluator.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::NotDone);
+}
+
+TEST(ExtremaPC2d_CurveTest, AnalyticalAdaptorDispatchMatchesSpecialists)
+{
+  const gp_Pnt2d aQuery(8.0, 3.0);
+  occ::handle<Geom2d_Line> aLine =
+    new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
+  Geom2dAdaptor_Curve aLineAdaptor(aLine, -10.0, 10.0);
+  ExtremaPC2d_Curve aLineAggregate(aLineAdaptor);
+  ExtremaPC2d_Line aLineDirect(aLine->Lin2d(), {-10.0, 10.0});
+  compareResults(aLineAggregate.Perform(aQuery, THE_TOL), aLineDirect.Perform(aQuery, THE_TOL));
+
+  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    4.0);
+  ExtremaPC2d_Curve aCircleAggregate(aCircle);
+  ExtremaPC2d_Circle aCircleDirect(aCircle->Circ2d());
+  compareResults(aCircleAggregate.Perform(aQuery, THE_TOL),
+                 aCircleDirect.Perform(aQuery, THE_TOL));
+
+  occ::handle<Geom2d_Ellipse> anEllipse = new Geom2d_Ellipse(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    5.0,
+    2.0);
+  ExtremaPC2d_Curve anEllipseAggregate(anEllipse);
+  ExtremaPC2d_Ellipse anEllipseDirect(anEllipse->Elips2d());
+  compareResults(anEllipseAggregate.Perform(aQuery, THE_TOL),
+                 anEllipseDirect.Perform(aQuery, THE_TOL));
+
+  occ::handle<Geom2d_Hyperbola> aHyperbola = new Geom2d_Hyperbola(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    3.0,
+    2.0);
+  Geom2dAdaptor_Curve aHyperbolaAdaptor(aHyperbola, -2.0, 2.0);
+  ExtremaPC2d_Curve aHyperbolaAggregate(aHyperbolaAdaptor);
+  ExtremaPC2d_Hyperbola aHyperbolaDirect(aHyperbola->Hypr2d(), {-2.0, 2.0});
+  compareResults(aHyperbolaAggregate.Perform(aQuery, THE_TOL),
+                 aHyperbolaDirect.Perform(aQuery, THE_TOL));
+
+  occ::handle<Geom2d_Parabola> aParabola = new Geom2d_Parabola(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    2.0);
+  Geom2dAdaptor_Curve aParabolaAdaptor(aParabola, -2.0, 2.0);
+  ExtremaPC2d_Curve aParabolaAggregate(aParabolaAdaptor);
+  ExtremaPC2d_Parabola aParabolaDirect(aParabola->Parab2d(), {-2.0, 2.0});
+  compareResults(aParabolaAggregate.Perform(aQuery, THE_TOL),
+                 aParabolaDirect.Perform(aQuery, THE_TOL));
+}
+
+TEST(ExtremaPC2d_CurveTest, NumericalHandleDispatchMatchesSpecialists)
+{
+  const gp_Pnt2d aQuery(2.0, 1.5);
+  occ::handle<Geom2d_BezierCurve> aBezier = makeBezier();
+  ExtremaPC2d_Curve aBezierAggregate(aBezier);
+  ExtremaPC2d_BezierCurve aBezierDirect(aBezier);
+  compareResults(aBezierAggregate.Perform(aQuery, THE_TOL),
+                 aBezierDirect.Perform(aQuery, THE_TOL));
+
+  occ::handle<Geom2d_BSplineCurve> aBSpline = makeBSpline();
+  ExtremaPC2d_Curve aBSplineAggregate(aBSpline);
+  ExtremaPC2d_BSplineCurve aBSplineDirect(aBSpline);
+  compareResults(aBSplineAggregate.Perform(aQuery, THE_TOL),
+                 aBSplineDirect.Perform(aQuery, THE_TOL));
+}
+
+TEST(ExtremaPC2d_CurveTest, OffsetDispatchAndSearchModes)
+{
+  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    3.0);
+  occ::handle<Geom2d_OffsetCurve> anOffset = new Geom2d_OffsetCurve(aCircle, 1.0);
+  ExtremaPC2d_Curve anEvaluator(anOffset, 0.0, 2.0 * M_PI);
+  const ExtremaPC2d::Result& aMin = anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aMin.NbExt(), 1);
+  EXPECT_TRUE(aMin[0].IsMinimum);
+  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_TRUE(aMax[0].IsMaximum);
+}
+
+TEST(ExtremaPC2d_CurveTest, GeneralCurveDispatchMatchesSpecialist)
+{
+  occ::handle<Geom2dEval_SineWaveCurve> aCurve = new Geom2dEval_SineWaveCurve(
+    gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)),
+    1.0,
+    2.0);
+  Geom2dAdaptor_Curve anAdaptor(aCurve, -2.0, 2.0);
+  ExtremaPC2d_Curve anAggregate(anAdaptor);
+  ExtremaPC2d_OtherCurve aDirect(anAdaptor, {-2.0, 2.0});
+  compareResults(anAggregate.Perform(gp_Pnt2d(0.5, 1.0), THE_TOL),
+                 aDirect.Perform(gp_Pnt2d(0.5, 1.0), THE_TOL));
+}
+
+TEST(ExtremaPC2d_CurveTest, TrimmedCurveUsesTrimBounds)
+{
+  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    3.0);
+  occ::handle<Geom2d_TrimmedCurve> aTrimmed = new Geom2d_TrimmedCurve(aCircle, 0.2, 1.0);
+  ExtremaPC2d_Curve anEvaluator(aTrimmed);
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(6.0, 0.0), THE_TOL);
+  ASSERT_TRUE(aResult.IsDone());
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    EXPECT_GE(aResult[anIndex].Parameter, 0.2 - THE_TOL);
+    EXPECT_LE(aResult[anIndex].Parameter, 1.0 + THE_TOL);
+  }
+}
+
+TEST(ExtremaPC2d_CurveTest, ExplicitBoundsIntersectTrimmedBounds)
+{
+  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
+    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
+    3.0);
+  occ::handle<Geom2d_TrimmedCurve> aTrimmed = new Geom2d_TrimmedCurve(aCircle, 0.2, 1.0);
+  ExtremaPC2d_Curve anEvaluator(aTrimmed, 0.5, 2.0);
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(6.0, 0.0), THE_TOL);
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    EXPECT_GE(aResult[anIndex].Parameter, 0.5 - THE_TOL);
+    EXPECT_LE(aResult[anIndex].Parameter, 1.0 + THE_TOL);
+  }
+}
+
+TEST(ExtremaPC2d_CurveTest, BezierMutationFlowsThroughAggregator)
+{
+  occ::handle<Geom2d_BezierCurve> aCurve = makeBezier();
+  ExtremaPC2d_Curve anEvaluator(aCurve);
+  const double aBefore = anEvaluator.Perform(gp_Pnt2d(2.0, 2.0), THE_TOL).MinSquareDistance();
+  aCurve->SetPole(2, gp_Pnt2d(3.5, -4.0));
+  const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(2.0, 2.0), THE_TOL);
+  EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
+  EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
+              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)), 0.0);
+}
+
+TEST(ExtremaPC2d_CurveTest, AnalyticalDispatchCopiesPrimitiveGeometry)
+{
+  occ::handle<Geom2d_Line> aLine =
+    new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
+  Geom2dAdaptor_Curve anAdaptor(aLine, -10.0, 10.0);
+  ExtremaPC2d_Curve anEvaluator(anAdaptor);
+  anAdaptor.Load(new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(0.0, 1.0)), -10.0, 10.0);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 4.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_CurveTest, ResultStorageIsEvaluatorLocal)
+{
+  ExtremaPC2d_Curve aFirst(makeBezier());
+  ExtremaPC2d_Curve aSecond(makeBSpline());
+  const ExtremaPC2d::Result* aFirstResult = &aFirst.Perform(gp_Pnt2d(1.0, 2.0), THE_TOL);
+  const ExtremaPC2d::Result* aSecondResult = &aSecond.Perform(gp_Pnt2d(1.0, 2.0), THE_TOL);
+  EXPECT_NE(aFirstResult, aSecondResult);
+  EXPECT_EQ(aFirstResult, &aFirst.Perform(gp_Pnt2d(3.0, 2.0), THE_TOL));
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Curve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Curve_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_Curve.hxx>
 
@@ -66,56 +76,47 @@ occ::handle<Geom2d_BSplineCurve> makeBSpline()
 TEST(ExtremaPC2d_CurveTest, NullCurveIsUninitializedAndNotDone)
 {
   occ::handle<Geom2d_Curve> aNull;
-  ExtremaPC2d_Curve anEvaluator(aNull);
+  ExtremaPC2d_Curve         anEvaluator(aNull);
   EXPECT_FALSE(anEvaluator.IsInitialized());
-  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::NotDone);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::NotDone);
   EXPECT_EQ(anEvaluator.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).Status,
             ExtremaPC2d::Status::NotDone);
 }
 
 TEST(ExtremaPC2d_CurveTest, AnalyticalAdaptorDispatchMatchesSpecialists)
 {
-  const gp_Pnt2d aQuery(8.0, 3.0);
-  occ::handle<Geom2d_Line> aLine =
-    new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
-  Geom2dAdaptor_Curve aLineAdaptor(aLine, -10.0, 10.0);
-  ExtremaPC2d_Curve aLineAggregate(aLineAdaptor);
-  ExtremaPC2d_Line aLineDirect(aLine->Lin2d(), {-10.0, 10.0});
+  const gp_Pnt2d           aQuery(8.0, 3.0);
+  occ::handle<Geom2d_Line> aLine = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
+  Geom2dAdaptor_Curve      aLineAdaptor(aLine, -10.0, 10.0);
+  ExtremaPC2d_Curve        aLineAggregate(aLineAdaptor);
+  ExtremaPC2d_Line         aLineDirect(aLine->Lin2d(), {-10.0, 10.0});
   compareResults(aLineAggregate.Perform(aQuery, THE_TOL), aLineDirect.Perform(aQuery, THE_TOL));
 
-  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    4.0);
-  ExtremaPC2d_Curve aCircleAggregate(aCircle);
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 4.0);
+  ExtremaPC2d_Curve  aCircleAggregate(aCircle);
   ExtremaPC2d_Circle aCircleDirect(aCircle->Circ2d());
-  compareResults(aCircleAggregate.Perform(aQuery, THE_TOL),
-                 aCircleDirect.Perform(aQuery, THE_TOL));
+  compareResults(aCircleAggregate.Perform(aQuery, THE_TOL), aCircleDirect.Perform(aQuery, THE_TOL));
 
-  occ::handle<Geom2d_Ellipse> anEllipse = new Geom2d_Ellipse(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    5.0,
-    2.0);
-  ExtremaPC2d_Curve anEllipseAggregate(anEllipse);
+  occ::handle<Geom2d_Ellipse> anEllipse =
+    new Geom2d_Ellipse(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 5.0, 2.0);
+  ExtremaPC2d_Curve   anEllipseAggregate(anEllipse);
   ExtremaPC2d_Ellipse anEllipseDirect(anEllipse->Elips2d());
   compareResults(anEllipseAggregate.Perform(aQuery, THE_TOL),
                  anEllipseDirect.Perform(aQuery, THE_TOL));
 
-  occ::handle<Geom2d_Hyperbola> aHyperbola = new Geom2d_Hyperbola(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    3.0,
-    2.0);
-  Geom2dAdaptor_Curve aHyperbolaAdaptor(aHyperbola, -2.0, 2.0);
-  ExtremaPC2d_Curve aHyperbolaAggregate(aHyperbolaAdaptor);
+  occ::handle<Geom2d_Hyperbola> aHyperbola =
+    new Geom2d_Hyperbola(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 3.0, 2.0);
+  Geom2dAdaptor_Curve   aHyperbolaAdaptor(aHyperbola, -2.0, 2.0);
+  ExtremaPC2d_Curve     aHyperbolaAggregate(aHyperbolaAdaptor);
   ExtremaPC2d_Hyperbola aHyperbolaDirect(aHyperbola->Hypr2d(), {-2.0, 2.0});
   compareResults(aHyperbolaAggregate.Perform(aQuery, THE_TOL),
                  aHyperbolaDirect.Perform(aQuery, THE_TOL));
 
-  occ::handle<Geom2d_Parabola> aParabola = new Geom2d_Parabola(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    2.0);
-  Geom2dAdaptor_Curve aParabolaAdaptor(aParabola, -2.0, 2.0);
-  ExtremaPC2d_Curve aParabolaAggregate(aParabolaAdaptor);
+  occ::handle<Geom2d_Parabola> aParabola =
+    new Geom2d_Parabola(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 2.0);
+  Geom2dAdaptor_Curve  aParabolaAdaptor(aParabola, -2.0, 2.0);
+  ExtremaPC2d_Curve    aParabolaAggregate(aParabolaAdaptor);
   ExtremaPC2d_Parabola aParabolaDirect(aParabola->Parab2d(), {-2.0, 2.0});
   compareResults(aParabolaAggregate.Perform(aQuery, THE_TOL),
                  aParabolaDirect.Perform(aQuery, THE_TOL));
@@ -123,45 +124,41 @@ TEST(ExtremaPC2d_CurveTest, AnalyticalAdaptorDispatchMatchesSpecialists)
 
 TEST(ExtremaPC2d_CurveTest, NumericalHandleDispatchMatchesSpecialists)
 {
-  const gp_Pnt2d aQuery(2.0, 1.5);
+  const gp_Pnt2d                  aQuery(2.0, 1.5);
   occ::handle<Geom2d_BezierCurve> aBezier = makeBezier();
-  ExtremaPC2d_Curve aBezierAggregate(aBezier);
-  ExtremaPC2d_BezierCurve aBezierDirect(aBezier);
-  compareResults(aBezierAggregate.Perform(aQuery, THE_TOL),
-                 aBezierDirect.Perform(aQuery, THE_TOL));
+  ExtremaPC2d_Curve               aBezierAggregate(aBezier);
+  ExtremaPC2d_BezierCurve         aBezierDirect(aBezier);
+  compareResults(aBezierAggregate.Perform(aQuery, THE_TOL), aBezierDirect.Perform(aQuery, THE_TOL));
 
   occ::handle<Geom2d_BSplineCurve> aBSpline = makeBSpline();
-  ExtremaPC2d_Curve aBSplineAggregate(aBSpline);
-  ExtremaPC2d_BSplineCurve aBSplineDirect(aBSpline);
+  ExtremaPC2d_Curve                aBSplineAggregate(aBSpline);
+  ExtremaPC2d_BSplineCurve         aBSplineDirect(aBSpline);
   compareResults(aBSplineAggregate.Perform(aQuery, THE_TOL),
                  aBSplineDirect.Perform(aQuery, THE_TOL));
 }
 
 TEST(ExtremaPC2d_CurveTest, OffsetDispatchAndSearchModes)
 {
-  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    3.0);
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 3.0);
   occ::handle<Geom2d_OffsetCurve> anOffset = new Geom2d_OffsetCurve(aCircle, 1.0);
-  ExtremaPC2d_Curve anEvaluator(anOffset, 0.0, 2.0 * M_PI);
-  const ExtremaPC2d::Result& aMin = anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Min);
+  ExtremaPC2d_Curve               anEvaluator(anOffset, 0.0, 2.0 * M_PI);
+  const ExtremaPC2d::Result&      aMin =
+    anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
   ASSERT_EQ(aMin.NbExt(), 1);
   EXPECT_TRUE(aMin[0].IsMinimum);
-  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Max);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
   ASSERT_EQ(aMax.NbExt(), 1);
   EXPECT_TRUE(aMax[0].IsMaximum);
 }
 
 TEST(ExtremaPC2d_CurveTest, GeneralCurveDispatchMatchesSpecialist)
 {
-  occ::handle<Geom2dEval_SineWaveCurve> aCurve = new Geom2dEval_SineWaveCurve(
-    gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)),
-    1.0,
-    2.0);
-  Geom2dAdaptor_Curve anAdaptor(aCurve, -2.0, 2.0);
-  ExtremaPC2d_Curve anAggregate(anAdaptor);
+  occ::handle<Geom2dEval_SineWaveCurve> aCurve =
+    new Geom2dEval_SineWaveCurve(gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), 1.0, 2.0);
+  Geom2dAdaptor_Curve    anAdaptor(aCurve, -2.0, 2.0);
+  ExtremaPC2d_Curve      anAggregate(anAdaptor);
   ExtremaPC2d_OtherCurve aDirect(anAdaptor, {-2.0, 2.0});
   compareResults(anAggregate.Perform(gp_Pnt2d(0.5, 1.0), THE_TOL),
                  aDirect.Perform(gp_Pnt2d(0.5, 1.0), THE_TOL));
@@ -169,12 +166,11 @@ TEST(ExtremaPC2d_CurveTest, GeneralCurveDispatchMatchesSpecialist)
 
 TEST(ExtremaPC2d_CurveTest, TrimmedCurveUsesTrimBounds)
 {
-  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    3.0);
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 3.0);
   occ::handle<Geom2d_TrimmedCurve> aTrimmed = new Geom2d_TrimmedCurve(aCircle, 0.2, 1.0);
-  ExtremaPC2d_Curve anEvaluator(aTrimmed);
-  const ExtremaPC2d::Result& aResult =
+  ExtremaPC2d_Curve                anEvaluator(aTrimmed);
+  const ExtremaPC2d::Result&       aResult =
     anEvaluator.PerformWithEndpoints(gp_Pnt2d(6.0, 0.0), THE_TOL);
   ASSERT_TRUE(aResult.IsDone());
   for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
@@ -186,12 +182,11 @@ TEST(ExtremaPC2d_CurveTest, TrimmedCurveUsesTrimBounds)
 
 TEST(ExtremaPC2d_CurveTest, ExplicitBoundsIntersectTrimmedBounds)
 {
-  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
-    gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true),
-    3.0);
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 3.0);
   occ::handle<Geom2d_TrimmedCurve> aTrimmed = new Geom2d_TrimmedCurve(aCircle, 0.2, 1.0);
-  ExtremaPC2d_Curve anEvaluator(aTrimmed, 0.5, 2.0);
-  const ExtremaPC2d::Result& aResult =
+  ExtremaPC2d_Curve                anEvaluator(aTrimmed, 0.5, 2.0);
+  const ExtremaPC2d::Result&       aResult =
     anEvaluator.PerformWithEndpoints(gp_Pnt2d(6.0, 0.0), THE_TOL);
   for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
   {
@@ -203,21 +198,21 @@ TEST(ExtremaPC2d_CurveTest, ExplicitBoundsIntersectTrimmedBounds)
 TEST(ExtremaPC2d_CurveTest, BezierMutationFlowsThroughAggregator)
 {
   occ::handle<Geom2d_BezierCurve> aCurve = makeBezier();
-  ExtremaPC2d_Curve anEvaluator(aCurve);
+  ExtremaPC2d_Curve               anEvaluator(aCurve);
   const double aBefore = anEvaluator.Perform(gp_Pnt2d(2.0, 2.0), THE_TOL).MinSquareDistance();
   aCurve->SetPole(2, gp_Pnt2d(3.5, -4.0));
   const ExtremaPC2d::Result& anAfter = anEvaluator.Perform(gp_Pnt2d(2.0, 2.0), THE_TOL);
   EXPECT_GT(std::abs(anAfter.MinSquareDistance() - aBefore), 1.0e-4);
   EXPECT_EQ(anAfter[anAfter.MinIndex()].Point.Distance(
-              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)), 0.0);
+              aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+            0.0);
 }
 
 TEST(ExtremaPC2d_CurveTest, AnalyticalDispatchCopiesPrimitiveGeometry)
 {
-  occ::handle<Geom2d_Line> aLine =
-    new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
-  Geom2dAdaptor_Curve anAdaptor(aLine, -10.0, 10.0);
-  ExtremaPC2d_Curve anEvaluator(anAdaptor);
+  occ::handle<Geom2d_Line> aLine = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
+  Geom2dAdaptor_Curve      anAdaptor(aLine, -10.0, 10.0);
+  ExtremaPC2d_Curve        anEvaluator(anAdaptor);
   anAdaptor.Load(new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(0.0, 1.0)), -10.0, 10.0);
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 1);
@@ -226,9 +221,9 @@ TEST(ExtremaPC2d_CurveTest, AnalyticalDispatchCopiesPrimitiveGeometry)
 
 TEST(ExtremaPC2d_CurveTest, ResultStorageIsEvaluatorLocal)
 {
-  ExtremaPC2d_Curve aFirst(makeBezier());
-  ExtremaPC2d_Curve aSecond(makeBSpline());
-  const ExtremaPC2d::Result* aFirstResult = &aFirst.Perform(gp_Pnt2d(1.0, 2.0), THE_TOL);
+  ExtremaPC2d_Curve          aFirst(makeBezier());
+  ExtremaPC2d_Curve          aSecond(makeBSpline());
+  const ExtremaPC2d::Result* aFirstResult  = &aFirst.Perform(gp_Pnt2d(1.0, 2.0), THE_TOL);
   const ExtremaPC2d::Result* aSecondResult = &aSecond.Perform(gp_Pnt2d(1.0, 2.0), THE_TOL);
   EXPECT_NE(aFirstResult, aSecondResult);
   EXPECT_EQ(aFirstResult, &aFirst.Perform(gp_Pnt2d(3.0, 2.0), THE_TOL));

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_DistanceFunction_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_DistanceFunction_Test.cxx
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_DistanceFunction.hxx>
+
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <gp_Ax22d.hxx>
+#include <gp_Dir2d.hxx>
+#include <NCollection_Array1.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_DistanceFunctionTest, LineValuesAreExact)
+{
+  occ::handle<Geom2d_Line> aLine =
+    new Geom2d_Line(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
+  Geom2dAdaptor_Curve anAdaptor(aLine, -4.0, 7.0);
+  ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(2.0, 3.0));
+  double aValue = 0.0;
+  double aDerivative = 0.0;
+  ASSERT_TRUE(aFunction.Values(5.0, aValue, aDerivative));
+  EXPECT_NEAR(aValue, 3.0, 1.0e-12);
+  EXPECT_NEAR(aDerivative, 1.0, 1.0e-12);
+  EXPECT_EQ(&aFunction.Curve(), &anAdaptor);
+  EXPECT_NEAR(aFunction.FirstParameter(), -4.0, 1.0e-12);
+  EXPECT_NEAR(aFunction.LastParameter(), 7.0, 1.0e-12);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_DistanceFunctionTest, CircleNormalizedFormulaIsExact)
+{
+  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
+    gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true),
+    5.0);
+  Geom2dAdaptor_Curve anAdaptor(aCircle);
+  ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(3.0, -4.0));
+  constexpr double aU = 0.7;
+  double aValue = 0.0;
+  double aDerivative = 0.0;
+  ASSERT_TRUE(aFunction.Values(aU, aValue, aDerivative));
+  EXPECT_NEAR(aValue, 3.0 * std::sin(aU) + 4.0 * std::cos(aU), 1.0e-11);
+  EXPECT_NEAR(aDerivative, 3.0 * std::cos(aU) - 4.0 * std::sin(aU), 1.0e-11);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_DistanceFunctionTest, DerivativeMatchesCenteredDifference)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles(1) = gp_Pnt2d(1.0, 0.0);
+  aPoles(2) = gp_Pnt2d(1.0, 1.0);
+  aPoles(3) = gp_Pnt2d(0.0, 1.0);
+  NCollection_Array1<double> aWeights(1, 3);
+  aWeights(1) = 1.0;
+  aWeights(2) = M_SQRT1_2;
+  aWeights(3) = 1.0;
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles, aWeights);
+  Geom2dAdaptor_Curve anAdaptor(aCurve);
+  ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(2.0, 0.3));
+  constexpr double aU = 0.37;
+  constexpr double aStep = 1.0e-6;
+  double aLeft = 0.0;
+  double aRight = 0.0;
+  double aDerivative = 0.0;
+  ASSERT_TRUE(aFunction.Value(aU - aStep, aLeft));
+  ASSERT_TRUE(aFunction.Value(aU + aStep, aRight));
+  ASSERT_TRUE(aFunction.Derivative(aU, aDerivative));
+  EXPECT_NEAR(aDerivative, (aRight - aLeft) / (2.0 * aStep), 1.0e-6);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_DistanceFunctionTest, ZeroSpeedReturnsDefinedZeros)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 4);
+  aPoles(1) = gp_Pnt2d(0.0, 0.0);
+  aPoles(2) = gp_Pnt2d(0.0, 0.0);
+  aPoles(3) = gp_Pnt2d(2.0, 1.0);
+  aPoles(4) = gp_Pnt2d(3.0, 0.0);
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
+  Geom2dAdaptor_Curve anAdaptor(aCurve);
+  ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(1.0, 1.0));
+  double aValue = 1.0;
+  double aDerivative = 1.0;
+  ASSERT_TRUE(aFunction.Values(0.0, aValue, aDerivative));
+  EXPECT_EQ(aValue, 0.0);
+  EXPECT_EQ(aDerivative, 0.0);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_DistanceFunction_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_DistanceFunction_Test.cxx
@@ -1,6 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
 //
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_DistanceFunction.hxx>
 
@@ -20,12 +29,11 @@
 
 TEST(ExtremaPC2d_DistanceFunctionTest, LineValuesAreExact)
 {
-  occ::handle<Geom2d_Line> aLine =
-    new Geom2d_Line(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
-  Geom2dAdaptor_Curve anAdaptor(aLine, -4.0, 7.0);
+  occ::handle<Geom2d_Line>     aLine = new Geom2d_Line(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0));
+  Geom2dAdaptor_Curve          anAdaptor(aLine, -4.0, 7.0);
   ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(2.0, 3.0));
-  double aValue = 0.0;
-  double aDerivative = 0.0;
+  double                       aValue      = 0.0;
+  double                       aDerivative = 0.0;
   ASSERT_TRUE(aFunction.Values(5.0, aValue, aDerivative));
   EXPECT_NEAR(aValue, 3.0, 1.0e-12);
   EXPECT_NEAR(aDerivative, 1.0, 1.0e-12);
@@ -38,14 +46,13 @@ TEST(ExtremaPC2d_DistanceFunctionTest, LineValuesAreExact)
 
 TEST(ExtremaPC2d_DistanceFunctionTest, CircleNormalizedFormulaIsExact)
 {
-  occ::handle<Geom2d_Circle> aCircle = new Geom2d_Circle(
-    gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true),
-    5.0);
-  Geom2dAdaptor_Curve anAdaptor(aCircle);
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 5.0);
+  Geom2dAdaptor_Curve          anAdaptor(aCircle);
   ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(3.0, -4.0));
-  constexpr double aU = 0.7;
-  double aValue = 0.0;
-  double aDerivative = 0.0;
+  constexpr double             aU          = 0.7;
+  double                       aValue      = 0.0;
+  double                       aDerivative = 0.0;
   ASSERT_TRUE(aFunction.Values(aU, aValue, aDerivative));
   EXPECT_NEAR(aValue, 3.0 * std::sin(aU) + 4.0 * std::cos(aU), 1.0e-11);
   EXPECT_NEAR(aDerivative, 3.0 * std::cos(aU) - 4.0 * std::sin(aU), 1.0e-11);
@@ -60,17 +67,17 @@ TEST(ExtremaPC2d_DistanceFunctionTest, DerivativeMatchesCenteredDifference)
   aPoles(2) = gp_Pnt2d(1.0, 1.0);
   aPoles(3) = gp_Pnt2d(0.0, 1.0);
   NCollection_Array1<double> aWeights(1, 3);
-  aWeights(1) = 1.0;
-  aWeights(2) = M_SQRT1_2;
-  aWeights(3) = 1.0;
+  aWeights(1)                            = 1.0;
+  aWeights(2)                            = M_SQRT1_2;
+  aWeights(3)                            = 1.0;
   occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles, aWeights);
-  Geom2dAdaptor_Curve anAdaptor(aCurve);
-  ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(2.0, 0.3));
-  constexpr double aU = 0.37;
-  constexpr double aStep = 1.0e-6;
-  double aLeft = 0.0;
-  double aRight = 0.0;
-  double aDerivative = 0.0;
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_DistanceFunction    aFunction(anAdaptor, gp_Pnt2d(2.0, 0.3));
+  constexpr double                aU          = 0.37;
+  constexpr double                aStep       = 1.0e-6;
+  double                          aLeft       = 0.0;
+  double                          aRight      = 0.0;
+  double                          aDerivative = 0.0;
   ASSERT_TRUE(aFunction.Value(aU - aStep, aLeft));
   ASSERT_TRUE(aFunction.Value(aU + aStep, aRight));
   ASSERT_TRUE(aFunction.Derivative(aU, aDerivative));
@@ -82,15 +89,15 @@ TEST(ExtremaPC2d_DistanceFunctionTest, DerivativeMatchesCenteredDifference)
 TEST(ExtremaPC2d_DistanceFunctionTest, ZeroSpeedReturnsDefinedZeros)
 {
   NCollection_Array1<gp_Pnt2d> aPoles(1, 4);
-  aPoles(1) = gp_Pnt2d(0.0, 0.0);
-  aPoles(2) = gp_Pnt2d(0.0, 0.0);
-  aPoles(3) = gp_Pnt2d(2.0, 1.0);
-  aPoles(4) = gp_Pnt2d(3.0, 0.0);
+  aPoles(1)                              = gp_Pnt2d(0.0, 0.0);
+  aPoles(2)                              = gp_Pnt2d(0.0, 0.0);
+  aPoles(3)                              = gp_Pnt2d(2.0, 1.0);
+  aPoles(4)                              = gp_Pnt2d(3.0, 0.0);
   occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
-  Geom2dAdaptor_Curve anAdaptor(aCurve);
-  ExtremaPC2d_DistanceFunction aFunction(anAdaptor, gp_Pnt2d(1.0, 1.0));
-  double aValue = 1.0;
-  double aDerivative = 1.0;
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_DistanceFunction    aFunction(anAdaptor, gp_Pnt2d(1.0, 1.0));
+  double                          aValue      = 1.0;
+  double                          aDerivative = 1.0;
   ASSERT_TRUE(aFunction.Values(0.0, aValue, aDerivative));
   EXPECT_EQ(aValue, 0.0);
   EXPECT_EQ(aDerivative, 0.0);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Ellipse_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Ellipse_Test.cxx
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_Ellipse.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+gp_Elips2d makeEllipse(double theMajor = 5.0, double theMinor = 3.0)
+{
+  return gp_Elips2d(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), theMajor, theMinor);
+}
+} // namespace
+
+TEST(ExtremaPC2d_EllipseTest, MajorAxisOutsideHasTwoExtrema)
+{
+  ExtremaPC2d_Ellipse anEvaluator(makeEllipse());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(10.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 25.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 225.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_EllipseTest, CenterHasFourAxisExtrema)
+{
+  ExtremaPC2d_Ellipse anEvaluator(makeEllipse());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 4);
+  int aMinima = 0;
+  int aMaxima = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    aMinima += aResult[anIndex].IsMinimum ? 1 : 0;
+    aMaxima += aResult[anIndex].IsMaximum ? 1 : 0;
+  }
+  EXPECT_EQ(aMinima, 2);
+  EXPECT_EQ(aMaxima, 2);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 9.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_EllipseTest, SearchModesAtCenterReturnSubsets)
+{
+  ExtremaPC2d_Ellipse anEvaluator(makeEllipse());
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL,
+                                ExtremaPC2d::SearchMode::Min).NbExt(), 2);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL,
+                                ExtremaPC2d::SearchMode::Max).NbExt(), 2);
+}
+
+TEST(ExtremaPC2d_EllipseTest, PointOnCurveHasZeroDistanceMinimum)
+{
+  const gp_Elips2d anEllipse = makeEllipse();
+  constexpr double aU = M_PI_4;
+  ExtremaPC2d_Ellipse anEvaluator(anEllipse);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(ElCLib::Value(aU, anEllipse), THE_TOL);
+  ASSERT_GE(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, aU, THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_EllipseTest, IndirectOrientationMapsLocalAxes)
+{
+  const gp_Ax22d aPosition(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
+  ExtremaPC2d_Ellipse anEvaluator(gp_Elips2d(aPosition, 5.0, 3.0));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(11.0, 2.0), THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, M_PI_2, THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 49.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_EllipseTest, CircularEllipseCenterIsInfinite)
+{
+  ExtremaPC2d_Ellipse anEvaluator(makeEllipse(5.0, 5.0));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_EllipseTest, ShiftedPeriodAndHalfArcEndpoints)
+{
+  ExtremaPC2d_Ellipse aShifted(makeEllipse(), {7.0, 7.0 + 2.0 * M_PI});
+  EXPECT_EQ(aShifted.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL).NbExt(), 2);
+
+  ExtremaPC2d_Ellipse aHalf(makeEllipse(), {M_PI_2, 3.0 * M_PI_2});
+  const ExtremaPC2d::Result& aHalfResult =
+    aHalf.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL);
+  ASSERT_EQ(aHalfResult.NbExt(), 3);
+  EXPECT_NEAR(aHalfResult[aHalfResult.MaxIndex()].Parameter, M_PI, THE_TOL);
+}
+
+TEST(ExtremaPC2d_EllipseTest, MultiplePeriodsReturnAllParameterExtrema)
+{
+  ExtremaPC2d_Ellipse anEvaluator(makeEllipse(), {0.0, 4.0 * M_PI});
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(12.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 4);
+  int aFirstPeriod = 0;
+  int aSecondPeriod = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    if (aResult[anIndex].Parameter < 2.0 * M_PI)
+    {
+      ++aFirstPeriod;
+    }
+    else
+    {
+      ++aSecondPeriod;
+    }
+  }
+  EXPECT_EQ(aFirstPeriod, 2);
+  EXPECT_EQ(aSecondPeriod, 2);
+}
+
+TEST(ExtremaPC2d_EllipseTest, SingletonInvalidAndAccessors)
+{
+  ExtremaPC2d_Ellipse aSingleton(makeEllipse(), {0.4, 0.4});
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
+  EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
+  ExtremaPC2d_Ellipse anInvalid(makeEllipse(), {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(aSingleton.Value(0.2).Distance(ElCLib::Value(0.2, makeEllipse())), 0.0);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Ellipse_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Ellipse_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_Ellipse.hxx>
 
@@ -10,6 +20,7 @@
 namespace
 {
 constexpr double THE_TOL = 1.0e-8;
+
 gp_Elips2d makeEllipse(double theMajor = 5.0, double theMinor = 3.0)
 {
   return gp_Elips2d(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), theMajor, theMinor);
@@ -18,7 +29,7 @@ gp_Elips2d makeEllipse(double theMajor = 5.0, double theMinor = 3.0)
 
 TEST(ExtremaPC2d_EllipseTest, MajorAxisOutsideHasTwoExtrema)
 {
-  ExtremaPC2d_Ellipse anEvaluator(makeEllipse());
+  ExtremaPC2d_Ellipse        anEvaluator(makeEllipse());
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(10.0, 0.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 2);
   EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.0, THE_TOL);
@@ -28,7 +39,7 @@ TEST(ExtremaPC2d_EllipseTest, MajorAxisOutsideHasTwoExtrema)
 
 TEST(ExtremaPC2d_EllipseTest, CenterHasFourAxisExtrema)
 {
-  ExtremaPC2d_Ellipse anEvaluator(makeEllipse());
+  ExtremaPC2d_Ellipse        anEvaluator(makeEllipse());
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 4);
   int aMinima = 0;
@@ -47,17 +58,15 @@ TEST(ExtremaPC2d_EllipseTest, CenterHasFourAxisExtrema)
 TEST(ExtremaPC2d_EllipseTest, SearchModesAtCenterReturnSubsets)
 {
   ExtremaPC2d_Ellipse anEvaluator(makeEllipse());
-  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL,
-                                ExtremaPC2d::SearchMode::Min).NbExt(), 2);
-  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL,
-                                ExtremaPC2d::SearchMode::Max).NbExt(), 2);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL, ExtremaPC2d::SearchMode::Min).NbExt(), 2);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL, ExtremaPC2d::SearchMode::Max).NbExt(), 2);
 }
 
 TEST(ExtremaPC2d_EllipseTest, PointOnCurveHasZeroDistanceMinimum)
 {
-  const gp_Elips2d anEllipse = makeEllipse();
-  constexpr double aU = M_PI_4;
-  ExtremaPC2d_Ellipse anEvaluator(anEllipse);
+  const gp_Elips2d           anEllipse = makeEllipse();
+  constexpr double           aU        = M_PI_4;
+  ExtremaPC2d_Ellipse        anEvaluator(anEllipse);
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(ElCLib::Value(aU, anEllipse), THE_TOL);
   ASSERT_GE(aResult.NbExt(), 2);
   EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, aU, THE_TOL);
@@ -66,8 +75,8 @@ TEST(ExtremaPC2d_EllipseTest, PointOnCurveHasZeroDistanceMinimum)
 
 TEST(ExtremaPC2d_EllipseTest, IndirectOrientationMapsLocalAxes)
 {
-  const gp_Ax22d aPosition(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
-  ExtremaPC2d_Ellipse anEvaluator(gp_Elips2d(aPosition, 5.0, 3.0));
+  const gp_Ax22d             aPosition(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
+  ExtremaPC2d_Ellipse        anEvaluator(gp_Elips2d(aPosition, 5.0, 3.0));
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(11.0, 2.0), THE_TOL);
   EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, M_PI_2, THE_TOL);
   EXPECT_NEAR(aResult.MinSquareDistance(), 49.0, THE_TOL);
@@ -75,7 +84,7 @@ TEST(ExtremaPC2d_EllipseTest, IndirectOrientationMapsLocalAxes)
 
 TEST(ExtremaPC2d_EllipseTest, CircularEllipseCenterIsInfinite)
 {
-  ExtremaPC2d_Ellipse anEvaluator(makeEllipse(5.0, 5.0));
+  ExtremaPC2d_Ellipse        anEvaluator(makeEllipse(5.0, 5.0));
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
   EXPECT_TRUE(aResult.IsInfinite());
   EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, THE_TOL);
@@ -86,19 +95,18 @@ TEST(ExtremaPC2d_EllipseTest, ShiftedPeriodAndHalfArcEndpoints)
   ExtremaPC2d_Ellipse aShifted(makeEllipse(), {7.0, 7.0 + 2.0 * M_PI});
   EXPECT_EQ(aShifted.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL).NbExt(), 2);
 
-  ExtremaPC2d_Ellipse aHalf(makeEllipse(), {M_PI_2, 3.0 * M_PI_2});
-  const ExtremaPC2d::Result& aHalfResult =
-    aHalf.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL);
+  ExtremaPC2d_Ellipse        aHalf(makeEllipse(), {M_PI_2, 3.0 * M_PI_2});
+  const ExtremaPC2d::Result& aHalfResult = aHalf.PerformWithEndpoints(gp_Pnt2d(10.0, 0.0), THE_TOL);
   ASSERT_EQ(aHalfResult.NbExt(), 3);
   EXPECT_NEAR(aHalfResult[aHalfResult.MaxIndex()].Parameter, M_PI, THE_TOL);
 }
 
 TEST(ExtremaPC2d_EllipseTest, MultiplePeriodsReturnAllParameterExtrema)
 {
-  ExtremaPC2d_Ellipse anEvaluator(makeEllipse(), {0.0, 4.0 * M_PI});
+  ExtremaPC2d_Ellipse        anEvaluator(makeEllipse(), {0.0, 4.0 * M_PI});
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(12.0, 0.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 4);
-  int aFirstPeriod = 0;
+  int aFirstPeriod  = 0;
   int aSecondPeriod = 0;
   for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
   {
@@ -121,7 +129,6 @@ TEST(ExtremaPC2d_EllipseTest, SingletonInvalidAndAccessors)
   EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
   EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
   ExtremaPC2d_Ellipse anInvalid(makeEllipse(), {1.0, 0.0});
-  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
   EXPECT_EQ(aSingleton.Value(0.2).Distance(ElCLib::Value(0.2, makeEllipse())), 0.0);
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_GridEvaluator_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_GridEvaluator_Test.cxx
@@ -1,6 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
 //
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_GridEvaluator.hxx>
 

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_GridEvaluator_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_GridEvaluator_Test.cxx
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_GridEvaluator.hxx>
+
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+#include <gp_Ax22d.hxx>
+#include <gp_Dir2d.hxx>
+#include <NCollection_Array1.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_GridEvaluatorTest, UniformParamsCoverDomainExactly)
+{
+  const math_Vector aParams = ExtremaPC2d_GridEvaluator::BuildUniformParams(-3.0, 5.0, 7);
+  ASSERT_EQ(aParams.Size(), 7u);
+  EXPECT_EQ(aParams.At(0), -3.0);
+  EXPECT_EQ(aParams.At(6), 5.0);
+  for (size_t anIndex = 1; anIndex < aParams.Size(); ++anIndex)
+  {
+    EXPECT_GT(aParams.At(anIndex), aParams.At(anIndex - 1));
+  }
+}
+
+TEST(ExtremaPC2d_GridEvaluatorTest, UniformParamsRejectInvalidSampleCount)
+{
+  EXPECT_THROW(ExtremaPC2d_GridEvaluator::BuildUniformParams(0.0, 1.0, 1), Standard_RangeError);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_GridEvaluatorTest, InvalidPartitionAndToleranceAreRejected)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 2);
+  aPoles(1)                              = gp_Pnt2d(0.0, 0.0);
+  aPoles(2)                              = gp_Pnt2d(1.0, 0.0);
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_GridEvaluator       anEvaluator;
+  EXPECT_EQ(
+    anEvaluator.Perform(anAdaptor, gp_Pnt2d(), {0.0, 1.0}, 1.0e-8, ExtremaPC2d::SearchMode::MinMax)
+      .Status,
+    ExtremaPC2d::Status::InvalidInput);
+
+  math_Vector aParams(3);
+  aParams.ChangeAt(0) = 0.0;
+  aParams.ChangeAt(1) = 0.5;
+  aParams.ChangeAt(2) = 1.0;
+  anEvaluator.SetParams(aParams);
+  EXPECT_EQ(
+    anEvaluator.Perform(anAdaptor, gp_Pnt2d(), {1.0, 0.0}, 1.0e-8, ExtremaPC2d::SearchMode::MinMax)
+      .Status,
+    ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(
+    anEvaluator.Perform(anAdaptor, gp_Pnt2d(), {0.0, 1.0}, 0.0, ExtremaPC2d::SearchMode::MinMax)
+      .Status,
+    ExtremaPC2d::Status::InvalidInput);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_GridEvaluatorTest, ConstantCurveHasInfiniteSolutions)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles.Init(gp_Pnt2d(2.0, -1.0));
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_GridEvaluator       anEvaluator;
+  anEvaluator.SetParams(ExtremaPC2d_GridEvaluator::BuildUniformParams(0.0, 1.0, 8));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(anAdaptor,
+                                                           gp_Pnt2d(5.0, 3.0),
+                                                           {0.0, 1.0},
+                                                           1.0e-8,
+                                                           ExtremaPC2d::SearchMode::MinMax);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 25.0, 1.0e-12);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_GridEvaluatorTest, ConstantCircleDistanceHasInfiniteSolutions)
+{
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 3.0);
+  Geom2dAdaptor_Curve       anAdaptor(aCircle);
+  ExtremaPC2d_GridEvaluator anEvaluator;
+  anEvaluator.SetParams(ExtremaPC2d_GridEvaluator::BuildUniformParams(0.0, 2.0 * M_PI, 32));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(anAdaptor,
+                                                           gp_Pnt2d(),
+                                                           {0.0, 2.0 * M_PI},
+                                                           1.0e-8,
+                                                           ExtremaPC2d::SearchMode::MinMax);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 9.0, 1.0e-10);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2d_GridEvaluatorTest, QuadraticCurveFindsCentralMinimum)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 3);
+  aPoles(1)                              = gp_Pnt2d(-2.0, 0.0);
+  aPoles(2)                              = gp_Pnt2d(0.0, 2.0);
+  aPoles(3)                              = gp_Pnt2d(2.0, 0.0);
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_GridEvaluator       anEvaluator;
+  anEvaluator.SetParams(ExtremaPC2d_GridEvaluator::BuildUniformParams(0.0, 1.0, 24));
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.Perform(anAdaptor, gp_Pnt2d(), {0.0, 1.0}, 1.0e-9, ExtremaPC2d::SearchMode::Min);
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.5, 1.0e-8);
+  EXPECT_NEAR(aResult[0].SquareDistance, 1.0, 1.0e-8);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+}
+
+TEST(ExtremaPC2d_GridEvaluatorTest, ShortOpenCurveIsNotClosed)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 2);
+  aPoles(1)                              = gp_Pnt2d(0.0, 0.0);
+  aPoles(2)                              = gp_Pnt2d(0.5 * Precision::Confusion(), 0.0);
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  EXPECT_FALSE(ExtremaPC2d_GridEvaluator::IsClosedDomain(anAdaptor, {0.0, 1.0}));
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_GridEvaluator_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_GridEvaluator_Test.cxx
@@ -40,7 +40,11 @@ TEST(ExtremaPC2d_GridEvaluatorTest, UniformParamsCoverDomainExactly)
 
 TEST(ExtremaPC2d_GridEvaluatorTest, UniformParamsRejectInvalidSampleCount)
 {
+#if !defined(No_Exception) && !defined(No_Standard_RangeError)
   EXPECT_THROW(ExtremaPC2d_GridEvaluator::BuildUniformParams(0.0, 1.0, 1), Standard_RangeError);
+#else
+  GTEST_SKIP() << "Standard_RangeError raising is disabled in this build.";
+#endif
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Hyperbola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Hyperbola_Test.cxx
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_Hyperbola.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+
+gp_Hypr2d makeHyperbola(double theMajor = 2.0, double theMinor = 1.0)
+{
+  return gp_Hypr2d(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), theMajor, theMinor);
+}
+} // namespace
+
+TEST(ExtremaPC2d_HyperbolaTest, CenterHasVertexMinimum)
+{
+  ExtremaPC2d_Hyperbola      anEvaluator(makeHyperbola());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 4.0, THE_TOL);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, MajorAxisPointHasThreeExtrema)
+{
+  const double               aRoot = std::acosh(2.0);
+  ExtremaPC2d_Hyperbola      anEvaluator(makeHyperbola());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(5.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  int  aMinima     = 0;
+  int  aMaxima     = 0;
+  bool hasNegative = false;
+  bool hasPositive = false;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    aMinima += aResult[anIndex].IsMinimum ? 1 : 0;
+    aMaxima += aResult[anIndex].IsMaximum ? 1 : 0;
+    hasNegative = hasNegative || std::abs(aResult[anIndex].Parameter + aRoot) <= THE_TOL;
+    hasPositive = hasPositive || std::abs(aResult[anIndex].Parameter - aRoot) <= THE_TOL;
+  }
+  EXPECT_EQ(aMinima, 2);
+  EXPECT_EQ(aMaxima, 1);
+  EXPECT_TRUE(hasNegative);
+  EXPECT_TRUE(hasPositive);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 4.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 9.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, RootWithinParameterToleranceIsClampedToBoundary)
+{
+  const double               aRoot   = std::acosh(2.0);
+  const double               anUpper = aRoot - 0.5 * ExtremaPC2d::THE_PARAM_TOLERANCE;
+  ExtremaPC2d_Hyperbola      anEvaluator(makeHyperbola(), {0.5, anUpper});
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(5.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_EQ(aResult[0].Parameter, anUpper);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, SearchModesReturnExactClasses)
+{
+  ExtremaPC2d_Hyperbola      anEvaluator(makeHyperbola());
+  const ExtremaPC2d::Result& aMin =
+    anEvaluator.Perform(gp_Pnt2d(5.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aMin.NbExt(), 2);
+  EXPECT_TRUE(aMin[0].IsMinimum && aMin[1].IsMinimum);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.Perform(gp_Pnt2d(5.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_NEAR(aMax[0].Parameter, 0.0, THE_TOL);
+  EXPECT_TRUE(aMax[0].IsMaximum);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, PointOnCurveHasZeroDistanceMinimum)
+{
+  const gp_Hypr2d            aCurve = makeHyperbola();
+  constexpr double           aU     = 0.7;
+  ExtremaPC2d_Hyperbola      anEvaluator(aCurve);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(ElCLib::Value(aU, aCurve), THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, aU, THE_TOL);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, IndirectOrientationPreservesSignedParameters)
+{
+  const gp_Ax22d             aPosition(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
+  const gp_Hypr2d            aCurve(aPosition, 2.0, 1.0);
+  ExtremaPC2d_Hyperbola      anEvaluator(aCurve);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(1.0, 7.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 4.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 9.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, BoundedArcAddsEndpointMinima)
+{
+  ExtremaPC2d_Hyperbola      anEvaluator(makeHyperbola(), {-0.5, 0.5});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(5.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 0.0, THE_TOL);
+  int aMinima = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    aMinima += aResult[anIndex].IsMinimum ? 1 : 0;
+  }
+  EXPECT_EQ(aMinima, 2);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, ZeroAxesDegeneracies)
+{
+  ExtremaPC2d_Hyperbola      aSinhLine(makeHyperbola(0.0, 1.0));
+  const ExtremaPC2d::Result& aLineResult = aSinhLine.Perform(gp_Pnt2d(3.0, 2.0), THE_TOL);
+  ASSERT_GE(aLineResult.NbExt(), 1);
+  EXPECT_NEAR(aLineResult.MinSquareDistance(), 9.0, THE_TOL);
+
+  ExtremaPC2d_Hyperbola      aPoint(makeHyperbola(0.0, 0.0));
+  const ExtremaPC2d::Result& aPointResult = aPoint.Perform(gp_Pnt2d(3.0, 4.0), THE_TOL);
+  EXPECT_TRUE(aPointResult.IsInfinite());
+  EXPECT_NEAR(aPointResult.InfiniteSquareDistance, 25.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_HyperbolaTest, SingletonInvalidAndValueAccessor)
+{
+  ExtremaPC2d_Hyperbola aSingleton(makeHyperbola(), {0.4, 0.4});
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
+  EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
+  ExtremaPC2d_Hyperbola anInvalid(makeHyperbola(), {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(aSingleton.Value(-0.7).Distance(ElCLib::Value(-0.7, makeHyperbola())), 0.0);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Hyperbola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Hyperbola_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_Hyperbola.hxx>
 

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Line_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Line_Test.cxx
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_Line.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-10;
+}
+
+TEST(ExtremaPC2d_LineTest, UnboundedProjectionIsExact)
+{
+  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(1.0, 2.0), gp_Dir2d(1.0, 0.0)));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(4.0, 6.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 3.0, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 16.0, THE_TOL);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+}
+
+TEST(ExtremaPC2d_LineTest, ReversedAndDiagonalDirectionsPreserveParameter)
+{
+  ExtremaPC2d_Line aReversed(gp_Lin2d(gp_Pnt2d(1.0, 2.0), gp_Dir2d(-1.0, 0.0)));
+  EXPECT_NEAR(aReversed.Perform(gp_Pnt2d(-2.0, 5.0), THE_TOL)[0].Parameter, 3.0, THE_TOL);
+
+  ExtremaPC2d_Line aDiagonal(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 1.0)));
+  const ExtremaPC2d::Result& aResult = aDiagonal.Perform(gp_Pnt2d(5.0, 5.0), THE_TOL);
+  EXPECT_NEAR(aResult[0].Parameter, 5.0 * std::sqrt(2.0), THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 0.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_LineTest, SearchModesFilterInteriorProjection)
+{
+  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)));
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL,
+                                ExtremaPC2d::SearchMode::Min).NbExt(), 1);
+  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL,
+                                                        ExtremaPC2d::SearchMode::Max);
+  EXPECT_EQ(aMax.Status, ExtremaPC2d::Status::NoSolution);
+  EXPECT_EQ(aMax.NbExt(), 0);
+}
+
+TEST(ExtremaPC2d_LineTest, BoundedProjectionAndEndpointsAreClassified)
+{
+  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(4.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 4.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].SquareDistance, 9.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 10.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_LineTest, ProjectionOutsideDomainUsesEndpointsOnlyWhenRequested)
+{
+  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(-2.0, 3.0), THE_TOL).NbExt(), 0);
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(-2.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].SquareDistance, 13.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 10.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_LineTest, BoundaryProjectionIsNotDuplicated)
+{
+  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(0.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 10.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_LineTest, SingletonDomainHonorsModes)
+{
+  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {2.0, 2.0});
+  const ExtremaPC2d::Result& aBoth =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(5.0, 3.0), THE_TOL);
+  ASSERT_EQ(aBoth.NbExt(), 1);
+  EXPECT_TRUE(aBoth[0].IsMinimum);
+  EXPECT_TRUE(aBoth[0].IsMaximum);
+  const ExtremaPC2d::Result& aMax = anEvaluator.PerformWithEndpoints(
+    gp_Pnt2d(5.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_FALSE(aMax[0].IsMinimum);
+  EXPECT_TRUE(aMax[0].IsMaximum);
+}
+
+TEST(ExtremaPC2d_LineTest, InvalidInputAndAccessors)
+{
+  const gp_Lin2d aLine(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0));
+  ExtremaPC2d_Line anEvaluator(aLine, {3.0, 1.0});
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status,
+            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), 0.0).Status,
+            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anEvaluator.Line().Location().Distance(aLine.Location()), 0.0);
+  EXPECT_EQ(anEvaluator.Value(2.0).Distance(gp_Pnt2d(1.0, 4.0)), 0.0);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Line_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Line_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_Line.hxx>
 
@@ -15,7 +25,7 @@ constexpr double THE_TOL = 1.0e-10;
 
 TEST(ExtremaPC2d_LineTest, UnboundedProjectionIsExact)
 {
-  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(1.0, 2.0), gp_Dir2d(1.0, 0.0)));
+  ExtremaPC2d_Line           anEvaluator(gp_Lin2d(gp_Pnt2d(1.0, 2.0), gp_Dir2d(1.0, 0.0)));
   const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(4.0, 6.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult[0].Parameter, 3.0, THE_TOL);
@@ -28,7 +38,7 @@ TEST(ExtremaPC2d_LineTest, ReversedAndDiagonalDirectionsPreserveParameter)
   ExtremaPC2d_Line aReversed(gp_Lin2d(gp_Pnt2d(1.0, 2.0), gp_Dir2d(-1.0, 0.0)));
   EXPECT_NEAR(aReversed.Perform(gp_Pnt2d(-2.0, 5.0), THE_TOL)[0].Parameter, 3.0, THE_TOL);
 
-  ExtremaPC2d_Line aDiagonal(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 1.0)));
+  ExtremaPC2d_Line           aDiagonal(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 1.0)));
   const ExtremaPC2d::Result& aResult = aDiagonal.Perform(gp_Pnt2d(5.0, 5.0), THE_TOL);
   EXPECT_NEAR(aResult[0].Parameter, 5.0 * std::sqrt(2.0), THE_TOL);
   EXPECT_NEAR(aResult[0].SquareDistance, 0.0, THE_TOL);
@@ -37,17 +47,17 @@ TEST(ExtremaPC2d_LineTest, ReversedAndDiagonalDirectionsPreserveParameter)
 TEST(ExtremaPC2d_LineTest, SearchModesFilterInteriorProjection)
 {
   ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)));
-  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL,
-                                ExtremaPC2d::SearchMode::Min).NbExt(), 1);
-  const ExtremaPC2d::Result& aMax = anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL,
-                                                        ExtremaPC2d::SearchMode::Max);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Min).NbExt(),
+            1);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.Perform(gp_Pnt2d(4.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
   EXPECT_EQ(aMax.Status, ExtremaPC2d::Status::NoSolution);
   EXPECT_EQ(aMax.NbExt(), 0);
 }
 
 TEST(ExtremaPC2d_LineTest, BoundedProjectionAndEndpointsAreClassified)
 {
-  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
+  ExtremaPC2d_Line           anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
   const ExtremaPC2d::Result& aResult =
     anEvaluator.PerformWithEndpoints(gp_Pnt2d(4.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 3);
@@ -70,7 +80,7 @@ TEST(ExtremaPC2d_LineTest, ProjectionOutsideDomainUsesEndpointsOnlyWhenRequested
 
 TEST(ExtremaPC2d_LineTest, BoundaryProjectionIsNotDuplicated)
 {
-  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
+  ExtremaPC2d_Line           anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {0.0, 10.0});
   const ExtremaPC2d::Result& aResult =
     anEvaluator.PerformWithEndpoints(gp_Pnt2d(0.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult.NbExt(), 2);
@@ -80,14 +90,13 @@ TEST(ExtremaPC2d_LineTest, BoundaryProjectionIsNotDuplicated)
 
 TEST(ExtremaPC2d_LineTest, SingletonDomainHonorsModes)
 {
-  ExtremaPC2d_Line anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {2.0, 2.0});
-  const ExtremaPC2d::Result& aBoth =
-    anEvaluator.PerformWithEndpoints(gp_Pnt2d(5.0, 3.0), THE_TOL);
+  ExtremaPC2d_Line           anEvaluator(gp_Lin2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), {2.0, 2.0});
+  const ExtremaPC2d::Result& aBoth = anEvaluator.PerformWithEndpoints(gp_Pnt2d(5.0, 3.0), THE_TOL);
   ASSERT_EQ(aBoth.NbExt(), 1);
   EXPECT_TRUE(aBoth[0].IsMinimum);
   EXPECT_TRUE(aBoth[0].IsMaximum);
-  const ExtremaPC2d::Result& aMax = anEvaluator.PerformWithEndpoints(
-    gp_Pnt2d(5.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(5.0, 3.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
   ASSERT_EQ(aMax.NbExt(), 1);
   EXPECT_FALSE(aMax[0].IsMinimum);
   EXPECT_TRUE(aMax[0].IsMaximum);
@@ -95,12 +104,10 @@ TEST(ExtremaPC2d_LineTest, SingletonDomainHonorsModes)
 
 TEST(ExtremaPC2d_LineTest, InvalidInputAndAccessors)
 {
-  const gp_Lin2d aLine(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0));
+  const gp_Lin2d   aLine(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0));
   ExtremaPC2d_Line anEvaluator(aLine, {3.0, 1.0});
-  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status,
-            ExtremaPC2d::Status::InvalidInput);
-  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), 0.0).Status,
-            ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), 0.0).Status, ExtremaPC2d::Status::InvalidInput);
   EXPECT_EQ(anEvaluator.Line().Location().Distance(aLine.Location()), 0.0);
   EXPECT_EQ(anEvaluator.Value(2.0).Distance(gp_Pnt2d(1.0, 4.0)), 0.0);
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OffsetCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OffsetCurve_Test.cxx
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_OffsetCurve.hxx>
+
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2d_Circle.hxx>
+#include <Geom2d_Ellipse.hxx>
+#include <Geom2d_Line.hxx>
+#include <Geom2d_OffsetCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+
+occ::handle<Geom2d_OffsetCurve> makeOffsetCircle(double theOffset)
+{
+  occ::handle<Geom2d_Circle> aCircle =
+    new Geom2d_Circle(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), 3.0);
+  return new Geom2d_OffsetCurve(aCircle, theOffset);
+}
+} // namespace
+
+TEST(ExtremaPC2d_OffsetCurveTest, OffsetCircleFindsExactMinAndMax)
+{
+  occ::handle<Geom2d_OffsetCurve> aCurve = makeOffsetCircle(1.0);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_OffsetCurve         anEvaluator(anAdaptor, {0.0, 2.0 * M_PI});
+  const ExtremaPC2d::Result&      aResult = anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 16.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 144.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_OffsetCurveTest, CenterHasConstantDistance)
+{
+  occ::handle<Geom2d_OffsetCurve> aCurve = makeOffsetCircle(1.0);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_OffsetCurve         anEvaluator(anAdaptor, {0.0, 2.0 * M_PI});
+  const ExtremaPC2d::Result&      aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  EXPECT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 16.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_OffsetCurveTest, NegativeOffsetUsesCorrectSide)
+{
+  occ::handle<Geom2d_OffsetCurve> aCurve = makeOffsetCircle(-1.0);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_OffsetCurve         anEvaluator(anAdaptor, {0.0, 2.0 * M_PI});
+  EXPECT_NEAR(anEvaluator.Perform(gp_Pnt2d(8.0, 0.0), THE_TOL).MinSquareDistance(), 36.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_OffsetCurveTest, OffsetLineProjectionIsExact)
+{
+  occ::handle<Geom2d_Line>        aLine  = new Geom2d_Line(gp_Pnt2d(), gp_Dir2d(1.0, 0.0));
+  occ::handle<Geom2d_OffsetCurve> aCurve = new Geom2d_OffsetCurve(aLine, 2.0);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve, 0.0, 4.0);
+  ExtremaPC2d_OffsetCurve         anEvaluator(anAdaptor, {0.0, 4.0});
+  const gp_Pnt2d                  aQuery  = aCurve->Value(2.0).Translated(gp_Vec2d(0.0, 3.0));
+  const ExtremaPC2d::Result&      aResult = anEvaluator.Perform(aQuery, THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 2.0, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 9.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_OffsetCurveTest, PartialArcAndSearchModes)
+{
+  occ::handle<Geom2d_OffsetCurve> aCurve = makeOffsetCircle(1.0);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve, 0.0, M_PI_2);
+  ExtremaPC2d_OffsetCurve         anEvaluator(anAdaptor, {0.0, M_PI_2});
+  const ExtremaPC2d::Result&      aMin =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(8.0, -1.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  ASSERT_EQ(aMin.NbExt(), 1);
+  EXPECT_NEAR(aMin[0].Parameter, 0.0, THE_TOL);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(8.0, -1.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_NEAR(aMax[0].Parameter, M_PI_2, THE_TOL);
+}
+
+TEST(ExtremaPC2d_OffsetCurveTest, InvalidDomainAndTolerance)
+{
+  occ::handle<Geom2d_OffsetCurve> aCurve = makeOffsetCircle(1.0);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_OffsetCurve         anInvalid(anAdaptor, {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  ExtremaPC2d_OffsetCurve anEvaluator(anAdaptor, {0.0, 2.0 * M_PI});
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(), 0.0).Status, ExtremaPC2d::Status::InvalidInput);
+}
+
+TEST(ExtremaPC2d_OffsetCurveTest, EndpointPathRefreshesPartitionAfterMutation)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 10);
+  for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
+  {
+    const double aParameter  = static_cast<double>(anIndex) / (aPoles.Size() - 1);
+    aPoles.ChangeAt(anIndex) = gp_Pnt2d(aParameter, 0.0);
+  }
+  occ::handle<Geom2d_BezierCurve> aBasis = new Geom2d_BezierCurve(aPoles);
+  occ::handle<Geom2d_OffsetCurve> aCurve = new Geom2d_OffsetCurve(aBasis, 0.1);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_OffsetCurve         aReusedEvaluator(anAdaptor, {0.0, 1.0});
+
+  for (size_t anIndex = 1; anIndex + 1 < aPoles.Size(); ++anIndex)
+  {
+    const int    aPoleNumber = static_cast<int>(anIndex + 1);
+    const double aParameter  = static_cast<double>(anIndex) / (aPoles.Size() - 1);
+    aBasis->SetPole(aPoleNumber, gp_Pnt2d(aParameter, aPoleNumber % 2 == 0 ? 2.0 : -2.0));
+  }
+
+  const gp_Pnt2d             aQuery(0.5, 0.25);
+  const ExtremaPC2d::Result& aReusedResult = aReusedEvaluator.PerformWithEndpoints(aQuery, THE_TOL);
+  ExtremaPC2d_OffsetCurve    aFreshEvaluator(anAdaptor, {0.0, 1.0});
+  const ExtremaPC2d::Result& aFreshResult = aFreshEvaluator.PerformWithEndpoints(aQuery, THE_TOL);
+
+  ASSERT_EQ(aReusedResult.Status, aFreshResult.Status);
+  ASSERT_EQ(aReusedResult.NbExt(), aFreshResult.NbExt());
+  for (size_t anIndex = 0; anIndex < aFreshResult.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aReusedResult[anIndex].Parameter, aFreshResult[anIndex].Parameter, 1.0e-7);
+    EXPECT_NEAR(aReusedResult[anIndex].SquareDistance,
+                aFreshResult[anIndex].SquareDistance,
+                1.0e-7);
+  }
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OffsetCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OffsetCurve_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_OffsetCurve.hxx>
 

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OtherCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OtherCurve_Test.cxx
@@ -1,0 +1,119 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_OtherCurve.hxx>
+
+#include <Geom2d_BezierCurve.hxx>
+#include <Geom2dEval_SineWaveCurve.hxx>
+#include <Geom2dAdaptor_Curve.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+}
+
+TEST(ExtremaPC2d_OtherCurveTest, SineWaveFindsOriginMinimum)
+{
+  occ::handle<Geom2dEval_SineWaveCurve> aCurve =
+    new Geom2dEval_SineWaveCurve(gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), 1.0, 1.0);
+  Geom2dAdaptor_Curve        anAdaptor(aCurve, -M_PI, M_PI);
+  ExtremaPC2d_OtherCurve     anEvaluator(anAdaptor, {-M_PI, M_PI});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.Perform(gp_Pnt2d(-1.0, 1.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  ASSERT_GE(aResult.NbExt(), 1);
+  bool hasOrigin = false;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    hasOrigin = hasOrigin || std::abs(aResult[anIndex].Parameter) <= THE_TOL;
+    EXPECT_EQ(aResult[anIndex].Point.Distance(aCurve->Value(aResult[anIndex].Parameter)), 0.0);
+  }
+  EXPECT_TRUE(hasOrigin);
+}
+
+TEST(ExtremaPC2d_OtherCurveTest, MultipleWavesReturnMultipleExtrema)
+{
+  occ::handle<Geom2dEval_SineWaveCurve> aCurve =
+    new Geom2dEval_SineWaveCurve(gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), 1.0, 3.0);
+  Geom2dAdaptor_Curve        anAdaptor(aCurve, -2.0, 2.0);
+  ExtremaPC2d_OtherCurve     anEvaluator(anAdaptor, {-2.0, 2.0});
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  ASSERT_TRUE(aResult.IsDone());
+  EXPECT_GE(aResult.NbExt(), 5);
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    gp_Pnt2d aPoint;
+    gp_Vec2d aDerivative;
+    aCurve->D1(aResult[anIndex].Parameter, aPoint, aDerivative);
+    EXPECT_NEAR(gp_Vec2d(gp_Pnt2d(), aPoint).Dot(aDerivative), 0.0, 1.0e-6);
+  }
+}
+
+TEST(ExtremaPC2d_OtherCurveTest, EndpointsAndModesAreForwarded)
+{
+  occ::handle<Geom2dEval_SineWaveCurve> aCurve =
+    new Geom2dEval_SineWaveCurve(gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), 1.0, 1.0);
+  Geom2dAdaptor_Curve        anAdaptor(aCurve, -1.0, 1.0);
+  ExtremaPC2d_OtherCurve     anEvaluator(anAdaptor, {-1.0, 1.0});
+  const ExtremaPC2d::Result& aMin =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(3.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Min);
+  for (size_t anIndex = 0; anIndex < aMin.NbExt(); ++anIndex)
+  {
+    EXPECT_TRUE(aMin[anIndex].IsMinimum);
+  }
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(3.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  for (size_t anIndex = 0; anIndex < aMax.NbExt(); ++anIndex)
+  {
+    EXPECT_TRUE(aMax[anIndex].IsMaximum);
+  }
+}
+
+TEST(ExtremaPC2d_OtherCurveTest, NaturalAndInvalidDomains)
+{
+  occ::handle<Geom2dEval_SineWaveCurve> aCurve =
+    new Geom2dEval_SineWaveCurve(gp_Ax2d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0)), 1.0, 1.0);
+  Geom2dAdaptor_Curve    anAdaptor(aCurve);
+  ExtremaPC2d_OtherCurve aNatural(anAdaptor);
+  EXPECT_EQ(aNatural.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  ExtremaPC2d_OtherCurve anInvalid(anAdaptor, {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+}
+
+TEST(ExtremaPC2d_OtherCurveTest, EndpointPathRefreshesPartitionAfterMutation)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 26);
+  for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
+  {
+    const double aParameter  = static_cast<double>(anIndex) / (aPoles.Size() - 1);
+    aPoles.ChangeAt(anIndex) = gp_Pnt2d(aParameter, 0.0);
+  }
+  occ::handle<Geom2d_BezierCurve> aCurve = new Geom2d_BezierCurve(aPoles);
+  Geom2dAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC2d_OtherCurve          aReusedEvaluator(anAdaptor, {0.0, 1.0});
+
+  for (size_t anIndex = 1; anIndex + 1 < aPoles.Size(); ++anIndex)
+  {
+    const int    aPoleNumber = static_cast<int>(anIndex + 1);
+    const double aParameter  = static_cast<double>(anIndex) / (aPoles.Size() - 1);
+    aCurve->SetPole(aPoleNumber, gp_Pnt2d(aParameter, aPoleNumber % 2 == 0 ? 4.0 : -4.0));
+  }
+
+  const gp_Pnt2d             aQuery(0.5, 0.25);
+  const ExtremaPC2d::Result& aReusedResult = aReusedEvaluator.PerformWithEndpoints(aQuery, THE_TOL);
+  ExtremaPC2d_OtherCurve     aFreshEvaluator(anAdaptor, {0.0, 1.0});
+  const ExtremaPC2d::Result& aFreshResult = aFreshEvaluator.PerformWithEndpoints(aQuery, THE_TOL);
+
+  ASSERT_EQ(aReusedResult.Status, aFreshResult.Status);
+  ASSERT_EQ(aReusedResult.NbExt(), aFreshResult.NbExt());
+  for (size_t anIndex = 0; anIndex < aFreshResult.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aReusedResult[anIndex].Parameter, aFreshResult[anIndex].Parameter, 1.0e-7);
+    EXPECT_NEAR(aReusedResult[anIndex].SquareDistance,
+                aFreshResult[anIndex].SquareDistance,
+                1.0e-7);
+  }
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OtherCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OtherCurve_Test.cxx
@@ -39,7 +39,9 @@ TEST(ExtremaPC2d_OtherCurveTest, SineWaveFindsOriginMinimum)
   for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
   {
     hasOrigin = hasOrigin || std::abs(aResult[anIndex].Parameter) <= THE_TOL;
-    EXPECT_EQ(aResult[anIndex].Point.Distance(aCurve->Value(aResult[anIndex].Parameter)), 0.0);
+    EXPECT_NEAR(aResult[anIndex].Point.Distance(aCurve->Value(aResult[anIndex].Parameter)),
+                0.0,
+                THE_TOL);
   }
   EXPECT_TRUE(hasOrigin);
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OtherCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_OtherCurve_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_OtherCurve.hxx>
 

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Parabola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Parabola_Test.cxx
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+// This file is part of Open CASCADE Technology software library.
+
+#include <ExtremaPC2d_Parabola.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+constexpr double THE_TOL = 1.0e-8;
+
+gp_Parab2d makeParabola(double theFocal = 1.0)
+{
+  return gp_Parab2d(gp_Ax22d(gp_Pnt2d(), gp_Dir2d(1.0, 0.0), true), theFocal);
+}
+} // namespace
+
+TEST(ExtremaPC2d_ParabolaTest, VertexAndBehindVertexHaveUniqueMinimum)
+{
+  ExtremaPC2d_Parabola       anEvaluator(makeParabola());
+  const ExtremaPC2d::Result& aVertex = anEvaluator.Perform(gp_Pnt2d(), THE_TOL);
+  ASSERT_EQ(aVertex.NbExt(), 1);
+  EXPECT_NEAR(aVertex[0].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aVertex[0].SquareDistance, 0.0, THE_TOL);
+  const ExtremaPC2d::Result& aBehind = anEvaluator.Perform(gp_Pnt2d(-2.0, 0.0), THE_TOL);
+  ASSERT_EQ(aBehind.NbExt(), 1);
+  EXPECT_NEAR(aBehind[0].SquareDistance, 4.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, AxisPointAheadHasThreeExtrema)
+{
+  ExtremaPC2d_Parabola       anEvaluator(makeParabola());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(3.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 8.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 9.0, THE_TOL);
+  int aMinima = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    aMinima += aResult[anIndex].IsMinimum ? 1 : 0;
+  }
+  EXPECT_EQ(aMinima, 2);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, SearchModesReturnExactClasses)
+{
+  ExtremaPC2d_Parabola anEvaluator(makeParabola());
+  EXPECT_EQ(anEvaluator.Perform(gp_Pnt2d(3.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Min).NbExt(),
+            2);
+  const ExtremaPC2d::Result& aMax =
+    anEvaluator.Perform(gp_Pnt2d(3.0, 0.0), THE_TOL, ExtremaPC2d::SearchMode::Max);
+  ASSERT_EQ(aMax.NbExt(), 1);
+  EXPECT_NEAR(aMax[0].Parameter, 0.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, KnownCubicHasThreeRoots)
+{
+  ExtremaPC2d_Parabola       anEvaluator(makeParabola());
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(3.75, -0.75), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  bool hasMinus3 = false;
+  bool has1      = false;
+  bool has2      = false;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    hasMinus3 = hasMinus3 || std::abs(aResult[anIndex].Parameter + 3.0) <= THE_TOL;
+    has1      = has1 || std::abs(aResult[anIndex].Parameter - 1.0) <= THE_TOL;
+    has2      = has2 || std::abs(aResult[anIndex].Parameter - 2.0) <= THE_TOL;
+  }
+  EXPECT_TRUE(hasMinus3);
+  EXPECT_TRUE(has1);
+  EXPECT_TRUE(has2);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, RootWithinParameterToleranceIsClampedToBoundary)
+{
+  const double               anUpper = 1.0 - 0.5 * ExtremaPC2d::THE_PARAM_TOLERANCE;
+  ExtremaPC2d_Parabola       anEvaluator(makeParabola(), {0.5, anUpper});
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(3.75, -0.75), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_EQ(aResult[0].Parameter, anUpper);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, PointOnCurveHasZeroDistanceMinimum)
+{
+  const gp_Parab2d           aCurve = makeParabola();
+  ExtremaPC2d_Parabola       anEvaluator(aCurve);
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(ElCLib::Value(2.0, aCurve), THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 2.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, IndirectOrientationPreservesParameterSense)
+{
+  const gp_Ax22d             aPosition(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0), gp_Dir2d(1.0, 0.0));
+  ExtremaPC2d_Parabola       anEvaluator(gp_Parab2d(aPosition, 1.0));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(1.0, 5.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 8.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, BoundedArcAddsEndpointMinima)
+{
+  ExtremaPC2d_Parabola       anEvaluator(makeParabola(), {-1.0, 1.0});
+  const ExtremaPC2d::Result& aResult =
+    anEvaluator.PerformWithEndpoints(gp_Pnt2d(3.0, 0.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 3);
+  EXPECT_NEAR(aResult[aResult.MaxIndex()].Parameter, 0.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, ZeroFocalMatchesMirrorAxisLine)
+{
+  const gp_Ax22d             aPosition(gp_Pnt2d(1.0, 2.0), gp_Dir2d(0.0, 1.0), true);
+  ExtremaPC2d_Parabola       anEvaluator(gp_Parab2d(aPosition, 0.0));
+  const ExtremaPC2d::Result& aResult = anEvaluator.Perform(gp_Pnt2d(4.0, 7.0), THE_TOL);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 5.0, THE_TOL);
+  EXPECT_NEAR(aResult[0].SquareDistance, 9.0, THE_TOL);
+}
+
+TEST(ExtremaPC2d_ParabolaTest, SingletonInvalidAndValueAccessor)
+{
+  ExtremaPC2d_Parabola aSingleton(makeParabola(), {0.4, 0.4});
+  EXPECT_EQ(aSingleton.Perform(gp_Pnt2d(), THE_TOL).NbExt(), 0);
+  EXPECT_EQ(aSingleton.PerformWithEndpoints(gp_Pnt2d(), THE_TOL).NbExt(), 1);
+  ExtremaPC2d_Parabola anInvalid(makeParabola(), {1.0, 0.0});
+  EXPECT_EQ(anInvalid.Perform(gp_Pnt2d(), THE_TOL).Status, ExtremaPC2d::Status::InvalidInput);
+  EXPECT_EQ(aSingleton.Value(-0.7).Distance(ElCLib::Value(-0.7, makeParabola())), 0.0);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Parabola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Parabola_Test.cxx
@@ -1,5 +1,15 @@
 // Copyright (c) 2026 OPEN CASCADE SAS
+//
 // This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
 
 #include <ExtremaPC2d_Parabola.hxx>
 

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Test.cxx
@@ -1,0 +1,156 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt.
+
+#include <ExtremaPC2d.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+namespace
+{
+struct LinearEvaluator2d
+{
+  gp_Pnt2d Value(double theU) const { return gp_Pnt2d(theU, 0.0); }
+};
+
+struct RapidEndpointEvaluator2d
+{
+  gp_Pnt2d Value(double theU) const { return gp_Pnt2d(1.0 + theU - 200.0 * theU * theU, 0.0); }
+};
+} // namespace
+
+//=================================================================================================
+
+TEST(ExtremaPC2dTest, Result_DefaultClearAndTraits)
+{
+  static_assert(!std::is_copy_constructible_v<ExtremaPC2d::Result>);
+  static_assert(!std::is_copy_assignable_v<ExtremaPC2d::Result>);
+  static_assert(std::is_move_constructible_v<ExtremaPC2d::Result>);
+
+  ExtremaPC2d::Result aResult;
+  EXPECT_EQ(aResult.Status, ExtremaPC2d::Status::NotDone);
+  EXPECT_EQ(aResult.NbExt(), 0);
+  EXPECT_EQ(aResult.MinIndex(), ExtremaPC2d::Result::INVALID_INDEX);
+  EXPECT_EQ(aResult.MaxIndex(), ExtremaPC2d::Result::INVALID_INDEX);
+  EXPECT_TRUE(std::isinf(aResult.MinSquareDistance()));
+  EXPECT_EQ(aResult.MaxSquareDistance(), 0.0);
+
+  aResult.Status = ExtremaPC2d::Status::OK;
+  aResult.Extrema.Append({0.0, gp_Pnt2d(), 9.0, true, false});
+  aResult.Extrema.Append({1.0, gp_Pnt2d(), 4.0, true, false});
+  aResult.Extrema.Append({2.0, gp_Pnt2d(), 9.0, false, true});
+  EXPECT_EQ(aResult.MinIndex(), 1);
+  EXPECT_EQ(aResult.MaxIndex(), 0);
+  aResult.Clear();
+  EXPECT_EQ(aResult.Status, ExtremaPC2d::Status::NotDone);
+  EXPECT_EQ(aResult.NbExt(), 0);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2dTest, ToleranceAndFiniteParameterValidation)
+{
+  EXPECT_TRUE(ExtremaPC2d::IsValidTolerance(1.0e-9));
+  EXPECT_FALSE(ExtremaPC2d::IsValidTolerance(0.0));
+  EXPECT_FALSE(ExtremaPC2d::IsValidTolerance(-1.0));
+  EXPECT_FALSE(ExtremaPC2d::IsValidTolerance(std::numeric_limits<double>::infinity()));
+  EXPECT_FALSE(ExtremaPC2d::IsValidTolerance(std::numeric_limits<double>::quiet_NaN()));
+  EXPECT_TRUE(ExtremaPC2d::IsFiniteParameter(1.0));
+  EXPECT_FALSE(ExtremaPC2d::IsFiniteParameter(Precision::Infinite()));
+  EXPECT_FALSE(ExtremaPC2d::IsFiniteParameter(std::numeric_limits<double>::infinity()));
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2dTest, ClosedPeriodicDomainValidation)
+{
+  constexpr double aTol = 1.0e-10;
+  EXPECT_TRUE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, 2.0 * M_PI}, 2.0 * M_PI, aTol));
+  EXPECT_TRUE(ExtremaPC2d::IsClosedPeriodicDomain({7.0, 7.0 + 4.0 * M_PI},
+                                                  2.0 * M_PI,
+                                                  aTol));
+  EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, M_PI}, 2.0 * M_PI, aTol));
+  EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({1.0, 0.0}, 2.0 * M_PI, aTol));
+  EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, 2.0 * M_PI}, 0.0, aTol));
+  EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, 2.0 * M_PI}, 2.0 * M_PI, -1.0));
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2dTest, EndpointClassificationAndModes)
+{
+  const LinearEvaluator2d anEvaluator;
+  const gp_Pnt2d aQuery(-2.0, 3.0);
+  ExtremaPC2d::Result aResult;
+  ExtremaPC2d::AddEndpointExtrema(aResult,
+                                   aQuery,
+                                   {0.0, 10.0},
+                                   anEvaluator,
+                                   ExtremaPC2d::SearchMode::MinMax,
+                                   false);
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, 1.0e-12);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+  EXPECT_NEAR(aResult[1].Parameter, 10.0, 1.0e-12);
+  EXPECT_TRUE(aResult[1].IsMaximum);
+
+  aResult.Clear();
+  ExtremaPC2d::AddEndpointExtrema(aResult,
+                                   aQuery,
+                                   {0.0, 10.0},
+                                   anEvaluator,
+                                   ExtremaPC2d::SearchMode::Min,
+                                   false);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, 1.0e-12);
+}
+
+//=================================================================================================
+
+TEST(ExtremaPC2dTest, SingletonAndClosedEndpointBehavior)
+{
+  const LinearEvaluator2d anEvaluator;
+  ExtremaPC2d::Result aResult;
+  ExtremaPC2d::AddEndpointExtrema(aResult,
+                                   gp_Pnt2d(5.0, 3.0),
+                                   {2.0, 2.0},
+                                   anEvaluator,
+                                   ExtremaPC2d::SearchMode::MinMax,
+                                   false);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+  EXPECT_TRUE(aResult[0].IsMaximum);
+
+  aResult.Clear();
+  ExtremaPC2d::AddEndpointExtrema(aResult,
+                                   gp_Pnt2d(),
+                                   {0.0, 1.0},
+                                   anEvaluator,
+                                   ExtremaPC2d::SearchMode::MinMax,
+                                   true);
+  EXPECT_EQ(aResult.NbExt(), 0);
+}
+
+TEST(ExtremaPC2dTest, EndpointClassificationUsesLocalBehavior)
+{
+  const RapidEndpointEvaluator2d anEvaluator;
+  ExtremaPC2d::Result aResult;
+  ExtremaPC2d::AddEndpointExtrema(aResult,
+                                   gp_Pnt2d(),
+                                   {0.0, 1.0},
+                                   anEvaluator,
+                                   ExtremaPC2d::SearchMode::Min,
+                                   false);
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, Precision::PConfusion());
+  EXPECT_TRUE(aResult[0].IsMinimum);
+}

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC2d_Test.cxx
@@ -75,9 +75,7 @@ TEST(ExtremaPC2dTest, ClosedPeriodicDomainValidation)
 {
   constexpr double aTol = 1.0e-10;
   EXPECT_TRUE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, 2.0 * M_PI}, 2.0 * M_PI, aTol));
-  EXPECT_TRUE(ExtremaPC2d::IsClosedPeriodicDomain({7.0, 7.0 + 4.0 * M_PI},
-                                                  2.0 * M_PI,
-                                                  aTol));
+  EXPECT_TRUE(ExtremaPC2d::IsClosedPeriodicDomain({7.0, 7.0 + 4.0 * M_PI}, 2.0 * M_PI, aTol));
   EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, M_PI}, 2.0 * M_PI, aTol));
   EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({1.0, 0.0}, 2.0 * M_PI, aTol));
   EXPECT_FALSE(ExtremaPC2d::IsClosedPeriodicDomain({0.0, 2.0 * M_PI}, 0.0, aTol));
@@ -89,14 +87,14 @@ TEST(ExtremaPC2dTest, ClosedPeriodicDomainValidation)
 TEST(ExtremaPC2dTest, EndpointClassificationAndModes)
 {
   const LinearEvaluator2d anEvaluator;
-  const gp_Pnt2d aQuery(-2.0, 3.0);
-  ExtremaPC2d::Result aResult;
+  const gp_Pnt2d          aQuery(-2.0, 3.0);
+  ExtremaPC2d::Result     aResult;
   ExtremaPC2d::AddEndpointExtrema(aResult,
-                                   aQuery,
-                                   {0.0, 10.0},
-                                   anEvaluator,
-                                   ExtremaPC2d::SearchMode::MinMax,
-                                   false);
+                                  aQuery,
+                                  {0.0, 10.0},
+                                  anEvaluator,
+                                  ExtremaPC2d::SearchMode::MinMax,
+                                  false);
   ASSERT_EQ(aResult.NbExt(), 2);
   EXPECT_NEAR(aResult[0].Parameter, 0.0, 1.0e-12);
   EXPECT_TRUE(aResult[0].IsMinimum);
@@ -105,11 +103,11 @@ TEST(ExtremaPC2dTest, EndpointClassificationAndModes)
 
   aResult.Clear();
   ExtremaPC2d::AddEndpointExtrema(aResult,
-                                   aQuery,
-                                   {0.0, 10.0},
-                                   anEvaluator,
-                                   ExtremaPC2d::SearchMode::Min,
-                                   false);
+                                  aQuery,
+                                  {0.0, 10.0},
+                                  anEvaluator,
+                                  ExtremaPC2d::SearchMode::Min,
+                                  false);
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult[0].Parameter, 0.0, 1.0e-12);
 }
@@ -119,37 +117,37 @@ TEST(ExtremaPC2dTest, EndpointClassificationAndModes)
 TEST(ExtremaPC2dTest, SingletonAndClosedEndpointBehavior)
 {
   const LinearEvaluator2d anEvaluator;
-  ExtremaPC2d::Result aResult;
+  ExtremaPC2d::Result     aResult;
   ExtremaPC2d::AddEndpointExtrema(aResult,
-                                   gp_Pnt2d(5.0, 3.0),
-                                   {2.0, 2.0},
-                                   anEvaluator,
-                                   ExtremaPC2d::SearchMode::MinMax,
-                                   false);
+                                  gp_Pnt2d(5.0, 3.0),
+                                  {2.0, 2.0},
+                                  anEvaluator,
+                                  ExtremaPC2d::SearchMode::MinMax,
+                                  false);
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_TRUE(aResult[0].IsMinimum);
   EXPECT_TRUE(aResult[0].IsMaximum);
 
   aResult.Clear();
   ExtremaPC2d::AddEndpointExtrema(aResult,
-                                   gp_Pnt2d(),
-                                   {0.0, 1.0},
-                                   anEvaluator,
-                                   ExtremaPC2d::SearchMode::MinMax,
-                                   true);
+                                  gp_Pnt2d(),
+                                  {0.0, 1.0},
+                                  anEvaluator,
+                                  ExtremaPC2d::SearchMode::MinMax,
+                                  true);
   EXPECT_EQ(aResult.NbExt(), 0);
 }
 
 TEST(ExtremaPC2dTest, EndpointClassificationUsesLocalBehavior)
 {
   const RapidEndpointEvaluator2d anEvaluator;
-  ExtremaPC2d::Result aResult;
+  ExtremaPC2d::Result            aResult;
   ExtremaPC2d::AddEndpointExtrema(aResult,
-                                   gp_Pnt2d(),
-                                   {0.0, 1.0},
-                                   anEvaluator,
-                                   ExtremaPC2d::SearchMode::Min,
-                                   false);
+                                  gp_Pnt2d(),
+                                  {0.0, 1.0},
+                                  anEvaluator,
+                                  ExtremaPC2d::SearchMode::Min,
+                                  false);
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult[0].Parameter, 0.0, Precision::PConfusion());
   EXPECT_TRUE(aResult[0].IsMinimum);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_BSplineCurve_Test.cxx
@@ -780,7 +780,9 @@ TEST_F(ExtremaPC_BSplineCurveTest, ShiftedMultiPeriodNonPlanarCurveFindsEveryMin
 
 TEST_F(ExtremaPC_BSplineCurveTest, GridUtilitiesRejectInvalidSamplesAndShortOpenClosure)
 {
+#if !defined(No_Exception) && !defined(No_Standard_RangeError)
   EXPECT_THROW(ExtremaPC_GridEvaluator::BuildUniformParams(0.0, 1.0, 1), Standard_RangeError);
+#endif
 
   NCollection_Array1<gp_Pnt> aPoles(1, 2);
   aPoles(1)                            = gp_Pnt(0.0, 0.0, 0.0);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_BSplineCurve_Test.cxx
@@ -15,10 +15,14 @@
 
 #include <ExtremaPC_BSplineCurve.hxx>
 #include <ExtremaPC_GridEvaluator.hxx>
+#include <ExtremaPC2d_BSplineCurve.hxx>
 
+#include <Geom_BezierCurve.hxx>
 #include <Geom_BSplineCurve.hxx>
+#include <Geom2d_BSplineCurve.hxx>
 #include <GeomAdaptor_Curve.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 
 #include <chrono>
 #include <cmath>
@@ -187,6 +191,21 @@ TEST_F(ExtremaPC_BSplineCurveTest, PointOnCurve_Middle)
   EXPECT_NEAR(aMinSqDist, 0.0, THE_TOL);
 }
 
+TEST_F(ExtremaPC_BSplineCurveTest, SingletonDomain_ReturnsSolePoint)
+{
+  occ::handle<Geom_BSplineCurve> aBSpline   = createCubicBSpline();
+  constexpr double               aParameter = 0.35;
+
+  ExtremaPC_BSplineCurve   anEval(aBSpline, ExtremaPC::Domain1D{aParameter, aParameter});
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(5, 5, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, aParameter, THE_TOL);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+  EXPECT_TRUE(aResult[0].IsMaximum);
+}
+
 //==================================================================================================
 // Point near curve tests
 //==================================================================================================
@@ -222,7 +241,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, PointNearCurve_Below)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBSpline->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
 
@@ -300,7 +319,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, QuadraticBSpline_PointNear)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBSpline->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnCurve), THE_TOL);
@@ -339,7 +358,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, MultiSpanBSpline_PointNear)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBSpline->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
 
@@ -361,7 +380,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, MultiSpanBSpline_MultipleExtrema)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify all extrema are on the curve
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     gp_Pnt aPtOnCurve = aBSpline->Value(aResult[i].Parameter);
     EXPECT_NEAR(aResult[i].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
@@ -400,7 +419,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, BSpline3D_PointNear)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBSpline->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnCurve), THE_TOL);
@@ -423,7 +442,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, PartialRange_FirstHalf)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // All parameters should be in first half
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, 0.0 - THE_TOL);
     EXPECT_LE(aResult[i].Parameter, 0.5 + THE_TOL);
@@ -443,7 +462,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, PartialRange_SecondHalf)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // All parameters should be in second half
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, 0.5 - THE_TOL);
     EXPECT_LE(aResult[i].Parameter, 1.0 + THE_TOL);
@@ -467,7 +486,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, VerifyProjectedPoint)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify the projected point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBSpline->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aPtOnCurve.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aPtOnCurve.Y(), THE_TOL);
@@ -487,7 +506,7 @@ TEST_F(ExtremaPC_BSplineCurveTest, VerifyDistanceConsistency)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify distance matches point distance
-  int    aMinIdx     = aResult.MinIndex();
+  size_t aMinIdx     = aResult.MinIndex();
   double aComputedSq = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedSq, THE_TOL);
 }
@@ -544,11 +563,229 @@ TEST_F(ExtremaPC_BSplineCurveTest, HighDegreeSpline_RefinementHelps)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBSpline->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
 
   // Verify the distance is reasonable (point is within expected range of curve)
   double aDist = std::sqrt(aResult.MinSquareDistance());
   EXPECT_LT(aDist, 2.0);
+}
+
+TEST_F(ExtremaPC_BSplineCurveTest, C1Junction_PointOnCurve_FindsMinimum)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 4);
+  aPoles(1) = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2) = gp_Pnt(1.0, 1.0, 0.0);
+  aPoles(3) = gp_Pnt(2.0, 1.0, 0.0);
+  aPoles(4) = gp_Pnt(3.0, 0.0, 0.0);
+
+  NCollection_Array1<double> aKnots(1, 3);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.5;
+  aKnots(3) = 1.0;
+
+  NCollection_Array1<int> aMultiplicities(1, 3);
+  aMultiplicities(1) = 3;
+  aMultiplicities(2) = 1;
+  aMultiplicities(3) = 3;
+
+  occ::handle<Geom_BSplineCurve> aBSpline =
+    new Geom_BSplineCurve(aPoles, aKnots, aMultiplicities, 2);
+  const gp_Pnt aPoint = aBSpline->Value(0.5);
+
+  ExtremaPC_BSplineCurve   anEvaluator(aBSpline);
+  const ExtremaPC::Result& aResult = anEvaluator.Perform(aPoint, THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_GT(aResult.NbExt(), 0);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.5, THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_BSplineCurveTest, ClusteredC0Junctions_FindsBothExtrema)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 4);
+  aPoles(1) = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2) = gp_Pnt(1.0, 1.0, 0.0);
+  aPoles(3) = gp_Pnt(2.0, 0.0, 0.0);
+  aPoles(4) = gp_Pnt(3.0, 1.0, 0.0);
+
+  NCollection_Array1<double> aKnots(1, 4);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.499;
+  aKnots(3) = 0.501;
+  aKnots(4) = 1.0;
+
+  NCollection_Array1<int> aMultiplicities(1, 4);
+  aMultiplicities(1) = 2;
+  aMultiplicities(2) = 1;
+  aMultiplicities(3) = 1;
+  aMultiplicities(4) = 2;
+
+  occ::handle<Geom_BSplineCurve> aBSpline =
+    new Geom_BSplineCurve(aPoles, aKnots, aMultiplicities, 1);
+  ExtremaPC_BSplineCurve   anEvaluator(aBSpline);
+  const ExtremaPC::Result& aResult = anEvaluator.Perform(gp_Pnt(1.5, 1.5, 0.0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  bool hasFirstJunction  = false;
+  bool hasSecondJunction = false;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    if (std::abs(aResult[anIndex].Parameter - 0.499) <= THE_TOL)
+    {
+      hasFirstJunction = true;
+      EXPECT_TRUE(aResult[anIndex].IsMinimum);
+    }
+    if (std::abs(aResult[anIndex].Parameter - 0.501) <= THE_TOL)
+    {
+      hasSecondJunction = true;
+      EXPECT_TRUE(aResult[anIndex].IsMaximum);
+    }
+  }
+  EXPECT_TRUE(hasFirstJunction);
+  EXPECT_TRUE(hasSecondJunction);
+
+  const ExtremaPC::Result& aMinResult =
+    anEvaluator.Perform(gp_Pnt(1.5, 1.5, 0.0), THE_TOL, ExtremaPC::SearchMode::Min);
+  hasFirstJunction  = false;
+  hasSecondJunction = false;
+  for (size_t anIndex = 0; anIndex < aMinResult.NbExt(); ++anIndex)
+  {
+    hasFirstJunction =
+      hasFirstJunction || std::abs(aMinResult[anIndex].Parameter - 0.499) <= THE_TOL;
+    hasSecondJunction =
+      hasSecondJunction || std::abs(aMinResult[anIndex].Parameter - 0.501) <= THE_TOL;
+  }
+  EXPECT_TRUE(hasFirstJunction);
+  EXPECT_FALSE(hasSecondJunction);
+
+  const ExtremaPC::Result& aMaxResult =
+    anEvaluator.Perform(gp_Pnt(1.5, 1.5, 0.0), THE_TOL, ExtremaPC::SearchMode::Max);
+  hasFirstJunction  = false;
+  hasSecondJunction = false;
+  for (size_t anIndex = 0; anIndex < aMaxResult.NbExt(); ++anIndex)
+  {
+    hasFirstJunction =
+      hasFirstJunction || std::abs(aMaxResult[anIndex].Parameter - 0.499) <= THE_TOL;
+    hasSecondJunction =
+      hasSecondJunction || std::abs(aMaxResult[anIndex].Parameter - 0.501) <= THE_TOL;
+  }
+  EXPECT_FALSE(hasFirstJunction);
+  EXPECT_TRUE(hasSecondJunction);
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_BSplineCurveTest, PlanarDelegation_RationalCurvePreservesDomainAndEndpoints)
+{
+  NCollection_Array1<gp_Pnt>   aPoles3d(1, 4);
+  NCollection_Array1<gp_Pnt2d> aPoles2d(1, 4);
+  NCollection_Array1<double>   aWeights(1, 4);
+  for (size_t anIndex = 0; anIndex < aPoles3d.Size(); ++anIndex)
+  {
+    const double anOrdinal     = static_cast<double>(anIndex + 1);
+    const double anX           = 10.0 + anOrdinal;
+    const double anY           = (anIndex + 1) % 2 == 0 ? 2.0 : -1.0;
+    aPoles3d.ChangeAt(anIndex) = gp_Pnt(anX, -4.0, anY);
+    aPoles2d.ChangeAt(anIndex) = gp_Pnt2d(anX, anY);
+    aWeights.ChangeAt(anIndex) = 0.5 + 0.25 * anOrdinal;
+  }
+  NCollection_Array1<double> aKnots(1, 2);
+  aKnots(1) = 2.0;
+  aKnots(2) = 6.0;
+  NCollection_Array1<int> aMultiplicities(1, 2);
+  aMultiplicities(1) = 4;
+  aMultiplicities(2) = 4;
+  occ::handle<Geom_BSplineCurve> aCurve3d =
+    new Geom_BSplineCurve(aPoles3d, aWeights, aKnots, aMultiplicities, 3);
+  occ::handle<Geom2d_BSplineCurve> aCurve2d =
+    new Geom2d_BSplineCurve(aPoles2d, aWeights, aKnots, aMultiplicities, 3);
+  ExtremaPC_BSplineCurve   anEvaluator3d(aCurve3d, ExtremaPC::Domain1D{2.5, 5.5});
+  ExtremaPC2d_BSplineCurve anEvaluator2d(aCurve2d, ExtremaPC2d::Domain1D{2.5, 5.5});
+  const ExtremaPC::Result& aResult3d =
+    anEvaluator3d.PerformWithEndpoints(gp_Pnt(12.0, 3.0, 0.5), THE_TOL);
+  const ExtremaPC2d::Result& aResult2d =
+    anEvaluator2d.PerformWithEndpoints(gp_Pnt2d(12.0, 0.5), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aResult3d[anIndex].Parameter, aResult2d[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(aResult3d[anIndex].SquareDistance,
+                aResult2d[anIndex].SquareDistance + 49.0,
+                THE_TOL);
+  }
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_BSplineCurveTest, PlanarDelegation_NonPlanarCurveUses3dFallback)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 4);
+  aPoles(1) = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2) = gp_Pnt(1.0, 2.0, 1.0);
+  aPoles(3) = gp_Pnt(2.0, -1.0, 3.0);
+  aPoles(4) = gp_Pnt(4.0, 0.0, -2.0);
+  NCollection_Array1<double> aKnots(1, 2);
+  aKnots(1) = 0.0;
+  aKnots(2) = 1.0;
+  NCollection_Array1<int> aMultiplicities(1, 2);
+  aMultiplicities(1)                    = 4;
+  aMultiplicities(2)                    = 4;
+  occ::handle<Geom_BSplineCurve> aCurve = new Geom_BSplineCurve(aPoles, aKnots, aMultiplicities, 3);
+  ExtremaPC_BSplineCurve         anEvaluator(aCurve);
+  const ExtremaPC::Result&       aResult = anEvaluator.Perform(gp_Pnt(1.0, 0.5, 2.0), THE_TOL);
+  EXPECT_TRUE(aResult.IsDone());
+  EXPECT_GE(aResult.NbExt(), 1);
+}
+
+TEST_F(ExtremaPC_BSplineCurveTest, ShiftedMultiPeriodNonPlanarCurveFindsEveryMinimum)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 5);
+  aPoles(1) = gp_Pnt(1.0, 0.0, 0.0);
+  aPoles(2) = gp_Pnt(0.3, 1.0, 0.4);
+  aPoles(3) = gp_Pnt(-0.8, 0.6, -0.2);
+  aPoles(4) = gp_Pnt(-0.7, -0.7, 0.8);
+  aPoles(5) = gp_Pnt(0.4, -0.9, -0.5);
+  NCollection_Array1<double> aKnots(1, 6);
+  for (size_t anIndex = 0; anIndex < aKnots.Size(); ++anIndex)
+  {
+    aKnots.ChangeAt(anIndex) = 0.2 * static_cast<double>(anIndex);
+  }
+  NCollection_Array1<int> aMultiplicities(1, 6);
+  aMultiplicities.Init(1);
+  occ::handle<Geom_BSplineCurve> aCurve =
+    new Geom_BSplineCurve(aPoles, aKnots, aMultiplicities, 3, true);
+
+  const double              aPeriod = aCurve->Period();
+  const double              aTarget = aCurve->FirstParameter() + 0.17 * aPeriod;
+  const ExtremaPC::Domain1D aDomain{aTarget - 0.1 * aPeriod, aTarget + 3.1 * aPeriod};
+  ExtremaPC_BSplineCurve    anEvaluator(aCurve, aDomain);
+  const ExtremaPC::Result&  aResult =
+    anEvaluator.Perform(aCurve->Value(aTarget), 1.0e-9, ExtremaPC::SearchMode::Min);
+
+  ASSERT_TRUE(aResult.IsDone());
+  int aNbZeroDistanceMinima = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    if (aResult[anIndex].SquareDistance <= 1.0e-16)
+    {
+      EXPECT_NEAR(aResult[anIndex].Parameter, aTarget + aNbZeroDistanceMinima * aPeriod, 1.0e-7);
+      ++aNbZeroDistanceMinima;
+    }
+  }
+  EXPECT_EQ(aNbZeroDistanceMinima, 4);
+}
+
+TEST_F(ExtremaPC_BSplineCurveTest, GridUtilitiesRejectInvalidSamplesAndShortOpenClosure)
+{
+  EXPECT_THROW(ExtremaPC_GridEvaluator::BuildUniformParams(0.0, 1.0, 1), Standard_RangeError);
+
+  NCollection_Array1<gp_Pnt> aPoles(1, 2);
+  aPoles(1)                            = gp_Pnt(0.0, 0.0, 0.0);
+  aPoles(2)                            = gp_Pnt(0.5 * Precision::Confusion(), 0.0, 0.0);
+  occ::handle<Geom_BezierCurve> aCurve = new Geom_BezierCurve(aPoles);
+  GeomAdaptor_Curve             anAdaptor(aCurve);
+  EXPECT_FALSE(ExtremaPC_GridEvaluator::IsClosedDomain(anAdaptor, {0.0, 1.0}));
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_BezierCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_BezierCurve_Test.cxx
@@ -14,9 +14,14 @@
 #include <gtest/gtest.h>
 
 #include <ExtremaPC_BezierCurve.hxx>
+#include <ExtremaPC_GridEvaluator.hxx>
+#include <ExtremaPC2d_BezierCurve.hxx>
 
 #include <Geom_BezierCurve.hxx>
+#include <Geom2d_BezierCurve.hxx>
+#include <GeomAdaptor_Curve.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 #include <gp_Vec.hxx>
 
 #include <cmath>
@@ -226,7 +231,7 @@ TEST_F(ExtremaPC_BezierCurveTest, QuadraticBezier_SymmetricArc)
 
   // Should find extremum at t=0.5
   bool aFoundMiddle = false;
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aU = aResult[i].Parameter;
     if (std::abs(aU - 0.5) < 0.01)
@@ -252,7 +257,7 @@ TEST_F(ExtremaPC_BezierCurveTest, QuadraticBezier_PointBelowApex)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBezier->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
 
@@ -273,7 +278,7 @@ TEST_F(ExtremaPC_BezierCurveTest, QuadraticBezier_AsymmetricArc)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBezier->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnCurve), THE_TOL);
@@ -297,7 +302,7 @@ TEST_F(ExtremaPC_BezierCurveTest, CubicBezier_SCurve)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBezier->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
 }
@@ -316,7 +321,7 @@ TEST_F(ExtremaPC_BezierCurveTest, CubicBezier_LoopedCurve)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // With a loop, may find multiple extrema - verify all are on curve
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     gp_Pnt aPtOnCurve = aBezier->Value(aResult[i].Parameter);
     EXPECT_NEAR(aResult[i].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
@@ -336,7 +341,7 @@ TEST_F(ExtremaPC_BezierCurveTest, CubicBezier_MultipleExtrema)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify all extrema are on the curve
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     gp_Pnt aPtOnCurve = aBezier->Value(aResult[i].Parameter);
     EXPECT_NEAR(aResult[i].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
@@ -363,7 +368,7 @@ TEST_F(ExtremaPC_BezierCurveTest, QuarticBezier_WavyCurve)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify all extrema are on the curve
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     gp_Pnt aPtOnCurve = aBezier->Value(aResult[i].Parameter);
     EXPECT_NEAR(aResult[i].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
@@ -402,12 +407,8 @@ TEST_F(ExtremaPC_BezierCurveTest, RationalQuadratic_CircularArc)
   ExtremaPC_BezierCurve    anEval(aBezier);
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
 
-  ASSERT_TRUE(aResult.IsDone());
-  EXPECT_GE(aResult.NbExt(), 1);
-
-  // All points on a circular arc should be equidistant from center (radius = 1)
-  double aMinDist = aResult.MinSquareDistance();
-  EXPECT_NEAR(aMinDist, 1.0, 0.01);
+  ASSERT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 1.0, 0.01);
 }
 
 TEST_F(ExtremaPC_BezierCurveTest, RationalQuadratic_HighWeight)
@@ -423,7 +424,7 @@ TEST_F(ExtremaPC_BezierCurveTest, RationalQuadratic_HighWeight)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBezier->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnCurve), THE_TOL);
@@ -446,7 +447,7 @@ TEST_F(ExtremaPC_BezierCurveTest, CubicBezier_3D_HelixLike)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBezier->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnCurve), THE_TOL);
@@ -498,7 +499,7 @@ TEST_F(ExtremaPC_BezierCurveTest, BoundedRange_ExtremumAtBound)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // All extrema should be within the bounded range [0, 0.3]
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aU = aResult[i].Parameter;
     EXPECT_GE(aU, -0.001);
@@ -520,12 +521,58 @@ TEST_F(ExtremaPC_BezierCurveTest, DegenerateBezier_AllPolesSame)
   ExtremaPC_BezierCurve    anEval(aBezier);
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
 
-  ASSERT_TRUE(aResult.IsDone());
-  EXPECT_GE(aResult.NbExt(), 1);
+  ASSERT_TRUE(aResult.IsInfinite());
+  EXPECT_NEAR(aResult.InfiniteSquareDistance, 1.0, THE_TOL);
+}
 
-  // Distance should be 1 (squared)
-  double aMinDist = aResult.MinSquareDistance();
-  EXPECT_NEAR(aMinDist, 1.0, THE_TOL);
+TEST_F(ExtremaPC_BezierCurveTest, SingletonDomain_ReturnsSolePoint)
+{
+  occ::handle<Geom_BezierCurve> aBezier =
+    createQuadraticBezier(gp_Pnt(0, 0, 0), gp_Pnt(1, 2, 0), gp_Pnt(3, 0, 0));
+  constexpr double aParameter = 0.4;
+
+  ExtremaPC_BezierCurve    anEval(aBezier, ExtremaPC::Domain1D{aParameter, aParameter});
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(5, 5, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, aParameter, THE_TOL);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+  EXPECT_TRUE(aResult[0].IsMaximum);
+}
+
+TEST_F(ExtremaPC_BezierCurveTest, RepeatedEndpointPole_DoesNotFailNumerically)
+{
+  occ::handle<Geom_BezierCurve> aBezier =
+    createCubicBezier(gp_Pnt(0, 0, 0), gp_Pnt(0, 0, 0), gp_Pnt(2, 1, 0), gp_Pnt(3, 0, 0));
+
+  ExtremaPC_BezierCurve    anEval(aBezier);
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(0, 0, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_GT(aResult.NbExt(), 0);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 0.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_BezierCurveTest, ClosedCurve_SeamHasSingleRepresentative)
+{
+  occ::handle<Geom_BezierCurve> aBezier =
+    createCubicBezier(gp_Pnt(1, 0, 0), gp_Pnt(1, 1, 0), gp_Pnt(1, -1, 0), gp_Pnt(1, 0, 0));
+
+  ExtremaPC_BezierCurve    anEval(aBezier);
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 0, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  int aNbSeamRepresentatives = 0;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    if (std::abs(aResult[anIndex].Parameter - aBezier->FirstParameter()) <= THE_TOL
+        || std::abs(aResult[anIndex].Parameter - aBezier->LastParameter()) <= THE_TOL)
+    {
+      ++aNbSeamRepresentatives;
+    }
+  }
+  EXPECT_EQ(aNbSeamRepresentatives, 1);
 }
 
 TEST_F(ExtremaPC_BezierCurveTest, PointFarFromCurve)
@@ -541,7 +588,7 @@ TEST_F(ExtremaPC_BezierCurveTest, PointFarFromCurve)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify closest point is on the curve
-  int    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = aBezier->Value(aResult[aMinIdx].Parameter);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnCurve), 0.0, THE_TOL);
 
@@ -587,7 +634,7 @@ TEST_F(ExtremaPC_BezierCurveTest, VerifyExtremumCondition)
   int aSatisfiedCount = 0;
 
   // Verify that (C(u) - P) . C'(u) ~= 0 at interior extrema
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aU = aResult[i].Parameter;
 
@@ -632,7 +679,7 @@ TEST_F(ExtremaPC_BezierCurveTest, ConsistentDistanceCalculation)
   ASSERT_TRUE(aResult.IsDone());
   EXPECT_GE(aResult.NbExt(), 1);
 
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aSqDist  = aResult[i].SquareDistance;
     double aU       = aResult[i].Parameter;
@@ -641,4 +688,85 @@ TEST_F(ExtremaPC_BezierCurveTest, ConsistentDistanceCalculation)
     double aExpectedSqDist = aPoint.SquareDistance(aCurvePt);
     EXPECT_NEAR(aSqDist, aExpectedSqDist, THE_TOL);
   }
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_BezierCurveTest, PlanarDelegation_PreservesOffPlaneExtrema)
+{
+  NCollection_Array1<gp_Pnt>   aPoles3d(1, 4);
+  NCollection_Array1<gp_Pnt2d> aPoles2d(1, 4);
+  for (size_t anIndex = 0; anIndex < aPoles3d.Size(); ++anIndex)
+  {
+    const size_t anOrdinal     = anIndex + 1;
+    const double anX           = static_cast<double>(anIndex);
+    const double anY           = anOrdinal == 2 ? 3.0 : (anOrdinal == 3 ? -1.0 : 0.0);
+    aPoles3d.ChangeAt(anIndex) = gp_Pnt(anX, anY, 2.0);
+    aPoles2d.ChangeAt(anIndex) = gp_Pnt2d(anX, anY);
+  }
+  occ::handle<Geom_BezierCurve>   aCurve3d = new Geom_BezierCurve(aPoles3d);
+  occ::handle<Geom2d_BezierCurve> aCurve2d = new Geom2d_BezierCurve(aPoles2d);
+  ExtremaPC_BezierCurve           anEvaluator3d(aCurve3d);
+  ExtremaPC2d_BezierCurve         anEvaluator2d(aCurve2d);
+  const ExtremaPC::Result&        aResult3d = anEvaluator3d.Perform(gp_Pnt(1.3, 1.0, 7.0), THE_TOL);
+  const ExtremaPC2d::Result&      aResult2d = anEvaluator2d.Perform(gp_Pnt2d(1.3, 1.0), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aResult3d[anIndex].Parameter, aResult2d[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(aResult3d[anIndex].SquareDistance,
+                aResult2d[anIndex].SquareDistance + 25.0,
+                THE_TOL);
+  }
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_BezierCurveTest, PlanarDelegation_ReprojectsMutationPerCall)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 3);
+  aPoles(1)                            = gp_Pnt(0.0, 0.0, 1.0);
+  aPoles(2)                            = gp_Pnt(2.0, 3.0, 1.0);
+  aPoles(3)                            = gp_Pnt(4.0, 0.0, 1.0);
+  occ::handle<Geom_BezierCurve> aCurve = new Geom_BezierCurve(aPoles);
+  ExtremaPC_BezierCurve         anEvaluator(aCurve);
+  const ExtremaPC::Result&      aBefore = anEvaluator.Perform(gp_Pnt(2.0, 2.0, 4.0), THE_TOL);
+  ASSERT_TRUE(aBefore.IsDone());
+  const double aBeforeParameter = aBefore[aBefore.MinIndex()].Parameter;
+
+  aCurve->SetPole(2, gp_Pnt(3.5, -4.0, 1.0));
+  const ExtremaPC::Result& anAfter = anEvaluator.Perform(gp_Pnt(2.0, 2.0, 4.0), THE_TOL);
+  ASSERT_TRUE(anAfter.IsDone());
+  ASSERT_GE(anAfter.NbExt(), 1);
+  EXPECT_GT(std::abs(anAfter[anAfter.MinIndex()].Parameter - aBeforeParameter), 1.0e-3);
+  EXPECT_NEAR(anAfter[anAfter.MinIndex()].Point.Distance(
+                aCurve->Value(anAfter[anAfter.MinIndex()].Parameter)),
+              0.0,
+              1.0e-12);
+}
+
+TEST_F(ExtremaPC_BezierCurveTest, SmallNonConstantCurveIsNotPromotedToInfinite)
+{
+  constexpr int              THE_NB_POLES = 12;
+  constexpr double           aLength      = 1.0e-3;
+  NCollection_Array1<gp_Pnt> aPoles(1, THE_NB_POLES);
+  for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
+  {
+    const double aRatio      = static_cast<double>(anIndex) / (aPoles.Size() - 1);
+    aPoles.ChangeAt(anIndex) = gp_Pnt(aRatio * aLength, 0.0, 0.0);
+  }
+  occ::handle<Geom_BezierCurve> aCurve = new Geom_BezierCurve(aPoles);
+  GeomAdaptor_Curve             anAdaptor(aCurve);
+  ExtremaPC_GridEvaluator       anEvaluator;
+  anEvaluator.SetParams(ExtremaPC_GridEvaluator::BuildUniformParams(0.0, 1.0, 8));
+
+  const ExtremaPC::Result& aResult = anEvaluator.Perform(anAdaptor,
+                                                         gp_Pnt(0.5 * aLength, 1.0, 0.0),
+                                                         {0.0, 1.0},
+                                                         1.0e-10,
+                                                         ExtremaPC::SearchMode::MinMax);
+  ASSERT_TRUE(aResult.IsDone());
+  EXPECT_FALSE(aResult.IsInfinite());
+  ASSERT_GE(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.5, 1.0e-7);
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Circle_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Circle_Test.cxx
@@ -14,10 +14,14 @@
 #include <gtest/gtest.h>
 
 #include <ExtremaPC_Circle.hxx>
+#include <ExtremaPC2d_Circle.hxx>
 
 #include <gp_Ax2.hxx>
+#include <gp_Ax22d.hxx>
 #include <gp_Circ.hxx>
+#include <gp_Circ2d.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 
 #include <cmath>
 
@@ -59,6 +63,56 @@ TEST_F(ExtremaPC_CircleTest, PointOutside_OnXAxis)
   EXPECT_NEAR(std::sqrt(aResult[aMaxIdx].SquareDistance), 30.0, THE_TOL);
   EXPECT_FALSE(aResult[aMaxIdx].IsMinimum);
   EXPECT_NEAR(aResult[aMaxIdx].Parameter, THE_PI, THE_TOL);
+}
+
+TEST_F(ExtremaPC_CircleTest, ShiftedFullPeriod_UniqueRepresentatives)
+{
+  gp_Circ aCircle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 10.0);
+  gp_Pnt  aPoint(20.0, 0.0, 0.0);
+
+  constexpr double         aUMin = 7.0;
+  ExtremaPC_Circle         anEval(aCircle, ExtremaPC::Domain1D{aUMin, aUMin + THE_2PI});
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 2);
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    EXPECT_GE(aResult[anIndex].Parameter, aUMin);
+    EXPECT_LE(aResult[anIndex].Parameter, aUMin + THE_2PI);
+  }
+}
+
+TEST_F(ExtremaPC_CircleTest, LargeTolerance_PreservesOppositeExtrema)
+{
+  gp_Circ          aCircle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 1.0);
+  ExtremaPC_Circle anEval(aCircle, ExtremaPC::Domain1D{0.0, THE_2PI});
+
+  const ExtremaPC::Result& aResult = anEval.Perform(gp_Pnt(2, 0, 0), 4.0);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult.MinSquareDistance(), 1.0, THE_TOL);
+  EXPECT_NEAR(aResult.MaxSquareDistance(), 9.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_CircleTest, MoreThanOnePeriod_RetainsConstrainedEndpoint)
+{
+  constexpr double aDomainEnd = THE_2PI + 0.1;
+  gp_Circ          aCircle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 10.0);
+  ExtremaPC_Circle anEval(aCircle, ExtremaPC::Domain1D{0.0, aDomainEnd});
+  const gp_Pnt     aPoint = ElCLib::Value(aDomainEnd, aCircle);
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  bool hasUpperEndpoint = false;
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    hasUpperEndpoint =
+      hasUpperEndpoint || std::abs(aResult[anIndex].Parameter - aDomainEnd) <= THE_TOL;
+  }
+  EXPECT_TRUE(hasUpperEndpoint);
 }
 
 TEST_F(ExtremaPC_CircleTest, PointOutside_OnYAxis)
@@ -314,7 +368,7 @@ TEST_F(ExtremaPC_CircleTest, PartialArc_ExtremaOutsideRange)
   // The natural extrema (at 0 and PI) - 0 is outside, PI is inside
   // Should find extremum at PI and possibly endpoints
   bool aFoundPi = false;
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     if (std::abs(aResult[i].Parameter - THE_PI) < 0.1)
     {
@@ -456,4 +510,33 @@ TEST_F(ExtremaPC_CircleTest, PointOnCircle_AtPi)
   // Minimum distance = 0 (point is on circle)
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Parameter, THE_PI, THE_TOL);
+}
+
+TEST_F(ExtremaPC_CircleTest, NonFiniteQueryIsRejected)
+{
+  ExtremaPC_Circle anEvaluator(gp_Circ(gp_Ax2(gp_Pnt(), gp_Dir(0.0, 0.0, 1.0)), 10.0));
+  const gp_Pnt     aQuery(Precision::Infinite(), 0.0, 0.0);
+  EXPECT_EQ(anEvaluator.Perform(aQuery, THE_TOL).Status, ExtremaPC::Status::InvalidInput);
+  EXPECT_EQ(anEvaluator.PerformWithEndpoints(aQuery, THE_TOL).Status,
+            ExtremaPC::Status::InvalidInput);
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_CircleTest, PlanarDelegation_PreservesParameterAndHeight)
+{
+  ExtremaPC_Circle anEvaluator3d(
+    gp_Circ(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 4.0));
+  ExtremaPC2d_Circle anEvaluator2d(
+    gp_Circ2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 4.0));
+  const ExtremaPC::Result&   aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aResult3d[anIndex].Parameter, aResult2d[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(aResult3d[anIndex].SquareDistance,
+                aResult2d[anIndex].SquareDistance + 36.0,
+                THE_TOL);
+  }
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Comparison_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Comparison_Test.cxx
@@ -72,17 +72,19 @@ protected:
     }
 
     // Find minimum from new implementation
-    double aNewMinSqDist = theNew.MinSquareDistance();
-    size_t aNewMinIdx    = theNew.MinIndex();
+    const double aNewMinSqDist = theNew.MinSquareDistance();
+    const size_t aNewMinIdx    = theNew.MinIndex();
+    const bool   hasOldMinimum = aOldMinIdx >= 1;
+    const bool   hasNewMinimum = aNewMinIdx != ExtremaPC::Result::INVALID_INDEX;
 
     // Both should find extrema (or both find none)
-    if (aOldMinIdx < 0 && aNewMinIdx < 0)
+    if (!hasOldMinimum && !hasNewMinimum)
     {
       return; // Both found no extrema - OK
     }
 
-    ASSERT_GE(aOldMinIdx, 1) << theTestName << ": Old implementation found no minimum";
-    ASSERT_GE(aNewMinIdx, 0) << theTestName << ": New implementation found no minimum";
+    ASSERT_TRUE(hasOldMinimum) << theTestName << ": Old implementation found no minimum";
+    ASSERT_TRUE(hasNewMinimum) << theTestName << ": New implementation found no minimum";
 
     // Compare minimum distances
     double aOldDist = std::sqrt(aOldMinSqDist);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Comparison_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Comparison_Test.cxx
@@ -73,7 +73,7 @@ protected:
 
     // Find minimum from new implementation
     double aNewMinSqDist = theNew.MinSquareDistance();
-    size_t    aNewMinIdx    = theNew.MinIndex();
+    size_t aNewMinIdx    = theNew.MinIndex();
 
     // Both should find extrema (or both find none)
     if (aOldMinIdx < 0 && aNewMinIdx < 0)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Comparison_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Comparison_Test.cxx
@@ -73,7 +73,7 @@ protected:
 
     // Find minimum from new implementation
     double aNewMinSqDist = theNew.MinSquareDistance();
-    int    aNewMinIdx    = theNew.MinIndex();
+    size_t    aNewMinIdx    = theNew.MinIndex();
 
     // Both should find extrema (or both find none)
     if (aOldMinIdx < 0 && aNewMinIdx < 0)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Curve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Curve_Test.cxx
@@ -63,7 +63,7 @@ TEST_F(ExtremaPC_CurveTest, Line_PointOnLine)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 0.0, THE_TOL);
   EXPECT_TRUE(aResult[aMinIdx].IsMinimum);
@@ -83,7 +83,7 @@ TEST_F(ExtremaPC_CurveTest, Line_PointOffLine)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL); // 3^2 + 4^2 = 25
   EXPECT_TRUE(aResult[aMinIdx].IsMinimum);
@@ -103,7 +103,7 @@ TEST_F(ExtremaPC_CurveTest, Line_ProjectionOutsideBounds)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2); // min at 0, max at 100
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   // Should be at endpoint U=0
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 0.0, THE_TOL);
 }
@@ -195,7 +195,7 @@ TEST_F(ExtremaPC_CurveTest, Aggregator_Line)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL);
 }
@@ -315,7 +315,7 @@ TEST_F(ExtremaPC_CurveTest, Aggregator_Hyperbola)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify that stored distance matches computed distance
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aStoredSqDist   = aResult[i].SquareDistance;
     double aComputedSqDist = aPoint.SquareDistance(aResult[i].Point);
@@ -346,7 +346,7 @@ TEST_F(ExtremaPC_CurveTest, Aggregator_Bezier)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify that stored distance matches computed distance
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aStoredSqDist   = aResult[i].SquareDistance;
     double aComputedSqDist = aPoint.SquareDistance(aResult[i].Point);
@@ -396,7 +396,7 @@ TEST_F(ExtremaPC_CurveTest, Aggregator_TrimmedCurve)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Check that all extrema are within bounds
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, -THE_TOL);
     EXPECT_LE(aResult[i].Parameter, M_PI / 2.0 + THE_TOL);
@@ -475,7 +475,7 @@ TEST_F(ExtremaPC_CurveTest, Result_Empty)
 
   EXPECT_FALSE(aResult.IsDone());
   EXPECT_EQ(aResult.NbExt(), 0);
-  EXPECT_EQ(aResult.MinIndex(), -1);
+  EXPECT_EQ(aResult.MinIndex(), ExtremaPC::Result::INVALID_INDEX);
   EXPECT_TRUE(std::isinf(aResult.MinSquareDistance()));
 }
 
@@ -597,7 +597,7 @@ TEST_F(ExtremaPC_CurveTest, Aggregator_BSpline_SearchMode_Min)
 
   ASSERT_TRUE(aResult.IsDone());
   // In Min mode, should only return minimum extrema
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_TRUE(aResult[i].IsMinimum);
   }
@@ -739,7 +739,7 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Translation_Line)
   ASSERT_TRUE(aResult.IsDone());
   EXPECT_GE(aResult.NbExt(), 1);
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), 10.0, THE_TOL);
@@ -788,8 +788,8 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Translation_BSpline)
   ASSERT_EQ(aResult.NbExt(), aResultTr.NbExt());
   EXPECT_NEAR(aResult.MinSquareDistance(), aResultTr.MinSquareDistance(), THE_TOL);
 
-  int aMinIdx   = aResult.MinIndex();
-  int aMinIdxTr = aResultTr.MinIndex();
+  size_t aMinIdx   = aResult.MinIndex();
+  size_t aMinIdxTr = aResultTr.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, aResultTr[aMinIdxTr].Parameter, THE_TOL);
   EXPECT_NEAR(aResultTr[aMinIdxTr].Point.X(), aResult[aMinIdx].Point.X() + 10.0, THE_TOL);
   EXPECT_NEAR(aResultTr[aMinIdxTr].Point.Y(), aResult[aMinIdx].Point.Y() + 20.0, THE_TOL);
@@ -818,7 +818,7 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Rotation_Line)
   ASSERT_TRUE(aResult.IsDone());
   EXPECT_GE(aResult.NbExt(), 1);
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(std::sqrt(aResult[aMinIdx].SquareDistance), 3.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), 5.0, THE_TOL);
@@ -846,8 +846,8 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Rotation_BSpline)
   ASSERT_TRUE(aResultTr.IsDone());
   EXPECT_NEAR(aResult.MinSquareDistance(), aResultTr.MinSquareDistance(), THE_TOL);
 
-  int aMinIdx   = aResult.MinIndex();
-  int aMinIdxTr = aResultTr.MinIndex();
+  size_t aMinIdx   = aResult.MinIndex();
+  size_t aMinIdxTr = aResultTr.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, aResultTr[aMinIdxTr].Parameter, THE_TOL);
 }
 
@@ -881,8 +881,8 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Compound_BSpline)
   ASSERT_TRUE(aResultTr.IsDone());
   EXPECT_NEAR(aResult.MinSquareDistance(), aResultTr.MinSquareDistance(), THE_TOL);
 
-  int aMinIdx   = aResult.MinIndex();
-  int aMinIdxTr = aResultTr.MinIndex();
+  size_t aMinIdx   = aResult.MinIndex();
+  size_t aMinIdxTr = aResultTr.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, aResultTr[aMinIdxTr].Parameter, THE_TOL);
 
   gp_Pnt aExpectedPt = aResult[aMinIdx].Point.Transformed(aTrsf);
@@ -919,8 +919,8 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Scale_BSpline)
   // Distances scale by s^2 = 4
   EXPECT_NEAR(aResultTr.MinSquareDistance(), aResult.MinSquareDistance() * 4.0, THE_TOL);
 
-  int aMinIdx   = aResult.MinIndex();
-  int aMinIdxTr = aResultTr.MinIndex();
+  size_t aMinIdx   = aResult.MinIndex();
+  size_t aMinIdxTr = aResultTr.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, aResultTr[aMinIdxTr].Parameter, THE_TOL);
 }
 
@@ -947,6 +947,54 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Scale_Bezier)
 
   // Distances scale by s^2 = 9
   EXPECT_NEAR(aResultTr.MinSquareDistance(), aResult.MinSquareDistance() * 9.0, 1.0e-4);
+}
+
+TEST_F(ExtremaPC_CurveTest, TransformedCurve_CompoundScale_LinePreservesParameter)
+{
+  occ::handle<Geom_Line> aLine = new Geom_Line(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+
+  gp_Trsf aTrsf;
+  aTrsf.SetScale(gp_Pnt(0, 0, 0), 2.0);
+  gp_Trsf aRotation;
+  aRotation.SetRotation(gp_Ax1(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), M_PI / 2.0);
+  aTrsf.PreMultiply(aRotation);
+  gp_Trsf aTranslation;
+  aTranslation.SetTranslation(gp_Vec(5, 7, 0));
+  aTrsf.PreMultiply(aTranslation);
+
+  GeomAdaptor_TransformedCurve aTransformed(aLine, 0.0, 10.0, aTrsf);
+  ExtremaPC_Curve              anExtPC(aTransformed);
+  const gp_Pnt                 aQuery = gp_Pnt(4, 7, 0).Transformed(aTrsf);
+  const ExtremaPC::Result&     aResult = anExtPC.Perform(aQuery, THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 4.0, THE_TOL);
+  EXPECT_NEAR(aResult[0].Point.Distance(aTransformed.Value(aResult[0].Parameter)), 0.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_CurveTest, TransformedCurve_CompoundScale_ParabolaPreservesParameter)
+{
+  occ::handle<Geom_Parabola> aParabola =
+    new Geom_Parabola(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 5.0);
+
+  gp_Trsf aTrsf;
+  aTrsf.SetScale(gp_Pnt(0, 0, 0), 3.0);
+  gp_Trsf aTranslation;
+  aTranslation.SetTranslation(gp_Vec(10, -4, 2));
+  aTrsf.PreMultiply(aTranslation);
+
+  GeomAdaptor_TransformedCurve aTransformed(aParabola, -10.0, 10.0, aTrsf);
+  ExtremaPC_Curve              anExtPC(aTransformed);
+  constexpr double            aParameter = 3.0;
+  const gp_Pnt                 aQuery = aTransformed.Value(aParameter);
+  const ExtremaPC::Result&     aResult = anExtPC.Perform(aQuery, THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_GE(aResult.NbExt(), 1);
+  const size_t aMinIndex = aResult.MinIndex();
+  EXPECT_NEAR(aResult[aMinIndex].Parameter, aParameter, THE_TOL);
+  EXPECT_NEAR(aResult[aMinIndex].Point.Distance(aQuery), 0.0, THE_TOL);
 }
 
 //==================================================================================================
@@ -993,7 +1041,7 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_DomainLimited_Circle)
   const ExtremaPC::Result& aResult = anExtPC.Perform(aPoint, THE_TOL);
 
   ASSERT_TRUE(aResult.IsDone());
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, -THE_TOL);
     EXPECT_LE(aResult[i].Parameter, M_PI / 2.0 + THE_TOL);
@@ -1016,7 +1064,7 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_DomainLimited_Constructor)
   ASSERT_TRUE(aResult.IsDone());
   EXPECT_GE(aResult.NbExt(), 1);
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 9.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), 5.0, THE_TOL);
@@ -1099,8 +1147,8 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Translation_Bezier)
   ASSERT_TRUE(aResultTr.IsDone());
   EXPECT_NEAR(aResult.MinSquareDistance(), aResultTr.MinSquareDistance(), THE_TOL);
 
-  int    aMinIdx     = aResult.MinIndex();
-  int    aMinIdxTr   = aResultTr.MinIndex();
+  size_t    aMinIdx     = aResult.MinIndex();
+  size_t    aMinIdxTr   = aResultTr.MinIndex();
   gp_Pnt aExpectedPt = aResult[aMinIdx].Point.Transformed(aTrsf);
   EXPECT_NEAR(aResultTr[aMinIdxTr].Point.X(), aExpectedPt.X(), THE_TOL);
   EXPECT_NEAR(aResultTr[aMinIdxTr].Point.Y(), aExpectedPt.Y(), THE_TOL);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Curve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Curve_Test.cxx
@@ -964,7 +964,7 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_CompoundScale_LinePreservesParamete
 
   GeomAdaptor_TransformedCurve aTransformed(aLine, 0.0, 10.0, aTrsf);
   ExtremaPC_Curve              anExtPC(aTransformed);
-  const gp_Pnt                 aQuery = gp_Pnt(4, 7, 0).Transformed(aTrsf);
+  const gp_Pnt                 aQuery  = gp_Pnt(4, 7, 0).Transformed(aTrsf);
   const ExtremaPC::Result&     aResult = anExtPC.Perform(aQuery, THE_TOL);
 
   ASSERT_TRUE(aResult.IsDone());
@@ -986,9 +986,9 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_CompoundScale_ParabolaPreservesPara
 
   GeomAdaptor_TransformedCurve aTransformed(aParabola, -10.0, 10.0, aTrsf);
   ExtremaPC_Curve              anExtPC(aTransformed);
-  constexpr double            aParameter = 3.0;
-  const gp_Pnt                 aQuery = aTransformed.Value(aParameter);
-  const ExtremaPC::Result&     aResult = anExtPC.Perform(aQuery, THE_TOL);
+  constexpr double             aParameter = 3.0;
+  const gp_Pnt                 aQuery     = aTransformed.Value(aParameter);
+  const ExtremaPC::Result&     aResult    = anExtPC.Perform(aQuery, THE_TOL);
 
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_GE(aResult.NbExt(), 1);
@@ -1147,8 +1147,8 @@ TEST_F(ExtremaPC_CurveTest, TransformedCurve_Translation_Bezier)
   ASSERT_TRUE(aResultTr.IsDone());
   EXPECT_NEAR(aResult.MinSquareDistance(), aResultTr.MinSquareDistance(), THE_TOL);
 
-  size_t    aMinIdx     = aResult.MinIndex();
-  size_t    aMinIdxTr   = aResultTr.MinIndex();
+  size_t aMinIdx     = aResult.MinIndex();
+  size_t aMinIdxTr   = aResultTr.MinIndex();
   gp_Pnt aExpectedPt = aResult[aMinIdx].Point.Transformed(aTrsf);
   EXPECT_NEAR(aResultTr[aMinIdxTr].Point.X(), aExpectedPt.X(), THE_TOL);
   EXPECT_NEAR(aResultTr[aMinIdxTr].Point.Y(), aExpectedPt.Y(), THE_TOL);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Ellipse_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Ellipse_Test.cxx
@@ -566,8 +566,12 @@ TEST_F(ExtremaPC_EllipseTest, NarrowRange_TinyArc)
   ExtremaPC_Ellipse        anEval(anEllipse, ExtremaPC::Domain1D{aUMin, aUMax});
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
 
-  // Should complete without error
-  ASSERT_TRUE(aResult.IsDone() || aResult.NbExt() >= 0);
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 2u);
+  EXPECT_EQ(aResult[0].Parameter, aUMin);
+  EXPECT_TRUE(aResult[0].IsMaximum);
+  EXPECT_EQ(aResult[1].Parameter, aUMax);
+  EXPECT_TRUE(aResult[1].IsMinimum);
 }
 
 TEST_F(ExtremaPC_EllipseTest, LargeRange_FullCircle)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Ellipse_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Ellipse_Test.cxx
@@ -14,10 +14,14 @@
 #include <gtest/gtest.h>
 
 #include <ExtremaPC_Ellipse.hxx>
+#include <ExtremaPC2d_Ellipse.hxx>
 
 #include <gp_Ax2.hxx>
+#include <gp_Ax22d.hxx>
 #include <gp_Elips.hxx>
+#include <gp_Elips2d.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 #include <ElCLib.hxx>
 
 #include <cmath>
@@ -31,6 +35,34 @@ protected:
   static constexpr double THE_PI   = M_PI;
   static constexpr double THE_PI_2 = M_PI / 2.0;
 };
+
+TEST_F(ExtremaPC_EllipseTest, ShiftedFullPeriod_UniqueRepresentatives)
+{
+  gp_Elips anEllipse(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 20.0, 10.0);
+  gp_Pnt   aPoint(30.0, 0.0, 0.0);
+
+  constexpr double aUMin = -10.0;
+  ExtremaPC_Ellipse anEval(anEllipse, ExtremaPC::Domain1D{aUMin, aUMin + THE_2PI});
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 2);
+  for (size_t anIndex = 0; anIndex < aResult.NbExt(); ++anIndex)
+  {
+    EXPECT_GE(aResult[anIndex].Parameter, aUMin);
+    EXPECT_LE(aResult[anIndex].Parameter, aUMin + THE_2PI);
+  }
+}
+
+TEST_F(ExtremaPC_EllipseTest, SingletonDomain_InvalidTolerance)
+{
+  gp_Elips anEllipse(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 20.0, 10.0);
+  ExtremaPC_Ellipse anEval(anEllipse, ExtremaPC::Domain1D{0.5, 0.5});
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(30, 0, 0), 0.0);
+
+  EXPECT_EQ(aResult.Status, ExtremaPC::Status::InvalidInput);
+}
 
 //==================================================================================================
 // Basic tests - point on major axis
@@ -143,7 +175,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInFirstQuadrant)
   EXPECT_GT(aMinSqDist, 0.0);
 
   // Verify the closest point is actually on the ellipse
-  int    aMinIdx      = aResult.MinIndex();
+  size_t    aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 }
@@ -160,7 +192,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInSecondQuadrant)
   EXPECT_GE(aResult.NbExt(), 2);
 
   // Verify the point on ellipse
-  int    aMinIdx      = aResult.MinIndex();
+  size_t    aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 }
@@ -177,7 +209,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInThirdQuadrant)
   EXPECT_GE(aResult.NbExt(), 2);
 
   // Verify the closest point is on the ellipse and distance is reasonable
-  int    aMinIdx      = aResult.MinIndex();
+  size_t    aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 
@@ -198,7 +230,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInFourthQuadrant)
   EXPECT_GE(aResult.NbExt(), 2);
 
   // Verify the closest point is on the ellipse
-  int    aMinIdx      = aResult.MinIndex();
+  size_t    aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 
@@ -234,7 +266,7 @@ TEST_F(ExtremaPC_EllipseTest, PointAtCenter_Degenerate)
   EXPECT_NEAR(aMaxDist, 20.0, THE_TOL);
 
   // Verify all extrema are on the ellipse
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[i].Parameter, anEllipse);
     EXPECT_NEAR(aResult[i].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
@@ -349,7 +381,7 @@ TEST_F(ExtremaPC_EllipseTest, EllipseInYZPlane)
   EXPECT_GT(aMinSqDist, 0.0);
 
   // Verify extremum point is on the ellipse (project back and check)
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     const ExtremaPC::ExtremumResult& anExt  = aResult[i];
     gp_Pnt                           aCheck = ElCLib::Value(anExt.Parameter, anEllipse);
@@ -489,7 +521,7 @@ TEST_F(ExtremaPC_EllipseTest, NarrowRange_VerySmall)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify all extrema are within parameter bounds
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, aUMin - THE_TOL);
     EXPECT_LE(aResult[i].Parameter, aUMax + THE_TOL);
@@ -512,7 +544,7 @@ TEST_F(ExtremaPC_EllipseTest, NarrowRange_MediumSmall)
   ASSERT_TRUE(aResult.IsDone());
 
   // Verify distance calculation is consistent
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[i].Parameter, anEllipse);
     EXPECT_NEAR(aPtOnEllipse.Distance(aResult[i].Point), 0.0, THE_TOL);
@@ -552,8 +584,28 @@ TEST_F(ExtremaPC_EllipseTest, LargeRange_FullCircle)
   EXPECT_GE(aResult.NbExt(), 4);
 
   // Verify all distances are positive
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GT(aResult[i].SquareDistance, 0.0);
+  }
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_EllipseTest, PlanarDelegation_PreservesParameterAndHeight)
+{
+  ExtremaPC_Ellipse anEvaluator3d(
+    gp_Elips(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 5.0, 2.0));
+  ExtremaPC2d_Ellipse anEvaluator2d(
+    gp_Elips2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 5.0, 2.0));
+  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aResult3d[anIndex].Parameter, aResult2d[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(aResult3d[anIndex].SquareDistance,
+                aResult2d[anIndex].SquareDistance + 36.0,
+                THE_TOL);
   }
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Ellipse_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Ellipse_Test.cxx
@@ -41,8 +41,8 @@ TEST_F(ExtremaPC_EllipseTest, ShiftedFullPeriod_UniqueRepresentatives)
   gp_Elips anEllipse(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 20.0, 10.0);
   gp_Pnt   aPoint(30.0, 0.0, 0.0);
 
-  constexpr double aUMin = -10.0;
-  ExtremaPC_Ellipse anEval(anEllipse, ExtremaPC::Domain1D{aUMin, aUMin + THE_2PI});
+  constexpr double         aUMin = -10.0;
+  ExtremaPC_Ellipse        anEval(anEllipse, ExtremaPC::Domain1D{aUMin, aUMin + THE_2PI});
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(aPoint, THE_TOL);
 
   ASSERT_TRUE(aResult.IsDone());
@@ -56,7 +56,7 @@ TEST_F(ExtremaPC_EllipseTest, ShiftedFullPeriod_UniqueRepresentatives)
 
 TEST_F(ExtremaPC_EllipseTest, SingletonDomain_InvalidTolerance)
 {
-  gp_Elips anEllipse(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 20.0, 10.0);
+  gp_Elips          anEllipse(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 20.0, 10.0);
   ExtremaPC_Ellipse anEval(anEllipse, ExtremaPC::Domain1D{0.5, 0.5});
 
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(30, 0, 0), 0.0);
@@ -175,7 +175,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInFirstQuadrant)
   EXPECT_GT(aMinSqDist, 0.0);
 
   // Verify the closest point is actually on the ellipse
-  size_t    aMinIdx      = aResult.MinIndex();
+  size_t aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 }
@@ -192,7 +192,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInSecondQuadrant)
   EXPECT_GE(aResult.NbExt(), 2);
 
   // Verify the point on ellipse
-  size_t    aMinIdx      = aResult.MinIndex();
+  size_t aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 }
@@ -209,7 +209,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInThirdQuadrant)
   EXPECT_GE(aResult.NbExt(), 2);
 
   // Verify the closest point is on the ellipse and distance is reasonable
-  size_t    aMinIdx      = aResult.MinIndex();
+  size_t aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 
@@ -230,7 +230,7 @@ TEST_F(ExtremaPC_EllipseTest, PointInFourthQuadrant)
   EXPECT_GE(aResult.NbExt(), 2);
 
   // Verify the closest point is on the ellipse
-  size_t    aMinIdx      = aResult.MinIndex();
+  size_t aMinIdx      = aResult.MinIndex();
   gp_Pnt aPtOnEllipse = ElCLib::Value(aResult[aMinIdx].Parameter, anEllipse);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnEllipse), 0.0, THE_TOL);
 
@@ -598,7 +598,7 @@ TEST_F(ExtremaPC_EllipseTest, PlanarDelegation_PreservesParameterAndHeight)
     gp_Elips(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 5.0, 2.0));
   ExtremaPC2d_Ellipse anEvaluator2d(
     gp_Elips2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 5.0, 2.0));
-  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC::Result&   aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
   const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
   for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_ExtendedGeometry_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_ExtendedGeometry_Test.cxx
@@ -486,7 +486,7 @@ TEST_F(ExtremaPC_ExtendedGeometryTest, Hyperbola_HighEccentricity)
 
   // Verify that the minimum extremum is correct by checking
   // the computed point is actually on the curve
-  size_t    aMinIdx   = aNewResult.MinIndex();
+  size_t aMinIdx   = aNewResult.MinIndex();
   gp_Pnt aMinPoint = aNewResult[aMinIdx].Point;
 
   // Verify the distance is consistent

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_ExtendedGeometry_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_ExtendedGeometry_Test.cxx
@@ -486,7 +486,7 @@ TEST_F(ExtremaPC_ExtendedGeometryTest, Hyperbola_HighEccentricity)
 
   // Verify that the minimum extremum is correct by checking
   // the computed point is actually on the curve
-  int    aMinIdx   = aNewResult.MinIndex();
+  size_t    aMinIdx   = aNewResult.MinIndex();
   gp_Pnt aMinPoint = aNewResult[aMinIdx].Point;
 
   // Verify the distance is consistent

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Hyperbola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Hyperbola_Test.cxx
@@ -14,10 +14,14 @@
 #include <gtest/gtest.h>
 
 #include <ExtremaPC_Hyperbola.hxx>
+#include <ExtremaPC2d_Hyperbola.hxx>
 
 #include <gp_Ax2.hxx>
+#include <gp_Ax22d.hxx>
 #include <gp_Hypr.hxx>
+#include <gp_Hypr2d.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 #include <ElCLib.hxx>
 
 #include <cmath>
@@ -97,7 +101,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PointOffAxis_FirstQuadrant)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the point is on the hyperbola
-  int    aMinIdx     = aResult.MinIndex();
+  size_t    aMinIdx     = aResult.MinIndex();
   gp_Pnt aPtOnHyper  = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   double aExpectedSq = aPoint.SquareDistance(aPtOnHyper);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aExpectedSq, THE_TOL);
@@ -115,7 +119,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PointOffAxis_FourthQuadrant)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -136,7 +140,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PointInsideAsymptotes)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 
@@ -196,7 +200,7 @@ TEST_F(ExtremaPC_HyperbolaTest, BoundsPositive)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // All parameters should be positive
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, 0.0 - THE_TOL);
   }
@@ -215,7 +219,7 @@ TEST_F(ExtremaPC_HyperbolaTest, BoundsNegative)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // All parameters should be negative or zero
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_LE(aResult[i].Parameter, 0.0 + THE_TOL);
   }
@@ -234,7 +238,7 @@ TEST_F(ExtremaPC_HyperbolaTest, NarrowBounds)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Parameter should be within bounds
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, 0.5 - THE_TOL);
     EXPECT_LE(aResult[i].Parameter, 1.5 + THE_TOL);
@@ -257,7 +261,7 @@ TEST_F(ExtremaPC_HyperbolaTest, SmallSemiAxes)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -275,7 +279,7 @@ TEST_F(ExtremaPC_HyperbolaTest, LargeSemiAxes)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 }
@@ -292,7 +296,7 @@ TEST_F(ExtremaPC_HyperbolaTest, NearlyRectangular)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -375,7 +379,7 @@ TEST_F(ExtremaPC_HyperbolaTest, HyperbolaWithOffset_PointOff)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -397,7 +401,7 @@ TEST_F(ExtremaPC_HyperbolaTest, HyperbolaInYZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 
@@ -417,7 +421,7 @@ TEST_F(ExtremaPC_HyperbolaTest, HyperbolaInXZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 
@@ -441,7 +445,7 @@ TEST_F(ExtremaPC_HyperbolaTest, VerifyProjectedPoint)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify the projected point is on the hyperbola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aPtOnCurve.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aPtOnCurve.Y(), THE_TOL);
@@ -460,7 +464,27 @@ TEST_F(ExtremaPC_HyperbolaTest, VerifyDistanceConsistency)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify distance matches point distance
-  int    aMinIdx     = aResult.MinIndex();
+  size_t    aMinIdx     = aResult.MinIndex();
   double aComputedSq = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedSq, THE_TOL);
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_HyperbolaTest, PlanarDelegation_PreservesParameterAndHeight)
+{
+  ExtremaPC_Hyperbola anEvaluator3d(
+    gp_Hypr(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 3.0, 1.5));
+  ExtremaPC2d_Hyperbola anEvaluator2d(
+    gp_Hypr2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 3.0, 1.5));
+  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aResult3d[anIndex].Parameter, aResult2d[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(aResult3d[anIndex].SquareDistance,
+                aResult2d[anIndex].SquareDistance + 36.0,
+                THE_TOL);
+  }
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Hyperbola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Hyperbola_Test.cxx
@@ -101,7 +101,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PointOffAxis_FirstQuadrant)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the point is on the hyperbola
-  size_t    aMinIdx     = aResult.MinIndex();
+  size_t aMinIdx     = aResult.MinIndex();
   gp_Pnt aPtOnHyper  = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   double aExpectedSq = aPoint.SquareDistance(aPtOnHyper);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aExpectedSq, THE_TOL);
@@ -119,7 +119,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PointOffAxis_FourthQuadrant)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -140,7 +140,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PointInsideAsymptotes)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 
@@ -261,7 +261,7 @@ TEST_F(ExtremaPC_HyperbolaTest, SmallSemiAxes)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -279,7 +279,7 @@ TEST_F(ExtremaPC_HyperbolaTest, LargeSemiAxes)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 }
@@ -296,7 +296,7 @@ TEST_F(ExtremaPC_HyperbolaTest, NearlyRectangular)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola and distance is consistent
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -379,7 +379,7 @@ TEST_F(ExtremaPC_HyperbolaTest, HyperbolaWithOffset_PointOff)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola and distance is consistent
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnHyper), THE_TOL);
@@ -401,7 +401,7 @@ TEST_F(ExtremaPC_HyperbolaTest, HyperbolaInYZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 
@@ -421,7 +421,7 @@ TEST_F(ExtremaPC_HyperbolaTest, HyperbolaInXZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnHyper = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnHyper), 0.0, THE_TOL);
 
@@ -445,7 +445,7 @@ TEST_F(ExtremaPC_HyperbolaTest, VerifyProjectedPoint)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify the projected point is on the hyperbola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = ElCLib::Value(aResult[aMinIdx].Parameter, aHyperbola);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aPtOnCurve.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aPtOnCurve.Y(), THE_TOL);
@@ -464,7 +464,7 @@ TEST_F(ExtremaPC_HyperbolaTest, VerifyDistanceConsistency)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify distance matches point distance
-  size_t    aMinIdx     = aResult.MinIndex();
+  size_t aMinIdx     = aResult.MinIndex();
   double aComputedSq = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedSq, THE_TOL);
 }
@@ -477,7 +477,7 @@ TEST_F(ExtremaPC_HyperbolaTest, PlanarDelegation_PreservesParameterAndHeight)
     gp_Hypr(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 3.0, 1.5));
   ExtremaPC2d_Hyperbola anEvaluator2d(
     gp_Hypr2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 3.0, 1.5));
-  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC::Result&   aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
   const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
   for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Line_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Line_Test.cxx
@@ -35,7 +35,7 @@ protected:
 
 TEST_F(ExtremaPC_LineTest, SingletonDomain_IsMinimumAndMaximum)
 {
-  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  gp_Lin         aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
   ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{2.0, 2.0});
 
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(5, 3, 0), THE_TOL);
@@ -49,7 +49,7 @@ TEST_F(ExtremaPC_LineTest, SingletonDomain_IsMinimumAndMaximum)
 
 TEST_F(ExtremaPC_LineTest, SingletonProjection_IsMinimumAndMaximum)
 {
-  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  gp_Lin         aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
   ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{2.0, 2.0});
 
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 3, 0), THE_TOL);
@@ -62,7 +62,7 @@ TEST_F(ExtremaPC_LineTest, SingletonProjection_IsMinimumAndMaximum)
 
 TEST_F(ExtremaPC_LineTest, EffectivelyUnboundedDomain_DoesNotAddEndpoints)
 {
-  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  gp_Lin         aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
   ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{-1.0e100, 1.0e100});
 
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 3, 0), THE_TOL);
@@ -74,7 +74,7 @@ TEST_F(ExtremaPC_LineTest, EffectivelyUnboundedDomain_DoesNotAddEndpoints)
 
 TEST_F(ExtremaPC_LineTest, LowerBoundedDomain_PreservesFiniteEndpoint)
 {
-  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  gp_Lin         aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
   ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{0.0, 1.0e100});
 
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(-2, 3, 0), THE_TOL);
@@ -87,7 +87,7 @@ TEST_F(ExtremaPC_LineTest, LowerBoundedDomain_PreservesFiniteEndpoint)
 
 TEST_F(ExtremaPC_LineTest, UpperBoundedDomain_PreservesFiniteEndpoint)
 {
-  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  gp_Lin         aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
   ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{-1.0e100, 0.0});
 
   const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 3, 0), THE_TOL);
@@ -100,7 +100,7 @@ TEST_F(ExtremaPC_LineTest, UpperBoundedDomain_PreservesFiniteEndpoint)
 
 TEST_F(ExtremaPC_LineTest, ReversedDomain_IsInvalidInput)
 {
-  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  gp_Lin         aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
   ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{1.0, -1.0});
 
   const ExtremaPC::Result& aResult = anEval.Perform(gp_Pnt(0, 0, 0), THE_TOL);
@@ -342,7 +342,7 @@ TEST_F(ExtremaPC_LineTest, LineDiagonal_XY)
 
   // Parameter along diagonal: (5,5,0) projected = 5*sqrt(2)
   double aExpectedParam = 5.0 * std::sqrt(2.0);
-  size_t    aMinIdx        = aResult.MinIndex();
+  size_t aMinIdx        = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, aExpectedParam, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 9.0, THE_TOL); // Z offset = 3
 }
@@ -485,7 +485,7 @@ TEST_F(ExtremaPC_LineTest, VerifyProjectedPoint)
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
   // Verify the minimum point (projected point)
-  size_t    aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   gp_Pnt aExpectedPt(7.0, 0.0, 0.0);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aExpectedPt.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aExpectedPt.Y(), THE_TOL);
@@ -504,7 +504,7 @@ TEST_F(ExtremaPC_LineTest, VerifyDistanceConsistency)
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
   // Verify distance matches point distance for minimum
-  size_t    aMinIdx       = aResult.MinIndex();
+  size_t aMinIdx       = aResult.MinIndex();
   double aComputedDist = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedDist, THE_TOL);
   EXPECT_NEAR(aResult.MinSquareDistance(), 100.0, THE_TOL); // 6^2 + 8^2 = 100
@@ -534,7 +534,7 @@ TEST_F(ExtremaPC_LineTest, EndpointsAsMaxima)
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 1.0, THE_TOL); // 1^2
 
   // Verify maximum is at one of the endpoints
-  size_t    aMaxIdx   = aResult.MaxIndex();
+  size_t aMaxIdx   = aResult.MaxIndex();
   double aMaxParam = aResult[aMaxIdx].Parameter;
   EXPECT_TRUE(std::abs(aMaxParam - 0.0) < THE_TOL || std::abs(aMaxParam - 10.0) < THE_TOL);
 }
@@ -543,10 +543,10 @@ TEST_F(ExtremaPC_LineTest, EndpointsAsMaxima)
 
 TEST_F(ExtremaPC_LineTest, PlanarDelegation_PreservesParameterAndHeight)
 {
-  ExtremaPC_Line anEvaluator3d(gp_Lin(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0)));
+  ExtremaPC_Line   anEvaluator3d(gp_Lin(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0)));
   ExtremaPC2d_Line anEvaluator2d(gp_Lin2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)));
 
-  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC::Result&   aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
   const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
   ASSERT_EQ(aResult3d.NbExt(), 1);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Line_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Line_Test.cxx
@@ -14,9 +14,12 @@
 #include <gtest/gtest.h>
 
 #include <ExtremaPC_Line.hxx>
+#include <ExtremaPC2d_Line.hxx>
 
 #include <gp_Lin.hxx>
+#include <gp_Lin2d.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 
 #include <cmath>
 
@@ -29,6 +32,81 @@ class ExtremaPC_LineTest : public testing::Test
 protected:
   static constexpr double THE_TOL = 1.0e-10;
 };
+
+TEST_F(ExtremaPC_LineTest, SingletonDomain_IsMinimumAndMaximum)
+{
+  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{2.0, 2.0});
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(5, 3, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+  EXPECT_TRUE(aResult[0].IsMaximum);
+  EXPECT_NEAR(aResult[0].Parameter, 2.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_LineTest, SingletonProjection_IsMinimumAndMaximum)
+{
+  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{2.0, 2.0});
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 3, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+  EXPECT_TRUE(aResult[0].IsMaximum);
+}
+
+TEST_F(ExtremaPC_LineTest, EffectivelyUnboundedDomain_DoesNotAddEndpoints)
+{
+  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{-1.0e100, 1.0e100});
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 3, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 2.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_LineTest, LowerBoundedDomain_PreservesFiniteEndpoint)
+{
+  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{0.0, 1.0e100});
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(-2, 3, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, THE_TOL);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+}
+
+TEST_F(ExtremaPC_LineTest, UpperBoundedDomain_PreservesFiniteEndpoint)
+{
+  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{-1.0e100, 0.0});
+
+  const ExtremaPC::Result& aResult = anEval.PerformWithEndpoints(gp_Pnt(2, 3, 0), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 0.0, THE_TOL);
+  EXPECT_TRUE(aResult[0].IsMinimum);
+}
+
+TEST_F(ExtremaPC_LineTest, ReversedDomain_IsInvalidInput)
+{
+  gp_Lin aLine(gp_Pnt(0, 0, 0), gp_Dir(1, 0, 0));
+  ExtremaPC_Line anEval(aLine, ExtremaPC::Domain1D{1.0, -1.0});
+
+  const ExtremaPC::Result& aResult = anEval.Perform(gp_Pnt(0, 0, 0), THE_TOL);
+
+  EXPECT_EQ(aResult.Status, ExtremaPC::Status::InvalidInput);
+}
 
 //==================================================================================================
 // Basic projection tests
@@ -46,7 +124,7 @@ TEST_F(ExtremaPC_LineTest, PointOnLine_AtOrigin)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 0.0, THE_TOL);
   EXPECT_TRUE(aResult[aMinIdx].IsMinimum);
@@ -63,7 +141,7 @@ TEST_F(ExtremaPC_LineTest, PointOnLine_Positive)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 0.0, THE_TOL);
 }
@@ -79,7 +157,7 @@ TEST_F(ExtremaPC_LineTest, PointOnLine_Negative)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, -7.5, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 0.0, THE_TOL);
 }
@@ -95,7 +173,7 @@ TEST_F(ExtremaPC_LineTest, PointOffLine_YOffset)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 9.0, THE_TOL); // 3^2 = 9
 }
@@ -111,7 +189,7 @@ TEST_F(ExtremaPC_LineTest, PointOffLine_ZOffset)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 16.0, THE_TOL); // 4^2 = 16
 }
@@ -127,7 +205,7 @@ TEST_F(ExtremaPC_LineTest, PointOffLine_YZOffset)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max (endpoints)
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL); // 3^2 + 4^2 = 25
 }
@@ -149,7 +227,7 @@ TEST_F(ExtremaPC_LineTest, ProjectionOutsideBounds_Left)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2); // min at 0, max at 100
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 0.0, THE_TOL); // Clamped to lower bound
 }
 
@@ -165,7 +243,7 @@ TEST_F(ExtremaPC_LineTest, ProjectionOutsideBounds_Right)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2); // min at 100, max at 0
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 100.0, THE_TOL); // Clamped to upper bound
 }
 
@@ -181,7 +259,7 @@ TEST_F(ExtremaPC_LineTest, ProjectionAtLowerBound)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2); // min at 10, max at 100
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 10.0, THE_TOL);
 }
 
@@ -196,7 +274,7 @@ TEST_F(ExtremaPC_LineTest, ProjectionAtUpperBound)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2); // min at 100, max at 0
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 100.0, THE_TOL);
 }
 
@@ -211,7 +289,7 @@ TEST_F(ExtremaPC_LineTest, NarrowBounds)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // min at 50, max at endpoints
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 50.0, THE_TOL);
 }
 
@@ -230,7 +308,7 @@ TEST_F(ExtremaPC_LineTest, LineAlongY)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL); // 3^2 + 4^2 = 25
 }
@@ -246,7 +324,7 @@ TEST_F(ExtremaPC_LineTest, LineAlongZ)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 10.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL); // 3^2 + 4^2 = 25
 }
@@ -264,7 +342,7 @@ TEST_F(ExtremaPC_LineTest, LineDiagonal_XY)
 
   // Parameter along diagonal: (5,5,0) projected = 5*sqrt(2)
   double aExpectedParam = 5.0 * std::sqrt(2.0);
-  int    aMinIdx        = aResult.MinIndex();
+  size_t    aMinIdx        = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, aExpectedParam, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 9.0, THE_TOL); // Z offset = 3
 }
@@ -298,7 +376,7 @@ TEST_F(ExtremaPC_LineTest, LineWithOffset_XAxis)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL); // 15 - 10 = 5
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 0.0, THE_TOL);
 }
@@ -314,7 +392,7 @@ TEST_F(ExtremaPC_LineTest, LineWithOffset_PointOff)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, THE_TOL); // 3^2 + 4^2 = 25
 }
@@ -334,7 +412,7 @@ TEST_F(ExtremaPC_LineTest, NegativeParameters)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, -25.0, THE_TOL);
 }
 
@@ -350,7 +428,7 @@ TEST_F(ExtremaPC_LineTest, NegativeBoundsClamp)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2); // min at -10, max at -50
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, -10.0, THE_TOL); // Clamped to upper bound
 }
 
@@ -370,7 +448,7 @@ TEST_F(ExtremaPC_LineTest, LargeCoordinates)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 100.0, 1e-6);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25.0, 1e-6);
 }
@@ -386,7 +464,7 @@ TEST_F(ExtremaPC_LineTest, SmallCoordinates)
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 1e-3, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 25e-8, THE_TOL); // (3e-4)^2 + (4e-4)^2
 }
@@ -407,7 +485,7 @@ TEST_F(ExtremaPC_LineTest, VerifyProjectedPoint)
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
   // Verify the minimum point (projected point)
-  int    aMinIdx = aResult.MinIndex();
+  size_t    aMinIdx = aResult.MinIndex();
   gp_Pnt aExpectedPt(7.0, 0.0, 0.0);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aExpectedPt.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aExpectedPt.Y(), THE_TOL);
@@ -426,7 +504,7 @@ TEST_F(ExtremaPC_LineTest, VerifyDistanceConsistency)
   ASSERT_EQ(aResult.NbExt(), 3); // 1 min + 2 max
 
   // Verify distance matches point distance for minimum
-  int    aMinIdx       = aResult.MinIndex();
+  size_t    aMinIdx       = aResult.MinIndex();
   double aComputedDist = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedDist, THE_TOL);
   EXPECT_NEAR(aResult.MinSquareDistance(), 100.0, THE_TOL); // 6^2 + 8^2 = 100
@@ -451,12 +529,27 @@ TEST_F(ExtremaPC_LineTest, EndpointsAsMaxima)
   ASSERT_EQ(aResult.NbExt(), 3);
 
   // Verify minimum is at the projection
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_NEAR(aResult[aMinIdx].Parameter, 5.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, 1.0, THE_TOL); // 1^2
 
   // Verify maximum is at one of the endpoints
-  int    aMaxIdx   = aResult.MaxIndex();
+  size_t    aMaxIdx   = aResult.MaxIndex();
   double aMaxParam = aResult[aMaxIdx].Parameter;
   EXPECT_TRUE(std::abs(aMaxParam - 0.0) < THE_TOL || std::abs(aMaxParam - 10.0) < THE_TOL);
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_LineTest, PlanarDelegation_PreservesParameterAndHeight)
+{
+  ExtremaPC_Line anEvaluator3d(gp_Lin(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(1.0, 0.0, 0.0)));
+  ExtremaPC2d_Line anEvaluator2d(gp_Lin2d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0)));
+
+  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  ASSERT_EQ(aResult3d.NbExt(), 1);
+  EXPECT_NEAR(aResult3d[0].Parameter, aResult2d[0].Parameter, THE_TOL);
+  EXPECT_NEAR(aResult3d[0].SquareDistance, aResult2d[0].SquareDistance + 36.0, THE_TOL);
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_OffsetCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_OffsetCurve_Test.cxx
@@ -350,15 +350,13 @@ TEST_F(ExtremaPC_OffsetCurveTest, VerifyDistanceConsistency)
 
 TEST_F(ExtremaPC_OffsetCurveTest, PlanarDelegation_PreservesNormalDirectionSign)
 {
-  occ::handle<Geom_Circle> aBasis = new Geom_Circle(
-    gp_Ax2(gp_Pnt(0.0, 0.0, 2.0), gp_Dir(0.0, 0.0, 1.0)),
-    3.0);
+  occ::handle<Geom_Circle> aBasis =
+    new Geom_Circle(gp_Ax2(gp_Pnt(0.0, 0.0, 2.0), gp_Dir(0.0, 0.0, 1.0)), 3.0);
   occ::handle<Geom_OffsetCurve> anOffset =
     new Geom_OffsetCurve(aBasis, 1.0, gp_Dir(0.0, 0.0, -1.0));
-  GeomAdaptor_Curve anAdaptor(anOffset);
-  ExtremaPC_OffsetCurve anEvaluator(anAdaptor,
-                                     ExtremaPC::Domain1D{0.0, 2.0 * M_PI});
-  const gp_Pnt aQuery(8.0, 0.0, 7.0);
+  GeomAdaptor_Curve        anAdaptor(anOffset);
+  ExtremaPC_OffsetCurve    anEvaluator(anAdaptor, ExtremaPC::Domain1D{0.0, 2.0 * M_PI});
+  const gp_Pnt             aQuery(8.0, 0.0, 7.0);
   const ExtremaPC::Result& aResult = anEvaluator.Perform(aQuery, THE_TOL);
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 2);
@@ -370,17 +368,16 @@ TEST_F(ExtremaPC_OffsetCurveTest, PlanarDelegation_PreservesNormalDirectionSign)
 
 TEST_F(ExtremaPC_OffsetCurveTest, ScaledTransformedOffsetUsesParameterSafeFallback)
 {
-  occ::handle<Geom_Line> aLine = new Geom_Line(gp_Pnt(), gp_Dir(1.0, 0.0, 0.0));
-  occ::handle<Geom_OffsetCurve> anOffset =
-    new Geom_OffsetCurve(aLine, 2.0, gp_Dir(0.0, 0.0, 1.0));
-  gp_Trsf aScale;
+  occ::handle<Geom_Line>        aLine    = new Geom_Line(gp_Pnt(), gp_Dir(1.0, 0.0, 0.0));
+  occ::handle<Geom_OffsetCurve> anOffset = new Geom_OffsetCurve(aLine, 2.0, gp_Dir(0.0, 0.0, 1.0));
+  gp_Trsf                       aScale;
   aScale.SetScale(gp_Pnt(), 3.0);
   GeomAdaptor_TransformedCurve anAdaptor(anOffset, -2.0, 2.0, aScale);
-  ExtremaPC_OffsetCurve anEvaluator(anAdaptor, {-2.0, 2.0});
+  ExtremaPC_OffsetCurve        anEvaluator(anAdaptor, {-2.0, 2.0});
 
-  const gp_Pnt aQuery = anAdaptor.Value(1.25).Translated(gp_Vec(0.0, 4.0, 0.0));
-  const ExtremaPC::Result& aResult = anEvaluator.Perform(aQuery, THE_TOL,
-                                                         ExtremaPC::SearchMode::Min);
+  const gp_Pnt             aQuery = anAdaptor.Value(1.25).Translated(gp_Vec(0.0, 4.0, 0.0));
+  const ExtremaPC::Result& aResult =
+    anEvaluator.Perform(aQuery, THE_TOL, ExtremaPC::SearchMode::Min);
   ASSERT_TRUE(aResult.IsDone());
   ASSERT_EQ(aResult.NbExt(), 1);
   EXPECT_NEAR(aResult[0].Parameter, 1.25, THE_TOL);

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_OffsetCurve_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_OffsetCurve_Test.cxx
@@ -20,6 +20,7 @@
 #include <Geom_Line.hxx>
 #include <Geom_OffsetCurve.hxx>
 #include <GeomAdaptor_Curve.hxx>
+#include <GeomAdaptor_TransformedCurve.hxx>
 #include <gp_Ax2.hxx>
 #include <gp_Circ.hxx>
 #include <gp_Dir.hxx>
@@ -249,7 +250,7 @@ TEST_F(ExtremaPC_OffsetCurveTest, PartialRange_FirstQuadrant)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Check that extremum is in the first quadrant
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, -THE_TOL);
     EXPECT_LE(aResult[i].Parameter, THE_PI / 2.0 + THE_TOL);
@@ -309,7 +310,7 @@ TEST_F(ExtremaPC_OffsetCurveTest, VerifyExtremumCondition)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify that stored distance matches computed distance
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aStoredSqDist   = aResult[i].SquareDistance;
     double aComputedSqDist = aPoint.SquareDistance(aResult[i].Point);
@@ -336,11 +337,55 @@ TEST_F(ExtremaPC_OffsetCurveTest, VerifyDistanceConsistency)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify that stored distance matches computed distance
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     double aStoredSqDist   = aResult[i].SquareDistance;
     double aComputedSqDist = aPoint.SquareDistance(aResult[i].Point);
 
     EXPECT_NEAR(aStoredSqDist, aComputedSqDist, THE_TOL) << "Distance mismatch at extremum " << i;
   }
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_OffsetCurveTest, PlanarDelegation_PreservesNormalDirectionSign)
+{
+  occ::handle<Geom_Circle> aBasis = new Geom_Circle(
+    gp_Ax2(gp_Pnt(0.0, 0.0, 2.0), gp_Dir(0.0, 0.0, 1.0)),
+    3.0);
+  occ::handle<Geom_OffsetCurve> anOffset =
+    new Geom_OffsetCurve(aBasis, 1.0, gp_Dir(0.0, 0.0, -1.0));
+  GeomAdaptor_Curve anAdaptor(anOffset);
+  ExtremaPC_OffsetCurve anEvaluator(anAdaptor,
+                                     ExtremaPC::Domain1D{0.0, 2.0 * M_PI});
+  const gp_Pnt aQuery(8.0, 0.0, 7.0);
+  const ExtremaPC::Result& aResult = anEvaluator.Perform(aQuery, THE_TOL);
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 2);
+  EXPECT_NEAR(aResult[aResult.MinIndex()].Parameter, 0.0, THE_TOL);
+  EXPECT_NEAR(aResult.MinSquareDistance(), aQuery.SquareDistance(anOffset->Value(0.0)), THE_TOL);
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_OffsetCurveTest, ScaledTransformedOffsetUsesParameterSafeFallback)
+{
+  occ::handle<Geom_Line> aLine = new Geom_Line(gp_Pnt(), gp_Dir(1.0, 0.0, 0.0));
+  occ::handle<Geom_OffsetCurve> anOffset =
+    new Geom_OffsetCurve(aLine, 2.0, gp_Dir(0.0, 0.0, 1.0));
+  gp_Trsf aScale;
+  aScale.SetScale(gp_Pnt(), 3.0);
+  GeomAdaptor_TransformedCurve anAdaptor(anOffset, -2.0, 2.0, aScale);
+  ExtremaPC_OffsetCurve anEvaluator(anAdaptor, {-2.0, 2.0});
+
+  const gp_Pnt aQuery = anAdaptor.Value(1.25).Translated(gp_Vec(0.0, 4.0, 0.0));
+  const ExtremaPC::Result& aResult = anEvaluator.Perform(aQuery, THE_TOL,
+                                                         ExtremaPC::SearchMode::Min);
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 1.25, THE_TOL);
+  gp_Pnt aPoint;
+  gp_Vec aDerivative;
+  anAdaptor.D1(aResult[0].Parameter, aPoint, aDerivative);
+  EXPECT_NEAR(gp_Vec(aQuery, aPoint).Dot(aDerivative), 0.0, THE_TOL);
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Parabola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Parabola_Test.cxx
@@ -14,10 +14,14 @@
 #include <gtest/gtest.h>
 
 #include <ExtremaPC_Parabola.hxx>
+#include <ExtremaPC2d_Parabola.hxx>
 
 #include <gp_Ax2.hxx>
+#include <gp_Ax22d.hxx>
 #include <gp_Parab.hxx>
+#include <gp_Parab2d.hxx>
 #include <gp_Pnt.hxx>
+#include <gp_Pnt2d.hxx>
 #include <ElCLib.hxx>
 
 #include <cmath>
@@ -47,6 +51,19 @@ TEST_F(ExtremaPC_ParabolaTest, PointOnAxis_AtVertex)
 
   double aMinSqDist = aResult.MinSquareDistance();
   EXPECT_NEAR(aMinSqDist, 0.0, THE_TOL);
+}
+
+TEST_F(ExtremaPC_ParabolaTest, ZeroFocal_DegeneratesToLine)
+{
+  gp_Parab aParabola(gp_Ax2(gp_Pnt(1, 2, 3), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)), 0.0);
+  ExtremaPC_Parabola anEval(aParabola, ExtremaPC::Domain1D{-10.0, 10.0});
+
+  const ExtremaPC::Result& aResult = anEval.Perform(gp_Pnt(5, 7, 3), THE_TOL);
+
+  ASSERT_TRUE(aResult.IsDone());
+  ASSERT_EQ(aResult.NbExt(), 1);
+  EXPECT_NEAR(aResult[0].Parameter, 4.0, THE_TOL);
+  EXPECT_NEAR(aResult[0].Point.Distance(gp_Pnt(5, 2, 3)), 0.0, THE_TOL);
 }
 
 TEST_F(ExtremaPC_ParabolaTest, PointOnAxis_Positive)
@@ -98,7 +115,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOffAxis_Positive)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the point is on the parabola
-  int    aMinIdx     = aResult.MinIndex();
+  size_t    aMinIdx     = aResult.MinIndex();
   gp_Pnt aPtOnParab  = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   double aExpectedSq = aPoint.SquareDistance(aPtOnParab);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aExpectedSq, THE_TOL);
@@ -116,7 +133,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOffAxis_Negative)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the parabola and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnParab), THE_TOL);
@@ -137,7 +154,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOffAxis_LargeY)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the parabola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 
@@ -202,7 +219,7 @@ TEST_F(ExtremaPC_ParabolaTest, BoundsPositive)
 
   // Since bounds are positive and point is at negative Y,
   // closest point should be at u=0 (vertex)
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_GE(aResult[aMinIdx].Parameter, 0.0);
 }
 
@@ -220,7 +237,7 @@ TEST_F(ExtremaPC_ParabolaTest, BoundsNegative)
 
   // Since bounds are negative and point is at positive Y,
   // closest point should be at u=0 (vertex)
-  int aMinIdx = aResult.MinIndex();
+  size_t aMinIdx = aResult.MinIndex();
   EXPECT_LE(aResult[aMinIdx].Parameter, 0.0);
 }
 
@@ -237,7 +254,7 @@ TEST_F(ExtremaPC_ParabolaTest, NarrowBounds)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Parameter should be within bounds
-  for (int i = 0; i < aResult.NbExt(); ++i)
+  for (size_t i = 0; i < aResult.NbExt(); ++i)
   {
     EXPECT_GE(aResult[i].Parameter, 4.0 - THE_TOL);
     EXPECT_LE(aResult[i].Parameter, 6.0 + THE_TOL);
@@ -260,7 +277,7 @@ TEST_F(ExtremaPC_ParabolaTest, SmallFocalLength)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on parabola and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnParab), THE_TOL);
@@ -278,7 +295,7 @@ TEST_F(ExtremaPC_ParabolaTest, LargeFocalLength)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on parabola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 }
@@ -360,7 +377,7 @@ TEST_F(ExtremaPC_ParabolaTest, ParabolaWithOffset_PointOff)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on parabola and distance is consistent
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnParab), THE_TOL);
@@ -382,7 +399,7 @@ TEST_F(ExtremaPC_ParabolaTest, ParabolaInYZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify extremum point is on the parabola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 
@@ -402,7 +419,7 @@ TEST_F(ExtremaPC_ParabolaTest, ParabolaInXZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify extremum point is on the parabola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 
@@ -426,7 +443,7 @@ TEST_F(ExtremaPC_ParabolaTest, VerifyProjectedPoint)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify the projected point is on the parabola
-  int    aMinIdx    = aResult.MinIndex();
+  size_t    aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aPtOnCurve.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aPtOnCurve.Y(), THE_TOL);
@@ -445,7 +462,27 @@ TEST_F(ExtremaPC_ParabolaTest, VerifyDistanceConsistency)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify distance matches point distance
-  int    aMinIdx     = aResult.MinIndex();
+  size_t    aMinIdx     = aResult.MinIndex();
   double aComputedSq = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedSq, THE_TOL);
+}
+
+//=================================================================================================
+
+TEST_F(ExtremaPC_ParabolaTest, PlanarDelegation_PreservesParameterAndHeight)
+{
+  ExtremaPC_Parabola anEvaluator3d(
+    gp_Parab(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 2.0));
+  ExtremaPC2d_Parabola anEvaluator2d(
+    gp_Parab2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 2.0));
+  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
+  ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
+  for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)
+  {
+    EXPECT_NEAR(aResult3d[anIndex].Parameter, aResult2d[anIndex].Parameter, THE_TOL);
+    EXPECT_NEAR(aResult3d[anIndex].SquareDistance,
+                aResult2d[anIndex].SquareDistance + 36.0,
+                THE_TOL);
+  }
 }

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Parabola_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_Parabola_Test.cxx
@@ -55,7 +55,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOnAxis_AtVertex)
 
 TEST_F(ExtremaPC_ParabolaTest, ZeroFocal_DegeneratesToLine)
 {
-  gp_Parab aParabola(gp_Ax2(gp_Pnt(1, 2, 3), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)), 0.0);
+  gp_Parab           aParabola(gp_Ax2(gp_Pnt(1, 2, 3), gp_Dir(0, 0, 1), gp_Dir(1, 0, 0)), 0.0);
   ExtremaPC_Parabola anEval(aParabola, ExtremaPC::Domain1D{-10.0, 10.0});
 
   const ExtremaPC::Result& aResult = anEval.Perform(gp_Pnt(5, 7, 3), THE_TOL);
@@ -115,7 +115,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOffAxis_Positive)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the point is on the parabola
-  size_t    aMinIdx     = aResult.MinIndex();
+  size_t aMinIdx     = aResult.MinIndex();
   gp_Pnt aPtOnParab  = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   double aExpectedSq = aPoint.SquareDistance(aPtOnParab);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aExpectedSq, THE_TOL);
@@ -133,7 +133,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOffAxis_Negative)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the parabola and distance is consistent
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnParab), THE_TOL);
@@ -154,7 +154,7 @@ TEST_F(ExtremaPC_ParabolaTest, PointOffAxis_LargeY)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify the closest point is on the parabola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 
@@ -277,7 +277,7 @@ TEST_F(ExtremaPC_ParabolaTest, SmallFocalLength)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on parabola and distance is consistent
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnParab), THE_TOL);
@@ -295,7 +295,7 @@ TEST_F(ExtremaPC_ParabolaTest, LargeFocalLength)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on parabola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 }
@@ -377,7 +377,7 @@ TEST_F(ExtremaPC_ParabolaTest, ParabolaWithOffset_PointOff)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify point is on parabola and distance is consistent
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aPoint.SquareDistance(aPtOnParab), THE_TOL);
@@ -399,7 +399,7 @@ TEST_F(ExtremaPC_ParabolaTest, ParabolaInYZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify extremum point is on the parabola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 
@@ -419,7 +419,7 @@ TEST_F(ExtremaPC_ParabolaTest, ParabolaInXZPlane)
   EXPECT_GE(aResult.NbExt(), 1);
 
   // Verify extremum point is on the parabola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnParab = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.Distance(aPtOnParab), 0.0, THE_TOL);
 
@@ -443,7 +443,7 @@ TEST_F(ExtremaPC_ParabolaTest, VerifyProjectedPoint)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify the projected point is on the parabola
-  size_t    aMinIdx    = aResult.MinIndex();
+  size_t aMinIdx    = aResult.MinIndex();
   gp_Pnt aPtOnCurve = ElCLib::Value(aResult[aMinIdx].Parameter, aParabola);
   EXPECT_NEAR(aResult[aMinIdx].Point.X(), aPtOnCurve.X(), THE_TOL);
   EXPECT_NEAR(aResult[aMinIdx].Point.Y(), aPtOnCurve.Y(), THE_TOL);
@@ -462,7 +462,7 @@ TEST_F(ExtremaPC_ParabolaTest, VerifyDistanceConsistency)
   ASSERT_GE(aResult.NbExt(), 1);
 
   // Verify distance matches point distance
-  size_t    aMinIdx     = aResult.MinIndex();
+  size_t aMinIdx     = aResult.MinIndex();
   double aComputedSq = aPoint.SquareDistance(aResult[aMinIdx].Point);
   EXPECT_NEAR(aResult[aMinIdx].SquareDistance, aComputedSq, THE_TOL);
 }
@@ -475,7 +475,7 @@ TEST_F(ExtremaPC_ParabolaTest, PlanarDelegation_PreservesParameterAndHeight)
     gp_Parab(gp_Ax2(gp_Pnt(0.0, 0.0, 0.0), gp_Dir(0.0, 0.0, 1.0)), 2.0));
   ExtremaPC2d_Parabola anEvaluator2d(
     gp_Parab2d(gp_Ax22d(gp_Pnt2d(0.0, 0.0), gp_Dir2d(1.0, 0.0), true), 2.0));
-  const ExtremaPC::Result& aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
+  const ExtremaPC::Result&   aResult3d = anEvaluator3d.Perform(gp_Pnt(8.0, 3.0, 6.0), THE_TOL);
   const ExtremaPC2d::Result& aResult2d = anEvaluator2d.Perform(gp_Pnt2d(8.0, 3.0), THE_TOL);
   ASSERT_EQ(aResult3d.NbExt(), aResult2d.NbExt());
   for (size_t anIndex = 0; anIndex < aResult3d.NbExt(); ++anIndex)

--- a/src/ModelingData/TKGeomBase/GTests/ExtremaPC_SearchMode_Test.cxx
+++ b/src/ModelingData/TKGeomBase/GTests/ExtremaPC_SearchMode_Test.cxx
@@ -707,7 +707,7 @@ TEST_F(ExtremaPC_SearchModeTest, BSpline_MinMaxMode)
   EXPECT_GE(aNewResult.NbExt(), 1);
 
   // Verify all found points are valid
-  for (int i = 0; i < aNewResult.NbExt(); ++i)
+  for (size_t i = 0; i < aNewResult.NbExt(); ++i)
   {
     const auto& aExtremum = aNewResult[i];
     EXPECT_GE(aExtremum.Parameter, 0.0 - THE_TOL);

--- a/src/ModelingData/TKGeomBase/GTests/FILES.cmake
+++ b/src/ModelingData/TKGeomBase/GTests/FILES.cmake
@@ -30,6 +30,19 @@ set(OCCT_TKGeomBase_GTests_FILES
   ExtremaPC_OffsetCurve_Test.cxx
   ExtremaPC_Parabola_Test.cxx
   ExtremaPC_SearchMode_Test.cxx
+  ExtremaPC2d_Curve_Test.cxx
+  ExtremaPC2d_Circle_Test.cxx
+  ExtremaPC2d_BSplineCurve_Test.cxx
+  ExtremaPC2d_BezierCurve_Test.cxx
+  ExtremaPC2d_DistanceFunction_Test.cxx
+  ExtremaPC2d_Ellipse_Test.cxx
+  ExtremaPC2d_GridEvaluator_Test.cxx
+  ExtremaPC2d_Hyperbola_Test.cxx
+  ExtremaPC2d_Line_Test.cxx
+  ExtremaPC2d_OffsetCurve_Test.cxx
+  ExtremaPC2d_OtherCurve_Test.cxx
+  ExtremaPC2d_Parabola_Test.cxx
+  ExtremaPC2d_Test.cxx
   GC_MakeArcOfCircle_Test.cxx
   GC_MakeCircle2d_Test.cxx
   GC_MakeConicalSurface_Test.cxx

--- a/src/ModelingData/TKGeomBase/PACKAGES.cmake
+++ b/src/ModelingData/TKGeomBase/PACKAGES.cmake
@@ -10,6 +10,7 @@ set(OCCT_TKGeomBase_LIST_OF_PACKAGES
   AppCont
   Extrema
   ExtremaPC
+  ExtremaPC2d
   IntAna
   IntAna2d
   GeomConvert


### PR DESCRIPTION
Rework ExtremaPC with analytical and derivative-aware numerical algorithms
  and introduce ExtremaPC2d for planar curves.
Add planar 3D delegation, checked periodic root enumeration, reusable workspaces,
  size_t indexing, adaptor lifetime contracts, and focused GTests.
Extend MathRoot utilities with safe periodic root counting.