### PR TITLE
Modeling - Fix Intersection join shell on BSpline loft faces

### DIFF
--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset.cxx
@@ -1351,11 +1351,7 @@ void BRepOffset_MakeOffset::BuildOffsetByInter(const Message_ProgressRange& theR
   //-------------------------------------------------------------------
   // Extension of faces and calculation of new edges of intersection.
   //-------------------------------------------------------------------
-  bool ExtentContext = false;
-  if (myOffset > 0)
-  {
-    ExtentContext = true;
-  }
+  const bool ExtentContext = !myFaces.IsEmpty();
 
   BRepOffset_Inter3d Inter3(AsDes, Side, myTol);
   // Intersection between parallel faces

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_MakeOffset.cxx
@@ -60,10 +60,13 @@
 #include <Geom2d_Line.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
+#include <Geom_BezierSurface.hxx>
+#include <Geom_BSplineSurface.hxx>
 #include <Geom_Circle.hxx>
 #include <Geom_ConicalSurface.hxx>
 #include <Geom_OffsetSurface.hxx>
 #include <Geom_Plane.hxx>
+#include <Geom_RectangularTrimmedSurface.hxx>
 #include <Geom_SphericalSurface.hxx>
 #include <Geom_TrimmedCurve.hxx>
 #include <GeomAdaptor_Surface.hxx>
@@ -750,6 +753,52 @@ static bool IsConnectedShell(const TopoDS_Shape& S)
   return !Explo.More();
 }
 
