### PR TITLE
Coding - Fix MSVC warnings

### DIFF
--- a/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_FaceConnect.cxx
+++ b/src/ModelingAlgorithms/TKShHealing/ShapeFix/ShapeFix_FaceConnect.cxx
@@ -503,7 +503,7 @@ TopoDS_Shell ShapeFix_FaceConnect::rebuildShell(const TopoDS_Shell& theShell,
       // Perform necessary fixes on subshapes
       // smh#8
       TopoDS_Shape emptyCopiedShell = result.EmptyCopied();
-      TopoDS_Shell theShell         = TopoDS::Shell(emptyCopiedShell);
+      TopoDS_Shell aShell           = TopoDS::Shell(emptyCopiedShell);
       for (TopoDS_Iterator itf1(result); itf1.More(); itf1.Next())
       {
         TopoDS_Face newface = TopoDS::Face(itf1.Value());
@@ -557,10 +557,10 @@ TopoDS_Shell ShapeFix_FaceConnect::rebuildShell(const TopoDS_Shell& theShell,
         {
           EmpFace = SFF->Face();
         }
-        theBuilder.Add(theShell, EmpFace);
+        theBuilder.Add(aShell, EmpFace);
       }
-      theShell.Closed(BRep_Tool::IsClosed(theShell));
-      result = theShell;
+      aShell.Closed(BRep_Tool::IsClosed(aShell));
+      result = aShell;
 
       if (!theRepVertices.IsEmpty())
       {

--- a/src/Visualization/TKV3d/StdPrs/StdPrs_BRepFont.cxx
+++ b/src/Visualization/TKV3d/StdPrs/StdPrs_BRepFont.cxx
@@ -203,9 +203,7 @@ public:
     if (const FileSource* aFileSource = std::get_if<FileSource>(&FontSource))
     {
       isInitialized =
-        aCopy->Font->Init(aFileSource->Path.ToCString(),
-                          THE_FONT_PARAMETERS,
-                          aFileSource->FaceId);
+        aCopy->Font->Init(aFileSource->Path.ToCString(), THE_FONT_PARAMETERS, aFileSource->FaceId);
     }
     else if (const NamedSource* aNamedSource = std::get_if<NamedSource>(&FontSource))
     {

--- a/src/Visualization/TKV3d/StdPrs/StdPrs_BRepFont.cxx
+++ b/src/Visualization/TKV3d/StdPrs/StdPrs_BRepFont.cxx
@@ -200,17 +200,19 @@ public:
     occ::handle<Impl>           aCopy = new Impl();
     aCopy->Font->SetUseUnicodeSubsetFallback(Font->ToUseUnicodeSubsetFallback());
     bool isInitialized = false;
-    if (const FileSource* aSource = std::get_if<FileSource>(&FontSource))
+    if (const FileSource* aFileSource = std::get_if<FileSource>(&FontSource))
     {
       isInitialized =
-        aCopy->Font->Init(aSource->Path.ToCString(), THE_FONT_PARAMETERS, aSource->FaceId);
+        aCopy->Font->Init(aFileSource->Path.ToCString(),
+                          THE_FONT_PARAMETERS,
+                          aFileSource->FaceId);
     }
-    else if (const NamedSource* aSource = std::get_if<NamedSource>(&FontSource))
+    else if (const NamedSource* aNamedSource = std::get_if<NamedSource>(&FontSource))
     {
-      isInitialized = aCopy->Font->FindAndInit(aSource->Name,
-                                               aSource->Aspect,
+      isInitialized = aCopy->Font->FindAndInit(aNamedSource->Name,
+                                               aNamedSource->Aspect,
                                                THE_FONT_PARAMETERS,
-                                               aSource->StrictLevel);
+                                               aNamedSource->StrictLevel);
     }
     else
     {


### PR DESCRIPTION
Rename local variables to not override exixted
