### PR TITLE
Modeling Algorithms - Poll the progress range for a user break in ChFi3d_Builder::Compute

### DIFF
--- a/src/ModelingAlgorithms/TKFillet/BRepFilletAPI/BRepFilletAPI_MakeChamfer.cxx
+++ b/src/ModelingAlgorithms/TKFillet/BRepFilletAPI/BRepFilletAPI_MakeChamfer.cxx
@@ -272,9 +272,9 @@ occ::handle<TopOpeBRepBuild_HBuilder> BRepFilletAPI_MakeChamfer::Builder() const
 
 //=================================================================================================
 
-void BRepFilletAPI_MakeChamfer::Build(const Message_ProgressRange& /*theRange*/)
+void BRepFilletAPI_MakeChamfer::Build(const Message_ProgressRange& theRange)
 {
-  myBuilder.Compute();
+  myBuilder.Compute(theRange);
   if (myBuilder.IsDone())
   {
     Done();

--- a/src/ModelingAlgorithms/TKFillet/BRepFilletAPI/BRepFilletAPI_MakeFillet.cxx
+++ b/src/ModelingAlgorithms/TKFillet/BRepFilletAPI/BRepFilletAPI_MakeFillet.cxx
@@ -368,9 +368,9 @@ occ::handle<TopOpeBRepBuild_HBuilder> BRepFilletAPI_MakeFillet::Builder() const
 
 //=================================================================================================
 
-void BRepFilletAPI_MakeFillet::Build(const Message_ProgressRange& /*theRange*/)
+void BRepFilletAPI_MakeFillet::Build(const Message_ProgressRange& theRange)
 {
-  myBuilder.Compute();
+  myBuilder.Compute(theRange);
   if (myBuilder.IsDone())
   {
     Done();

--- a/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder.cxx
+++ b/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder.cxx
@@ -181,7 +181,7 @@ void ChFi3d_Builder::ExtentAnalyse()
 
 //=================================================================================================
 
-void ChFi3d_Builder::Compute()
+void ChFi3d_Builder::Compute(const Message_ProgressRange& theRange)
 {
 
 #ifdef OCCT_DEBUG // perf
@@ -272,6 +272,11 @@ void ChFi3d_Builder::Compute()
   // Construction of the stripe of fillet on each stripe.
   for (itel.Initialize(myListStripe); itel.More(); itel.Next())
   {
+    if (theRange.UserBreak())
+    {
+      done = false;
+      return;
+    }
     itel.Value()->Spine()->SetErrorStatus(ChFiDS_Ok);
     try
     {
@@ -310,6 +315,11 @@ void ChFi3d_Builder::Compute()
     int j;
     for (j = 1; j <= myVDataMap.Extent(); j++)
     {
+      if (theRange.UserBreak())
+      {
+        done = false;
+        return;
+      }
       try
       {
         OCC_CATCH_SIGNALS
@@ -341,6 +351,12 @@ void ChFi3d_Builder::Compute()
   ChFi3d_ResultChron(cl_perffilletonvertex, t_perffilletonvertex);
   ChFi3d_InitChron(cl_filds);
 #endif
+
+  if (theRange.UserBreak())
+  {
+    done = false;
+    return;
+  }
 
   NCollection_Map<int> MapIndSo;
   TopExp_Explorer      expso(myShape, TopAbs_SOLID);

--- a/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder.hxx
+++ b/src/ModelingAlgorithms/TKFillet/ChFi3d/ChFi3d_Builder.hxx
@@ -29,6 +29,7 @@
 #include <ChFiDS_StripeMap.hxx>
 #include <ChFiDS_ElSpine.hxx>
 #include <math_Vector.hxx>
+#include <Message_ProgressRange.hxx>
 #include <TopoDS_Shape.hxx>
 #include <Standard_Integer.hxx>
 #include <TopTools_ShapeMapHasher.hxx>
@@ -128,7 +129,10 @@ public:
 
   //! general calculation of geometry on all edges,
   //! topologic reconstruction.
-  Standard_EXPORT void Compute();
+  //! @param theRange the range polled for a user break; the computation is given up between
+  //!                 contours, between vertices and before the topological reconstruction, and
+  //!                 IsDone() then returns false.
+  Standard_EXPORT void Compute(const Message_ProgressRange& theRange = Message_ProgressRange());
 
   //! returns True if the computation is success
   Standard_EXPORT bool IsDone() const;

--- a/src/ModelingAlgorithms/TKFillet/GTests/BRepFilletAPI_MakeChamfer_Test.cxx
+++ b/src/ModelingAlgorithms/TKFillet/GTests/BRepFilletAPI_MakeChamfer_Test.cxx
@@ -20,6 +20,8 @@
 #include <gp_Ax2.hxx>
 #include <NCollection_IndexedDataMap.hxx>
 #include <NCollection_IndexedMap.hxx>
+#include <Message_ProgressIndicator.hxx>
+#include <Message_ProgressScope.hxx>
 #include <NCollection_List.hxx>
 #include <Standard_ConstructionError.hxx>
 #include <Standard_Failure.hxx>
@@ -296,4 +298,56 @@ TEST(BRepFilletAPI_MakeChamferTest, SequentialChamferNoCrash)
   // Verify at least one chamfer iteration succeeded, ensuring the test
   // meaningfully exercises topology changes rather than trivially passing.
   EXPECT_GE(aSuccessCount, 1);
+}
+
+namespace
+{
+//! A progress indicator that asks for a user break as soon as it is polled.
+class ChFi3d_BreakAtOnce : public Message_ProgressIndicator
+{
+public:
+  bool UserBreak() override
+  {
+    ++myPolls;
+    return true;
+  }
+
+  //! Returns how many times the algorithm polled for a user break.
+  int Polls() const { return myPolls; }
+
+protected:
+  void Show(const Message_ProgressScope&, const bool) override {}
+
+private:
+  int myPolls = 0;
+};
+} // namespace
+
+// The chamfer builder shares ChFi3d_Builder::Compute() with the fillet, so the progress range
+// given to Build() must reach it here as well.
+TEST(BRepFilletAPI_MakeChamferTest, UserBreakGivesUpTheBuild)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(20.0, 20.0, 20.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+  ASSERT_TRUE(aBoxMaker.IsDone());
+
+  BRepFilletAPI_MakeChamfer aMaker(aBox);
+  for (TopExp_Explorer anExp(aBox, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    aMaker.Add(2.0, TopoDS::Edge(anExp.Current()));
+  }
+
+  occ::handle<ChFi3d_BreakAtOnce> aBreakAtOnce = new ChFi3d_BreakAtOnce();
+  aMaker.Build(aBreakAtOnce->Start());
+
+  EXPECT_FALSE(aMaker.IsDone()) << "A user break must leave the chamfer not done";
+  EXPECT_EQ(aBreakAtOnce->Polls(), 1) << "The build must give up at the first poll";
+
+  aMaker.Reset();
+  for (TopExp_Explorer anExp(aBox, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    aMaker.Add(2.0, TopoDS::Edge(anExp.Current()));
+  }
+  aMaker.Build();
+  EXPECT_TRUE(aMaker.IsDone()) << "A maker broken off must build again after Reset()";
 }

--- a/src/ModelingAlgorithms/TKFillet/GTests/BRepFilletAPI_MakeFillet_Test.cxx
+++ b/src/ModelingAlgorithms/TKFillet/GTests/BRepFilletAPI_MakeFillet_Test.cxx
@@ -41,6 +41,8 @@
 #include <GC_MakeArcOfCircle.hxx>
 #include <GC_MakeSegment.hxx>
 #include <GProp_GProps.hxx>
+#include <Message_ProgressIndicator.hxx>
+#include <Message_ProgressScope.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_List.hxx>
 #include <NCollection_Sequence.hxx>
@@ -64,6 +66,7 @@
 #include <gtest/gtest.h>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 // Regression for fillets that must remove an intervening face or meet on opposite
 // edges of a prism. Related reports:
@@ -765,4 +768,84 @@ TEST(BRepFilletAPI_MakeFilletTest, OCC426_RevolveFuseUnifyFillet)
   GProp_GProps aResultProps;
   BRepGProp::SurfaceProperties(aResult, aResultProps);
   EXPECT_NEAR(aResultProps.Mass(), 7507.61, 7507.61 * 0.001) << "Surface area mismatch";
+}
+
+namespace
+{
+//! A progress indicator that reports a user break once its poll allowance is spent.
+class ChFi3d_BreakAfterPolls : public Message_ProgressIndicator
+{
+public:
+  explicit ChFi3d_BreakAfterPolls(const int theAllowance)
+      : myAllowance(theAllowance)
+  {
+  }
+
+  //! Counts the poll and asks for a break past the allowance.
+  bool UserBreak() override { return ++myPolls > myAllowance; }
+
+  //! Returns how many times the algorithm polled for a user break.
+  int Polls() const { return myPolls; }
+
+protected:
+  void Show(const Message_ProgressScope&, const bool) override {}
+
+private:
+  int myAllowance = 0;
+  int myPolls     = 0;
+};
+
+//! Asks the maker for a constant fillet on every edge of the shape.
+void FilletEveryEdge(BRepFilletAPI_MakeFillet& theMaker,
+                     const TopoDS_Shape&       theShape,
+                     const double              theRadius)
+{
+  for (TopExp_Explorer anExp(theShape, TopAbs_EDGE); anExp.More(); anExp.Next())
+  {
+    theMaker.Add(theRadius, TopoDS::Edge(anExp.Current()));
+  }
+}
+} // namespace
+
+// The progress range given to Build() must reach ChFi3d_Builder::Compute(): a break asked for
+// before the first contour gives up without a result, and Reset() puts the maker back to work.
+TEST(BRepFilletAPI_MakeFilletTest, UserBreakGivesUpTheBuild)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 10.0, 10.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+
+  BRepFilletAPI_MakeFillet aMaker(aBox);
+  FilletEveryEdge(aMaker, aBox, 1.0);
+
+  occ::handle<ChFi3d_BreakAfterPolls> aBreakAtOnce = new ChFi3d_BreakAfterPolls(0);
+  aMaker.Build(aBreakAtOnce->Start());
+
+  EXPECT_FALSE(aMaker.IsDone()) << "A user break must leave the fillet not done";
+  EXPECT_EQ(aBreakAtOnce->Polls(), 1) << "The build must give up at the first poll";
+
+  aMaker.Reset();
+  FilletEveryEdge(aMaker, aBox, 1.0);
+  aMaker.Build();
+  EXPECT_TRUE(aMaker.IsDone()) << "A maker broken off must build again after Reset()";
+}
+
+// A range that never breaks must not change the outcome, and the build must reach all three poll
+// points: between contours, between vertices and before the topological reconstruction.
+TEST(BRepFilletAPI_MakeFilletTest, UnbrokenProgressRangeBuildsAsBefore)
+{
+  BRepPrimAPI_MakeBox aBoxMaker(10.0, 10.0, 10.0);
+  const TopoDS_Shape& aBox = aBoxMaker.Shape();
+
+  BRepFilletAPI_MakeFillet aMaker(aBox);
+  FilletEveryEdge(aMaker, aBox, 1.0);
+
+  occ::handle<ChFi3d_BreakAfterPolls> aNeverBreaks =
+    new ChFi3d_BreakAfterPolls(std::numeric_limits<int>::max());
+  aMaker.Build(aNeverBreaks->Start());
+
+  ASSERT_TRUE(aMaker.IsDone()) << "Fillet must be done";
+  EXPECT_GE(aNeverBreaks->Polls(), 3) << "Every poll point must be reached";
+
+  BRepCheck_Analyzer aChecker(aMaker.Shape());
+  EXPECT_TRUE(aChecker.IsValid()) << "Result shape must be valid";
 }


### PR DESCRIPTION
## Pre-Submission Checks

- [x] I checked existing issues, pull requests, discussions, and forum topics for related work.
- [x] I followed the contribution guidance in `.github/CONTRIBUTING.md`.
- [x] I used a PR title in the `Group - Summary` format.

## Problem / Motivation

`BRepFilletAPI_MakeFillet::Build` and `BRepFilletAPI_MakeChamfer::Build` accept a `Message_ProgressRange` and drop it. The argument name is commented out in the signature itself, because `ChFi3d_Builder::Compute` has nowhere to take it:

```cpp
void BRepFilletAPI_MakeFillet::Build(const Message_ProgressRange& /*theRange*/)
{
  myBuilder.Compute();   // the range does not go any further
  ...
}
```

There is no `UserBreak` anywhere in `ChFi3d`. Booleans, meshing, offsetting and shape healing all poll for a user break; fillet and chamfer are the ones that cannot be interrupted once started. An application that runs a fillet on a background thread has no way to give up on it — the only remaining options are to wait, or to kill the process.

That matters because a fillet build can run for a long time on input that is not obviously pathological, and an interactive caller (a radius dragged in a UI, a preview recomputed per frame) needs to abandon superseded work rather than accumulate it.

## Proposed Solution

`ChFi3d_Builder::Compute` now takes a `Message_ProgressRange`, defaulted to `Message_ProgressRange()` so every existing caller keeps compiling and behaving exactly as before.

It polls `UserBreak()` at the three places the algorithm is already between units of work, so no partially built unit is ever abandoned mid-way:

1. before each contour, at the head of the `myListStripe` loop, ahead of `PerformSetOfSurf`;
2. before each vertex, at the head of the `myVDataMap` loop, ahead of `PerformFilletOnVertex`;
3. before the topological reconstruction.

On a break the builder sets `done = false` and returns, so `IsDone()` reports false and the caller gets no half-made shape. `Reset()` puts the maker back to work as usual.

Both `Build` methods now pass their range down. Progress *reporting* is deliberately not added here: the fillet has no cheap way to state how much work is left, and a break poll is the part callers actually need. The parameter is in place should someone want to scale the range later.

## Validation

Three GTests added, covering both makers:

- `BRepFilletAPI_MakeFilletTest.UserBreakGivesUpTheBuild` — a break asked for before the first contour leaves the maker not done after exactly one poll, and `Reset()` lets the same maker build successfully again.
- `BRepFilletAPI_MakeFilletTest.UnbrokenProgressRangeBuildsAsBefore` — a range that never breaks produces the same valid result as before, and all three poll points are reached.
- `BRepFilletAPI_MakeChamferTest.UserBreakGivesUpTheBuild` — the same for the chamfer builder, which shares `Compute`.

Local build: minimal-module `Release`, `FoundationClasses` + `ModelingData` + `ModelingAlgorithms`.

- New GTests: 3/3 pass.
- Fillet-related suites (`*Fillet*`, `*Chamfer*`, `*ChFi*`, `*Blend*`, `*Offset*`): 248/249 pass, 1 pre-existing skip (`BRepOffsetAPI_MakePipeShellTest.Bug24909_2_ClosedCircularSpine`).
- Full `OpenCascadeGTest`: **7574/7579 pass, 0 failures**; the 5 skips are pre-existing and unrelated.

> Both figures were measured with this change and its companion PR applied together; the two are independent and touch disjoint code, but I did not run the suite with only one of them in the tree.

Checks performed:

- [x] Relevant tests were added or updated when applicable.
- [x] Relevant local tests were run.
- [x] `clang-format --style=file` applied to all changed files.

## CLA Confirmation

- [ ] I confirm that I have read the contribution requirements, and that I have signed and submitted the CLA or I am covered by an approved company CLA.

CLA ID / submission reference: **not signed yet — please tell me where to send it.**

I have read `.github/CLA.md` and am ready to sign, but every route `CONTRIBUTING.md` gives for submitting it currently 301-redirects to `https://occt3d.com/open-cascade-technology/index.html`, a page with no contribution or CLA section at all:

- the submission form, `https://dev.opencascade.org/get_involed/cla_submission_form`
- the portal root, `https://dev.opencascade.org`
- the agreement PDF linked from `.github/CLA.md` itself, `https://dev.opencascade.org/sites/default/files/Contributor_License_Agreement.pdf`

Point me at a current form or address and I will sign and submit before you merge; happy to have this PR held until then. Either way the stale links are probably worth fixing in `CONTRIBUTING.md` and `CLA.md`.

## Review Notes

- The default argument keeps this source- and behaviour-compatible for every existing caller of `Compute()`.
- Touches `ChFi3d_Builder.cxx` near the `ChFi3d_InitChron(cl_filds)` block, which #1490 also edits. No semantic conflict; whichever lands second may need a two-line context rebase.
- Companion PR #1491 bounds an unbounded probe loop in `ChFi3d_Builder_6.cxx::StoreData` — that fixes one specific stall, while this PR gives callers a way out of any other.
