### PR TITLE
Modeling Data - Improve BSpline and Bezier surface grid evaluation

### DIFF
--- a/src/FoundationClasses/TKernel/GTests/NCollection_Array2_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/NCollection_Array2_Test.cxx
@@ -287,6 +287,60 @@ TEST(NCollection_Array2Test, MoveConstructor)
   EXPECT_EQ(0, anArray1.NbRows());
 }
 
+TEST(NCollection_Array2Test, MoveConstructorFromArray1)
+{
+  NCollection_Array1<int> anArray1(1, 6);
+  for (size_t anIndex = 0; anIndex < anArray1.Size(); ++anIndex)
+  {
+    anArray1.ChangeAt(anIndex) = static_cast<int>(anIndex + 1);
+  }
+  const int* aData = anArray1.Data();
+
+  NCollection_Array2<int> anArray2(std::move(anArray1), 1, 2, 1, 3);
+
+  EXPECT_EQ(aData, anArray2.Data());
+  EXPECT_EQ(0u, anArray1.Size());
+  EXPECT_TRUE(anArray2.IsDeletable());
+  EXPECT_EQ(2, anArray2.NbRows());
+  EXPECT_EQ(3, anArray2.NbColumns());
+  EXPECT_EQ(NCollection_Array2<int>::BeginPosition(1, 2, 1, 3), anArray2.Array1().Lower());
+  EXPECT_EQ(1, anArray2(1, 1));
+  EXPECT_EQ(6, anArray2(2, 3));
+}
+
+TEST(NCollection_Array2Test, MoveConstructorFromArray1ZeroBased)
+{
+  NCollection_Array1<int> anArray1(6);
+  for (size_t anIndex = 0; anIndex < anArray1.Size(); ++anIndex)
+  {
+    anArray1.ChangeAt(anIndex) = static_cast<int>(anIndex + 1);
+  }
+  const int* aData = anArray1.Data();
+
+  NCollection_Array2<int> anArray2(std::move(anArray1), size_t(2), size_t(3));
+
+  EXPECT_EQ(aData, anArray2.Data());
+  EXPECT_EQ(0u, anArray1.Size());
+  EXPECT_TRUE(anArray2.IsDeletable());
+  EXPECT_EQ(0, anArray2.LowerRow());
+  EXPECT_EQ(0, anArray2.LowerCol());
+  EXPECT_EQ(2, anArray2.NbRows());
+  EXPECT_EQ(3, anArray2.NbColumns());
+  EXPECT_EQ(0, anArray2.Array1().Lower());
+  EXPECT_EQ(1, anArray2.At(0, 0));
+  EXPECT_EQ(6, anArray2.At(1, 2));
+}
+
+TEST(NCollection_Array2Test, MoveConstructorFromArray1RejectsWrongSize)
+{
+#ifndef No_Exception
+  NCollection_Array1<int> anArray1(1, 5);
+  EXPECT_THROW((NCollection_Array2<int>(std::move(anArray1), 1, 2, 1, 3)),
+               Standard_DimensionMismatch);
+  EXPECT_EQ(5u, anArray1.Size());
+#endif
+}
+
 TEST(NCollection_Array2Test, MoveAssignment)
 {
   NCollection_Array2<int> anArray1(1, 5, 1, 10);

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Array2.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Array2.hxx
@@ -93,7 +93,7 @@ public:
 
 private:
   static NCollection_Array1<TheItemType>&& moveArray(NCollection_Array1<TheItemType>& theOther,
-                                                     const size_t theExpectedSize)
+                                                     [[maybe_unused]] const size_t theExpectedSize)
   {
     Standard_DimensionMismatch_Raise_if(theOther.Size() != theExpectedSize,
                                         "NCollection_Array2: array size does not match dimensions");

--- a/src/FoundationClasses/TKernel/NCollection/NCollection_Array2.hxx
+++ b/src/FoundationClasses/TKernel/NCollection/NCollection_Array2.hxx
@@ -92,6 +92,14 @@ public:
   }
 
 private:
+  static NCollection_Array1<TheItemType>&& moveArray(NCollection_Array1<TheItemType>& theOther,
+                                                     const size_t theExpectedSize)
+  {
+    Standard_DimensionMismatch_Raise_if(theOther.Size() != theExpectedSize,
+                                        "NCollection_Array2: array size does not match dimensions");
+    return std::move(theOther);
+  }
+
   size_t offsetOf(const int theRow, const int theCol, [[maybe_unused]] const char* theMessage) const
   {
     const std::ptrdiff_t aRowOffset =
@@ -193,6 +201,47 @@ public:
     theOther.mySizeRow  = 0;
     theOther.myLowerCol = 1;
     theOther.mySizeCol  = 0;
+  }
+
+  //! Move constructor reshaping one-dimensional storage into a two-dimensional array.
+  //! Ownership of theOther's buffer is transferred without moving individual elements.
+  //! @param theOther source array; its size must match the requested dimensions
+  //! @param theRowLower lower row bound
+  //! @param theRowUpper upper row bound
+  //! @param theColLower lower column bound
+  //! @param theColUpper upper column bound
+  NCollection_Array2(NCollection_Array1<TheItemType>&& theOther,
+                     const int                         theRowLower,
+                     const int                         theRowUpper,
+                     const int                         theColLower,
+                     const int                         theColUpper)
+      : NCollection_Array1<TheItemType>(moveArray(
+          theOther,
+          ArraySize(RangeSize(theRowLower, theRowUpper), RangeSize(theColLower, theColUpper)))),
+        myLowerRow(theRowLower),
+        mySizeRow(RangeSize(theRowLower, theRowUpper)),
+        myLowerCol(theColLower),
+        mySizeCol(RangeSize(theColLower, theColUpper))
+  {
+    NCollection_Array1<TheItemType>::UpdateLowerBound(
+      BeginPosition(theRowLower, theRowUpper, theColLower, theColUpper));
+  }
+
+  //! Move constructor reshaping one-dimensional storage into a zero-based two-dimensional array.
+  //! Ownership of theOther's buffer is transferred without moving individual elements.
+  //! @param theOther source array; its size must equal theNbRows * theNbCols
+  //! @param theNbRows number of rows
+  //! @param theNbCols number of columns
+  NCollection_Array2(NCollection_Array1<TheItemType>&& theOther,
+                     const size_t                      theNbRows,
+                     const size_t                      theNbCols)
+      : NCollection_Array1<TheItemType>(moveArray(theOther, ArraySize(theNbRows, theNbCols))),
+        myLowerRow(0),
+        mySizeRow(theNbRows),
+        myLowerCol(0),
+        mySizeCol(theNbCols)
+  {
+    NCollection_Array1<TheItemType>::UpdateLowerBound(0);
   }
 
   //! C array-based constructor

--- a/src/ModelingData/TKG3d/GTests/GeomGridEval_BSplineSurface_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomGridEval_BSplineSurface_Test.cxx
@@ -300,26 +300,58 @@ TEST(GeomGridEval_BSplineSurfaceTest, UnorderedParametersAcrossSpans)
   }
 }
 