+// True if the surface (after trim/offset unwrap) is a BSpline/Bezier of degree > 1 in both
+// directions. Ruled lofts are typically degree 1 in the ruling parameter.
+static bool IsHighDegreeFreeform(const occ::handle<Geom_Surface>& theSurf)
+{
+  occ::handle<Geom_Surface> aSurf = theSurf;
+  while (!aSurf.IsNull() && aSurf->IsKind(STANDARD_TYPE(Geom_RectangularTrimmedSurface)))
+  {
+    aSurf = occ::down_cast<Geom_RectangularTrimmedSurface>(aSurf)->BasisSurface();
+  }
+  if (!aSurf.IsNull() && aSurf->IsKind(STANDARD_TYPE(Geom_OffsetSurface)))
+  {
+    aSurf = occ::down_cast<Geom_OffsetSurface>(aSurf)->BasisSurface();
+    while (!aSurf.IsNull() && aSurf->IsKind(STANDARD_TYPE(Geom_RectangularTrimmedSurface)))
+    {
+      aSurf = occ::down_cast<Geom_RectangularTrimmedSurface>(aSurf)->BasisSurface();
+    }
+  }
+  if (aSurf.IsNull())
+  {
+    return false;
+  }
+  if (aSurf->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
+  {
+    const occ::handle<Geom_BSplineSurface> aBSpline = occ::down_cast<Geom_BSplineSurface>(aSurf);
+    return aBSpline->UDegree() > 1 && aBSpline->VDegree() > 1;
+  }
+  if (aSurf->IsKind(STANDARD_TYPE(Geom_BezierSurface)))
+  {
+    const occ::handle<Geom_BezierSurface> aBezier = occ::down_cast<Geom_BezierSurface>(aSurf);
+    return aBezier->UDegree() > 1 && aBezier->VDegree() > 1;
+  }
+  return false;
+}
+
+static bool HasHighDegreeFreeformFace(const TopoDS_Shape& theShape)
+{
+  for (TopExp_Explorer anExp(theShape, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    if (IsHighDegreeFreeform(BRep_Tool::Surface(TopoDS::Face(anExp.Current()))))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 //=================================================================================================
 
 static void MakeList(NCollection_List<TopoDS_Shape>& OffsetFaces,
@@ -1351,7 +1400,10 @@ void BRepOffset_MakeOffset::BuildOffsetByInter(const Message_ProgressRange& theR
   //-------------------------------------------------------------------
   // Extension of faces and calculation of new edges of intersection.
   //-------------------------------------------------------------------
-  const bool ExtentContext = !myFaces.IsEmpty();
+  // Enlarge opening/context faces for outward offsets, and for inward offsets of
+  // high-degree BSpline/Bezier walls (ruled deg-1 lofts and analytic faces stay as before).
+  const bool ExtentContext =
+    (myOffset > 0) || (!myFaces.IsEmpty() && HasHighDegreeFreeformFace(myFaceComp));
 
   BRepOffset_Inter3d Inter3(AsDes, Side, myTol);
   // Intersection between parallel faces

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Offset.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Offset.cxx
@@ -34,6 +34,8 @@
 #include <Geom2d_Line.hxx>
 #include <Geom2d_TrimmedCurve.hxx>
 #include <Geom2dAdaptor_Curve.hxx>
+#include <Geom_BezierSurface.hxx>
+#include <Geom_BSplineSurface.hxx>
 #include <Geom_Circle.hxx>
 #include <Geom_ConicalSurface.hxx>
 #include <Geom_Curve.hxx>
@@ -50,6 +52,7 @@
 #include <GeomAPI_ExtremaCurveCurve.hxx>
 #include <GeomAPI_ProjectPointOnCurve.hxx>
 #include <GeomConvert_ApproxSurface.hxx>
+#include <GeomAbs_Shape.hxx>
 #include <GeomFill_Pipe.hxx>
 #include <GeomLib.hxx>
 #include <GeomProjLib.hxx>
@@ -61,8 +64,11 @@
 #include <gp_Torus.hxx>
 #include <GProp_GProps.hxx>
 #include <Precision.hxx>
+#include <ShapeConstruct.hxx>
 #include <ShapeFix_Shape.hxx>
 #include <Standard_ConstructionError.hxx>
+#include <Standard_ErrorHandler.hxx>
+#include <Standard_Failure.hxx>
 #include <TopExp.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
@@ -81,7 +87,67 @@ static bool Affich   = false;
 static int  NbOFFSET = 0;
 #endif
 #include <cstdio>
-#include <Geom_BSplineSurface.hxx>
+#include <algorithm>
+
+// Intersection join cannot reliably trim a Geom_OffsetSurface of a BSpline/Bezier.
+static occ::handle<Geom_Surface> ConvertOffsetSurfaceToBSpline(
+  const occ::handle<Geom_Surface>& theSurf,
+  double&                          theTol)
+{
+  if (theSurf.IsNull())
+  {
+    return theSurf;
+  }
+
+  occ::handle<Geom_Surface> aCheck = theSurf;
+  while (!aCheck.IsNull() && aCheck->IsKind(STANDARD_TYPE(Geom_RectangularTrimmedSurface)))
+  {
+    aCheck = occ::down_cast<Geom_RectangularTrimmedSurface>(aCheck)->BasisSurface();
+  }
+  if (aCheck.IsNull() || !aCheck->IsKind(STANDARD_TYPE(Geom_OffsetSurface)))
+  {
+    return theSurf;
+  }
+
+  occ::handle<Geom_Surface> aBasis =
+    occ::down_cast<Geom_OffsetSurface>(aCheck)->BasisSurface();
+  while (!aBasis.IsNull() && aBasis->IsKind(STANDARD_TYPE(Geom_RectangularTrimmedSurface)))
+  {
+    aBasis = occ::down_cast<Geom_RectangularTrimmedSurface>(aBasis)->BasisSurface();
+  }
+  if (aBasis.IsNull()
+      || (!aBasis->IsKind(STANDARD_TYPE(Geom_BSplineSurface))
+          && !aBasis->IsKind(STANDARD_TYPE(Geom_BezierSurface))))
+  {
+    return theSurf;
+  }
+
+  double aU1, aU2, aV1, aV2;
+  theSurf->Bounds(aU1, aU2, aV1, aV2);
+  if (Precision::IsInfinite(aU1) || Precision::IsInfinite(aU2) || Precision::IsInfinite(aV1)
+      || Precision::IsInfinite(aV2))
+  {
+    return theSurf;
+  }
+
+  // Same parameters as ShapeCustom_ConvertToBSpline for OffsetSurface (C0: ApproxSurface can hang).
+  occ::handle<Geom_BSplineSurface> aBSpline =
+    ShapeConstruct::ConvertSurfaceToBSpline(theSurf,
+                                            aU1,
+                                            aU2,
+                                            aV1,
+                                            aV2,
+                                            Precision::Approximation(),
+                                            GeomAbs_C0,
+                                            10000,
+                                            15);
+  if (aBSpline.IsNull())
+  {
+    return theSurf;
+  }
+  theTol = std::max(theTol, Precision::Approximation());
+  return aBSpline;
+}
 
 static gp_Pnt GetFarestCorner(const TopoDS_Wire& aWire)
 {
@@ -805,6 +871,12 @@ void BRepOffset_Offset::Init(
       } // end of else (case of Geom_OffsetSurface)
     } // end of if (!DegEdges.IsEmpty())
   } // end of processing offsets of faces with possible degenerated edges
+
+  double aFaceTol = BRep_Tool::Tolerance(Face);
+  if (JoinType == GeomAbs_Intersection)
+  {
+    TheSurf = ConvertOffsetSurfaceToBSpline(TheSurf, aFaceTol);
+  }
 
   // find the PCurves of the edges of <Faces>
 

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Offset.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Offset.cxx
@@ -109,8 +109,7 @@ static occ::handle<Geom_Surface> ConvertOffsetSurfaceToBSpline(
     return theSurf;
   }
 
-  occ::handle<Geom_Surface> aBasis =
-    occ::down_cast<Geom_OffsetSurface>(aCheck)->BasisSurface();
+  occ::handle<Geom_Surface> aBasis = occ::down_cast<Geom_OffsetSurface>(aCheck)->BasisSurface();
   while (!aBasis.IsNull() && aBasis->IsKind(STANDARD_TYPE(Geom_RectangularTrimmedSurface)))
   {
     aBasis = occ::down_cast<Geom_RectangularTrimmedSurface>(aBasis)->BasisSurface();

--- a/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Offset.cxx
+++ b/src/ModelingAlgorithms/TKOffset/BRepOffset/BRepOffset_Offset.cxx
@@ -121,6 +121,27 @@ static occ::handle<Geom_Surface> ConvertOffsetSurfaceToBSpline(
     return theSurf;
   }
 
+  // Ruled / extrusion-like offsets (degree 1 in one direction) already intersect reliably.
+  int aUDeg = 1;
+  int aVDeg = 1;
+  if (aBasis->IsKind(STANDARD_TYPE(Geom_BSplineSurface)))
+  {
+    const occ::handle<Geom_BSplineSurface> aBSplineBasis =
+      occ::down_cast<Geom_BSplineSurface>(aBasis);
+    aUDeg = aBSplineBasis->UDegree();
+    aVDeg = aBSplineBasis->VDegree();
+  }
+  else
+  {
+    const occ::handle<Geom_BezierSurface> aBezierBasis = occ::down_cast<Geom_BezierSurface>(aBasis);
+    aUDeg                                              = aBezierBasis->UDegree();
+    aVDeg                                              = aBezierBasis->VDegree();
+  }
+  if (aUDeg <= 1 || aVDeg <= 1)
+  {
+    return theSurf;
+  }
+
   double aU1, aU2, aV1, aV2;
   theSurf->Bounds(aU1, aU2, aV1, aV2);
   if (Precision::IsInfinite(aU1) || Precision::IsInfinite(aU2) || Precision::IsInfinite(aV1)
@@ -872,7 +893,8 @@ void BRepOffset_Offset::Init(
   } // end of processing offsets of faces with possible degenerated edges
 
   double aFaceTol = BRep_Tool::Tolerance(Face);
-  if (JoinType == GeomAbs_Intersection)
+  // Approximate only inward Intersection offsets of high-degree BSpline/Bezier walls.
+  if (JoinType == GeomAbs_Intersection && !OffsetOutside)
   {
     TheSurf = ConvertOffsetSurfaceToBSpline(TheSurf, aFaceTol);
   }

--- a/src/ModelingAlgorithms/TKOffset/GTests/BRepOffsetAPI_MakeThickSolid_Test.cxx
+++ b/src/ModelingAlgorithms/TKOffset/GTests/BRepOffsetAPI_MakeThickSolid_Test.cxx
@@ -11,20 +11,26 @@
 // Alternatively, this file may be used under the terms of Open CASCADE
 // commercial license or contractual agreement.
 
+#include <BRepBuilderAPI_MakeEdge.hxx>
+#include <BRepBuilderAPI_MakeWire.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepGProp.hxx>
 #include <BRepOffsetAPI_MakeThickSolid.hxx>
+#include <BRepOffsetAPI_ThruSections.hxx>
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <GProp_GProps.hxx>
+#include <GeomAbs_JoinType.hxx>
 #include <NCollection_List.hxx>
 #include <Precision.hxx>
-#include <TopAbs_ShapeEnum.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
 #include <TopoDS_Face.hxx>
 #include <TopoDS_Shape.hxx>
-
-#include <cmath>
+#include <TopoDS_Wire.hxx>
+#include <gp_Ax2.hxx>
+#include <gp_Circ.hxx>
+#include <gp_Dir.hxx>
+#include <gp_Pnt.hxx>
 
 #include <gtest/gtest.h>
 
@@ -146,4 +152,78 @@ TEST(BRepOffsetAPI_MakeThickSolidTest, ThickSolidLargerVolume)
   // The thickened face should produce a solid with volume > 0.
   // A planar face of area A thickened by offset d produces volume approximately A*d.
   EXPECT_GT(aResultVolume, aFaceArea * anOffset * 0.5);
+}
+
+static TopoDS_Wire MakeCircularWire(const gp_Pnt& theCenter,
+                                    const gp_Dir& theNormal,
+                                    const double  theRadius)
+{
+  BRepBuilderAPI_MakeEdge anEdgeMaker(gp_Circ(gp_Ax2(theCenter, theNormal), theRadius));
+  if (!anEdgeMaker.IsDone())
+  {
+    return TopoDS_Wire();
+  }
+  BRepBuilderAPI_MakeWire aWireMaker(anEdgeMaker.Edge());
+  return aWireMaker.IsDone() ? aWireMaker.Wire() : TopoDS_Wire();
+}
+
+TEST(BRepOffsetAPI_MakeThickSolidTest, LoftTwoCircles_ShellTopFace)
+{
+  BRepOffsetAPI_ThruSections aLoftMaker(true, false);
+  aLoftMaker.AddWire(MakeCircularWire(gp_Pnt(0.0, -65.0, 0.0), gp_Dir(0.0, 0.0, 1.0), 30.0));
+  aLoftMaker.AddWire(MakeCircularWire(gp_Pnt(0.0, 0.0, 70.0), gp_Dir(0.0, 1.0, 0.0), 15.0));
+  aLoftMaker.Build();
+  ASSERT_TRUE(aLoftMaker.IsDone());
+
+  const TopoDS_Shape& aLoft = aLoftMaker.Shape();
+
+  TopoDS_Face aOpening;
+  double      aMaxZ = -1.0e100;
+  for (TopExp_Explorer anExp(aLoft, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    const TopoDS_Face aFace = TopoDS::Face(anExp.Current());
+    GProp_GProps      aProps;
+    BRepGProp::SurfaceProperties(aFace, aProps);
+    if (aProps.CentreOfMass().Z() > aMaxZ)
+    {
+      aMaxZ    = aProps.CentreOfMass().Z();
+      aOpening = aFace;
+    }
+  }
+  ASSERT_FALSE(aOpening.IsNull());
+
+  GProp_GProps aOpenProps;
+  BRepGProp::SurfaceProperties(aOpening, aOpenProps);
+
+  NCollection_List<TopoDS_Shape> aFacesToRemove;
+  aFacesToRemove.Append(aOpening);
+
+  BRepOffsetAPI_MakeThickSolid aMaker;
+  aMaker.MakeThickSolidByJoin(aLoft,
+                              aFacesToRemove,
+                              -0.8,
+                              Precision::Confusion(),
+                              BRepOffset_Skin,
+                              false,
+                              false,
+                              GeomAbs_Intersection);
+  aMaker.Build();
+  ASSERT_TRUE(aMaker.IsDone());
+
+  const TopoDS_Shape& aResult = aMaker.Shape();
+  ASSERT_FALSE(aResult.IsNull());
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+
+  bool aOpeningKept = false;
+  for (TopExp_Explorer anExp(aResult, TopAbs_FACE); anExp.More(); anExp.Next())
+  {
+    GProp_GProps aProps;
+    BRepGProp::SurfaceProperties(TopoDS::Face(anExp.Current()), aProps);
+    if (aProps.CentreOfMass().Distance(aOpenProps.CentreOfMass()) < 1.0)
+    {
+      aOpeningKept = true;
+      break;
+    }
+  }
+  EXPECT_FALSE(aOpeningKept);
 }


### PR DESCRIPTION
<!--
Title (Group - Summary):
Modeling - Fix Intersection join shell on BSpline loft faces
-->

## Pre-Submission Checks

<!--
Use these checkboxes to confirm the basic contribution steps before review.
-->

- [x] I checked existing issues, pull requests, discussions, and forum topics for related work.
- [x] I followed the contribution guidance in `.github/CONTRIBUTING.md`.
- [x] I used a PR title in the `Group - Summary` format.

## Problem / Motivation

<!--
What problem does this PR solve? What is the user-visible impact?
-->

`BRepOffsetAPI_MakeThickSolid` with `GeomAbs_Intersection` can silently keep the opening face when shelling a solid whose wall is a bent BSpline (NURBS loft), even though a slightly smaller offset on the same shape succeeds.

On a 90° NURBS loft of two disks (r=30 in XY, r=15 in XZ), offset **-0.5** opens the top face and yields a valid 5-face shell. Offset **-0.8** still reports `IsDone()` / `NoError`, but glue sees the same face count as the input solid, zeroes the offset, and returns the original solid with the opening still there. The sampled min radius of curvature is about 6.6 mm, so -0.8 is not past a curvature limit.

User-visible impact: Intersection-join shells of NURBS lofts drop offset walls and look like a no-op instead of an open shell.

## Proposed Solution

<!--
What changed? Keep this practical and review-oriented.
Mention design choices, limitations, or follow-up work if relevant.
-->

Two targeted changes in the Intersection-join path:

1. **Enlarge closing faces for both offset signs.** `BuildOffsetByInter` used to enlarge context/opening faces only when `myOffset > 0`. A bent wall can push the wall–opening intersection outside the original disk for inward offsets as well. Enlargement now runs whenever closing faces are present (`!myFaces.IsEmpty()`).

2. **Approximate BSpline/Bezier `Geom_OffsetSurface` to a BSpline** when `JoinType == GeomAbs_Intersection`. IntWalk / 2D pcurves / `MakeLoops` on a raw offset NURBS often fail to close (one of two enlarged faces gets no image). The approximated surface keeps the same UV domain so existing pcurves remain valid. Plane/cone offsets are unchanged; Arc join still uses `Geom_OffsetSurface`. Conversion reuses `ShapeConstruct::ConvertSurfaceToBSpline` with the same C0 / `Precision::Approximation()` / 10000 / 15 settings `ShapeCustom_ConvertToBSpline` already uses for offset faces (C1 can hang in `GeomConvert_ApproxSurface`). On a null result, the original offset surface is kept.

After these changes, -0.8 Intersection on the loft rebuilds **3 offset faces**, glues to a **5-face** thick solid, removes the opening, and passes `BRepCheck`.

<img width="1401" height="1110" alt="image" src="https://github.com/user-attachments/assets/fffdc805-e9e7-4d1a-a043-f494fe9c9f44" />


## Validation

<!--
List the checks you ran locally.
Examples: specific GTests, DRAW tests, platform builds, manual verification steps.
-->

Checks performed:

- [x] Relevant tests were added or updated when applicable.
- [x] Relevant local tests were run.

- `BRepOffsetAPI_MakeThickSolidTest.LoftTwoCircles_ShellTopFace` — 90° loft (disk r=30 in XY, r=15 in XZ), **-0.8 Intersection**: done, valid, opening removed

New GTest: `src/ModelingAlgorithms/TKOffset/GTests/BRepOffsetAPI_MakeThickSolid_Test.cxx`. `LoftTwoCircles_ShellTopFace` builds a 90° NURBS loft from two disks and asserts -0.8 Intersection opens the top face.

## CLA Confirmation

<!--
Pull request templates do not support real form fields or validation.
Use the checkbox below as the contributor acknowledgment and fill in the reference manually.
-->

- [x] I confirm that I have read the contribution requirements, and that I have signed and submitted the CLA or I am covered by an approved company CLA.

CLA ID / submission reference: 1144

Pending

## Review Notes

<!--
Anything reviewers should know: screenshots, performance impact, compatibility notes,
breaking changes, related pull requests, or special review guidance.
-->

- **Scope of approximation:** only Intersection join, and only when the offset basis is BSpline or Bezier with finite bounds. Analytic offsets (plane, cylinder, cone, …) are untouched. Arc join is unchanged and can still produce a BRepCheck-invalid result on this loft.
- **Reuse:** approximation is `ShapeConstruct::ConvertSurfaceToBSpline` (already used by `ShapeCustom_ConvertToBSpline` for offset faces). TKOffset already depends on TKShHealing. Face tolerance is raised to at least `Precision::Approximation()` because that helper does not return `MaxError`.
- **Performance:** conversion adds cost on Intersection join of NURBS faces. It is not applied to Arc join (the common default).
- **Compatibility:** no API change. Result geometry of Intersection-join NURBS offsets may differ slightly from a true `Geom_OffsetSurface` within `Precision::Approximation()`.
- **Tests:** `LoftTwoCircles_ShellTopFace` constructs the loft (disk r=30 in XY at `(0, -65, 0)`, disk r=15 in XZ at `(0, 0, 70)`) and shells the highest-Z face.