### PR TITLE
Modeling Data - Unify Adaptor2d curve evaluation API

### DIFF
--- a/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Curve2d.cxx
+++ b/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Curve2d.cxx
@@ -111,58 +111,6 @@ double Adaptor2d_Curve2d::Period() const
 
 //=================================================================================================
 
-// gp_Pnt2d Adaptor2d_Curve2d::Value(const double U) const
-gp_Pnt2d Adaptor2d_Curve2d::Value(const double) const
-{
-  throw Standard_NotImplemented("Adaptor2d_Curve2d::Value");
-}
-
-//=================================================================================================
-
-// void Adaptor2d_Curve2d::D0(const double U, gp_Pnt2d& P) const
-void Adaptor2d_Curve2d::D0(const double, gp_Pnt2d&) const
-{
-  throw Standard_NotImplemented("Adaptor2d_Curve2d::D0");
-}
-
-//=================================================================================================
-
-// void Adaptor2d_Curve2d::D1(const double U,
-//			 gp_Pnt2d& P, gp_Vec2d& V) const
-void Adaptor2d_Curve2d::D1(const double, gp_Pnt2d&, gp_Vec2d&) const
-{
-  throw Standard_NotImplemented("Adaptor2d_Curve2d::D1");
-}
-
-//=================================================================================================
-
-// void Adaptor2d_Curve2d::D2(const double U,
-//			 gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const
-void Adaptor2d_Curve2d::D2(const double, gp_Pnt2d&, gp_Vec2d&, gp_Vec2d&) const
-{
-  throw Standard_NotImplemented("Adaptor2d_Curve2d::D2");
-}
-
-//=================================================================================================
-
-// void Adaptor2d_Curve2d::D3(const double U,
-//			 gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2, gp_Vec2d& V3)
-void Adaptor2d_Curve2d::D3(const double, gp_Pnt2d&, gp_Vec2d&, gp_Vec2d&, gp_Vec2d&) const
-{
-  throw Standard_NotImplemented("Adaptor2d_Curve2d::D3");
-}
-
-//=================================================================================================
-
-// gp_Vec2d Adaptor2d_Curve2d::DN(const double U,
-//			     const int N) const
-gp_Vec2d Adaptor2d_Curve2d::DN(const double, const int) const
-{
-  throw Standard_NotImplemented("Adaptor2d_Curve2d::DN");
-}
-
-//=================================================================================================
-
 // double Adaptor2d_Curve2d::Resolution(const double R3d) const
 double Adaptor2d_Curve2d::Resolution(const double) const
 {
@@ -264,41 +212,39 @@ int Adaptor2d_Curve2d::NbSamples() const
 
 gp_Pnt2d Adaptor2d_Curve2d::EvalD0(const double theU) const
 {
-  gp_Pnt2d aP;
-  D0(theU, aP);
-  return aP;
+  (void)theU;
+  throw Standard_NotImplemented("Adaptor2d_Curve2d::EvalD0");
 }
 
 //=================================================================================================
 
 Geom2d_Curve::ResD1 Adaptor2d_Curve2d::EvalD1(const double theU) const
 {
-  Geom2d_Curve::ResD1 aResult;
-  D1(theU, aResult.Point, aResult.D1);
-  return aResult;
+  (void)theU;
+  throw Standard_NotImplemented("Adaptor2d_Curve2d::EvalD1");
 }
 
 //=================================================================================================
 
 Geom2d_Curve::ResD2 Adaptor2d_Curve2d::EvalD2(const double theU) const
 {
-  Geom2d_Curve::ResD2 aResult;
-  D2(theU, aResult.Point, aResult.D1, aResult.D2);
-  return aResult;
+  (void)theU;
+  throw Standard_NotImplemented("Adaptor2d_Curve2d::EvalD2");
 }
 
 //=================================================================================================
 
 Geom2d_Curve::ResD3 Adaptor2d_Curve2d::EvalD3(const double theU) const
 {
-  Geom2d_Curve::ResD3 aResult;
-  D3(theU, aResult.Point, aResult.D1, aResult.D2, aResult.D3);
-  return aResult;
+  (void)theU;
+  throw Standard_NotImplemented("Adaptor2d_Curve2d::EvalD3");
 }
 
 //=================================================================================================
 
 gp_Vec2d Adaptor2d_Curve2d::EvalDN(const double theU, const int theN) const
 {
-  return DN(theU, theN);
+  (void)theU;
+  (void)theN;
+  throw Standard_NotImplemented("Adaptor2d_Curve2d::EvalDN");
 }

--- a/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Curve2d.hxx
+++ b/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Curve2d.hxx
@@ -85,39 +85,57 @@ public:
   Standard_EXPORT virtual double Period() const;
 
   //! Computes the point of parameter U on the curve.
-  Standard_EXPORT virtual gp_Pnt2d Value(const double U) const;
+  gp_Pnt2d Value(const double theU) const { return EvalD0(theU); }
 
   //! Computes the point of parameter U on the curve.
-  Standard_EXPORT virtual void D0(const double U, gp_Pnt2d& P) const;
+  void D0(const double theU, gp_Pnt2d& theP) const { theP = EvalD0(theU); }
 
   //! Computes the point of parameter U on the curve with its
   //! first derivative.
   //! Raised if the continuity of the current interval
   //! is not C1.
-  Standard_EXPORT virtual void D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const;
+  void D1(const double theU, gp_Pnt2d& theP, gp_Vec2d& theV) const
+  {
+    const Geom2d_Curve::ResD1 aRes = EvalD1(theU);
+    theP                           = aRes.Point;
+    theV                           = aRes.D1;
+  }
 
   //! Returns the point P of parameter U, the first and second
   //! derivatives V1 and V2.
   //! Raised if the continuity of the current interval
   //! is not C2.
-  Standard_EXPORT virtual void D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const;
+  void D2(const double theU, gp_Pnt2d& theP, gp_Vec2d& theV1, gp_Vec2d& theV2) const
+  {
+    const Geom2d_Curve::ResD2 aRes = EvalD2(theU);
+    theP                           = aRes.Point;
+    theV1                          = aRes.D1;
+    theV2                          = aRes.D2;
+  }
 
   //! Returns the point P of parameter U, the first, the second
   //! and the third derivative.
   //! Raised if the continuity of the current interval
   //! is not C3.
-  Standard_EXPORT virtual void D3(const double U,
-                                  gp_Pnt2d&    P,
-                                  gp_Vec2d&    V1,
-                                  gp_Vec2d&    V2,
-                                  gp_Vec2d&    V3) const;
+  void D3(const double theU,
+          gp_Pnt2d&    theP,
+          gp_Vec2d&    theV1,
+          gp_Vec2d&    theV2,
+          gp_Vec2d&    theV3) const
+  {
+    const Geom2d_Curve::ResD3 aRes = EvalD3(theU);
+    theP                           = aRes.Point;
+    theV1                          = aRes.D1;
+    theV2                          = aRes.D2;
+    theV3                          = aRes.D3;
+  }
 
   //! The returned vector gives the value of the derivative for the
   //! order of derivation N.
   //! Raised if the continuity of the current interval
   //! is not CN.
   //! Raised if N < 1.
-  Standard_EXPORT virtual gp_Vec2d DN(const double U, const int N) const;
+  gp_Vec2d DN(const double theU, const int theN) const { return EvalDN(theU, theN); }
 
   //! Returns the parametric resolution corresponding
   //! to the real space resolution <R3d>.

--- a/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Line2d.cxx
+++ b/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Line2d.cxx
@@ -154,56 +154,51 @@ double Adaptor2d_Line2d::Period() const
 
 //=================================================================================================
 
-gp_Pnt2d Adaptor2d_Line2d::Value(const double X) const
+gp_Pnt2d Adaptor2d_Line2d::EvalD0(const double theX) const
 {
-  return ElCLib::LineValue(X, myAx2d);
+  return ElCLib::LineValue(theX, myAx2d);
 }
 
 //=================================================================================================
 
-void Adaptor2d_Line2d::D0(const double X, gp_Pnt2d& P) const
+Geom2d_Curve::ResD1 Adaptor2d_Line2d::EvalD1(const double theX) const
 {
-  P = ElCLib::LineValue(X, myAx2d);
+  Geom2d_Curve::ResD1 aResult;
+  ElCLib::LineD1(theX, myAx2d, aResult.Point, aResult.D1);
+  return aResult;
 }
 
 //=================================================================================================
 
-void Adaptor2d_Line2d::D1(const double X, gp_Pnt2d& P, gp_Vec2d& V) const
+Geom2d_Curve::ResD2 Adaptor2d_Line2d::EvalD2(const double theX) const
 {
-  ElCLib::LineD1(X, myAx2d, P, V);
+  Geom2d_Curve::ResD2 aResult;
+  ElCLib::LineD1(theX, myAx2d, aResult.Point, aResult.D1);
+  aResult.D2.SetCoord(0., 0.);
+  return aResult;
 }
 
 //=================================================================================================
 
-void Adaptor2d_Line2d::D2(const double X, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const
+Geom2d_Curve::ResD3 Adaptor2d_Line2d::EvalD3(const double theX) const
 {
-  ElCLib::LineD1(X, myAx2d, P, V1);
-  V2.SetCoord(0., 0.);
-}
-
-//=================================================================================================
-
-void Adaptor2d_Line2d::D3(const double X,
-                          gp_Pnt2d&    P,
-                          gp_Vec2d&    V1,
-                          gp_Vec2d&    V2,
-                          gp_Vec2d&    V3) const
-{
-  ElCLib::LineD1(X, myAx2d, P, V1);
-  V2.SetCoord(0., 0.);
-  V3.SetCoord(0., 0.);
+  Geom2d_Curve::ResD3 aResult;
+  ElCLib::LineD1(theX, myAx2d, aResult.Point, aResult.D1);
+  aResult.D2.SetCoord(0., 0.);
+  aResult.D3.SetCoord(0., 0.);
+  return aResult;
 }
 
 //=================================================================================================
 
 // gp_Vec2d Adaptor2d_Line2d::DN(const double U, const int N) const
-gp_Vec2d Adaptor2d_Line2d::DN(const double, const int N) const
+gp_Vec2d Adaptor2d_Line2d::EvalDN(const double, const int theN) const
 {
-  if (N <= 0)
+  if (theN <= 0)
   {
     throw Standard_OutOfRange();
   }
-  if (N == 1)
+  if (theN == 1)
   {
     return myAx2d.Direction();
   }

--- a/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Line2d.hxx
+++ b/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_Line2d.hxx
@@ -91,21 +91,31 @@ public:
 
   Standard_EXPORT double Period() const override;
 
-  Standard_EXPORT gp_Pnt2d Value(const double X) const override;
+  //! Evaluates the point on the line.
+  //! @param[in] theX parameter on the line
+  //! @return evaluated point
+  [[nodiscard]] Standard_EXPORT gp_Pnt2d EvalD0(const double theX) const final;
 
-  Standard_EXPORT void D0(const double X, gp_Pnt2d& P) const override;
+  //! Evaluates the point and first derivative on the line.
+  //! @param[in] theX parameter on the line
+  //! @return point and first derivative
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD1 EvalD1(const double theX) const final;
 
-  Standard_EXPORT void D1(const double X, gp_Pnt2d& P, gp_Vec2d& V) const override;
+  //! Evaluates the point and first two derivatives on the line.
+  //! @param[in] theX parameter on the line
+  //! @return point and derivatives through the second order
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD2 EvalD2(const double theX) const final;
 
-  Standard_EXPORT void D2(const double X, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const override;
+  //! Evaluates the point and first three derivatives on the line.
+  //! @param[in] theX parameter on the line
+  //! @return point and derivatives through the third order
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD3 EvalD3(const double theX) const final;
 
-  Standard_EXPORT void D3(const double X,
-                          gp_Pnt2d&    P,
-                          gp_Vec2d&    V1,
-                          gp_Vec2d&    V2,
-                          gp_Vec2d&    V3) const override;
-
-  Standard_EXPORT gp_Vec2d DN(const double U, const int N) const override;
+  //! Evaluates a derivative of the requested order.
+  //! @param[in] theU parameter on the line
+  //! @param[in] theN derivative order; must be greater than zero
+  //! @return derivative vector of order theN
+  [[nodiscard]] Standard_EXPORT gp_Vec2d EvalDN(const double theU, const int theN) const final;
 
   Standard_EXPORT double Resolution(const double R3d) const override;
 

--- a/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_OffsetCurve.cxx
+++ b/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_OffsetCurve.cxx
@@ -292,86 +292,73 @@ double Adaptor2d_OffsetCurve::Period() const
 
 //=================================================================================================
 
-gp_Pnt2d Adaptor2d_OffsetCurve::Value(const double U) const
+gp_Pnt2d Adaptor2d_OffsetCurve::EvalD0(const double theU) const
 {
   if (myOffset != 0.)
   {
-    gp_Pnt2d aP;
-    gp_Vec2d aV;
-    myCurve->D1(U, aP, aV);
-    Geom2d_OffsetCurveUtils::CalculateD0(aP, aV, myOffset);
-    return aP;
+    Geom2d_Curve::ResD1 aResult = myCurve->EvalD1(theU);
+    Geom2d_OffsetCurveUtils::CalculateD0(aResult.Point, aResult.D1, myOffset);
+    return aResult.Point;
   }
-  else
-  {
-    return myCurve->Value(U);
-  }
+  return myCurve->EvalD0(theU);
 }
 
 //=================================================================================================
 
-void Adaptor2d_OffsetCurve::D0(const double U, gp_Pnt2d& P) const
-{
-  P = Value(U);
-}
-
-//=================================================================================================
-
-void Adaptor2d_OffsetCurve::D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const
+Geom2d_Curve::ResD1 Adaptor2d_OffsetCurve::EvalD1(const double theU) const
 {
   if (myOffset != 0.)
   {
-    gp_Vec2d aV2;
-    myCurve->D2(U, P, V, aV2);
-    Geom2d_OffsetCurveUtils::CalculateD1(P, V, aV2, myOffset);
+    Geom2d_Curve::ResD2 aBasis = myCurve->EvalD2(theU);
+    Geom2d_OffsetCurveUtils::CalculateD1(aBasis.Point, aBasis.D1, aBasis.D2, myOffset);
+    return {aBasis.Point, aBasis.D1};
   }
-  else
-  {
-    myCurve->D1(U, P, V);
-  }
+  return myCurve->EvalD1(theU);
 }
 
 //=================================================================================================
 
-void Adaptor2d_OffsetCurve::D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const
+Geom2d_Curve::ResD2 Adaptor2d_OffsetCurve::EvalD2(const double theU) const
 {
   if (myOffset != 0.)
   {
-    gp_Vec2d aV3;
-    myCurve->D3(U, P, V1, V2, aV3);
-    Geom2d_OffsetCurveUtils::CalculateD2(P, V1, V2, aV3, false, myOffset);
+    Geom2d_Curve::ResD3 aBasis = myCurve->EvalD3(theU);
+    Geom2d_OffsetCurveUtils::CalculateD2(aBasis.Point,
+                                         aBasis.D1,
+                                         aBasis.D2,
+                                         aBasis.D3,
+                                         false,
+                                         myOffset);
+    return {aBasis.Point, aBasis.D1, aBasis.D2};
   }
-  else
-  {
-    myCurve->D2(U, P, V1, V2);
-  }
+  return myCurve->EvalD2(theU);
 }
 
 //=================================================================================================
 
-void Adaptor2d_OffsetCurve::D3(const double U,
-                               gp_Pnt2d&    P,
-                               gp_Vec2d&    V1,
-                               gp_Vec2d&    V2,
-                               gp_Vec2d&    V3) const
+Geom2d_Curve::ResD3 Adaptor2d_OffsetCurve::EvalD3(const double theU) const
 {
   if (myOffset != 0.)
   {
-    gp_Vec2d aV4 = myCurve->DN(U, 4);
-    myCurve->D3(U, P, V1, V2, V3);
-    Geom2d_OffsetCurveUtils::CalculateD3(P, V1, V2, V3, aV4, false, myOffset);
+    const gp_Vec2d      aD4     = myCurve->EvalDN(theU, 4);
+    Geom2d_Curve::ResD3 aResult = myCurve->EvalD3(theU);
+    Geom2d_OffsetCurveUtils::CalculateD3(aResult.Point,
+                                         aResult.D1,
+                                         aResult.D2,
+                                         aResult.D3,
+                                         aD4,
+                                         false,
+                                         myOffset);
+    return aResult;
   }
-  else
-  {
-    myCurve->D3(U, P, V1, V2, V3);
-  }
+  return myCurve->EvalD3(theU);
 }
 
 //=================================================================================================
 
-gp_Vec2d Adaptor2d_OffsetCurve::DN(const double, const int) const
+gp_Vec2d Adaptor2d_OffsetCurve::EvalDN(const double, const int) const
 {
-  throw Standard_NotImplemented("Adaptor2d_OffsetCurve::DN");
+  throw Standard_NotImplemented("Adaptor2d_OffsetCurve::EvalDN");
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_OffsetCurve.hxx
+++ b/src/ModelingData/TKG2d/Adaptor2d/Adaptor2d_OffsetCurve.hxx
@@ -105,40 +105,32 @@ public:
 
   Standard_EXPORT double Period() const override;
 
-  //! Computes the point of parameter U on the curve.
-  Standard_EXPORT gp_Pnt2d Value(const double U) const override;
+  //! Evaluates the point on the offset curve.
+  //! @param[in] theU curve parameter
+  //! @return evaluated point
+  [[nodiscard]] Standard_EXPORT gp_Pnt2d EvalD0(const double theU) const final;
 
-  //! Computes the point of parameter U on the curve.
-  Standard_EXPORT void D0(const double U, gp_Pnt2d& P) const override;
+  //! Evaluates the point and first derivative on the offset curve.
+  //! @param[in] theU curve parameter
+  //! @return point and first derivative
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD1 EvalD1(const double theU) const final;
 
-  //! Computes the point of parameter U on the curve with its
-  //! first derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C1.
-  Standard_EXPORT void D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const override;
+  //! Evaluates the point and first two derivatives on the offset curve.
+  //! @param[in] theU curve parameter
+  //! @return point and derivatives through the second order
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD2 EvalD2(const double theU) const final;
 
-  //! Returns the point P of parameter U, the first and second
-  //! derivatives V1 and V2.
-  //! Raised if the continuity of the current interval
-  //! is not C2.
-  Standard_EXPORT void D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const override;
+  //! Evaluates the point and first three derivatives on the offset curve.
+  //! @param[in] theU curve parameter
+  //! @return point and derivatives through the third order
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD3 EvalD3(const double theU) const final;
 
-  //! Returns the point P of parameter U, the first, the second
-  //! and the third derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C3.
-  Standard_EXPORT void D3(const double U,
-                          gp_Pnt2d&    P,
-                          gp_Vec2d&    V1,
-                          gp_Vec2d&    V2,
-                          gp_Vec2d&    V3) const override;
-
-  //! The returned vector gives the value of the derivative for the
-  //! order of derivation N.
-  //! Raised if the continuity of the current interval
-  //! is not CN.
-  //! Raised if N < 1.
-  Standard_EXPORT gp_Vec2d DN(const double U, const int N) const override;
+  //! Evaluates a derivative of the requested order.
+  //! @param[in] theU curve parameter
+  //! @param[in] theN derivative order
+  //! @return derivative vector of order theN
+  //! @throws Standard_NotImplemented this operation is not implemented
+  [[nodiscard]] Standard_EXPORT gp_Vec2d EvalDN(const double theU, const int theN) const final;
 
   //! Returns the parametric resolution corresponding
   //! to the real space resolution <R3d>.

--- a/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
+++ b/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.cxx
@@ -694,22 +694,6 @@ bool Geom2dAdaptor_Curve::IsBoundary(const double theU, int& theSpanStart, int& 
 
 //=================================================================================================
 
-gp_Pnt2d Geom2dAdaptor_Curve::Value(const double U) const
-{
-  gp_Pnt2d aRes;
-  D0(U, aRes);
-  return aRes;
-}
-
-//=================================================================================================
-
-void Geom2dAdaptor_Curve::D0(const double U, gp_Pnt2d& P) const
-{
-  P = EvalD0(U);
-}
-
-//=================================================================================================
-
 gp_Pnt2d Geom2dAdaptor_Curve::EvalD0(const double theU) const
 {
   const double U = theU;
@@ -791,15 +775,6 @@ gp_Pnt2d Geom2dAdaptor_Curve::EvalD0(const double theU) const
     default:
       return myCurve->EvalD0(U);
   }
-}
-
-//=================================================================================================
-
-void Geom2dAdaptor_Curve::D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const
-{
-  const Geom2d_Curve::ResD1 aResult = EvalD1(U);
-  P                                 = aResult.Point;
-  V                                 = aResult.D1;
 }
 
 //=================================================================================================
@@ -890,16 +865,6 @@ Geom2d_Curve::ResD1 Geom2dAdaptor_Curve::EvalD1(const double theU) const
 
 //=================================================================================================
 
-void Geom2dAdaptor_Curve::D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const
-{
-  const Geom2d_Curve::ResD2 aResult = EvalD2(U);
-  P                                 = aResult.Point;
-  V1                                = aResult.D1;
-  V2                                = aResult.D2;
-}
-
-//=================================================================================================
-
 Geom2d_Curve::ResD2 Geom2dAdaptor_Curve::EvalD2(const double theU) const
 {
   const double        U = theU;
@@ -984,21 +949,6 @@ Geom2d_Curve::ResD2 Geom2dAdaptor_Curve::EvalD2(const double theU) const
     default:
       return myCurve->EvalD2(U);
   }
-}
-
-//=================================================================================================
-
-void Geom2dAdaptor_Curve::D3(const double U,
-                             gp_Pnt2d&    P,
-                             gp_Vec2d&    V1,
-                             gp_Vec2d&    V2,
-                             gp_Vec2d&    V3) const
-{
-  const Geom2d_Curve::ResD3 aResult = EvalD3(U);
-  P                                 = aResult.Point;
-  V1                                = aResult.D1;
-  V2                                = aResult.D2;
-  V3                                = aResult.D3;
 }
 
 //=================================================================================================
@@ -1106,13 +1056,6 @@ Geom2d_Curve::ResD3 Geom2dAdaptor_Curve::EvalD3(const double theU) const
     default:
       return myCurve->EvalD3(U);
   }
-}
-
-//=================================================================================================
-
-gp_Vec2d Geom2dAdaptor_Curve::DN(const double U, const int N) const
-{
-  return EvalDN(U, N);
 }
 
 //=================================================================================================

--- a/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.hxx
+++ b/src/ModelingData/TKG2d/Geom2dAdaptor/Geom2dAdaptor_Curve.hxx
@@ -168,41 +168,6 @@ public:
 
   Standard_EXPORT double Period() const override;
 
-  //! Computes the point of parameter U on the curve
-  Standard_EXPORT gp_Pnt2d Value(const double U) const final;
-
-  //! Computes the point of parameter U.
-  Standard_EXPORT void D0(const double U, gp_Pnt2d& P) const final;
-
-  //! Computes the point of parameter U on the curve with its
-  //! first derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C1.
-  Standard_EXPORT void D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const final;
-
-  //! Returns the point P of parameter U, the first and second
-  //! derivatives V1 and V2.
-  //! Raised if the continuity of the current interval
-  //! is not C2.
-  Standard_EXPORT void D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const final;
-
-  //! Returns the point P of parameter U, the first, the second
-  //! and the third derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C3.
-  Standard_EXPORT void D3(const double U,
-                          gp_Pnt2d&    P,
-                          gp_Vec2d&    V1,
-                          gp_Vec2d&    V2,
-                          gp_Vec2d&    V3) const final;
-
-  //! The returned vector gives the value of the derivative for the
-  //! order of derivation N.
-  //! Raised if the continuity of the current interval
-  //! is not CN.
-  //! Raised if N < 1.
-  Standard_EXPORT gp_Vec2d DN(const double U, const int N) const final;
-
   //! returns the parametric resolution
   Standard_EXPORT double Resolution(const double Ruv) const override;
 

--- a/src/ModelingData/TKG2d/Geom2dGridEval/Geom2dGridEval_Curve.hxx
+++ b/src/ModelingData/TKG2d/Geom2dGridEval/Geom2dGridEval_Curve.hxx
@@ -48,7 +48,7 @@
 //! - BezierCurve: Optimized batch evaluation via BSplCLib
 //! - BSplineCurve: Optimized batch evaluation via BSplCLib with span caching
 //! - OffsetCurve: Composite evaluation using basis curve batch evaluator
-//! - Other: Fallback using Adaptor2d_Curve2d::D0
+//! - Other: Fallback using Adaptor2d_Curve2d::EvalD0
 //!
 //! Usage:
 //! @code

--- a/src/ModelingData/TKG2d/Geom2dGridEval/Geom2dGridEval_OtherCurve.hxx
+++ b/src/ModelingData/TKG2d/Geom2dGridEval/Geom2dGridEval_OtherCurve.hxx
@@ -24,7 +24,7 @@
 
 //! @brief Fallback evaluator for unknown 2D curve types.
 //!
-//! Uses Adaptor2d_Curve2d::D0 for point-by-point evaluation.
+//! Uses Adaptor2d_Curve2d::EvalD0 for point-by-point evaluation.
 //! This is the slowest evaluator but handles any 2D curve type.
 //!
 //! @note The curve adaptor reference must remain valid during the lifetime

--- a/src/ModelingData/TKGeomBase/ProjLib/ProjLib_CompProjectedCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ProjLib/ProjLib_CompProjectedCurve.cxx
@@ -1550,20 +1550,12 @@ bool ProjLib_CompProjectedCurve::IsVIso(const int Index, double& V) const
 
 //=================================================================================================
 
-gp_Pnt2d ProjLib_CompProjectedCurve::Value(const double t) const
+gp_Pnt2d ProjLib_CompProjectedCurve::EvalD0(const double U) const
 {
   gp_Pnt2d P;
-  D0(t, P);
-  return P;
-}
-
-//=================================================================================================
-
-void ProjLib_CompProjectedCurve::D0(const double U, gp_Pnt2d& P) const
-{
-  int    i, j;
-  double Udeb, Ufin;
-  bool   found = false;
+  int      i, j;
+  double   Udeb, Ufin;
+  bool     found = false;
 
   for (i = 1; i <= myNbCurves; i++)
   {
@@ -1701,33 +1693,32 @@ void ProjLib_CompProjectedCurve::D0(const double U, gp_Pnt2d& P) const
       P.SetCoord(U0, V0);
     }
   }
+  return P;
 }
 
 //=================================================================================================
 
-void ProjLib_CompProjectedCurve::D1(const double t, gp_Pnt2d& P, gp_Vec2d& V) const
+Geom2d_Curve::ResD1 ProjLib_CompProjectedCurve::EvalD1(const double t) const
 {
-  double u, v;
-  D0(t, P);
-  u = P.X();
-  v = P.Y();
-  d1(t, u, v, V, myCurve, mySurface);
+  Geom2d_Curve::ResD1 aResult;
+  aResult.Point = EvalD0(t);
+  d1(t, aResult.Point.X(), aResult.Point.Y(), aResult.D1, myCurve, mySurface);
+  return aResult;
 }
 
 //=================================================================================================
 
-void ProjLib_CompProjectedCurve::D2(const double t, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const
+Geom2d_Curve::ResD2 ProjLib_CompProjectedCurve::EvalD2(const double t) const
 {
-  double u, v;
-  D0(t, P);
-  u = P.X();
-  v = P.Y();
-  d2(t, u, v, V1, V2, myCurve, mySurface);
+  Geom2d_Curve::ResD2 aResult;
+  aResult.Point = EvalD0(t);
+  d2(t, aResult.Point.X(), aResult.Point.Y(), aResult.D1, aResult.D2, myCurve, mySurface);
+  return aResult;
 }
 
 //=================================================================================================
 
-gp_Vec2d ProjLib_CompProjectedCurve::DN(const double t, const int N) const
+gp_Vec2d ProjLib_CompProjectedCurve::EvalDN(const double t, const int N) const
 {
   if (N < 1)
   {
@@ -1735,21 +1726,15 @@ gp_Vec2d ProjLib_CompProjectedCurve::DN(const double t, const int N) const
   }
   else if (N == 1)
   {
-    gp_Pnt2d P;
-    gp_Vec2d V;
-    D1(t, P, V);
-    return V;
+    return EvalD1(t).D1;
   }
   else if (N == 2)
   {
-    gp_Pnt2d P;
-    gp_Vec2d V1, V2;
-    D2(t, P, V1, V2);
-    return V2;
+    return EvalD2(t).D2;
   }
   else if (N > 2)
   {
-    throw Standard_NotImplemented("ProjLib_CompProjectedCurve::DN");
+    throw Standard_NotImplemented("ProjLib_CompProjectedCurve::EvalDN");
   }
   return gp_Vec2d();
 }

--- a/src/ModelingData/TKGeomBase/ProjLib/ProjLib_CompProjectedCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ProjLib/ProjLib_CompProjectedCurve.hxx
@@ -134,29 +134,28 @@ public:
   //! input surface
   Standard_EXPORT bool IsVIso(const int Index, double& V) const;
 
-  //! Computes the point of parameter U on the curve.
-  Standard_EXPORT gp_Pnt2d Value(const double U) const override;
+  //! Evaluates a point of the composite projected curve.
+  //! @param[in] theU curve parameter
+  //! @return projected point in the surface parameter space
+  [[nodiscard]] Standard_EXPORT gp_Pnt2d EvalD0(const double theU) const final;
 
-  //! Computes the point of parameter U on the curve.
-  Standard_EXPORT void D0(const double U, gp_Pnt2d& P) const override;
+  //! Evaluates a point and first derivative of the composite projected curve.
+  //! @param[in] theU curve parameter
+  //! @return projected point and first derivative
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD1 EvalD1(const double theU) const final;
 
-  //! Computes the point of parameter U on the curve with its
-  //! first derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C1.
-  Standard_EXPORT void D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const override;
+  //! Evaluates a point and first two derivatives of the composite projected curve.
+  //! @param[in] theU curve parameter
+  //! @return projected point and derivatives through the second order
+  [[nodiscard]] Standard_EXPORT Geom2d_Curve::ResD2 EvalD2(const double theU) const final;
 
-  //! Returns the point P of parameter U, the first and second
-  //! derivatives V1 and V2.
-  //! Raised if the continuity of the current interval
-  //! is not C2.
-  Standard_EXPORT void D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const override;
-
-  //! The returned vector gives the value of the derivative for the
-  //! order of derivation N.
-  //! Raised if N < 1.
-  //! Raised if N > 2.
-  Standard_EXPORT gp_Vec2d DN(const double U, const int N) const override;
+  //! Evaluates a derivative of the composite projected curve.
+  //! @param[in] theU curve parameter
+  //! @param[in] theN derivative order; only first and second orders are supported
+  //! @return derivative vector of order theN
+  //! @throws Standard_OutOfRange if theN is less than one
+  //! @throws Standard_NotImplemented if theN is greater than two
+  [[nodiscard]] Standard_EXPORT gp_Vec2d EvalDN(const double theU, const int theN) const final;
 
   //! Returns the first parameter of the curve C
   //! which has a projection on S.

--- a/src/ModelingData/TKGeomBase/ProjLib/ProjLib_ProjectedCurve.cxx
+++ b/src/ModelingData/TKGeomBase/ProjLib/ProjLib_ProjectedCurve.cxx
@@ -995,48 +995,6 @@ double ProjLib_ProjectedCurve::Period() const
 
 //=================================================================================================
 
-gp_Pnt2d ProjLib_ProjectedCurve::Value(const double) const
-{
-  throw Standard_NotImplemented("ProjLib_ProjectedCurve::Value() - method is not implemented");
-}
-
-//=================================================================================================
-
-void ProjLib_ProjectedCurve::D0(const double, gp_Pnt2d&) const
-{
-  throw Standard_NotImplemented("ProjLib_ProjectedCurve::D0() - method is not implemented");
-}
-
-//=================================================================================================
-
-void ProjLib_ProjectedCurve::D1(const double, gp_Pnt2d&, gp_Vec2d&) const
-{
-  throw Standard_NotImplemented("ProjLib_ProjectedCurve::D1() - method is not implemented");
-}
-
-//=================================================================================================
-
-void ProjLib_ProjectedCurve::D2(const double, gp_Pnt2d&, gp_Vec2d&, gp_Vec2d&) const
-{
-  throw Standard_NotImplemented("ProjLib_ProjectedCurve::D2() - method is not implemented");
-}
-
-//=================================================================================================
-
-void ProjLib_ProjectedCurve::D3(const double, gp_Pnt2d&, gp_Vec2d&, gp_Vec2d&, gp_Vec2d&) const
-{
-  throw Standard_NotImplemented("ProjLib_ProjectedCurve::D3() - method is not implemented");
-}
-
-//=================================================================================================
-
-gp_Vec2d ProjLib_ProjectedCurve::DN(const double, const int) const
-{
-  throw Standard_NotImplemented("ProjLib_ProjectedCurve::DN() - method is not implemented");
-}
-
-//=================================================================================================
-
 double ProjLib_ProjectedCurve::Resolution(const double) const
 {
   throw Standard_NotImplemented("ProjLib_ProjectedCurve::Resolution() - method is not implemented");

--- a/src/ModelingData/TKGeomBase/ProjLib/ProjLib_ProjectedCurve.hxx
+++ b/src/ModelingData/TKGeomBase/ProjLib/ProjLib_ProjectedCurve.hxx
@@ -144,41 +144,6 @@ public:
 
   Standard_EXPORT double Period() const override;
 
-  //! Computes the point of parameter U on the curve.
-  Standard_EXPORT gp_Pnt2d Value(const double U) const override;
-
-  //! Computes the point of parameter U on the curve.
-  Standard_EXPORT void D0(const double U, gp_Pnt2d& P) const override;
-
-  //! Computes the point of parameter U on the curve with its
-  //! first derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C1.
-  Standard_EXPORT void D1(const double U, gp_Pnt2d& P, gp_Vec2d& V) const override;
-
-  //! Returns the point P of parameter U, the first and second
-  //! derivatives V1 and V2.
-  //! Raised if the continuity of the current interval
-  //! is not C2.
-  Standard_EXPORT void D2(const double U, gp_Pnt2d& P, gp_Vec2d& V1, gp_Vec2d& V2) const override;
-
-  //! Returns the point P of parameter U, the first, the second
-  //! and the third derivative.
-  //! Raised if the continuity of the current interval
-  //! is not C3.
-  Standard_EXPORT void D3(const double U,
-                          gp_Pnt2d&    P,
-                          gp_Vec2d&    V1,
-                          gp_Vec2d&    V2,
-                          gp_Vec2d&    V3) const override;
-
-  //! The returned vector gives the value of the derivative for the
-  //! order of derivation N.
-  //! Raised if the continuity of the current interval
-  //! is not CN.
-  //! Raised if N < 1.
-  Standard_EXPORT gp_Vec2d DN(const double U, const int N) const override;
-
   //! Returns the parametric resolution corresponding
   //! to the real space resolution <R3d>.
   Standard_EXPORT double Resolution(const double R3d) const override;


### PR DESCRIPTION
  - Make Value(), D0-D3(), and DN() non-virtual wrappers delegating to EvalD*().
  - Move evaluation logic to EvalD*() in Adaptor2d_Line2d and Adaptor2d_OffsetCurve.
  - Remove redundant legacy evaluation overrides from Geom2dAdaptor_Curve.
  - Migrate ProjLib_CompProjectedCurve evaluation logic to EvalD*().
  - Remove unimplemented evaluation overrides from ProjLib_ProjectedCurve.
  - Update related documentation for the Eval-based API.