### PR TITLE
Modeling Algorithms - Bound the degenerate-normal search in ChFi3d_Builder::StoreData

### DIFF
--- a/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
+++ b/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder_6.cxx
@@ -917,6 +917,18 @@ bool ChFi3d_Builder::StoreData(occ::handle<ChFiDS_SurfData>&         Data,
   //   if (Du1.Dot(Du2)>0) Data->ChangeOrientation() = TopAbs_FORWARD;
   //   else Data->ChangeOrientation() = TopAbs_REVERSED;
 
+  // The walk below looks for a parameter where both surfaces have a well-defined normal, probing
+  // VFirst + (VLast - VFirst) / aDenom for aDenom = 2, 3, 4, ... -- from the middle of the range
+  // towards its start. Where such a parameter exists it is reached within the first few steps.
+  // Where it does not -- on a surface degenerate along the whole of this boundary, as happens on
+  // the seam of an extrusion whose profile has a cusp -- the step shrinks harmonically and falls
+  // under the parametric tolerance only after (VLast - VFirst) / tolget2d probes, each evaluating
+  // two B-spline surfaces. With the tolerance the approximation usually reaches, that is hundreds
+  // of millions of probes, and the caller sees a hang instead of the false returned in the end.
+  // The count is therefore bounded: a case needing more probes than that to find a usable
+  // parameter does not have one.
+  constexpr int aMaxProbes = 1000;
+
   double aDelta = VLast - VFirst;
   int    aDenom = 2;
 
@@ -943,7 +955,7 @@ bool ChFi3d_Builder::StoreData(occ::handle<ChFiDS_SurfData>&         Data,
     {
       aDenom++;
 
-      if (std::abs(aDeltav) <= tolget2d)
+      if (std::abs(aDeltav) <= tolget2d || aDenom > aMaxProbes)
       {
         return false;
       }


### PR DESCRIPTION
## Pre-Submission Checks

- [x] I checked existing issues, pull requests, discussions, and forum topics for related work.
- [x] I followed the contribution guidance in `.github/CONTRIBUTING.md`.
- [x] I used a PR title in the `Group - Summary` format.

## Problem / Motivation

`ChFi3d_Builder::StoreData` settles the orientation of a fillet face against its support by looking for a parameter where both surfaces have a well-defined normal. It probes `VFirst + (VLast - VFirst) / aDenom` for `aDenom = 2, 3, 4, ...`, walking from the middle of the boundary towards its start:

```cpp
double aDelta = VLast - VFirst;
int    aDenom = 2;

for (;;)
{
  double aDeltav = aDelta / aDenom;
  ...
  if (Du1.Magnitude() <= tolget3d || Du2.Magnitude() <= tolget3d)
  {
    aDenom++;
    if (std::abs(aDeltav) <= tolget2d)
    {
      return false;
    }
    continue;
  }
  break;   // a healthy surface leaves on the very first probe
}
```

Where a usable parameter exists, the loop leaves on the first probe or two. Where the surface is degenerate along the whole of that boundary there is none, and the only exit left is the tolerance test. The step shrinks harmonically, so that test needs `(VLast - VFirst) / tolget2d` iterations — and `tolget2d` is the tolerance the approximation actually *reached* (`approx.TolReached`), not a requested one, so it is commonly around 1e-9. That is hundreds of millions of probes, each evaluating two B-spline surfaces, all to reach the same `false` the first probe could have given.

The caller sees this as a hang. It is reachable from ordinary modelling: a surface degenerate along a whole boundary is what an extrusion produces on the seam when its profile has a cusp — the tangent at a cusp of a spline is exactly zero — and what nearly tangent junctions produce.

## Proposed Solution

Bound the probe count at 1000. A case that needs more probes than that to find a usable parameter does not have one, so the bound changes the answer for no input that previously terminated in reasonable time — it only shortcuts to the `false` the loop was already heading for.

The added comment states why the loop is bounded, so the next reader does not have to rediscover the harmonic step.

## Validation

Measured on a model that reaches this search (an extruded profile with a cusp, filleted at a radius that degenerates the fillet surface): a `BRepFilletAPI_MakeFillet::Build` that ran for **over three minutes without finishing** now returns in **128 ms**, reporting the same failure that the neighbouring radii report. Radii that already worked are unchanged (90 ms before and after).

Local build: minimal-module `Release`, `FoundationClasses` + `ModelingData` + `ModelingAlgorithms`.

- Fillet-related suites (`*Fillet*`, `*Chamfer*`, `*ChFi*`, `*Blend*`, `*Offset*`): 248/249 pass, 1 pre-existing skip (`BRepOffsetAPI_MakePipeShellTest.Bug24909_2_ClosedCircularSpine`).
- Full `OpenCascadeGTest`: **7574/7579 pass, 0 failures**; the 5 skips are pre-existing and unrelated.

> Both figures were measured with this change and its companion PR applied together; the two are independent and touch disjoint code, but I did not run the suite with only one of them in the tree.

Checks performed:

- [x] Relevant local tests were run.
- [ ] Relevant tests were added or updated when applicable — no GTest is added here. Reproducing the degenerate case needs a specific artifact rather than a synthesised shape, and a timing assertion would be a poor gate. Happy to add one if you would like the artifact contributed as test data.

## CLA Confirmation

- [ ] I confirm that I have read the contribution requirements, and that I have signed and submitted the CLA or I am covered by an approved company CLA.

CLA ID / submission reference: **not signed yet — please tell me where to send it.**

I have read `.github/CLA.md` and am ready to sign, but every route `CONTRIBUTING.md` gives for submitting it currently 301-redirects to `https://occt3d.com/open-cascade-technology/index.html`, a page with no contribution or CLA section at all:

- the submission form, `https://dev.opencascade.org/get_involed/cla_submission_form`
- the portal root, `https://dev.opencascade.org`
- the agreement PDF linked from `.github/CLA.md` itself, `https://dev.opencascade.org/sites/default/files/Contributor_License_Agreement.pdf`

Point me at a current form or address and I will sign and submit before you merge; happy to have this PR held until then. Either way the stale links are probably worth fixing in `CONTRIBUTING.md` and `CLA.md`.

## Review Notes

- Independent of #1490, which touches `ChFi3d_Builder_6.cxx` as well but only removes `OCCT_DEBUG` chronometer instrumentation. No overlap in the changed region.
- Companion PR #1492 makes the fillet interruptible (`Message_ProgressRange` threaded into `ChFi3d_Builder::Compute`), which covers the general case this bound cannot: any other unbounded stretch inside a fillet build.
