### PR TITLE
DRAW - misprint in scale and 2dscale commands

### DIFF
--- a/resources/DrawResources/Vector.tcl
+++ b/resources/DrawResources/Vector.tcl
@@ -274,7 +274,7 @@ help scale {scale x y z factor
 } {Vector and measurement Commands}
 
 proc scale {x y z factor} {
-    list [dval $x*$factor] [dval $y^$factor] [dval $z*$factor]
+    list [dval $x*$factor] [dval $y*$factor] [dval $z*$factor]
 }
 
 help 2dscale {2dscale x y factor
@@ -282,7 +282,7 @@ help 2dscale {2dscale x y factor
 } {Vector and measurement Commands}
 
 proc 2dscale {x y factor} {
-    list [dval $x*$factor] [dval $y^$factor]
+    list [dval $x*$factor] [dval $y*$factor]
 }
 
 help pntc {pntc curve u

--- a/tests/bugs/fclasses/bug1488
+++ b/tests/bugs/fclasses/bug1488
@@ -1,0 +1,12 @@
+puts "========"
+puts "GitHub Issue #1488: Vector scale error in DRAW"
+puts "========"
+
+set aScaled2d [2dscale 1 2 5]
+checkreal "2D scaled vector X component" [lindex ${aScaled2d} 0] 5 0 0
+checkreal "2D scaled vector Y component" [lindex ${aScaled2d} 1] 10 0 0
+
+set aScaled3d [scale 1 -2 3 -4]
+checkreal "3D scaled vector X component" [lindex ${aScaled3d} 0] -4 0 0
+checkreal "3D scaled vector Y component" [lindex ${aScaled3d} 1] 8 0 0
+checkreal "3D scaled vector Z component" [lindex ${aScaled3d} 2] -12 0 0

--- a/tests/bugs/fclasses/bug1488
+++ b/tests/bugs/fclasses/bug1488
@@ -1,5 +1,5 @@
 puts "========"
-puts "GitHub Issue #1488: Vector scale error in DRAW"
+puts "GitHub Issue #1488: Vector scale issue in DRAW"
 puts "========"
 
 set aScaled2d [2dscale 1 2 5]


### PR DESCRIPTION
Fixed incorrect operator for scale and 2dscale.
Replaced ^ with *