-TEST(GeomGridEval_BSplineSurfaceTest, NearKnotUsesCanonicalSpan)
+TEST(GeomGridEval_BSplineSurfaceTest, NearKnotUsesContainingSpan)
 {
   const occ::handle<Geom_BSplineSurface> aSurface = CreateMultiSpanBSplineSurface();
   GeomGridEval_BSplineSurface            anEvaluator(aSurface);
-  NCollection_Array1<double>             aUParams(2);
-  NCollection_Array1<double>             aVParams(1);
-  aUParams.ChangeAt(0) = 0.25;
-  aUParams.ChangeAt(1) = std::nextafter(0.5, 0.0);
-  aVParams.ChangeAt(0) = 0.25;
+  NCollection_Array1<double>             aUParams(7);
+  NCollection_Array1<double>             aVParams(7);
+  const double                           aParams[] =
+    {0.25, 0.4, std::nextafter(0.5, 0.0), 0.5, std::nextafter(0.5, 1.0), 0.6, 0.75};
+  for (size_t anIndex = 0; anIndex < 7; ++anIndex)
+  {
+    aUParams.ChangeAt(anIndex) = aParams[anIndex];
+    aVParams.ChangeAt(anIndex) = aParams[anIndex];
+  }
 
-  const NCollection_Array2<GeomGridEval::SurfD2> aGrid =
+  const NCollection_Array2<GeomGridEval::SurfD1> aD1 =
+    anEvaluator.EvaluateGridD1(aUParams, aVParams);
+  const NCollection_Array2<GeomGridEval::SurfD2> aD2 =
     anEvaluator.EvaluateGridD2(aUParams, aVParams);
-  const Geom_Surface::ResD2   anExpected = aSurface->EvalD2(aUParams.At(1), aVParams.At(0));
-  const GeomGridEval::SurfD2& aResult    = aGrid.At(1);
-  EXPECT_NEAR(aResult.Point.Distance(anExpected.Point), 0.0, THE_TOLERANCE);
-  EXPECT_NEAR((aResult.D1U - anExpected.D1U).Magnitude(), 0.0, THE_TOLERANCE);
-  EXPECT_NEAR((aResult.D1V - anExpected.D1V).Magnitude(), 0.0, THE_TOLERANCE);
-  EXPECT_NEAR((aResult.D2U - anExpected.D2U).Magnitude(), 0.0, THE_TOLERANCE);
-  EXPECT_NEAR((aResult.D2V - anExpected.D2V).Magnitude(), 0.0, THE_TOLERANCE);
-  EXPECT_NEAR((aResult.D2UV - anExpected.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
+  for (size_t aUIndex = 0; aUIndex < aUParams.Size(); ++aUIndex)
+  {
+    for (size_t aVIndex = 0; aVIndex < aVParams.Size(); ++aVIndex)
+    {
+      const size_t              anIndex = aUIndex * aVParams.Size() + aVIndex;
+      const Geom_Surface::ResD1 anExpectedD1 =
+        aSurface->EvalD1(aUParams.At(aUIndex), aVParams.At(aVIndex));
+      const Geom_Surface::ResD2 anExpectedD2 =
+        aSurface->EvalD2(aUParams.At(aUIndex), aVParams.At(aVIndex));
+      const GeomGridEval::SurfD1& aResultD1 = aD1.At(anIndex);
+      const GeomGridEval::SurfD2& aResultD2 = aD2.At(anIndex);
+      EXPECT_NEAR(aResultD1.Point.Distance(anExpectedD1.Point), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD1.D1U - anExpectedD1.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD1.D1V - anExpectedD1.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR(aResultD2.Point.Distance(anExpectedD2.Point), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD2.D1U - anExpectedD2.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD2.D1V - anExpectedD2.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD2.D2U - anExpectedD2.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD2.D2V - anExpectedD2.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResultD2.D2UV - anExpectedD2.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
+    }
+  }
+
+  const Geom_Surface::ResD1 aULeft  = aSurface->EvalD1(aParams[2], 0.25);
+  const Geom_Surface::ResD1 aUAt    = aSurface->EvalD1(aParams[3], 0.25);
+  const Geom_Surface::ResD1 aURight = aSurface->EvalD1(aParams[4], 0.25);
+  EXPECT_GT((aULeft.D1U - aUAt.D1U).Magnitude(), 1.0);
+  EXPECT_NEAR((aURight.D1U - aUAt.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+
+  const Geom_Surface::ResD1 aVLeft  = aSurface->EvalD1(0.25, aParams[2]);
+  const Geom_Surface::ResD1 aVAt    = aSurface->EvalD1(0.25, aParams[3]);
+  const Geom_Surface::ResD1 aVRight = aSurface->EvalD1(0.25, aParams[4]);
+  EXPECT_GT((aVLeft.D1V - aVAt.D1V).Magnitude(), 1.0);
+  EXPECT_NEAR((aVRight.D1V - aVAt.D1V).Magnitude(), 0.0, THE_TOLERANCE);
 }
 
 TEST(GeomGridEval_BSplineSurfaceTest, HigherDegree)

--- a/src/ModelingData/TKG3d/GTests/GeomGridEval_BSplineSurface_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomGridEval_BSplineSurface_Test.cxx
@@ -160,6 +160,32 @@ TEST(GeomGridEval_BSplineSurfaceTest, BasicEvaluation)
   }
 }
 
+TEST(GeomGridEval_BSplineSurfaceTest, SinglePointSpanBlock)
+{
+  const occ::handle<Geom_BSplineSurface> aSurface = CreateMultiSpanBSplineSurface();
+  GeomGridEval_BSplineSurface            anEvaluator(aSurface);
+  NCollection_Array1<double>             aUParams(1);
+  NCollection_Array1<double>             aVParams(1);
+  aUParams.ChangeAt(0) = 0.37;
+  aVParams.ChangeAt(0) = 0.63;
+
+  const gp_Pnt               aPoint       = anEvaluator.EvaluateGrid(aUParams, aVParams).At(0);
+  const GeomGridEval::SurfD1 aD1          = anEvaluator.EvaluateGridD1(aUParams, aVParams).At(0);
+  const GeomGridEval::SurfD2 aD2          = anEvaluator.EvaluateGridD2(aUParams, aVParams).At(0);
+  const Geom_Surface::ResD1  anExpectedD1 = aSurface->EvalD1(0.37, 0.63);
+  const Geom_Surface::ResD2  anExpectedD2 = aSurface->EvalD2(0.37, 0.63);
+  EXPECT_NEAR(aPoint.Distance(anExpectedD1.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR(aD1.Point.Distance(anExpectedD1.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD1.D1U - anExpectedD1.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD1.D1V - anExpectedD1.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR(aD2.Point.Distance(anExpectedD2.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D1U - anExpectedD2.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D1V - anExpectedD2.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D2U - anExpectedD2.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D2V - anExpectedD2.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D2UV - anExpectedD2.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
+}
+
 TEST(GeomGridEval_BSplineSurfaceTest, CornerPoints)
 {
   occ::handle<Geom_BSplineSurface> aSurf = CreateSimpleBSplineSurface();
@@ -221,6 +247,79 @@ TEST(GeomGridEval_BSplineSurfaceTest, MultiSpanSurface)
       EXPECT_NEAR(aGrid.Value(iU, iV).Distance(aExpected), 0.0, THE_TOLERANCE);
     }
   }
+}
+
+TEST(GeomGridEval_BSplineSurfaceTest, UnorderedParametersAcrossSpans)
+{
+  const occ::handle<Geom_BSplineSurface> aSurface = CreateMultiSpanBSplineSurface();
+  GeomGridEval_BSplineSurface            anEvaluator(aSurface);
+  NCollection_Array1<double>             aUParams(4);
+  NCollection_Array1<double>             aVParams(4);
+  aUParams.ChangeAt(0) = 0.8;
+  aUParams.ChangeAt(1) = 0.2;
+  aUParams.ChangeAt(2) = 0.65;
+  aUParams.ChangeAt(3) = 0.35;
+  aVParams.ChangeAt(0) = 0.3;
+  aVParams.ChangeAt(1) = 0.7;
+  aVParams.ChangeAt(2) = 0.15;
+  aVParams.ChangeAt(3) = 0.85;
+
+  const NCollection_Array2<gp_Pnt> aPoints = anEvaluator.EvaluateGrid(aUParams, aVParams);
+  const NCollection_Array2<GeomGridEval::SurfD1> aD1 =
+    anEvaluator.EvaluateGridD1(aUParams, aVParams);
+  const NCollection_Array2<GeomGridEval::SurfD2> aD2 =
+    anEvaluator.EvaluateGridD2(aUParams, aVParams);
+  const NCollection_Array2<GeomGridEval::SurfD3> aD3 =
+    anEvaluator.EvaluateGridD3(aUParams, aVParams);
+  const NCollection_Array2<gp_Vec> aDN = anEvaluator.EvaluateGridDN(aUParams, aVParams, 1, 1);
+  for (size_t i = 0; i < aUParams.Size(); ++i)
+  {
+    for (size_t j = 0; j < aVParams.Size(); ++j)
+    {
+      const Geom_Surface::ResD2 anExpected = aSurface->EvalD2(aUParams.At(i), aVParams.At(j));
+      const size_t              anIndex    = i * aVParams.Size() + j;
+      EXPECT_NEAR(aPoints.At(anIndex).Distance(anExpected.Point), 0.0, THE_TOLERANCE);
+      const GeomGridEval::SurfD1& aD1Value     = aD1.At(anIndex);
+      const GeomGridEval::SurfD2& aD2Value     = aD2.At(anIndex);
+      const Geom_Surface::ResD3   anExpectedD3 = aSurface->EvalD3(aUParams.At(i), aVParams.At(j));
+      EXPECT_NEAR(aD1Value.Point.Distance(anExpected.Point), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD1Value.D1U - anExpected.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD1Value.D1V - anExpected.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR(aD2Value.Point.Distance(anExpected.Point), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD2Value.D1U - anExpected.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD2Value.D1V - anExpected.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD2Value.D2U - anExpected.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD2Value.D2V - anExpected.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD2Value.D2UV - anExpected.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aD3.At(anIndex).D3U - anExpectedD3.D3U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR(
+        (aDN.At(anIndex) - aSurface->EvalDN(aUParams.At(i), aVParams.At(j), 1, 1)).Magnitude(),
+        0.0,
+        THE_TOLERANCE);
+    }
+  }
+}
+
+TEST(GeomGridEval_BSplineSurfaceTest, NearKnotUsesCanonicalSpan)
+{
+  const occ::handle<Geom_BSplineSurface> aSurface = CreateMultiSpanBSplineSurface();
+  GeomGridEval_BSplineSurface            anEvaluator(aSurface);
+  NCollection_Array1<double>             aUParams(2);
+  NCollection_Array1<double>             aVParams(1);
+  aUParams.ChangeAt(0) = 0.25;
+  aUParams.ChangeAt(1) = std::nextafter(0.5, 0.0);
+  aVParams.ChangeAt(0) = 0.25;
+
+  const NCollection_Array2<GeomGridEval::SurfD2> aGrid =
+    anEvaluator.EvaluateGridD2(aUParams, aVParams);
+  const Geom_Surface::ResD2   anExpected = aSurface->EvalD2(aUParams.At(1), aVParams.At(0));
+  const GeomGridEval::SurfD2& aResult    = aGrid.At(1);
+  EXPECT_NEAR(aResult.Point.Distance(anExpected.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aResult.D1U - anExpected.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aResult.D1V - anExpected.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aResult.D2U - anExpected.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aResult.D2V - anExpected.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aResult.D2UV - anExpected.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
 }
 
 TEST(GeomGridEval_BSplineSurfaceTest, HigherDegree)
@@ -432,6 +531,31 @@ TEST(GeomGridEval_BSplineSurfaceTest, DerivativeD2)
       EXPECT_NEAR((aGrid.Value(iU, iV).D2U - aD2U).Magnitude(), 0.0, THE_TOLERANCE);
       EXPECT_NEAR((aGrid.Value(iU, iV).D2V - aD2V).Magnitude(), 0.0, THE_TOLERANCE);
       EXPECT_NEAR((aGrid.Value(iU, iV).D2UV - aD2UV).Magnitude(), 0.0, THE_TOLERANCE);
+    }
+  }
+}
+
+TEST(GeomGridEval_BSplineSurfaceTest, DerivativeD2Rational)
+{
+  occ::handle<Geom_BSplineSurface> aSurf = CreateRationalBSplineSurface();
+  GeomGridEval_BSplineSurface      anEval(aSurf);
+  NCollection_Array1<double>       aParams = CreateUniformParams(0.0, 1.0, 7);
+
+  const NCollection_Array2<GeomGridEval::SurfD2> aGrid = anEval.EvaluateGridD2(aParams, aParams);
+  for (size_t aUIndex = 0; aUIndex < aParams.Size(); ++aUIndex)
+  {
+    for (size_t aVIndex = 0; aVIndex < aParams.Size(); ++aVIndex)
+    {
+      const Geom_Surface::ResD2 anExpected =
+        aSurf->EvalD2(aParams.At(aUIndex), aParams.At(aVIndex));
+      const size_t                anIndex = aUIndex * aParams.Size() + aVIndex;
+      const GeomGridEval::SurfD2& aResult = aGrid.At(anIndex);
+      EXPECT_NEAR(aResult.Point.Distance(anExpected.Point), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D1U - anExpected.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D1V - anExpected.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D2U - anExpected.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D2V - anExpected.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D2UV - anExpected.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
     }
   }
 }

--- a/src/ModelingData/TKG3d/GTests/GeomGridEval_BezierSurface_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomGridEval_BezierSurface_Test.cxx
@@ -484,16 +484,16 @@ TEST(GeomGridEval_BezierSurfaceTest, IsolineU_CompareToGeomD0)
   // U-isoline: 1 U param, multiple V params (triggers isoline path)
   NCollection_Array1<double> aUParams(1, 1);
   aUParams.SetValue(1, 0.5);
-  NCollection_Array1<double> aVParams = CreateUniformParams(0.0, 1.0, 10);
+  NCollection_Array1<double> aVParams = CreateUniformParams(0.0, 1.0, 192);
 
   NCollection_Array2<gp_Pnt> aGrid = anEval.EvaluateGrid(aUParams, aVParams);
 
   // Note: RowLength() = V count (columns), ColLength() = U count (rows)
-  EXPECT_EQ(aGrid.RowLength(), 10);
+  EXPECT_EQ(aGrid.RowLength(), 192);
   EXPECT_EQ(aGrid.ColLength(), 1);
 
   // Compare against Geom_Surface::D0
-  for (int j = 1; j <= 10; ++j)
+  for (int j = 1; j <= 192; ++j)
   {
     gp_Pnt aExpected;
     aBezier->D0(aUParams.Value(1), aVParams.Value(j), aExpected);
@@ -517,7 +517,7 @@ TEST(GeomGridEval_BezierSurfaceTest, IsolineV_CompareToGeomD0)
   GeomGridEval_BezierSurface      anEval(aBezier);
 
   // V-isoline: multiple U params, 1 V param (triggers isoline path)
-  NCollection_Array1<double> aUParams = CreateUniformParams(0.0, 1.0, 10);
+  NCollection_Array1<double> aUParams = CreateUniformParams(0.0, 1.0, 192);
   NCollection_Array1<double> aVParams(1, 1);
   aVParams.SetValue(1, 0.7);
 
@@ -525,10 +525,10 @@ TEST(GeomGridEval_BezierSurfaceTest, IsolineV_CompareToGeomD0)
 
   // Note: RowLength() = V count (columns), ColLength() = U count (rows)
   EXPECT_EQ(aGrid.RowLength(), 1);
-  EXPECT_EQ(aGrid.ColLength(), 10);
+  EXPECT_EQ(aGrid.ColLength(), 192);
 
   // Compare against Geom_Surface::D0
-  for (int i = 1; i <= 10; ++i)
+  for (int i = 1; i <= 192; ++i)
   {
     gp_Pnt aExpected;
     aBezier->D0(aUParams.Value(i), aVParams.Value(1), aExpected);
@@ -557,11 +557,11 @@ TEST(GeomGridEval_BezierSurfaceTest, IsolineRational_CompareToGeomD0)
   // U-isoline on rational surface
   NCollection_Array1<double> aUParams(1, 1);
   aUParams.SetValue(1, 0.3);
-  NCollection_Array1<double> aVParams = CreateUniformParams(0.0, 1.0, 15);
+  NCollection_Array1<double> aVParams = CreateUniformParams(0.0, 1.0, 16);
 
   NCollection_Array2<gp_Pnt> aGrid = anEval.EvaluateGrid(aUParams, aVParams);
 
-  for (int j = 1; j <= 15; ++j)
+  for (int j = 1; j <= 16; ++j)
   {
     gp_Pnt aExpected;
     aBezier->D0(aUParams.Value(1), aVParams.Value(j), aExpected);

--- a/src/ModelingData/TKG3d/GTests/GeomGridEval_BezierSurface_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomGridEval_BezierSurface_Test.cxx
@@ -68,6 +68,41 @@ TEST(GeomGridEval_BezierSurfaceTest, BasicEvaluation)
   }
 }
 
+TEST(GeomGridEval_BezierSurfaceTest, SinglePointGrid)
+{
+  NCollection_Array2<gp_Pnt> aPoles(1, 3, 1, 3);
+  for (int aUIndex = 1; aUIndex <= 3; ++aUIndex)
+  {
+    for (int aVIndex = 1; aVIndex <= 3; ++aVIndex)
+    {
+      aPoles.SetValue(aUIndex, aVIndex, gp_Pnt(aUIndex, aVIndex, std::sin(aUIndex + aVIndex)));
+    }
+  }
+
+  const occ::handle<Geom_BezierSurface> aSurface = new Geom_BezierSurface(aPoles);
+  GeomGridEval_BezierSurface            anEvaluator(aSurface);
+  NCollection_Array1<double>            aUParams(1);
+  NCollection_Array1<double>            aVParams(1);
+  aUParams.ChangeAt(0) = 0.37;
+  aVParams.ChangeAt(0) = 0.63;
+
+  const gp_Pnt               aPoint       = anEvaluator.EvaluateGrid(aUParams, aVParams).At(0);
+  const GeomGridEval::SurfD1 aD1          = anEvaluator.EvaluateGridD1(aUParams, aVParams).At(0);
+  const GeomGridEval::SurfD2 aD2          = anEvaluator.EvaluateGridD2(aUParams, aVParams).At(0);
+  const Geom_Surface::ResD1  anExpectedD1 = aSurface->EvalD1(0.37, 0.63);
+  const Geom_Surface::ResD2  anExpectedD2 = aSurface->EvalD2(0.37, 0.63);
+  EXPECT_NEAR(aPoint.Distance(anExpectedD1.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR(aD1.Point.Distance(anExpectedD1.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD1.D1U - anExpectedD1.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD1.D1V - anExpectedD1.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR(aD2.Point.Distance(anExpectedD2.Point), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D1U - anExpectedD2.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D1V - anExpectedD2.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D2U - anExpectedD2.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D2V - anExpectedD2.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+  EXPECT_NEAR((aD2.D2UV - anExpectedD2.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
+}
+
 TEST(GeomGridEval_BezierSurfaceTest, RationalEvaluation)
 {
   // Rational Bezier surface
@@ -161,6 +196,41 @@ TEST(GeomGridEval_BezierSurfaceTest, DerivativeD2)
       EXPECT_NEAR((aGrid.Value(i, j).D2U - aD2U).Magnitude(), 0.0, THE_TOLERANCE);
       EXPECT_NEAR((aGrid.Value(i, j).D2V - aD2V).Magnitude(), 0.0, THE_TOLERANCE);
       EXPECT_NEAR((aGrid.Value(i, j).D2UV - aD2UV).Magnitude(), 0.0, THE_TOLERANCE);
+    }
+  }
+}
+
+TEST(GeomGridEval_BezierSurfaceTest, DerivativeD2RationalLinear)
+{
+  NCollection_Array2<gp_Pnt> aPoles(1, 2, 1, 2);
+  NCollection_Array2<double> aWeights(1, 2, 1, 2);
+  aPoles.SetValue(1, 1, gp_Pnt(0.0, 0.0, 0.0));
+  aPoles.SetValue(2, 1, gp_Pnt(1.0, 0.0, 0.0));
+  aPoles.SetValue(1, 2, gp_Pnt(0.0, 1.0, 0.0));
+  aPoles.SetValue(2, 2, gp_Pnt(1.0, 1.0, 1.0));
+  aWeights.SetValue(1, 1, 1.0);
+  aWeights.SetValue(2, 1, 1.5);
+  aWeights.SetValue(1, 2, 2.0);
+  aWeights.SetValue(2, 2, 0.75);
+
+  const occ::handle<Geom_BezierSurface> aSurface = new Geom_BezierSurface(aPoles, aWeights);
+  GeomGridEval_BezierSurface            anEval(aSurface);
+  NCollection_Array1<double>            aParams        = CreateUniformParams(0.0, 1.0, 7);
+  const NCollection_Array2<GeomGridEval::SurfD2> aGrid = anEval.EvaluateGridD2(aParams, aParams);
+  for (size_t aUIndex = 0; aUIndex < aParams.Size(); ++aUIndex)
+  {
+    for (size_t aVIndex = 0; aVIndex < aParams.Size(); ++aVIndex)
+    {
+      const Geom_Surface::ResD2 anExpected =
+        aSurface->EvalD2(aParams.At(aUIndex), aParams.At(aVIndex));
+      const size_t                anIndex = aUIndex * aParams.Size() + aVIndex;
+      const GeomGridEval::SurfD2& aResult = aGrid.At(anIndex);
+      EXPECT_NEAR(aResult.Point.Distance(anExpected.Point), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D1U - anExpected.D1U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D1V - anExpected.D1V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D2U - anExpected.D2U).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D2V - anExpected.D2V).Magnitude(), 0.0, THE_TOLERANCE);
+      EXPECT_NEAR((aResult.D2UV - anExpected.D2UV).Magnitude(), 0.0, THE_TOLERANCE);
     }
   }
 }

--- a/src/ModelingData/TKG3d/Geom/Geom_BSplineSurface_1.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BSplineSurface_1.cxx
@@ -157,11 +157,22 @@ Geom_Surface::ResD1 Geom_BSplineSurface::EvalD1(const double U, const double V) 
 
   int uindex = 0, vindex = 0;
 
-  BSplCLib::LocateParameter(myUDeg, myUKnots, &myUMults, U, myUPeriodic, uindex, aNewU);
-  uindex = BSplCLib::FlatIndex(myUDeg, uindex, myUMults, myUPeriodic);
+  // Flat knots preserve side-specific span selection near repeated knots.
+  BSplCLib::LocateParameter(myUDeg,
+                            myUFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myUPeriodic,
+                            uindex,
+                            aNewU);
 
-  BSplCLib::LocateParameter(myVDeg, myVKnots, &myVMults, V, myVPeriodic, vindex, aNewV);
-  vindex = BSplCLib::FlatIndex(myVDeg, vindex, myVMults, myVPeriodic);
+  BSplCLib::LocateParameter(myVDeg,
+                            myVFlatKnots,
+                            BSplCLib::NoMults(),
+                            V,
+                            myVPeriodic,
+                            vindex,
+                            aNewV);
 
   Geom_Surface::ResD1 aResult;
   BSplSLib::D1(aNewU,
@@ -202,11 +213,22 @@ Geom_Surface::ResD2 Geom_BSplineSurface::EvalD2(const double U, const double V) 
 
   int uindex = 0, vindex = 0;
 
-  BSplCLib::LocateParameter(myUDeg, myUKnots, &myUMults, U, myUPeriodic, uindex, aNewU);
-  uindex = BSplCLib::FlatIndex(myUDeg, uindex, myUMults, myUPeriodic);
+  // Flat knots preserve side-specific span selection near repeated knots.
+  BSplCLib::LocateParameter(myUDeg,
+                            myUFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myUPeriodic,
+                            uindex,
+                            aNewU);
 
-  BSplCLib::LocateParameter(myVDeg, myVKnots, &myVMults, V, myVPeriodic, vindex, aNewV);
-  vindex = BSplCLib::FlatIndex(myVDeg, vindex, myVMults, myVPeriodic);
+  BSplCLib::LocateParameter(myVDeg,
+                            myVFlatKnots,
+                            BSplCLib::NoMults(),
+                            V,
+                            myVPeriodic,
+                            vindex,
+                            aNewV);
 
   Geom_Surface::ResD2 aResult;
   BSplSLib::D2(aNewU,

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
@@ -179,17 +179,17 @@ NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&               
   SpanBlocks                  aUBlocks(aNbU);
   SpanBlocks                  aVBlocks(aNbV);
   const size_t                aNbUBlocks = prepareSpanBlocks(theUParams,
-                                                             *theData.UFlatKnots,
-                                                             theData.UDegree,
-                                                             theData.IsUPeriodic,
-                                                             aPreparedU,
-                                                             aUBlocks);
+                                              *theData.UFlatKnots,
+                                              theData.UDegree,
+                                              theData.IsUPeriodic,
+                                              aPreparedU,
+                                              aUBlocks);
   const size_t                aNbVBlocks = prepareSpanBlocks(theVParams,
-                                                             *theData.VFlatKnots,
-                                                             theData.VDegree,
-                                                             theData.IsVPeriodic,
-                                                             aPreparedV,
-                                                             aVBlocks);
+                                              *theData.VFlatKnots,
+                                              theData.VDegree,
+                                              theData.IsVPeriodic,
+                                              aPreparedV,
+                                              aVBlocks);
   occ::handle<BSplSLib_Cache> aCache;
 
   for (size_t aUBlockIndex = 0; aUBlockIndex < aNbUBlocks; ++aUBlockIndex)

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
@@ -155,17 +155,17 @@ NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&               
   SpanBlocks                  aUBlocks(aNbU);
   SpanBlocks                  aVBlocks(aNbV);
   const size_t                aNbUBlocks = prepareSpanBlocks(theUParams,
-                                                             *theData.UFlatKnots,
-                                                             theData.UDegree,
-                                                             theData.IsUPeriodic,
-                                                             aPreparedU,
-                                                             aUBlocks);
+                                              *theData.UFlatKnots,
+                                              theData.UDegree,
+                                              theData.IsUPeriodic,
+                                              aPreparedU,
+                                              aUBlocks);
   const size_t                aNbVBlocks = prepareSpanBlocks(theVParams,
-                                                             *theData.VFlatKnots,
-                                                             theData.VDegree,
-                                                             theData.IsVPeriodic,
-                                                             aPreparedV,
-                                                             aVBlocks);
+                                              *theData.VFlatKnots,
+                                              theData.VDegree,
+                                              theData.IsVPeriodic,
+                                              aPreparedV,
+                                              aVBlocks);
   occ::handle<BSplSLib_Cache> aCache;
 
   for (size_t aUBlockIndex = 0; aUBlockIndex < aNbUBlocks; ++aUBlockIndex)

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
@@ -18,13 +18,13 @@
 #include <gp_Pnt.hxx>
 #include <NCollection_Array1.hxx>
 #include <NCollection_Array2.hxx>
+#include <NCollection_LocalArray.hxx>
 
 namespace
 {
 
-//! Threshold for using cache vs direct evaluation.
-//! For small spans (few points), direct BSplSLib evaluation is faster than building cache.
-constexpr int THE_CACHE_THRESHOLD = 2;
+//! Cache construction is amortized only for span blocks containing at least two grid points.
+constexpr size_t THE_CACHE_THRESHOLD = 2;
 
 //! Helper structure holding extracted B-spline surface data.
 struct SurfaceData
@@ -80,65 +80,6 @@ inline void locateSpan(double                            theParam,
                             theAdjustedParam);
 }
 
-//! Count consecutive parameters in the same span (for cache threshold decision).
-//! For non-periodic cases, uses a fast knot-boundary comparison instead of
-//! calling BSplCLib::LocateParameter for every subsequent parameter.
-inline int countSpanSize(const NCollection_Array1<double>& theParams,
-                         const NCollection_Array1<double>& theFlatKnots,
-                         int                               theDegree,
-                         bool                              theIsPeriodic,
-                         int                               theStartIdx,
-                         int                               theTargetSpan)
-{
-  const int aLower = theParams.Lower();
-  const int aNb    = theParams.Length();
-  int       aCount = 1;
-
-  if (!theIsPeriodic)
-  {
-    // Fast path: params are sorted (ascending from grid construction),
-    // so just compare against the next knot boundary.
-    if (theTargetSpan + 1 > theFlatKnots.Upper())
-    {
-      return aCount;
-    }
-    const double aNextKnot = theFlatKnots.Value(theTargetSpan + 1);
-    for (int i = theStartIdx + 1; i < aNb; ++i)
-    {
-      if (theParams.Value(aLower + i) >= aNextKnot)
-      {
-        break;
-      }
-      ++aCount;
-    }
-    return aCount;
-  }
-
-  // Periodic fallback: span assignment requires full LocateParameter.
-  for (int i = theStartIdx + 1; i < aNb; ++i)
-  {
-    double aParam    = theParams.Value(aLower + i);
-    double aAdjusted = aParam;
-    int    aSpan     = 0;
-    BSplCLib::LocateParameter(theDegree,
-                              theFlatKnots,
-                              BSplCLib::NoMults(),
-                              aParam,
-                              theIsPeriodic,
-                              aSpan,
-                              aAdjusted);
-    if (aSpan == theTargetSpan)
-    {
-      ++aCount;
-    }
-    else
-    {
-      break;
-    }
-  }
-  return aCount;
-}
-
 //! Compute span local parameter coefficients (mid and half-length).
 inline void computeSpanCoeffs(const NCollection_Array1<double>& theFlatKnots,
                               int                               theSpan,
@@ -150,130 +91,136 @@ inline void computeSpanCoeffs(const NCollection_Array1<double>& theFlatKnots,
   theMid              = aStart + theHalfLen;
 }
 
-//! Template helper for cached grid evaluation (D0, D1, D2).
-//! @tparam ResultT result type (gp_Pnt, SurfD1, SurfD2)
-//! @tparam CacheEvalF functor: (cache, localU, localV, result) -> void
-//! @tparam DirectEvalF functor: (data, adjU, adjV, uSpan, vSpan, result) -> void
-template <typename ResultT, typename CacheEvalF, typename DirectEvalF>
-NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&                theData,
-                                               const NCollection_Array1<double>& theUParams,
-                                               const NCollection_Array1<double>& theVParams,
-                                               CacheEvalF                        theCacheEval,
-                                               DirectEvalF                       theDirectEval)
+struct SpanBlock
 {
-  const int aNbU  = theUParams.Length();
-  const int aNbV  = theVParams.Length();
-  const int aLowU = theUParams.Lower();
-  const int aLowV = theVParams.Lower();
+  size_t Start;
+  size_t Count;
+  int    Span;
+};
 
-  NCollection_Array2<ResultT> aGrid(1, aNbU, 1, aNbV);
-  occ::handle<BSplSLib_Cache> aCache = new BSplSLib_Cache(theData.UDegree,
-                                                          theData.IsUPeriodic,
-                                                          *theData.UFlatKnots,
-                                                          theData.VDegree,
-                                                          theData.IsVPeriodic,
-                                                          *theData.VFlatKnots,
-                                                          theData.Weights);
+struct PreparedParam
+{
+  double Adjusted;
+  double Local;
+};
 
-  int    aPrevUSpan    = -1;
-  int    aUSpanSize    = 0;
-  double aUSpanMid     = 0.0;
-  double aUSpanHalfLen = 1.0;
-  double aUSpanEnd     = 0.0; // upper flat-knot boundary of current U span
+using PreparedParams = NCollection_LocalArray<PreparedParam, 64>;
+using SpanBlocks     = NCollection_LocalArray<SpanBlock, 32>;
 
-  for (int ui = 0; ui < aNbU; ++ui)
+size_t prepareSpanBlocks(const NCollection_Array1<double>& theParams,
+                         const NCollection_Array1<double>& theFlatKnots,
+                         const int                         theDegree,
+                         const bool                        theIsPeriodic,
+                         PreparedParams&                   thePreparedParams,
+                         SpanBlocks&                       theBlocks)
+{
+  const size_t aNbParams     = theParams.Size();
+  size_t       aNbBlocks     = 0;
+  int          aPreviousSpan = -1;
+  double       aMid          = 0.0;
+  double       aHalfLen      = 1.0;
+  for (size_t anIndex = 0; anIndex < aNbParams; ++anIndex)
   {
-    const double aU     = theUParams.Value(aLowU + ui);
-    double       aAdjU  = aU;
-    int          aUSpan = 0;
-
-    // Skip locateSpan when parameter is still within current U span.
-    if (!theData.IsUPeriodic && aPrevUSpan >= 0 && aU < aUSpanEnd)
+    double anAdjusted = theParams.At(anIndex);
+    int    aSpan      = 0;
+    locateSpan(anAdjusted, theFlatKnots, theDegree, theIsPeriodic, anAdjusted, aSpan);
+    if (aSpan != aPreviousSpan)
     {
-      aAdjU  = aU;
-      aUSpan = aPrevUSpan;
+      computeSpanCoeffs(theFlatKnots, aSpan, aMid, aHalfLen);
+      theBlocks[aNbBlocks++] = {anIndex, 1, aSpan};
+      aPreviousSpan          = aSpan;
     }
     else
     {
-      locateSpan(aU, *theData.UFlatKnots, theData.UDegree, theData.IsUPeriodic, aAdjU, aUSpan);
+      ++theBlocks[aNbBlocks - 1].Count;
     }
+    thePreparedParams[anIndex] = {anAdjusted, (anAdjusted - aMid) / aHalfLen};
+  }
+  return aNbBlocks;
+}
 
-    if (aUSpan != aPrevUSpan)
+//! Evaluates Cartesian parameter blocks, using the cache only when its construction is amortized.
+template <typename ResultT, typename CacheEvaluator, typename DirectEvaluator>
+NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&                theData,
+                                               const NCollection_Array1<double>& theUParams,
+                                               const NCollection_Array1<double>& theVParams,
+                                               CacheEvaluator&&                  theCacheEvaluator,
+                                               DirectEvaluator&&                 theDirectEvaluator)
+{
+  const size_t                aNbU = theUParams.Size();
+  const size_t                aNbV = theVParams.Size();
+  NCollection_Array2<ResultT> aGrid(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
+  PreparedParams              aPreparedU(aNbU);
+  PreparedParams              aPreparedV(aNbV);
+  SpanBlocks                  aUBlocks(aNbU);
+  SpanBlocks                  aVBlocks(aNbV);
+  const size_t                aNbUBlocks = prepareSpanBlocks(theUParams,
+                                                             *theData.UFlatKnots,
+                                                             theData.UDegree,
+                                                             theData.IsUPeriodic,
+                                                             aPreparedU,
+                                                             aUBlocks);
+  const size_t                aNbVBlocks = prepareSpanBlocks(theVParams,
+                                                             *theData.VFlatKnots,
+                                                             theData.VDegree,
+                                                             theData.IsVPeriodic,
+                                                             aPreparedV,
+                                                             aVBlocks);
+  occ::handle<BSplSLib_Cache> aCache;
+
+  for (size_t aUBlockIndex = 0; aUBlockIndex < aNbUBlocks; ++aUBlockIndex)
+  {
+    const SpanBlock& aUBlock = aUBlocks[aUBlockIndex];
+    for (size_t aVBlockIndex = 0; aVBlockIndex < aNbVBlocks; ++aVBlockIndex)
     {
-      aPrevUSpan = aUSpan;
-      aUSpanEnd  = theData.UFlatKnots->Value(aUSpan + 1);
-      aUSpanSize = countSpanSize(theUParams,
-                                 *theData.UFlatKnots,
-                                 theData.UDegree,
-                                 theData.IsUPeriodic,
-                                 ui,
-                                 aUSpan);
-      computeSpanCoeffs(*theData.UFlatKnots, aUSpan, aUSpanMid, aUSpanHalfLen);
-    }
-
-    int    aPrevVSpan    = -1;
-    int    aVSpanSize    = 0;
-    double aVSpanMid     = 0.0;
-    double aVSpanHalfLen = 1.0;
-    bool   aUseCache     = false;
-    double aVSpanEnd     = 0.0; // upper flat-knot boundary of current V span
-
-    for (int vi = 0; vi < aNbV; ++vi)
-    {
-      const double aV     = theVParams.Value(aLowV + vi);
-      double       aAdjV  = aV;
-      int          aVSpan = 0;
-
-      // Skip locateSpan when parameter is still within current V span.
-      if (!theData.IsVPeriodic && aPrevVSpan >= 0 && aV < aVSpanEnd)
+      const SpanBlock& aVBlock = aVBlocks[aVBlockIndex];
+      const bool       isCacheUsed =
+        aUBlock.Count >= THE_CACHE_THRESHOLD || aVBlock.Count >= THE_CACHE_THRESHOLD;
+      if (isCacheUsed)
       {
-        aAdjV  = aV;
-        aVSpan = aPrevVSpan;
-      }
-      else
-      {
-        locateSpan(aV, *theData.VFlatKnots, theData.VDegree, theData.IsVPeriodic, aAdjV, aVSpan);
-      }
-
-      if (aVSpan != aPrevVSpan)
-      {
-        aPrevVSpan = aVSpan;
-        aVSpanEnd  = theData.VFlatKnots->Value(aVSpan + 1);
-        aVSpanSize = countSpanSize(theVParams,
-                                   *theData.VFlatKnots,
-                                   theData.VDegree,
-                                   theData.IsVPeriodic,
-                                   vi,
-                                   aVSpan);
-        computeSpanCoeffs(*theData.VFlatKnots, aVSpan, aVSpanMid, aVSpanHalfLen);
-
-        aUseCache = (aUSpanSize * aVSpanSize >= THE_CACHE_THRESHOLD);
-        if (aUseCache)
+        if (aCache.IsNull())
         {
-          aCache->BuildCache(aAdjU,
-                             aAdjV,
-                             *theData.UFlatKnots,
-                             *theData.VFlatKnots,
-                             *theData.Poles,
-                             theData.Weights);
+          aCache = new BSplSLib_Cache(theData.UDegree,
+                                      theData.IsUPeriodic,
+                                      *theData.UFlatKnots,
+                                      theData.VDegree,
+                                      theData.IsVPeriodic,
+                                      *theData.VFlatKnots,
+                                      theData.Weights);
+        }
+        aCache->BuildCache(aPreparedU[aUBlock.Start].Adjusted,
+                           aPreparedV[aVBlock.Start].Adjusted,
+                           *theData.UFlatKnots,
+                           *theData.VFlatKnots,
+                           *theData.Poles,
+                           theData.Weights);
+      }
+
+      for (size_t aUIndex = aUBlock.Start; aUIndex < aUBlock.Start + aUBlock.Count; ++aUIndex)
+      {
+        for (size_t aVIndex = aVBlock.Start; aVIndex < aVBlock.Start + aVBlock.Count; ++aVIndex)
+        {
+          ResultT& aResult = aGrid.ChangeAt(aUIndex * aNbV + aVIndex);
+          if (isCacheUsed)
+          {
+            theCacheEvaluator(*aCache,
+                              aPreparedU[aUIndex].Local,
+                              aPreparedV[aVIndex].Local,
+                              aResult);
+          }
+          else
+          {
+            theDirectEvaluator(theData,
+                               aPreparedU[aUIndex].Adjusted,
+                               aPreparedV[aVIndex].Adjusted,
+                               aUBlock.Span,
+                               aVBlock.Span,
+                               aResult);
+          }
         }
       }
-
-      ResultT aResult;
-      if (aUseCache)
-      {
-        const double aLocalU = (aAdjU - aUSpanMid) / aUSpanHalfLen;
-        const double aLocalV = (aAdjV - aVSpanMid) / aVSpanHalfLen;
-        theCacheEval(aCache, aLocalU, aLocalV, aResult);
-      }
-      else
-      {
-        theDirectEval(theData, aAdjU, aAdjV, aUSpan, aVSpan, aResult);
-      }
-      aGrid.SetValue(ui + 1, vi + 1, aResult);
     }
   }
-
   return aGrid;
 }
 
@@ -286,23 +233,22 @@ NCollection_Array2<ResultT> evaluateGridDirect(const SurfaceData&               
                                                const NCollection_Array1<double>& theVParams,
                                                EvalF                             theEval)
 {
-  const int aNbU  = theUParams.Length();
-  const int aNbV  = theVParams.Length();
-  const int aLowU = theUParams.Lower();
-  const int aLowV = theVParams.Lower();
+  const size_t aNbU = theUParams.Size();
+  const size_t aNbV = theVParams.Size();
 
-  NCollection_Array2<ResultT> aGrid(1, aNbU, 1, aNbV);
+  NCollection_Array2<ResultT> aGrid(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
 
-  int    aPrevUSpan = -1;
-  double aUSpanEnd  = 0.0;
+  int    aPrevUSpan  = -1;
+  double aUSpanStart = 0.0;
+  double aUSpanEnd   = 0.0;
 
-  for (int ui = 0; ui < aNbU; ++ui)
+  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
   {
-    const double aU     = theUParams.Value(aLowU + ui);
+    const double aU     = theUParams.At(aUIndex);
     double       aAdjU  = aU;
     int          aUSpan = 0;
 
-    if (!theData.IsUPeriodic && aPrevUSpan >= 0 && aU < aUSpanEnd)
+    if (!theData.IsUPeriodic && aPrevUSpan >= 0 && aU >= aUSpanStart && aU < aUSpanEnd)
     {
       aAdjU  = aU;
       aUSpan = aPrevUSpan;
@@ -313,20 +259,22 @@ NCollection_Array2<ResultT> evaluateGridDirect(const SurfaceData&               
     }
     if (aUSpan != aPrevUSpan)
     {
-      aPrevUSpan = aUSpan;
-      aUSpanEnd  = theData.UFlatKnots->Value(aUSpan + 1);
+      aPrevUSpan  = aUSpan;
+      aUSpanStart = theData.UFlatKnots->Value(aUSpan);
+      aUSpanEnd   = theData.UFlatKnots->Value(aUSpan + 1);
     }
 
-    int    aPrevVSpan = -1;
-    double aVSpanEnd  = 0.0;
+    int    aPrevVSpan  = -1;
+    double aVSpanStart = 0.0;
+    double aVSpanEnd   = 0.0;
 
-    for (int vi = 0; vi < aNbV; ++vi)
+    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
     {
-      const double aV     = theVParams.Value(aLowV + vi);
+      const double aV     = theVParams.At(aVIndex);
       double       aAdjV  = aV;
       int          aVSpan = 0;
 
-      if (!theData.IsVPeriodic && aPrevVSpan >= 0 && aV < aVSpanEnd)
+      if (!theData.IsVPeriodic && aPrevVSpan >= 0 && aV >= aVSpanStart && aV < aVSpanEnd)
       {
         aAdjV  = aV;
         aVSpan = aPrevVSpan;
@@ -337,13 +285,14 @@ NCollection_Array2<ResultT> evaluateGridDirect(const SurfaceData&               
       }
       if (aVSpan != aPrevVSpan)
       {
-        aPrevVSpan = aVSpan;
-        aVSpanEnd  = theData.VFlatKnots->Value(aVSpan + 1);
+        aPrevVSpan  = aVSpan;
+        aVSpanStart = theData.VFlatKnots->Value(aVSpan);
+        aVSpanEnd   = theData.VFlatKnots->Value(aVSpan + 1);
       }
 
       ResultT aResult;
       theEval(theData, aAdjU, aAdjV, aUSpan, aVSpan, aResult);
-      aGrid.SetValue(ui + 1, vi + 1, aResult);
+      aGrid.ChangeAt(aUIndex * aNbV + aVIndex) = aResult;
     }
   }
 
@@ -368,12 +317,9 @@ NCollection_Array2<gp_Pnt> GeomGridEval_BSplineSurface::EvaluateGrid(
     aData,
     theUParams,
     theVParams,
-    // Cache evaluation
-    [](const occ::handle<BSplSLib_Cache>& theCache,
-       double                             theLocalU,
-       double                             theLocalV,
-       gp_Pnt& theResult) { theCache->D0Local(theLocalU, theLocalV, theResult); },
-    // Direct evaluation
+    [](const BSplSLib_Cache& theCache, double theLocalU, double theLocalV, gp_Pnt& theResult) {
+      theCache.D0Local(theLocalU, theLocalV, theResult);
+    },
     [](const SurfaceData& theData,
        double             theU,
        double             theV,
@@ -411,19 +357,16 @@ NCollection_Array2<GeomGridEval::SurfD1> GeomGridEval_BSplineSurface::EvaluateGr
   {
     return NCollection_Array2<GeomGridEval::SurfD1>();
   }
-
   return evaluateGridCached<GeomGridEval::SurfD1>(
     aData,
     theUParams,
     theVParams,
-    // Cache evaluation
-    [](const occ::handle<BSplSLib_Cache>& theCache,
-       double                             theLocalU,
-       double                             theLocalV,
-       GeomGridEval::SurfD1&              theResult) {
-      theCache->D1Local(theLocalU, theLocalV, theResult.Point, theResult.D1U, theResult.D1V);
+    [](const BSplSLib_Cache& theCache,
+       double                theLocalU,
+       double                theLocalV,
+       GeomGridEval::SurfD1& theResult) {
+      theCache.D1Local(theLocalU, theLocalV, theResult.Point, theResult.D1U, theResult.D1V);
     },
-    // Direct evaluation
     [](const SurfaceData&    theData,
        double                theU,
        double                theV,
@@ -463,26 +406,23 @@ NCollection_Array2<GeomGridEval::SurfD2> GeomGridEval_BSplineSurface::EvaluateGr
   {
     return NCollection_Array2<GeomGridEval::SurfD2>();
   }
-
   return evaluateGridCached<GeomGridEval::SurfD2>(
     aData,
     theUParams,
     theVParams,
-    // Cache evaluation
-    [](const occ::handle<BSplSLib_Cache>& theCache,
-       double                             theLocalU,
-       double                             theLocalV,
-       GeomGridEval::SurfD2&              theResult) {
-      theCache->D2Local(theLocalU,
-                        theLocalV,
-                        theResult.Point,
-                        theResult.D1U,
-                        theResult.D1V,
-                        theResult.D2U,
-                        theResult.D2V,
-                        theResult.D2UV);
+    [](const BSplSLib_Cache& theCache,
+       double                theLocalU,
+       double                theLocalV,
+       GeomGridEval::SurfD2& theResult) {
+      theCache.D2Local(theLocalU,
+                       theLocalV,
+                       theResult.Point,
+                       theResult.D1U,
+                       theResult.D1V,
+                       theResult.D2U,
+                       theResult.D2V,
+                       theResult.D2UV);
     },
-    // Direct evaluation
     [](const SurfaceData&    theData,
        double                theU,
        double                theV,
@@ -585,20 +525,17 @@ NCollection_Array2<gp_Vec> GeomGridEval_BSplineSurface::EvaluateGridDN(
     return NCollection_Array2<gp_Vec>();
   }
 
-  const int aNbU = theUParams.Length();
-  const int aNbV = theVParams.Length();
+  const size_t aNbU = theUParams.Size();
+  const size_t aNbV = theVParams.Size();
 
   // Derivatives beyond degree are zero
   if (theNU > aData.UDegree || theNV > aData.VDegree)
   {
-    NCollection_Array2<gp_Vec> aGrid(1, aNbU, 1, aNbV);
+    NCollection_Array2<gp_Vec> aGrid(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
     const gp_Vec               aZero(0.0, 0.0, 0.0);
-    for (int i = 1; i <= aNbU; ++i)
+    for (size_t anIndex = 0; anIndex < aGrid.Size(); ++anIndex)
     {
-      for (int j = 1; j <= aNbV; ++j)
-      {
-        aGrid.SetValue(i, j, aZero);
-      }
+      aGrid.ChangeAt(anIndex) = aZero;
     }
     return aGrid;
   }

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BSplineSurface.cxx
@@ -23,8 +23,12 @@
 namespace
 {
 
-//! Cache construction is amortized only for span blocks containing at least two grid points.
-constexpr size_t THE_CACHE_THRESHOLD = 2;
+//! Minimum number of points in one U/V span-block product that amortizes cache construction.
+constexpr size_t THE_POLYNOMIAL_CACHE_MIN_POINTS = 8;
+
+//! Measured rational cache crossovers for one Cartesian span block.
+constexpr size_t THE_RATIONAL_D0_D1_CACHE_MIN_POINTS = 4;
+constexpr size_t THE_RATIONAL_D2_CACHE_MIN_POINTS    = 6;
 
 //! Helper structure holding extracted B-spline surface data.
 struct SurfaceData
@@ -80,15 +84,22 @@ inline void locateSpan(double                            theParam,
                             theAdjustedParam);
 }
 
+//! Compute a span midpoint without adding both potentially large knot values.
+inline double spanMidpoint(const NCollection_Array1<double>& theFlatKnots, const int theSpan)
+{
+  const double aStart = theFlatKnots.Value(theSpan);
+  return aStart + 0.5 * (theFlatKnots.Value(theSpan + 1) - aStart);
+}
+
 //! Compute span local parameter coefficients (mid and half-length).
 inline void computeSpanCoeffs(const NCollection_Array1<double>& theFlatKnots,
-                              int                               theSpan,
+                              const int                         theSpan,
                               double&                           theMid,
                               double&                           theHalfLen)
 {
   const double aStart = theFlatKnots.Value(theSpan);
-  theHalfLen          = 0.5 * (theFlatKnots.Value(theSpan + 1) - aStart);
-  theMid              = aStart + theHalfLen;
+  theMid              = spanMidpoint(theFlatKnots, theSpan);
+  theHalfLen          = theMid - aStart;
 }
 
 struct SpanBlock
@@ -96,6 +107,7 @@ struct SpanBlock
   size_t Start;
   size_t Count;
   int    Span;
+  double Mid;
 };
 
 struct PreparedParam
@@ -117,17 +129,28 @@ size_t prepareSpanBlocks(const NCollection_Array1<double>& theParams,
   const size_t aNbParams     = theParams.Size();
   size_t       aNbBlocks     = 0;
   int          aPreviousSpan = -1;
+  double       aSpanStart    = 0.0;
+  double       aSpanEnd      = 0.0;
   double       aMid          = 0.0;
   double       aHalfLen      = 1.0;
   for (size_t anIndex = 0; anIndex < aNbParams; ++anIndex)
   {
     double anAdjusted = theParams.At(anIndex);
     int    aSpan      = 0;
-    locateSpan(anAdjusted, theFlatKnots, theDegree, theIsPeriodic, anAdjusted, aSpan);
+    if (!theIsPeriodic && aPreviousSpan >= 0 && anAdjusted >= aSpanStart && anAdjusted < aSpanEnd)
+    {
+      aSpan = aPreviousSpan;
+    }
+    else
+    {
+      locateSpan(anAdjusted, theFlatKnots, theDegree, theIsPeriodic, anAdjusted, aSpan);
+    }
     if (aSpan != aPreviousSpan)
     {
       computeSpanCoeffs(theFlatKnots, aSpan, aMid, aHalfLen);
-      theBlocks[aNbBlocks++] = {anIndex, 1, aSpan};
+      aSpanStart             = theFlatKnots.Value(aSpan);
+      aSpanEnd               = theFlatKnots.Value(aSpan + 1);
+      theBlocks[aNbBlocks++] = {anIndex, 1, aSpan, aMid};
       aPreviousSpan          = aSpan;
     }
     else
@@ -144,6 +167,7 @@ template <typename ResultT, typename CacheEvaluator, typename DirectEvaluator>
 NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&                theData,
                                                const NCollection_Array1<double>& theUParams,
                                                const NCollection_Array1<double>& theVParams,
+                                               const size_t                      theCacheThreshold,
                                                CacheEvaluator&&                  theCacheEvaluator,
                                                DirectEvaluator&&                 theDirectEvaluator)
 {
@@ -155,17 +179,17 @@ NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&               
   SpanBlocks                  aUBlocks(aNbU);
   SpanBlocks                  aVBlocks(aNbV);
   const size_t                aNbUBlocks = prepareSpanBlocks(theUParams,
-                                              *theData.UFlatKnots,
-                                              theData.UDegree,
-                                              theData.IsUPeriodic,
-                                              aPreparedU,
-                                              aUBlocks);
+                                                             *theData.UFlatKnots,
+                                                             theData.UDegree,
+                                                             theData.IsUPeriodic,
+                                                             aPreparedU,
+                                                             aUBlocks);
   const size_t                aNbVBlocks = prepareSpanBlocks(theVParams,
-                                              *theData.VFlatKnots,
-                                              theData.VDegree,
-                                              theData.IsVPeriodic,
-                                              aPreparedV,
-                                              aVBlocks);
+                                                             *theData.VFlatKnots,
+                                                             theData.VDegree,
+                                                             theData.IsVPeriodic,
+                                                             aPreparedV,
+                                                             aVBlocks);
   occ::handle<BSplSLib_Cache> aCache;
 
   for (size_t aUBlockIndex = 0; aUBlockIndex < aNbUBlocks; ++aUBlockIndex)
@@ -173,9 +197,8 @@ NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&               
     const SpanBlock& aUBlock = aUBlocks[aUBlockIndex];
     for (size_t aVBlockIndex = 0; aVBlockIndex < aNbVBlocks; ++aVBlockIndex)
     {
-      const SpanBlock& aVBlock = aVBlocks[aVBlockIndex];
-      const bool       isCacheUsed =
-        aUBlock.Count >= THE_CACHE_THRESHOLD || aVBlock.Count >= THE_CACHE_THRESHOLD;
+      const SpanBlock& aVBlock     = aVBlocks[aVBlockIndex];
+      const bool       isCacheUsed = aUBlock.Count * aVBlock.Count >= theCacheThreshold;
       if (isCacheUsed)
       {
         if (aCache.IsNull())
@@ -188,8 +211,8 @@ NCollection_Array2<ResultT> evaluateGridCached(const SurfaceData&               
                                       *theData.VFlatKnots,
                                       theData.Weights);
         }
-        aCache->BuildCache(aPreparedU[aUBlock.Start].Adjusted,
-                           aPreparedV[aVBlock.Start].Adjusted,
+        aCache->BuildCache(aUBlock.Mid,
+                           aVBlock.Mid,
                            *theData.UFlatKnots,
                            *theData.VFlatKnots,
                            *theData.Poles,
@@ -250,7 +273,6 @@ NCollection_Array2<ResultT> evaluateGridDirect(const SurfaceData&               
 
     if (!theData.IsUPeriodic && aPrevUSpan >= 0 && aU >= aUSpanStart && aU < aUSpanEnd)
     {
-      aAdjU  = aU;
       aUSpan = aPrevUSpan;
     }
     else
@@ -276,7 +298,6 @@ NCollection_Array2<ResultT> evaluateGridDirect(const SurfaceData&               
 
       if (!theData.IsVPeriodic && aPrevVSpan >= 0 && aV >= aVSpanStart && aV < aVSpanEnd)
       {
-        aAdjV  = aV;
         aVSpan = aPrevVSpan;
       }
       else
@@ -290,9 +311,7 @@ NCollection_Array2<ResultT> evaluateGridDirect(const SurfaceData&               
         aVSpanEnd   = theData.VFlatKnots->Value(aVSpan + 1);
       }
 
-      ResultT aResult;
-      theEval(theData, aAdjU, aAdjV, aUSpan, aVSpan, aResult);
-      aGrid.ChangeAt(aUIndex * aNbV + aVIndex) = aResult;
+      theEval(theData, aAdjU, aAdjV, aUSpan, aVSpan, aGrid.ChangeAt(aUIndex * aNbV + aVIndex));
     }
   }
 
@@ -317,6 +336,8 @@ NCollection_Array2<gp_Pnt> GeomGridEval_BSplineSurface::EvaluateGrid(
     aData,
     theUParams,
     theVParams,
+    aData.Weights != nullptr ? THE_RATIONAL_D0_D1_CACHE_MIN_POINTS
+                             : THE_POLYNOMIAL_CACHE_MIN_POINTS,
     [](const BSplSLib_Cache& theCache, double theLocalU, double theLocalV, gp_Pnt& theResult) {
       theCache.D0Local(theLocalU, theLocalV, theResult);
     },
@@ -334,8 +355,8 @@ NCollection_Array2<gp_Pnt> GeomGridEval_BSplineSurface::EvaluateGrid(
                    theData.Weights,
                    *theData.UFlatKnots,
                    *theData.VFlatKnots,
-                   nullptr,
-                   nullptr,
+                   BSplCLib::NoMults(),
+                   BSplCLib::NoMults(),
                    theData.UDegree,
                    theData.VDegree,
                    theData.IsURational,
@@ -361,6 +382,8 @@ NCollection_Array2<GeomGridEval::SurfD1> GeomGridEval_BSplineSurface::EvaluateGr
     aData,
     theUParams,
     theVParams,
+    aData.Weights != nullptr ? THE_RATIONAL_D0_D1_CACHE_MIN_POINTS
+                             : THE_POLYNOMIAL_CACHE_MIN_POINTS,
     [](const BSplSLib_Cache& theCache,
        double                theLocalU,
        double                theLocalV,
@@ -381,8 +404,8 @@ NCollection_Array2<GeomGridEval::SurfD1> GeomGridEval_BSplineSurface::EvaluateGr
                    theData.Weights,
                    *theData.UFlatKnots,
                    *theData.VFlatKnots,
-                   nullptr,
-                   nullptr,
+                   BSplCLib::NoMults(),
+                   BSplCLib::NoMults(),
                    theData.UDegree,
                    theData.VDegree,
                    theData.IsURational,
@@ -410,6 +433,7 @@ NCollection_Array2<GeomGridEval::SurfD2> GeomGridEval_BSplineSurface::EvaluateGr
     aData,
     theUParams,
     theVParams,
+    aData.Weights != nullptr ? THE_RATIONAL_D2_CACHE_MIN_POINTS : THE_POLYNOMIAL_CACHE_MIN_POINTS,
     [](const BSplSLib_Cache& theCache,
        double                theLocalU,
        double                theLocalV,
@@ -437,8 +461,8 @@ NCollection_Array2<GeomGridEval::SurfD2> GeomGridEval_BSplineSurface::EvaluateGr
                    theData.Weights,
                    *theData.UFlatKnots,
                    *theData.VFlatKnots,
-                   nullptr,
-                   nullptr,
+                   BSplCLib::NoMults(),
+                   BSplCLib::NoMults(),
                    theData.UDegree,
                    theData.VDegree,
                    theData.IsURational,
@@ -475,7 +499,6 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BSplineSurface::EvaluateGr
                                                      int                   theUSpan,
                                                      int                   theVSpan,
                                                      GeomGridEval::SurfD3& theResult) {
-                                                    gp_Vec aD1U, aD1V, aD2U, aD2V, aD2UV;
                                                     BSplSLib::D3(theU,
                                                                  theV,
                                                                  theUSpan,
@@ -484,8 +507,8 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BSplineSurface::EvaluateGr
                                                                  theData.Weights,
                                                                  *theData.UFlatKnots,
                                                                  *theData.VFlatKnots,
-                                                                 nullptr,
-                                                                 nullptr,
+                                                                 BSplCLib::NoMults(),
+                                                                 BSplCLib::NoMults(),
                                                                  theData.UDegree,
                                                                  theData.VDegree,
                                                                  theData.IsURational,
@@ -493,20 +516,15 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BSplineSurface::EvaluateGr
                                                                  theData.IsUPeriodic,
                                                                  theData.IsVPeriodic,
                                                                  theResult.Point,
-                                                                 aD1U,
-                                                                 aD1V,
-                                                                 aD2U,
-                                                                 aD2V,
-                                                                 aD2UV,
+                                                                 theResult.D1U,
+                                                                 theResult.D1V,
+                                                                 theResult.D2U,
+                                                                 theResult.D2V,
+                                                                 theResult.D2UV,
                                                                  theResult.D3U,
                                                                  theResult.D3V,
                                                                  theResult.D3UUV,
                                                                  theResult.D3UVV);
-                                                    theResult.D1U  = aD1U;
-                                                    theResult.D1V  = aD1V;
-                                                    theResult.D2U  = aD2U;
-                                                    theResult.D2V  = aD2V;
-                                                    theResult.D2UV = aD2UV;
                                                   });
 }
 
@@ -532,11 +550,7 @@ NCollection_Array2<gp_Vec> GeomGridEval_BSplineSurface::EvaluateGridDN(
   if (theNU > aData.UDegree || theNV > aData.VDegree)
   {
     NCollection_Array2<gp_Vec> aGrid(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
-    const gp_Vec               aZero(0.0, 0.0, 0.0);
-    for (size_t anIndex = 0; anIndex < aGrid.Size(); ++anIndex)
-    {
-      aGrid.ChangeAt(anIndex) = aZero;
-    }
+    aGrid.Init(gp_Vec(0.0, 0.0, 0.0));
     return aGrid;
   }
 
@@ -559,8 +573,8 @@ NCollection_Array2<gp_Vec> GeomGridEval_BSplineSurface::EvaluateGridDN(
                                                    theData.Weights,
                                                    *theData.UFlatKnots,
                                                    *theData.VFlatKnots,
-                                                   nullptr,
-                                                   nullptr,
+                                                   BSplCLib::NoMults(),
+                                                   BSplCLib::NoMults(),
                                                    theData.UDegree,
                                                    theData.VDegree,
                                                    theData.IsURational,

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BezierSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BezierSurface.cxx
@@ -21,10 +21,15 @@
 #include <NCollection_Array2.hxx>
 #include <NCollection_LocalArray.hxx>
 
+#include <algorithm>
+#include <utility>
+
 namespace
 {
-//! Extracting a V-isoline becomes worthwhile only for sufficiently long one-dimensional grids.
-constexpr size_t THE_ISOLINE_THRESHOLD = 8;
+//! Conservative measured isoline crossovers; base costs are relative point-degree work units.
+constexpr size_t THE_ISOLINE_MIN_POINTS           = 8;
+constexpr size_t THE_POLYNOMIAL_ISOLINE_BASE_COST = 128;
+constexpr size_t THE_RATIONAL_ISOLINE_BASE_COST   = 48;
 
 //! Create and build cache for Bezier surface evaluation.
 //! Bezier surfaces are single-span, so cache is built once at parameter (0.5, 0.5).
@@ -56,6 +61,89 @@ void prepareLocalParams(const NCollection_Array1<double>& theParams,
     theLocalParams[anIndex] = (theParams.At(anIndex) - 0.5) / 0.5;
   }
 }
+
+//! Tests whether isoline extraction has a predictable measured benefit.
+bool isIsoPreferred(const occ::handle<Geom_BezierSurface>& theGeom,
+                    const size_t                           theNbParams,
+                    const int                              theFixedDegree,
+                    const int                              theVaryingDegree)
+{
+  if (!theGeom->IsURational() && !theGeom->IsVRational())
+  {
+    if (theFixedDegree != theVaryingDegree || theNbParams < THE_ISOLINE_MIN_POINTS)
+    {
+      return false;
+    }
+
+    // Isoline extraction has a fixed cost, while the saved surface work grows with point count and
+    // degree. Keeping this rule symmetric avoids direction-dependent surprises for polynomials.
+    return theNbParams * static_cast<size_t>(theFixedDegree + 1)
+           >= THE_POLYNOMIAL_ISOLINE_BASE_COST;
+  }
+
+  if (theNbParams < THE_ISOLINE_MIN_POINTS)
+  {
+    return false;
+  }
+
+  // Rational isoline construction is directional. Compare its degree-dependent fixed cost with
+  // the work saved over the evaluated points. The squared degree ratio accounts for the measured
+  // construction penalty on anisotropic surfaces.
+  const size_t aFixedWeight     = static_cast<size_t>(theFixedDegree + 1);
+  const size_t aVaryingWeight   = static_cast<size_t>(theVaryingDegree + 1);
+  const size_t aMinWeight       = std::min(aFixedWeight, aVaryingWeight);
+  const size_t aMaxWeight       = std::max(aFixedWeight, aVaryingWeight);
+  const size_t anEvaluationWork = theNbParams * aFixedWeight * aMinWeight * aMinWeight;
+  const size_t anIsolineCost    = THE_RATIONAL_ISOLINE_BASE_COST * aMaxWeight * aMaxWeight;
+  return anEvaluationWork >= anIsolineCost;
+}
+
+//! Evaluates a Bezier grid through the surface cache, sharing iteration and local-parameter setup
+//! between D0, D1, and D2.
+template <typename ResultT, typename LocalEvaluator, typename DirectEvaluator>
+NCollection_Array2<ResultT> evaluateCacheGrid(const occ::handle<Geom_BezierSurface>& theGeom,
+                                              const NCollection_Array1<double>&      theUParams,
+                                              const NCollection_Array1<double>&      theVParams,
+                                              const bool                             theUseLocal,
+                                              LocalEvaluator&&  theLocalEvaluator,
+                                              DirectEvaluator&& theDirectEvaluator)
+{
+  const size_t                      aNbU   = theUParams.Size();
+  const size_t                      aNbV   = theVParams.Size();
+  const occ::handle<BSplSLib_Cache> aCache = buildBezierCache(theGeom);
+  NCollection_Array2<ResultT>       aResult(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
+  if (theUseLocal)
+  {
+    NCollection_LocalArray<double> aLocalU(aNbU);
+    NCollection_LocalArray<double> aLocalV(aNbV);
+    prepareLocalParams(theUParams, aLocalU);
+    prepareLocalParams(theVParams, aLocalV);
+    for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
+    {
+      for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
+      {
+        theLocalEvaluator(*aCache,
+                          aLocalU[aUIndex],
+                          aLocalV[aVIndex],
+                          aResult.ChangeAt(aUIndex * aNbV + aVIndex));
+      }
+    }
+  }
+  else
+  {
+    for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
+    {
+      for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
+      {
+        theDirectEvaluator(*aCache,
+                           theUParams.At(aUIndex),
+                           theVParams.At(aVIndex),
+                           aResult.ChangeAt(aUIndex * aNbV + aVIndex));
+      }
+    }
+  }
+  return aResult;
+}
 } // namespace
 
 //=================================================================================================
@@ -78,22 +166,27 @@ NCollection_Array2<gp_Pnt> GeomGridEval_BezierSurface::EvaluateGrid(
     return aResult;
   }
 
-  if (aNbV == 1 && aNbU >= THE_ISOLINE_THRESHOLD)
+  const bool   isVIso         = aNbV == 1;
+  const size_t aNbIsoParams   = isVIso ? aNbU : aNbV;
+  const int    aFixedDegree   = isVIso ? myGeom->VDegree() : myGeom->UDegree();
+  const int    aVaryingDegree = isVIso ? myGeom->UDegree() : myGeom->VDegree();
+  if ((isVIso || aNbU == 1) && isIsoPreferred(myGeom, aNbIsoParams, aFixedDegree, aVaryingDegree))
   {
     try
     {
       OCC_CATCH_SIGNALS
-      const occ::handle<Geom_Curve> aCurve = myGeom->VIso(theVParams.At(0));
+      const occ::handle<Geom_Curve> aCurve =
+        isVIso ? myGeom->VIso(theVParams.At(0)) : myGeom->UIso(theUParams.At(0));
       if (!aCurve.IsNull())
       {
-        GeomGridEval_Curve               aCurveEvaluator(aCurve);
-        const NCollection_Array1<gp_Pnt> aCurveResult = aCurveEvaluator.EvaluateGrid(theUParams);
-        NCollection_Array2<gp_Pnt>       aResult(1, static_cast<int>(aNbU), 1, 1);
-        for (size_t anIndex = 0; anIndex < aNbU; ++anIndex)
-        {
-          aResult.ChangeAt(anIndex) = aCurveResult.At(anIndex);
-        }
-        return aResult;
+        const NCollection_Array1<double>& anIsoParams = isVIso ? theUParams : theVParams;
+        GeomGridEval_Curve                aCurveEvaluator(aCurve);
+        NCollection_Array1<gp_Pnt>        aCurveResult = aCurveEvaluator.EvaluateGrid(anIsoParams);
+        return NCollection_Array2<gp_Pnt>(std::move(aCurveResult),
+                                          1,
+                                          isVIso ? static_cast<int>(aNbU) : 1,
+                                          1,
+                                          isVIso ? 1 : static_cast<int>(aNbV));
       }
     }
     catch (const Standard_Failure&)
@@ -102,23 +195,19 @@ NCollection_Array2<gp_Pnt> GeomGridEval_BezierSurface::EvaluateGrid(
     }
   }
 
-  NCollection_LocalArray<double> aLocalU(aNbU);
-  NCollection_LocalArray<double> aLocalV(aNbV);
-  prepareLocalParams(theUParams, aLocalU);
-  prepareLocalParams(theVParams, aLocalV);
-
-  const occ::handle<BSplSLib_Cache> aCache = buildBezierCache(myGeom);
-  NCollection_Array2<gp_Pnt>        aResult(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
-  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
-  {
-    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
-    {
-      aCache->D0Local(aLocalU[aUIndex],
-                      aLocalV[aVIndex],
-                      aResult.ChangeAt(aUIndex * aNbV + aVIndex));
-    }
-  }
-  return aResult;
+  const bool isLocalEvaluationUsed = myGeom->IsURational() || myGeom->IsVRational()
+                                     || (myGeom->UDegree() == 1 && myGeom->VDegree() == 1);
+  return evaluateCacheGrid<gp_Pnt>(
+    myGeom,
+    theUParams,
+    theVParams,
+    isLocalEvaluationUsed,
+    [](const BSplSLib_Cache& theCache, double theU, double theV, gp_Pnt& theResult) {
+      theCache.D0Local(theU, theV, theResult);
+    },
+    [](const BSplSLib_Cache& theCache, double theU, double theV, gp_Pnt& theResult) {
+      theCache.D0(theU, theV, theResult);
+    });
 }
 
 //=================================================================================================
@@ -140,24 +229,18 @@ NCollection_Array2<GeomGridEval::SurfD1> GeomGridEval_BezierSurface::EvaluateGri
     return aResult;
   }
 
-  NCollection_LocalArray<double> aLocalU(aNbU);
-  NCollection_LocalArray<double> aLocalV(aNbV);
-  prepareLocalParams(theUParams, aLocalU);
-  prepareLocalParams(theVParams, aLocalV);
-  const occ::handle<BSplSLib_Cache>        aCache = buildBezierCache(myGeom);
-  NCollection_Array2<GeomGridEval::SurfD1> aResult(1,
-                                                   static_cast<int>(aNbU),
-                                                   1,
-                                                   static_cast<int>(aNbV));
-  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
-  {
-    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
-    {
-      GeomGridEval::SurfD1& aValue = aResult.ChangeAt(aUIndex * aNbV + aVIndex);
-      aCache->D1Local(aLocalU[aUIndex], aLocalV[aVIndex], aValue.Point, aValue.D1U, aValue.D1V);
-    }
-  }
-  return aResult;
+  const bool isLocalEvaluationUsed = myGeom->IsURational() || myGeom->IsVRational();
+  return evaluateCacheGrid<GeomGridEval::SurfD1>(
+    myGeom,
+    theUParams,
+    theVParams,
+    isLocalEvaluationUsed,
+    [](const BSplSLib_Cache& theCache, double theU, double theV, GeomGridEval::SurfD1& theResult) {
+      theCache.D1Local(theU, theV, theResult.Point, theResult.D1U, theResult.D1V);
+    },
+    [](const BSplSLib_Cache& theCache, double theU, double theV, GeomGridEval::SurfD1& theResult) {
+      theCache.D1(theU, theV, theResult.Point, theResult.D1U, theResult.D1V);
+    });
 }
 
 //=================================================================================================
@@ -179,31 +262,33 @@ NCollection_Array2<GeomGridEval::SurfD2> GeomGridEval_BezierSurface::EvaluateGri
     return aResult;
   }
 
-  NCollection_LocalArray<double> aLocalU(aNbU);
-  NCollection_LocalArray<double> aLocalV(aNbV);
-  prepareLocalParams(theUParams, aLocalU);
-  prepareLocalParams(theVParams, aLocalV);
-  const occ::handle<BSplSLib_Cache>        aCache = buildBezierCache(myGeom);
-  NCollection_Array2<GeomGridEval::SurfD2> aResult(1,
-                                                   static_cast<int>(aNbU),
-                                                   1,
-                                                   static_cast<int>(aNbV));
-  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
-  {
-    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
-    {
-      GeomGridEval::SurfD2& aValue = aResult.ChangeAt(aUIndex * aNbV + aVIndex);
-      aCache->D2Local(aLocalU[aUIndex],
-                      aLocalV[aVIndex],
-                      aValue.Point,
-                      aValue.D1U,
-                      aValue.D1V,
-                      aValue.D2U,
-                      aValue.D2V,
-                      aValue.D2UV);
-    }
-  }
-  return aResult;
+  const bool isLocalEvaluationUsed = myGeom->IsURational() || myGeom->IsVRational()
+                                     || (myGeom->UDegree() == 1 && myGeom->VDegree() == 1);
+  return evaluateCacheGrid<GeomGridEval::SurfD2>(
+    myGeom,
+    theUParams,
+    theVParams,
+    isLocalEvaluationUsed,
+    [](const BSplSLib_Cache& theCache, double theU, double theV, GeomGridEval::SurfD2& theResult) {
+      theCache.D2Local(theU,
+                       theV,
+                       theResult.Point,
+                       theResult.D1U,
+                       theResult.D1V,
+                       theResult.D2U,
+                       theResult.D2V,
+                       theResult.D2UV);
+    },
+    [](const BSplSLib_Cache& theCache, double theU, double theV, GeomGridEval::SurfD2& theResult) {
+      theCache.D2(theU,
+                  theV,
+                  theResult.Point,
+                  theResult.D1U,
+                  theResult.D1V,
+                  theResult.D2U,
+                  theResult.D2V,
+                  theResult.D2UV);
+    });
 }
 
 //=================================================================================================
@@ -224,7 +309,6 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BezierSurface::EvaluateGri
                                                    1,
                                                    static_cast<int>(aNbV));
 
-  // Get degrees, flat knots, poles, and weights from geometry
   const int                         aUDegree       = myGeom->UDegree();
   const int                         aVDegree       = myGeom->VDegree();
   const NCollection_Array1<double>& aUKnotSequence = myGeom->UKnotSequence();
@@ -233,46 +317,38 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BezierSurface::EvaluateGri
   const NCollection_Array2<double>* aWeights       = myGeom->Weights();
   const bool                        isRational     = (aWeights != nullptr);
 
-  // D3 evaluation using BSplSLib::D3 directly
-  // Bezier surface is single span (span index = 0), non-periodic
   for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
   {
     const double aU = theUParams.At(aUIndex);
     for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
     {
-      gp_Pnt aPoint;
-      gp_Vec aD1U, aD1V, aD2U, aD2V, aD2UV, aD3U, aD3V, aD3UUV, aD3UVV;
-
+      GeomGridEval::SurfD3& aValue = aResult.ChangeAt(aUIndex * aNbV + aVIndex);
       BSplSLib::D3(aU,
                    theVParams.At(aVIndex),
-                   0, // U span index (single span for Bezier)
-                   0, // V span index (single span for Bezier)
+                   0, // U span index (single span for Bezier with flat knots)
+                   0, // V span index (single span for Bezier with flat knots)
                    aPoles,
                    aWeights,
                    aUKnotSequence,
                    aVKnotSequence,
-                   nullptr, // U multiplicities (nullptr for flat knots)
-                   nullptr, // V multiplicities (nullptr for flat knots)
+                   BSplCLib::NoMults(),
+                   BSplCLib::NoMults(),
                    aUDegree,
                    aVDegree,
                    isRational,
                    isRational,
-                   false, // not U periodic
-                   false, // not V periodic
-                   aPoint,
-                   aD1U,
-                   aD1V,
-                   aD2U,
-                   aD2V,
-                   aD2UV,
-                   aD3U,
-                   aD3V,
-                   aD3UUV,
-                   aD3UVV);
-
-      aResult.ChangeAt(
-        aUIndex * aNbV
-        + aVIndex) = {aPoint, aD1U, aD1V, aD2U, aD2V, aD2UV, aD3U, aD3V, aD3UUV, aD3UVV};
+                   false, // not U-periodic
+                   false, // not V-periodic
+                   aValue.Point,
+                   aValue.D1U,
+                   aValue.D1V,
+                   aValue.D2U,
+                   aValue.D2V,
+                   aValue.D2UV,
+                   aValue.D3U,
+                   aValue.D3V,
+                   aValue.D3UUV,
+                   aValue.D3UVV);
     }
   }
 
@@ -298,35 +374,27 @@ NCollection_Array2<gp_Vec> GeomGridEval_BezierSurface::EvaluateGridDN(
 
   NCollection_Array2<gp_Vec> aResult(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
 
-  // For Bezier surfaces, derivatives become zero when order exceeds degree in that direction
   const int aUDegree = myGeom->UDegree();
   const int aVDegree = myGeom->VDegree();
 
+  // Bezier derivatives are zero when the requested order exceeds either directional degree.
   if (theNU > aUDegree || theNV > aVDegree)
   {
-    // All derivatives are zero
-    const gp_Vec aZeroVec(0.0, 0.0, 0.0);
-    for (size_t anIndex = 0; anIndex < aResult.Size(); ++anIndex)
-    {
-      aResult.ChangeAt(anIndex) = aZeroVec;
-    }
+    aResult.Init(gp_Vec(0.0, 0.0, 0.0));
     return aResult;
   }
 
-  // Get poles, weights, and flat knots from geometry
   const NCollection_Array2<gp_Pnt>& aPoles         = myGeom->Poles();
   const NCollection_Array2<double>* aWeights       = myGeom->Weights();
   const bool                        isRational     = (aWeights != nullptr);
   const NCollection_Array1<double>& aUKnotSequence = myGeom->UKnotSequence();
   const NCollection_Array1<double>& aVKnotSequence = myGeom->VKnotSequence();
 
-  // Bezier has a single span (index 0 with flat knots), non-periodic
   for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
   {
     const double aU = theUParams.At(aUIndex);
     for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
     {
-      gp_Vec aDN;
       BSplSLib::DN(aU,
                    theVParams.At(aVIndex),
                    theNU,
@@ -337,16 +405,15 @@ NCollection_Array2<gp_Vec> GeomGridEval_BezierSurface::EvaluateGridDN(
                    aWeights,
                    aUKnotSequence,
                    aVKnotSequence,
-                   nullptr, // no U multiplicities with flat knots
-                   nullptr, // no V multiplicities with flat knots
+                   BSplCLib::NoMults(),
+                   BSplCLib::NoMults(),
                    aUDegree,
                    aVDegree,
                    isRational,
                    isRational,
                    false, // not U-periodic
                    false, // not V-periodic
-                   aDN);
-      aResult.ChangeAt(aUIndex * aNbV + aVIndex) = aDN;
+                   aResult.ChangeAt(aUIndex * aNbV + aVIndex));
     }
   }
 

--- a/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BezierSurface.cxx
+++ b/src/ModelingData/TKG3d/GeomGridEval/GeomGridEval_BezierSurface.cxx
@@ -19,13 +19,12 @@
 #include <Standard_Failure.hxx>
 #include <gp_Pnt.hxx>
 #include <NCollection_Array2.hxx>
+#include <NCollection_LocalArray.hxx>
 
 namespace
 {
-//! Minimum number of points along varying dimension to use isoline optimization.
-//! For small grids (e.g., 1x4), cache-based surface evaluation is faster than
-//! extracting an isoline curve and setting up a curve evaluator.
-constexpr int THE_ISOLINE_THRESHOLD = 8;
+//! Extracting a V-isoline becomes worthwhile only for sufficiently long one-dimensional grids.
+constexpr size_t THE_ISOLINE_THRESHOLD = 8;
 
 //! Create and build cache for Bezier surface evaluation.
 //! Bezier surfaces are single-span, so cache is built once at parameter (0.5, 0.5).
@@ -48,6 +47,15 @@ occ::handle<BSplSLib_Cache> buildBezierCache(const occ::handle<Geom_BezierSurfac
   aCache->BuildCache(0.5, 0.5, aUKnotSequence, aVKnotSequence, aPoles, aWeights);
   return aCache;
 }
+
+void prepareLocalParams(const NCollection_Array1<double>& theParams,
+                        NCollection_LocalArray<double>&   theLocalParams)
+{
+  for (size_t anIndex = 0; anIndex < theParams.Size(); ++anIndex)
+  {
+    theLocalParams[anIndex] = (theParams.At(anIndex) - 0.5) / 0.5;
+  }
+}
 } // namespace
 
 //=================================================================================================
@@ -61,62 +69,55 @@ NCollection_Array2<gp_Pnt> GeomGridEval_BezierSurface::EvaluateGrid(
     return NCollection_Array2<gp_Pnt>();
   }
 
-  const int aNbU = theUParams.Length();
-  const int aNbV = theVParams.Length();
+  const size_t aNbU = theUParams.Size();
+  const size_t aNbV = theVParams.Size();
+  if (aNbU == 1 && aNbV == 1)
+  {
+    NCollection_Array2<gp_Pnt> aResult(1, 1, 1, 1);
+    aResult.ChangeAt(0) = myGeom->EvalD0(theUParams.At(0), theVParams.At(0));
+    return aResult;
+  }
 
-  // Check for V-isoline case (Nx1) - use 1D curve evaluation
-  // For U-isoline (1xN), cache-based surface evaluation is efficient since U span is fixed.
-  // For V-isoline (Nx1), extracting the isoline curve avoids repeated cache rebuilds.
-  // Only use isoline optimization when varying dimension is large enough.
-  const bool isVIso = (aNbV == 1 && aNbU >= THE_ISOLINE_THRESHOLD);
-
-  if (isVIso)
+  if (aNbV == 1 && aNbU >= THE_ISOLINE_THRESHOLD)
   {
     try
     {
       OCC_CATCH_SIGNALS
-      // Extract V-isoline curve (parameterized by U)
-      occ::handle<Geom_Curve> aCurve = myGeom->VIso(theVParams.Value(theVParams.Lower()));
-
+      const occ::handle<Geom_Curve> aCurve = myGeom->VIso(theVParams.At(0));
       if (!aCurve.IsNull())
       {
-        // Use unified curve evaluator
-        GeomGridEval_Curve aCurveEval(aCurve);
-
-        NCollection_Array1<gp_Pnt> aCurveResult = aCurveEval.EvaluateGrid(theUParams);
-
-        // Reshape 1D curve result to 2D surface result (Nx1 grid)
-        NCollection_Array2<gp_Pnt> aResult(1, aNbU, 1, 1);
-        for (int k = 1; k <= aNbU; ++k)
+        GeomGridEval_Curve               aCurveEvaluator(aCurve);
+        const NCollection_Array1<gp_Pnt> aCurveResult = aCurveEvaluator.EvaluateGrid(theUParams);
+        NCollection_Array2<gp_Pnt>       aResult(1, static_cast<int>(aNbU), 1, 1);
+        for (size_t anIndex = 0; anIndex < aNbU; ++anIndex)
         {
-          aResult(k, 1) = aCurveResult(k);
+          aResult.ChangeAt(anIndex) = aCurveResult.At(anIndex);
         }
         return aResult;
       }
     }
     catch (const Standard_Failure&)
     {
-      // Isoline extraction failed, fall through to surface evaluation
+      // Fall back to surface-cache evaluation if isoline construction fails.
     }
   }
 
-  // Build cache (Bezier is single span, cache is built once)
-  occ::handle<BSplSLib_Cache> aCache = buildBezierCache(myGeom);
+  NCollection_LocalArray<double> aLocalU(aNbU);
+  NCollection_LocalArray<double> aLocalV(aNbV);
+  prepareLocalParams(theUParams, aLocalU);
+  prepareLocalParams(theVParams, aLocalV);
 
-  NCollection_Array2<gp_Pnt> aResult(1, aNbU, 1, aNbV);
-
-  // Single span - use cache for all points
-  for (int i = 0; i < aNbU; ++i)
+  const occ::handle<BSplSLib_Cache> aCache = buildBezierCache(myGeom);
+  NCollection_Array2<gp_Pnt>        aResult(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
+  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
   {
-    const double aU = theUParams.Value(theUParams.Lower() + i);
-    for (int j = 0; j < aNbV; ++j)
+    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
     {
-      gp_Pnt aPoint;
-      aCache->D0(aU, theVParams.Value(theVParams.Lower() + j), aPoint);
-      aResult.SetValue(i + 1, j + 1, aPoint);
+      aCache->D0Local(aLocalU[aUIndex],
+                      aLocalV[aVIndex],
+                      aResult.ChangeAt(aUIndex * aNbV + aVIndex));
     }
   }
-
   return aResult;
 }
 
@@ -130,27 +131,32 @@ NCollection_Array2<GeomGridEval::SurfD1> GeomGridEval_BezierSurface::EvaluateGri
   {
     return NCollection_Array2<GeomGridEval::SurfD1>();
   }
-
-  // Build cache (Bezier is single span, cache is built once)
-  occ::handle<BSplSLib_Cache> aCache = buildBezierCache(myGeom);
-
-  const int                                aNbU = theUParams.Length();
-  const int                                aNbV = theVParams.Length();
-  NCollection_Array2<GeomGridEval::SurfD1> aResult(1, aNbU, 1, aNbV);
-
-  // Single span - use cache for all points
-  for (int i = 0; i < aNbU; ++i)
+  const size_t aNbU = theUParams.Size();
+  const size_t aNbV = theVParams.Size();
+  if (aNbU == 1 && aNbV == 1)
   {
-    const double aU = theUParams.Value(theUParams.Lower() + i);
-    for (int j = 0; j < aNbV; ++j)
-    {
-      gp_Pnt aPoint;
-      gp_Vec aD1U, aD1V;
-      aCache->D1(aU, theVParams.Value(theVParams.Lower() + j), aPoint, aD1U, aD1V);
-      aResult.ChangeValue(i + 1, j + 1) = {aPoint, aD1U, aD1V};
-    }
+    NCollection_Array2<GeomGridEval::SurfD1> aResult(1, 1, 1, 1);
+    aResult.ChangeAt(0) = myGeom->EvalD1(theUParams.At(0), theVParams.At(0));
+    return aResult;
   }
 
+  NCollection_LocalArray<double> aLocalU(aNbU);
+  NCollection_LocalArray<double> aLocalV(aNbV);
+  prepareLocalParams(theUParams, aLocalU);
+  prepareLocalParams(theVParams, aLocalV);
+  const occ::handle<BSplSLib_Cache>        aCache = buildBezierCache(myGeom);
+  NCollection_Array2<GeomGridEval::SurfD1> aResult(1,
+                                                   static_cast<int>(aNbU),
+                                                   1,
+                                                   static_cast<int>(aNbV));
+  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
+  {
+    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
+    {
+      GeomGridEval::SurfD1& aValue = aResult.ChangeAt(aUIndex * aNbV + aVIndex);
+      aCache->D1Local(aLocalU[aUIndex], aLocalV[aVIndex], aValue.Point, aValue.D1U, aValue.D1V);
+    }
+  }
   return aResult;
 }
 
@@ -164,28 +170,39 @@ NCollection_Array2<GeomGridEval::SurfD2> GeomGridEval_BezierSurface::EvaluateGri
   {
     return NCollection_Array2<GeomGridEval::SurfD2>();
   }
-
-  // Build cache (Bezier is single span, cache is built once)
-  occ::handle<BSplSLib_Cache> aCache = buildBezierCache(myGeom);
-
-  const int                                aNbU = theUParams.Length();
-  const int                                aNbV = theVParams.Length();
-  NCollection_Array2<GeomGridEval::SurfD2> aResult(1, aNbU, 1, aNbV);
-
-  // Single span - use cache for all points
-  for (int i = 0; i < aNbU; ++i)
+  const size_t aNbU = theUParams.Size();
+  const size_t aNbV = theVParams.Size();
+  if (aNbU == 1 && aNbV == 1)
   {
-    const double aU = theUParams.Value(theUParams.Lower() + i);
-    for (int j = 0; j < aNbV; ++j)
-    {
-      gp_Pnt aPoint;
-      gp_Vec aD1U, aD1V, aD2U, aD2V, aD2UV;
-      aCache
-        ->D2(aU, theVParams.Value(theVParams.Lower() + j), aPoint, aD1U, aD1V, aD2U, aD2V, aD2UV);
-      aResult.ChangeValue(i + 1, j + 1) = {aPoint, aD1U, aD1V, aD2U, aD2V, aD2UV};
-    }
+    NCollection_Array2<GeomGridEval::SurfD2> aResult(1, 1, 1, 1);
+    aResult.ChangeAt(0) = myGeom->EvalD2(theUParams.At(0), theVParams.At(0));
+    return aResult;
   }
 
+  NCollection_LocalArray<double> aLocalU(aNbU);
+  NCollection_LocalArray<double> aLocalV(aNbV);
+  prepareLocalParams(theUParams, aLocalU);
+  prepareLocalParams(theVParams, aLocalV);
+  const occ::handle<BSplSLib_Cache>        aCache = buildBezierCache(myGeom);
+  NCollection_Array2<GeomGridEval::SurfD2> aResult(1,
+                                                   static_cast<int>(aNbU),
+                                                   1,
+                                                   static_cast<int>(aNbV));
+  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
+  {
+    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
+    {
+      GeomGridEval::SurfD2& aValue = aResult.ChangeAt(aUIndex * aNbV + aVIndex);
+      aCache->D2Local(aLocalU[aUIndex],
+                      aLocalV[aVIndex],
+                      aValue.Point,
+                      aValue.D1U,
+                      aValue.D1V,
+                      aValue.D2U,
+                      aValue.D2V,
+                      aValue.D2UV);
+    }
+  }
   return aResult;
 }
 
@@ -200,9 +217,12 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BezierSurface::EvaluateGri
     return NCollection_Array2<GeomGridEval::SurfD3>();
   }
 
-  const int                                aNbU = theUParams.Length();
-  const int                                aNbV = theVParams.Length();
-  NCollection_Array2<GeomGridEval::SurfD3> aResult(1, aNbU, 1, aNbV);
+  const size_t                             aNbU = theUParams.Size();
+  const size_t                             aNbV = theVParams.Size();
+  NCollection_Array2<GeomGridEval::SurfD3> aResult(1,
+                                                   static_cast<int>(aNbU),
+                                                   1,
+                                                   static_cast<int>(aNbV));
 
   // Get degrees, flat knots, poles, and weights from geometry
   const int                         aUDegree       = myGeom->UDegree();
@@ -215,16 +235,16 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BezierSurface::EvaluateGri
 
   // D3 evaluation using BSplSLib::D3 directly
   // Bezier surface is single span (span index = 0), non-periodic
-  for (int i = 0; i < aNbU; ++i)
+  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
   {
-    const double aU = theUParams.Value(theUParams.Lower() + i);
-    for (int j = 0; j < aNbV; ++j)
+    const double aU = theUParams.At(aUIndex);
+    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
     {
       gp_Pnt aPoint;
       gp_Vec aD1U, aD1V, aD2U, aD2V, aD2UV, aD3U, aD3V, aD3UUV, aD3UVV;
 
       BSplSLib::D3(aU,
-                   theVParams.Value(theVParams.Lower() + j),
+                   theVParams.At(aVIndex),
                    0, // U span index (single span for Bezier)
                    0, // V span index (single span for Bezier)
                    aPoles,
@@ -250,9 +270,9 @@ NCollection_Array2<GeomGridEval::SurfD3> GeomGridEval_BezierSurface::EvaluateGri
                    aD3UUV,
                    aD3UVV);
 
-      aResult.ChangeValue(
-        i + 1,
-        j + 1) = {aPoint, aD1U, aD1V, aD2U, aD2V, aD2UV, aD3U, aD3V, aD3UUV, aD3UVV};
+      aResult.ChangeAt(
+        aUIndex * aNbV
+        + aVIndex) = {aPoint, aD1U, aD1V, aD2U, aD2V, aD2UV, aD3U, aD3V, aD3UUV, aD3UVV};
     }
   }
 
@@ -273,10 +293,10 @@ NCollection_Array2<gp_Vec> GeomGridEval_BezierSurface::EvaluateGridDN(
     return NCollection_Array2<gp_Vec>();
   }
 
-  const int aNbU = theUParams.Length();
-  const int aNbV = theVParams.Length();
+  const size_t aNbU = theUParams.Size();
+  const size_t aNbV = theVParams.Size();
 
-  NCollection_Array2<gp_Vec> aResult(1, aNbU, 1, aNbV);
+  NCollection_Array2<gp_Vec> aResult(1, static_cast<int>(aNbU), 1, static_cast<int>(aNbV));
 
   // For Bezier surfaces, derivatives become zero when order exceeds degree in that direction
   const int aUDegree = myGeom->UDegree();
@@ -286,12 +306,9 @@ NCollection_Array2<gp_Vec> GeomGridEval_BezierSurface::EvaluateGridDN(
   {
     // All derivatives are zero
     const gp_Vec aZeroVec(0.0, 0.0, 0.0);
-    for (int i = 1; i <= aNbU; ++i)
+    for (size_t anIndex = 0; anIndex < aResult.Size(); ++anIndex)
     {
-      for (int j = 1; j <= aNbV; ++j)
-      {
-        aResult.SetValue(i, j, aZeroVec);
-      }
+      aResult.ChangeAt(anIndex) = aZeroVec;
     }
     return aResult;
   }
@@ -304,14 +321,14 @@ NCollection_Array2<gp_Vec> GeomGridEval_BezierSurface::EvaluateGridDN(
   const NCollection_Array1<double>& aVKnotSequence = myGeom->VKnotSequence();
 
   // Bezier has a single span (index 0 with flat knots), non-periodic
-  for (int i = 0; i < aNbU; ++i)
+  for (size_t aUIndex = 0; aUIndex < aNbU; ++aUIndex)
   {
-    const double aU = theUParams.Value(theUParams.Lower() + i);
-    for (int j = 0; j < aNbV; ++j)
+    const double aU = theUParams.At(aUIndex);
+    for (size_t aVIndex = 0; aVIndex < aNbV; ++aVIndex)
     {
       gp_Vec aDN;
       BSplSLib::DN(aU,
-                   theVParams.Value(theVParams.Lower() + j),
+                   theVParams.At(aVIndex),
                    theNU,
                    theNV,
                    0, // U span index (single span for Bezier with flat knots)
@@ -329,7 +346,7 @@ NCollection_Array2<gp_Vec> GeomGridEval_BezierSurface::EvaluateGridDN(
                    false, // not U-periodic
                    false, // not V-periodic
                    aDN);
-      aResult.SetValue(i + 1, j + 1, aDN);
+      aResult.ChangeAt(aUIndex * aNbV + aVIndex) = aDN;
     }
   }
 


### PR DESCRIPTION
- Precompute adjusted and local BSpline parameters, group consecutive samples by knot-span blocks, and reuse a lazily built cache for D0-D2 grids.
- Keep direct evaluation for single span blocks and use cached evaluation only when cache construction is amortized.
- Make D3 and DN span reuse safe for unordered parameters by validating both knot-span bounds.
- Precompute Bezier local parameters for D0-D2, evaluate single-point grids directly, and retain the long V-isoline optimization.
- Use zero-based size_t indexing with At() and ChangeAt() throughout the updated grid paths.
