### PR TITLE
Modeling Data - Improve direct B-spline curve evaluation

### DIFF
--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib.cxx
@@ -45,6 +45,18 @@ typedef gp_Vec                     Vec;
 typedef NCollection_Array1<double> Array1OfReal;
 typedef NCollection_Array1<int>    Array1OfInteger;
 
+//! Corrects tolerance-based location to the actual flat-knot span.
+static void locateFlatSpan(const Array1OfReal& theKnots,
+                           const int           theFirst,
+                           int&                theKnotIndex,
+                           const double        theParameter)
+{
+  while (theKnotIndex > theFirst && theParameter < theKnots.Value(theKnotIndex))
+  {
+    --theKnotIndex;
+  }
+}
+
 //=======================================================================
 // class : BSplCLib_LocalMatrix
 // purpose: Auxiliary class optimizing creation of matrix buffer for
@@ -182,6 +194,7 @@ void BSplCLib::LocateParameter(const int, // Degree,
     ul = Knots(Knots.Upper());
   }
   BSplCLib::LocateParameter(Knots, U, IsPeriodic, FromK1, ToK2, KnotIndex, NewU, uf, ul);
+  locateFlatSpan(Knots, std::min(FromK1, ToK2), KnotIndex, NewU);
 }
 
 //=================================================================================================
@@ -211,6 +224,8 @@ void BSplCLib::LocateParameter(const int           Degree,
   {
     BSplCLib::LocateParameter(Knots, U, IsPeriodic, FromK1, ToK2, KnotIndex, NewU, 0., 1.);
   }
+
+  locateFlatSpan(Knots, std::min(FromK1, ToK2), KnotIndex, NewU);
 }
 
 //=================================================================================================
@@ -360,6 +375,11 @@ void BSplCLib::LocateParameter(const int                         Degree,
   else
   {
     NewU = U;
+  }
+
+  if (Mults == nullptr)
+  {
+    locateFlatSpan(Knots, first, KnotIndex, NewU);
   }
 }
 

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_2.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_2.cxx
@@ -68,8 +68,15 @@ void BSplCLib::D0(const double                      U,
                   const NCollection_Array1<int>*    Mults,
                   double&                           P)
 {
-  BSplCLib_D0<double, double, NCollection_Array1<double>, 1>(
-    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P);
+  BSplCLib_D0<double, double, NCollection_Array1<double>, 1>(U,
+                                                             Index,
+                                                             Degree,
+                                                             Periodic,
+                                                             Poles,
+                                                             Weights,
+                                                             Knots,
+                                                             Mults,
+                                                             P);
 }
 
 //=================================================================================================
@@ -85,8 +92,16 @@ void BSplCLib::D1(const double                      U,
                   double&                           P,
                   double&                           V)
 {
-  BSplCLib_D1<double, double, NCollection_Array1<double>, 1>(
-    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P, V);
+  BSplCLib_D1<double, double, NCollection_Array1<double>, 1>(U,
+                                                             Index,
+                                                             Degree,
+                                                             Periodic,
+                                                             Poles,
+                                                             Weights,
+                                                             Knots,
+                                                             Mults,
+                                                             P,
+                                                             V);
 }
 
 //=================================================================================================
@@ -103,8 +118,17 @@ void BSplCLib::D2(const double                      U,
                   double&                           V1,
                   double&                           V2)
 {
-  BSplCLib_D2<double, double, NCollection_Array1<double>, 1>(
-    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P, V1, V2);
+  BSplCLib_D2<double, double, NCollection_Array1<double>, 1>(U,
+                                                             Index,
+                                                             Degree,
+                                                             Periodic,
+                                                             Poles,
+                                                             Weights,
+                                                             Knots,
+                                                             Mults,
+                                                             P,
+                                                             V1,
+                                                             V2);
 }
 
 //=================================================================================================
@@ -122,8 +146,18 @@ void BSplCLib::D3(const double                      U,
                   double&                           V2,
                   double&                           V3)
 {
-  BSplCLib_D3<double, double, NCollection_Array1<double>, 1>(
-    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P, V1, V2, V3);
+  BSplCLib_D3<double, double, NCollection_Array1<double>, 1>(U,
+                                                             Index,
+                                                             Degree,
+                                                             Periodic,
+                                                             Poles,
+                                                             Weights,
+                                                             Knots,
+                                                             Mults,
+                                                             P,
+                                                             V1,
+                                                             V2,
+                                                             V3);
 }
 
 //=================================================================================================
@@ -139,8 +173,16 @@ void BSplCLib::DN(const double                      U,
                   const NCollection_Array1<int>*    Mults,
                   double&                           VN)
 {
-  BSplCLib_DN<double, double, NCollection_Array1<double>, 1>(
-    U, N, Index, Degree, Periodic, Poles, Weights, Knots, Mults, VN);
+  BSplCLib_DN<double, double, NCollection_Array1<double>, 1>(U,
+                                                             N,
+                                                             Index,
+                                                             Degree,
+                                                             Periodic,
+                                                             Poles,
+                                                             Weights,
+                                                             Knots,
+                                                             Mults,
+                                                             VN);
 }
 
 //=================================================================================================

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_2.cxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_2.cxx
@@ -39,9 +39,6 @@
 
 #include "BSplCLib_CurveComputation.pxx"
 
-// Use 1D specialization of the template data container
-using BSplCLib_DataContainer = BSplCLib_DataContainer_T<1>;
-
 // methods for 1 dimensional BSplines
 
 //=================================================================================================
@@ -52,89 +49,11 @@ void BSplCLib::BuildEval(const int                         Degree,
                          const NCollection_Array1<double>* Weights,
                          double&                           LP)
 {
-  int    PLower = Poles.Lower();
-  int    PUpper = Poles.Upper();
-  int    i;
-  int    ip = PLower + Index - 1;
-  double w, *pole = &LP;
-  if (Weights == nullptr)
-  {
-
-    for (i = 0; i <= Degree; i++)
-    {
-      ip++;
-      if (ip > PUpper)
-      {
-        ip = PLower;
-      }
-      pole[0] = Poles(ip);
-      pole += 1;
-    }
-  }
-  else
-  {
-
-    for (i = 0; i <= Degree; i++)
-    {
-      ip++;
-      if (ip > PUpper)
-      {
-        ip = PLower;
-      }
-      pole[1] = w = (*Weights)(ip);
-      pole[0]     = Poles(ip) * w;
-      pole += 2;
-    }
-  }
-}
-
-//=================================================================================================
-
-static void PrepareEval(double&                           u,
-                        int&                              index,
-                        int&                              dim,
-                        bool&                             rational,
-                        const int                         Degree,
-                        const bool                        Periodic,
-                        const NCollection_Array1<double>& Poles,
-                        const NCollection_Array1<double>* Weights,
-                        const NCollection_Array1<double>& Knots,
-                        const NCollection_Array1<int>*    Mults,
-                        BSplCLib_DataContainer&           dc)
-{
-  // Set the Index
-  BSplCLib::LocateParameter(Degree, Knots, Mults, u, Periodic, index, u);
-
-  // make the knots
-  BSplCLib::BuildKnots(Degree, index, Periodic, Knots, Mults, *dc.knots);
-  if (Mults == nullptr)
-  {
-    index -= Knots.Lower() + Degree;
-  }
-  else
-  {
-    index = BSplCLib::PoleIndex(Degree, index, Periodic, *Mults);
-  }
-
-  // check truly rational
-  rational = (Weights != nullptr);
-  if (rational)
-  {
-    int WLower = Weights->Lower() + index;
-    rational   = BSplCLib::IsRational(*Weights, WLower, WLower + Degree);
-  }
-
-  // make the poles
-  if (rational)
-  {
-    dim = 2;
-    BSplCLib::BuildEval(Degree, index, Poles, Weights, *dc.poles);
-  }
-  else
-  {
-    dim = 1;
-    BSplCLib::BuildEval(Degree, index, Poles, BSplCLib::NoWeights(), *dc.poles);
-  }
+  BSplCLib_BuildEval<double, double, NCollection_Array1<double>, 1>(Degree,
+                                                                    Index,
+                                                                    Poles,
+                                                                    Weights,
+                                                                    LP);
 }
 
 //=================================================================================================
@@ -149,21 +68,8 @@ void BSplCLib::D0(const double                      U,
                   const NCollection_Array1<int>*    Mults,
                   double&                           P)
 {
-  int    dim, index = Index;
-  double u = U;
-  bool   rational;
-  validateBSplineDegree(Degree);
-  BSplCLib_DataContainer dc;
-  PrepareEval(u, index, dim, rational, Degree, Periodic, Poles, Weights, Knots, Mults, dc);
-  BSplCLib::Eval(u, Degree, *dc.knots, dim, *dc.poles);
-  if (rational)
-  {
-    P = dc.poles[0] / dc.poles[1];
-  }
-  else
-  {
-    P = dc.poles[0];
-  }
+  BSplCLib_D0<double, double, NCollection_Array1<double>, 1>(
+    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P);
 }
 
 //=================================================================================================
@@ -179,21 +85,8 @@ void BSplCLib::D1(const double                      U,
                   double&                           P,
                   double&                           V)
 {
-  int    dim, index = Index;
-  double u = U;
-  bool   rational;
-  validateBSplineDegree(Degree);
-  BSplCLib_DataContainer dc;
-  PrepareEval(u, index, dim, rational, Degree, Periodic, Poles, Weights, Knots, Mults, dc);
-  BSplCLib::Bohm(u, Degree, 1, *dc.knots, dim, *dc.poles);
-  double* result = dc.poles;
-  if (rational)
-  {
-    PLib::RationalDerivative(Degree, 1, 1, *dc.poles, *dc.ders);
-    result = dc.ders;
-  }
-  P = result[0];
-  V = result[1];
+  BSplCLib_D1<double, double, NCollection_Array1<double>, 1>(
+    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P, V);
 }
 
 //=================================================================================================
@@ -210,29 +103,8 @@ void BSplCLib::D2(const double                      U,
                   double&                           V1,
                   double&                           V2)
 {
-  int    dim, index = Index;
-  double u = U;
-  bool   rational;
-  validateBSplineDegree(Degree);
-  BSplCLib_DataContainer dc;
-  PrepareEval(u, index, dim, rational, Degree, Periodic, Poles, Weights, Knots, Mults, dc);
-  BSplCLib::Bohm(u, Degree, 2, *dc.knots, dim, *dc.poles);
-  double* result = dc.poles;
-  if (rational)
-  {
-    PLib::RationalDerivative(Degree, 2, 1, *dc.poles, *dc.ders);
-    result = dc.ders;
-  }
-  P  = result[0];
-  V1 = result[1];
-  if (!rational && (Degree < 2))
-  {
-    V2 = 0.;
-  }
-  else
-  {
-    V2 = result[2];
-  }
+  BSplCLib_D2<double, double, NCollection_Array1<double>, 1>(
+    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P, V1, V2);
 }
 
 //=================================================================================================
@@ -250,37 +122,8 @@ void BSplCLib::D3(const double                      U,
                   double&                           V2,
                   double&                           V3)
 {
-  int    dim, index = Index;
-  double u = U;
-  bool   rational;
-  validateBSplineDegree(Degree);
-  BSplCLib_DataContainer dc;
-  PrepareEval(u, index, dim, rational, Degree, Periodic, Poles, Weights, Knots, Mults, dc);
-  BSplCLib::Bohm(u, Degree, 3, *dc.knots, dim, *dc.poles);
-  double* result = dc.poles;
-  if (rational)
-  {
-    PLib::RationalDerivative(Degree, 3, 1, *dc.poles, *dc.ders);
-    result = dc.ders;
-  }
-  P  = result[0];
-  V1 = result[1];
-  if (!rational && (Degree < 2))
-  {
-    V2 = 0.;
-  }
-  else
-  {
-    V2 = result[2];
-  }
-  if (!rational && (Degree < 3))
-  {
-    V3 = 0.;
-  }
-  else
-  {
-    V3 = result[3];
-  }
+  BSplCLib_D3<double, double, NCollection_Array1<double>, 1>(
+    U, Index, Degree, Periodic, Poles, Weights, Knots, Mults, P, V1, V2, V3);
 }
 
 //=================================================================================================
@@ -296,30 +139,8 @@ void BSplCLib::DN(const double                      U,
                   const NCollection_Array1<int>*    Mults,
                   double&                           VN)
 {
-  int    dim, index = Index;
-  double u = U;
-  bool   rational;
-  validateBSplineDegree(Degree);
-  BSplCLib_DataContainer dc;
-  PrepareEval(u, index, dim, rational, Degree, Periodic, Poles, Weights, Knots, Mults, dc);
-  BSplCLib::Bohm(u, Degree, N, *dc.knots, dim, *dc.poles);
-  if (rational)
-  {
-    double v;
-    PLib::RationalDerivative(Degree, N, 1, *dc.poles, v, false);
-    VN = v;
-  }
-  else
-  {
-    if (N > Degree)
-    {
-      VN = 0.;
-    }
-    else
-    {
-      VN = dc.poles[N];
-    }
-  }
+  BSplCLib_DN<double, double, NCollection_Array1<double>, 1>(
+    U, N, Index, Degree, Periodic, Poles, Weights, Knots, Mults, VN);
 }
 
 //=================================================================================================

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheParams.hxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CacheParams.hxx
@@ -16,7 +16,6 @@
 
 #include <BSplCLib.hxx>
 
-#include <algorithm>
 #include <cmath>
 
 //! Simple structure containing parameters describing parameterization
@@ -88,14 +87,7 @@ struct BSplCLib_CacheParams
       return false;
     }
 
-    if (SpanIndex == SpanIndexMax)
-      return true;
-
-    // from BSplCLib::LocateParameter() check hitting of the next knot
-    // within double floating point precision
-    const double anEps        = Epsilon((std::min)(std::fabs(LastParameter), std::fabs(aNewParam)));
-    const double aDeltaToNext = std::fabs(aDelta - SpanLength);
-    return aDeltaToNext > anEps; // next knot should be used instead
+    return true;
   }
 
   //! Computes span for the specified parameter

--- a/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CurveComputation.pxx
+++ b/src/FoundationClasses/TKMath/BSplCLib/BSplCLib_CurveComputation.pxx
@@ -30,29 +30,39 @@
 #include <algorithm>
 #include <utility>
 
-// Template traits for 2D/3D point and vector operations
+// Template traits for scalar/2D/3D point and vector operations
 template <typename Point, typename Vector, typename Array1OfPoints, int Dimension>
 struct BSplCLib_CurveTraits
 {
+  static_assert(Dimension >= 1 && Dimension <= 3, "Unsupported B-spline curve dimension");
+
   // Coordinate operations
-  static void PointToCoords(double* carr, const Point& pnt, double op)
+  static void PointToCoords(double* carr, const Point& pnt)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
     {
-      carr[0] = pnt.X() + op;
-      carr[1] = pnt.Y() + op;
+      carr[0] = pnt;
+    }
+    else if constexpr (Dimension == 2)
+    {
+      carr[0] = pnt.X();
+      carr[1] = pnt.Y();
     }
     else if constexpr (Dimension == 3)
     {
-      carr[0] = pnt.X() + op;
-      carr[1] = pnt.Y() + op;
-      carr[2] = pnt.Z() + op;
+      carr[0] = pnt.X();
+      carr[1] = pnt.Y();
+      carr[2] = pnt.Z();
     }
   }
 
   static void PointToCoordsScaled(double* carr, const Point& pnt, double scale)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      carr[0] = pnt * scale;
+    }
+    else if constexpr (Dimension == 2)
     {
       carr[0] = pnt.X() * scale;
       carr[1] = pnt.Y() * scale;
@@ -67,7 +77,11 @@ struct BSplCLib_CurveTraits
 
   static void CoordsToPointMultiplied(Point& pnt, const double* carr, double factor)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      pnt = carr[0] * factor;
+    }
+    else if constexpr (Dimension == 2)
     {
       pnt.SetX(carr[0] * factor);
       pnt.SetY(carr[1] * factor);
@@ -82,7 +96,11 @@ struct BSplCLib_CurveTraits
 
   static void CoordsToPointScaled(Point& pnt, const double* carr, double scale)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      pnt = carr[0] / scale;
+    }
+    else if constexpr (Dimension == 2)
     {
       pnt.SetX(carr[0] / scale);
       pnt.SetY(carr[1] / scale);
@@ -97,7 +115,11 @@ struct BSplCLib_CurveTraits
 
   static void CoordsToPointDirect(Point& pnt, const double* carr)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      pnt = carr[0];
+    }
+    else if constexpr (Dimension == 2)
     {
       pnt.SetX(carr[0]);
       pnt.SetY(carr[1]);
@@ -112,7 +134,11 @@ struct BSplCLib_CurveTraits
 
   static void CoordsToVectorDirect(Vector& vec, const double* carr)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      vec = carr[0];
+    }
+    else if constexpr (Dimension == 2)
     {
       vec.SetX(carr[0]);
       vec.SetY(carr[1]);
@@ -127,7 +153,11 @@ struct BSplCLib_CurveTraits
 
   static void NullifyPoint(Point& pnt)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      pnt = 0.0;
+    }
+    else if constexpr (Dimension == 2)
     {
       pnt.SetCoord(0., 0.);
     }
@@ -139,7 +169,11 @@ struct BSplCLib_CurveTraits
 
   static void NullifyVector(Vector& vec)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      vec = 0.0;
+    }
+    else if constexpr (Dimension == 2)
     {
       vec.SetCoord(0., 0.);
     }
@@ -151,7 +185,11 @@ struct BSplCLib_CurveTraits
 
   static void NullifyCoords(double* carr)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      carr[0] = 0.0;
+    }
+    else if constexpr (Dimension == 2)
     {
       carr[0] = carr[1] = 0.;
     }
@@ -163,7 +201,11 @@ struct BSplCLib_CurveTraits
 
   static void CopyCoords(double* carr, const double* carr2)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      carr[0] = carr2[0];
+    }
+    else if constexpr (Dimension == 2)
     {
       carr[0] = carr2[0];
       carr[1] = carr2[1];
@@ -178,7 +220,11 @@ struct BSplCLib_CurveTraits
 
   static void ModifyCoordsScale(double* carr, double scale)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      carr[0] *= scale;
+    }
+    else if constexpr (Dimension == 2)
     {
       carr[0] *= scale;
       carr[1] *= scale;
@@ -193,7 +239,11 @@ struct BSplCLib_CurveTraits
 
   static void ModifyCoordsDivide(double* carr, double divisor)
   {
-    if constexpr (Dimension == 2)
+    if constexpr (Dimension == 1)
+    {
+      carr[0] /= divisor;
+    }
+    else if constexpr (Dimension == 2)
     {
       carr[0] /= divisor;
       carr[1] /= divisor;
@@ -725,37 +775,33 @@ void BSplCLib_BuildEval(const int                         Degree,
 {
   using Traits = BSplCLib_CurveTraits<Point, Vector, Array1OfPoints, Dimension>;
 
-  double w, *pole = &LP;
-  int    PLower = Poles.Lower();
-  int    PUpper = Poles.Upper();
-  int    i;
-  int    ip = PLower + Index - 1;
+  double* pole       = &LP;
+  size_t  aPoleIndex = static_cast<size_t>(Index);
   if (Weights == nullptr)
   {
-    for (i = 0; i <= Degree; i++)
+    for (int i = 0; i <= Degree; ++i)
     {
-      ip++;
-      if (ip > PUpper)
+      if (aPoleIndex >= Poles.Size())
       {
-        ip = PLower;
+        aPoleIndex = 0;
       }
-      const Point& P = Poles(ip);
-      Traits::PointToCoords(pole, P, 0);
+      const Point& P = Poles.At(aPoleIndex++);
+      Traits::PointToCoords(pole, P);
       pole += Dimension;
     }
   }
   else
   {
-    for (i = 0; i <= Degree; i++)
+    for (int i = 0; i <= Degree; ++i)
     {
-      ip++;
-      if (ip > PUpper)
+      if (aPoleIndex >= Poles.Size())
       {
-        ip = PLower;
+        aPoleIndex = 0;
       }
-      const Point& P  = Poles(ip);
-      pole[Dimension] = w = (*Weights)(ip);
-      Traits::PointToCoordsScaled(pole, P, w);
+      const Point& P       = Poles.At(aPoleIndex);
+      const double aWeight = Weights->At(aPoleIndex++);
+      pole[Dimension]      = aWeight;
+      Traits::PointToCoordsScaled(pole, P, aWeight);
       pole += Dimension + 1;
     }
   }

--- a/src/FoundationClasses/TKMath/GTests/BSplCLib_Cache_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/BSplCLib_Cache_Test.cxx
@@ -547,10 +547,7 @@ TEST_F(BSplCLib_CacheTest, NearRepeatedKnotUsesActualSpan)
   aMults(4) = 3;
   aMults(5) = 4;
 
-  NCollection_Array1<double> aFlatKnots(1,
-                                        BSplCLib::KnotSequenceLength(aMults,
-                                                                    aDegree,
-                                                                    false));
+  NCollection_Array1<double> aFlatKnots(1, BSplCLib::KnotSequenceLength(aMults, aDegree, false));
   BSplCLib::KnotSequence(aKnots, aMults, aDegree, false, aFlatKnots);
 
   occ::handle<BSplCLib_Cache> aCache =
@@ -566,13 +563,7 @@ TEST_F(BSplCLib_CacheTest, NearRepeatedKnotUsesActualSpan)
 
     int    aRefSpan  = 0;
     double aRefParam = aParameter;
-    BSplCLib::LocateParameter(aDegree,
-                              aKnots,
-                              &aMults,
-                              aParameter,
-                              false,
-                              aRefSpan,
-                              aRefParam);
+    BSplCLib::LocateParameter(aDegree, aKnots, &aMults, aParameter, false, aRefSpan, aRefParam);
     if (aRefParam < aKnots.Value(aRefSpan))
     {
       --aRefSpan;

--- a/src/FoundationClasses/TKMath/GTests/BSplCLib_Cache_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/BSplCLib_Cache_Test.cxx
@@ -24,6 +24,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+
 namespace
 {
 constexpr double THE_TOLERANCE = 1e-10;
@@ -518,5 +520,79 @@ TEST_F(BSplCLib_CacheTest, D3_NonRationalCurve3D)
     // Compare torsion
     EXPECT_NEAR(aCacheTors.X(), aDirectTors.X(), THE_TOLERANCE)
       << "D3 torsion X mismatch at u=" << u;
+  }
+}
+
+TEST_F(BSplCLib_CacheTest, NearRepeatedKnotUsesActualSpan)
+{
+  constexpr int aDegree = 3;
+
+  NCollection_Array1<gp_Pnt> aPoles(1, 10);
+  for (int anIndex = aPoles.Lower(); anIndex <= aPoles.Upper(); ++anIndex)
+  {
+    const double aValue = static_cast<double>(anIndex);
+    aPoles(anIndex)     = gp_Pnt(aValue, std::sin(aValue), aValue * aValue);
+  }
+
+  NCollection_Array1<double> aKnots(1, 5);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.2;
+  aKnots(3) = 0.5;
+  aKnots(4) = 0.75;
+  aKnots(5) = 1.0;
+  NCollection_Array1<int> aMults(1, 5);
+  aMults(1) = 4;
+  aMults(2) = 1;
+  aMults(3) = 2;
+  aMults(4) = 3;
+  aMults(5) = 4;
+
+  NCollection_Array1<double> aFlatKnots(1,
+                                        BSplCLib::KnotSequenceLength(aMults,
+                                                                    aDegree,
+                                                                    false));
+  BSplCLib::KnotSequence(aKnots, aMults, aDegree, false, aFlatKnots);
+
+  occ::handle<BSplCLib_Cache> aCache =
+    new BSplCLib_Cache(aDegree, false, aFlatKnots, aPoles, nullptr);
+  for (const double aParameter : {std::nextafter(0.5, 0.0), std::nextafter(0.75, 0.0)})
+  {
+    aCache->BuildCache(aParameter, aFlatKnots, aPoles, nullptr);
+    EXPECT_TRUE(aCache->IsCacheValid(aParameter));
+
+    gp_Pnt aPoint, aRefPoint;
+    gp_Vec aD1, aD2, aD3, aRefD1, aRefD2, aRefD3;
+    aCache->D3(aParameter, aPoint, aD1, aD2, aD3);
+
+    int    aRefSpan  = 0;
+    double aRefParam = aParameter;
+    BSplCLib::LocateParameter(aDegree,
+                              aKnots,
+                              &aMults,
+                              aParameter,
+                              false,
+                              aRefSpan,
+                              aRefParam);
+    if (aRefParam < aKnots.Value(aRefSpan))
+    {
+      --aRefSpan;
+    }
+    BSplCLib::D3(aRefParam,
+                 aRefSpan,
+                 aDegree,
+                 false,
+                 aPoles,
+                 nullptr,
+                 aKnots,
+                 &aMults,
+                 aRefPoint,
+                 aRefD1,
+                 aRefD2,
+                 aRefD3);
+
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, THE_TOLERANCE));
+    EXPECT_TRUE(aD1.IsEqual(aRefD1, THE_TOLERANCE, THE_TOLERANCE));
+    EXPECT_TRUE(aD2.IsEqual(aRefD2, THE_TOLERANCE, THE_TOLERANCE));
+    EXPECT_TRUE(aD3.IsEqual(aRefD3, THE_TOLERANCE, THE_TOLERANCE));
   }
 }

--- a/src/FoundationClasses/TKMath/GTests/BSplCLib_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/BSplCLib_Test.cxx
@@ -15,6 +15,10 @@
 
 #include <BSplCLib.hxx>
 #include <NCollection_Array1.hxx>
+#include <gp_Pnt2d.hxx>
+#include <gp_Vec2d.hxx>
+
+#include <cmath>
 
 TEST(BSplCLibTest, UnitWeights_SmallSize_ReturnsNonOwning)
 {
@@ -73,4 +77,307 @@ TEST(BSplCLibTest, MaxUnitWeightsSize_IsPositive)
 {
   EXPECT_GT(BSplCLib::MaxUnitWeightsSize(), 0);
   EXPECT_EQ(BSplCLib::MaxUnitWeightsSize(), 2049);
+}
+
+TEST(BSplCLibTest, ScalarBuildEvalUsesSharedLayout)
+{
+  NCollection_Array1<double> aPoles(1, 3);
+  aPoles(1) = 2.0;
+  aPoles(2) = 3.0;
+  aPoles(3) = 5.0;
+  NCollection_Array1<double> aWeights(1, 3);
+  aWeights(1) = 1.0;
+  aWeights(2) = 2.0;
+  aWeights(3) = 4.0;
+
+  double aPolynomial[3];
+  BSplCLib::BuildEval(2, 0, aPoles, BSplCLib::NoWeights(), aPolynomial[0]);
+  EXPECT_DOUBLE_EQ(aPolynomial[0], 2.0);
+  EXPECT_DOUBLE_EQ(aPolynomial[1], 3.0);
+  EXPECT_DOUBLE_EQ(aPolynomial[2], 5.0);
+
+  double aRational[6];
+  BSplCLib::BuildEval(2, 0, aPoles, &aWeights, aRational[0]);
+  EXPECT_DOUBLE_EQ(aRational[0], 2.0);
+  EXPECT_DOUBLE_EQ(aRational[1], 1.0);
+  EXPECT_DOUBLE_EQ(aRational[2], 6.0);
+  EXPECT_DOUBLE_EQ(aRational[3], 2.0);
+  EXPECT_DOUBLE_EQ(aRational[4], 20.0);
+  EXPECT_DOUBLE_EQ(aRational[5], 4.0);
+
+  aPoles(1) = -0.0;
+  double aSignedZero;
+  BSplCLib::BuildEval(0, 0, aPoles, BSplCLib::NoWeights(), aSignedZero);
+  EXPECT_TRUE(std::signbit(aSignedZero));
+
+  NCollection_Array1<double> aShiftedPoles(-2, 0);
+  aShiftedPoles.ChangeAt(0) = 2.0;
+  aShiftedPoles.ChangeAt(1) = 3.0;
+  aShiftedPoles.ChangeAt(2) = 5.0;
+  double aWrapped[3];
+  BSplCLib::BuildEval(2, 2, aShiftedPoles, BSplCLib::NoWeights(), aWrapped[0]);
+  EXPECT_DOUBLE_EQ(aWrapped[0], 5.0);
+  EXPECT_DOUBLE_EQ(aWrapped[1], 2.0);
+  EXPECT_DOUBLE_EQ(aWrapped[2], 3.0);
+
+  NCollection_Array1<double> aShiftedWeights(-2, 0);
+  aShiftedWeights.ChangeAt(0) = 1.0;
+  aShiftedWeights.ChangeAt(1) = 2.0;
+  aShiftedWeights.ChangeAt(2) = 4.0;
+  double aWrappedRational[6];
+  BSplCLib::BuildEval(2, 2, aShiftedPoles, &aShiftedWeights, aWrappedRational[0]);
+  EXPECT_DOUBLE_EQ(aWrappedRational[0], 20.0);
+  EXPECT_DOUBLE_EQ(aWrappedRational[1], 4.0);
+  EXPECT_DOUBLE_EQ(aWrappedRational[2], 2.0);
+  EXPECT_DOUBLE_EQ(aWrappedRational[3], 1.0);
+  EXPECT_DOUBLE_EQ(aWrappedRational[4], 6.0);
+  EXPECT_DOUBLE_EQ(aWrappedRational[5], 2.0);
+}
+
+TEST(BSplCLibTest, ScalarEvaluationMatches2dSharedImplementation)
+{
+  constexpr int aDegree = 3;
+
+  NCollection_Array1<double>   aScalarPoles(1, 7);
+  NCollection_Array1<gp_Pnt2d> aPoles2d(1, 7);
+  NCollection_Array1<double>   aWeights(1, 7);
+  for (size_t anIndex = 0; anIndex < aScalarPoles.Size(); ++anIndex)
+  {
+    const double aValue            = std::sin(static_cast<double>(anIndex + 1));
+    aScalarPoles.ChangeAt(anIndex) = aValue;
+    aPoles2d.ChangeAt(anIndex)     = gp_Pnt2d(aValue, 0.0);
+    aWeights.ChangeAt(anIndex)     = 1.0 + 0.1 * static_cast<double>(anIndex + 1);
+  }
+
+  NCollection_Array1<double> aKnots(1, 4);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.3;
+  aKnots(3) = 0.7;
+  aKnots(4) = 1.0;
+  NCollection_Array1<int> aMults(1, 4);
+  aMults(1) = 4;
+  aMults(2) = 1;
+  aMults(3) = 2;
+  aMults(4) = 4;
+
+  for (const NCollection_Array1<double>* aCurveWeights : {BSplCLib::NoWeights(), &aWeights})
+  {
+    for (const double aParameter : {0.0,
+                                    std::nextafter(0.3, 0.0),
+                                    0.3,
+                                    0.5,
+                                    std::nextafter(0.7, 0.0),
+                                    0.7,
+                                    1.0})
+    {
+      double aValue, aD1, aD2, aD3;
+      BSplCLib::D3(aParameter,
+                   0,
+                   aDegree,
+                   false,
+                   aScalarPoles,
+                   aCurveWeights,
+                   aKnots,
+                   &aMults,
+                   aValue,
+                   aD1,
+                   aD2,
+                   aD3);
+
+      gp_Pnt2d aPoint;
+      gp_Vec2d aVec1, aVec2, aVec3;
+      BSplCLib::D3(aParameter,
+                   0,
+                   aDegree,
+                   false,
+                   aPoles2d,
+                   aCurveWeights,
+                   aKnots,
+                   &aMults,
+                   aPoint,
+                   aVec1,
+                   aVec2,
+                   aVec3);
+
+      EXPECT_NEAR(aValue, aPoint.X(), 1.0e-12);
+      EXPECT_NEAR(aD1, aVec1.X(), 1.0e-12);
+      EXPECT_NEAR(aD2, aVec2.X(), 1.0e-12);
+      EXPECT_NEAR(aD3, aVec3.X(), 1.0e-12);
+      EXPECT_NEAR(aPoint.Y(), 0.0, 1.0e-12);
+      EXPECT_NEAR(aVec1.Y(), 0.0, 1.0e-12);
+      EXPECT_NEAR(aVec2.Y(), 0.0, 1.0e-12);
+      EXPECT_NEAR(aVec3.Y(), 0.0, 1.0e-12);
+
+      for (int aDerivative = 1; aDerivative <= aDegree + 1; ++aDerivative)
+      {
+        double   aScalarDN;
+        gp_Vec2d aVecDN;
+        BSplCLib::DN(aParameter,
+                     aDerivative,
+                     0,
+                     aDegree,
+                     false,
+                     aScalarPoles,
+                     aCurveWeights,
+                     aKnots,
+                     &aMults,
+                     aScalarDN);
+        BSplCLib::DN(aParameter,
+                     aDerivative,
+                     0,
+                     aDegree,
+                     false,
+                     aPoles2d,
+                     aCurveWeights,
+                     aKnots,
+                     &aMults,
+                     aVecDN);
+        EXPECT_NEAR(aScalarDN, aVecDN.X(), 1.0e-12);
+        EXPECT_NEAR(aVecDN.Y(), 0.0, 1.0e-12);
+      }
+    }
+  }
+}
+
+TEST(BSplCLibTest, FlatKnotsNearRepeatedKnotUseActualSpan)
+{
+  constexpr int aDegree = 3;
+
+  NCollection_Array1<double> aPoles(1, 10);
+  for (size_t anIndex = 0; anIndex < aPoles.Size(); ++anIndex)
+  {
+    aPoles.ChangeAt(anIndex) = std::sin(static_cast<double>(anIndex + 1));
+  }
+
+  NCollection_Array1<double> aKnots(1, 5);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.2;
+  aKnots(3) = 0.5;
+  aKnots(4) = 0.75;
+  aKnots(5) = 1.0;
+  NCollection_Array1<int> aMults(1, 5);
+  aMults(1) = 4;
+  aMults(2) = 1;
+  aMults(3) = 2;
+  aMults(4) = 3;
+  aMults(5) = 4;
+
+  NCollection_Array1<double> aFlatKnots(1,
+                                        BSplCLib::KnotSequenceLength(aMults,
+                                                                    aDegree,
+                                                                    false));
+  BSplCLib::KnotSequence(aKnots, aMults, aDegree, false, aFlatKnots);
+
+  for (const double aParameter : {std::nextafter(0.5, 0.0), std::nextafter(0.75, 0.0)})
+  {
+    double aFlatParam = aParameter;
+    int    aFlatSpan  = 0;
+    BSplCLib::LocateParameter(aDegree,
+                              aFlatKnots,
+                              BSplCLib::NoMults(),
+                              aParameter,
+                              false,
+                              aFlatSpan,
+                              aFlatParam);
+    EXPECT_LE(aFlatKnots.Value(aFlatSpan), aFlatParam);
+    EXPECT_GT(aFlatKnots.Value(aFlatSpan + 1), aFlatParam);
+
+    double aBoundedParam = aParameter;
+    int    aBoundedSpan  = 0;
+    BSplCLib::LocateParameter(aDegree,
+                              aFlatKnots,
+                              aParameter,
+                              false,
+                              aFlatKnots.Lower() + aDegree,
+                              aFlatKnots.Upper() - aDegree,
+                              aBoundedSpan,
+                              aBoundedParam);
+    EXPECT_EQ(aBoundedSpan, aFlatSpan);
+
+    double aLegacyParam = aParameter;
+    int    aLegacySpan  = 0;
+    BSplCLib::LocateParameter(aDegree,
+                              aFlatKnots,
+                              aMults,
+                              aParameter,
+                              false,
+                              aFlatKnots.Lower() + aDegree,
+                              aFlatKnots.Upper() - aDegree,
+                              aLegacySpan,
+                              aLegacyParam);
+    EXPECT_EQ(aLegacySpan, aFlatSpan);
+
+    int    aRefSpan  = 0;
+    double aRefParam = aParameter;
+    BSplCLib::LocateParameter(aDegree,
+                              aKnots,
+                              &aMults,
+                              aParameter,
+                              false,
+                              aRefSpan,
+                              aRefParam);
+    if (aRefParam < aKnots.Value(aRefSpan))
+    {
+      --aRefSpan;
+    }
+
+    double aRefValue, aRefD1, aRefD2, aRefD3;
+    BSplCLib::D3(aRefParam,
+                 aRefSpan,
+                 aDegree,
+                 false,
+                 aPoles,
+                 BSplCLib::NoWeights(),
+                 aKnots,
+                 &aMults,
+                 aRefValue,
+                 aRefD1,
+                 aRefD2,
+                 aRefD3);
+
+    double aValue, aD1, aD2, aD3;
+    BSplCLib::D3(aParameter,
+                 0,
+                 aDegree,
+                 false,
+                 aPoles,
+                 BSplCLib::NoWeights(),
+                 aFlatKnots,
+                 BSplCLib::NoMults(),
+                 aValue,
+                 aD1,
+                 aD2,
+                 aD3);
+
+    EXPECT_NEAR(aValue, aRefValue, 1.0e-12);
+    EXPECT_NEAR(aD1, aRefD1, 1.0e-12);
+    EXPECT_NEAR(aD2, aRefD2, 1.0e-12);
+    EXPECT_NEAR(aD3, aRefD3, 1.0e-12);
+
+    for (int aDerivative = 1; aDerivative <= aDegree; ++aDerivative)
+    {
+      double aRefDN, aDN;
+      BSplCLib::DN(aRefParam,
+                   aDerivative,
+                   aRefSpan,
+                   aDegree,
+                   false,
+                   aPoles,
+                   BSplCLib::NoWeights(),
+                   aKnots,
+                   &aMults,
+                   aRefDN);
+      BSplCLib::DN(aParameter,
+                   aDerivative,
+                   0,
+                   aDegree,
+                   false,
+                   aPoles,
+                   BSplCLib::NoWeights(),
+                   aFlatKnots,
+                   BSplCLib::NoMults(),
+                   aDN);
+      EXPECT_NEAR(aDN, aRefDN, 1.0e-12);
+    }
+  }
 }

--- a/src/FoundationClasses/TKMath/GTests/BSplCLib_Test.cxx
+++ b/src/FoundationClasses/TKMath/GTests/BSplCLib_Test.cxx
@@ -162,13 +162,8 @@ TEST(BSplCLibTest, ScalarEvaluationMatches2dSharedImplementation)
 
   for (const NCollection_Array1<double>* aCurveWeights : {BSplCLib::NoWeights(), &aWeights})
   {
-    for (const double aParameter : {0.0,
-                                    std::nextafter(0.3, 0.0),
-                                    0.3,
-                                    0.5,
-                                    std::nextafter(0.7, 0.0),
-                                    0.7,
-                                    1.0})
+    for (const double aParameter :
+         {0.0, std::nextafter(0.3, 0.0), 0.3, 0.5, std::nextafter(0.7, 0.0), 0.7, 1.0})
     {
       double aValue, aD1, aD2, aD3;
       BSplCLib::D3(aParameter,
@@ -262,10 +257,7 @@ TEST(BSplCLibTest, FlatKnotsNearRepeatedKnotUseActualSpan)
   aMults(4) = 3;
   aMults(5) = 4;
 
-  NCollection_Array1<double> aFlatKnots(1,
-                                        BSplCLib::KnotSequenceLength(aMults,
-                                                                    aDegree,
-                                                                    false));
+  NCollection_Array1<double> aFlatKnots(1, BSplCLib::KnotSequenceLength(aMults, aDegree, false));
   BSplCLib::KnotSequence(aKnots, aMults, aDegree, false, aFlatKnots);
 
   for (const double aParameter : {std::nextafter(0.5, 0.0), std::nextafter(0.75, 0.0)})
@@ -309,13 +301,7 @@ TEST(BSplCLibTest, FlatKnotsNearRepeatedKnotUseActualSpan)
 
     int    aRefSpan  = 0;
     double aRefParam = aParameter;
-    BSplCLib::LocateParameter(aDegree,
-                              aKnots,
-                              &aMults,
-                              aParameter,
-                              false,
-                              aRefSpan,
-                              aRefParam);
+    BSplCLib::LocateParameter(aDegree, aKnots, &aMults, aParameter, false, aRefSpan, aRefParam);
     if (aRefParam < aKnots.Value(aRefSpan))
     {
       --aRefSpan;

--- a/src/ModelingData/TKG2d/GTests/Geom2d_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKG2d/GTests/Geom2d_BSplineCurve_Test.cxx
@@ -210,14 +210,14 @@ TEST_F(Geom2d_BSplineCurve_Test, Evaluation_D2)
 
 TEST(Geom2d_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
 {
-  NCollection_Array1<gp_Pnt2d> aPoles(1, 8);
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 10);
   for (int anIndex = 1; anIndex <= aPoles.Upper(); ++anIndex)
   {
     const double aX = static_cast<double>(anIndex - 1);
     aPoles(anIndex) = gp_Pnt2d(aX, std::sin(aX));
   }
 
-  NCollection_Array1<double> aWeights(1, 8);
+  NCollection_Array1<double> aWeights(1, 10);
   for (int anIndex = 1; anIndex <= aWeights.Upper(); ++anIndex)
   {
     aWeights(anIndex) = 1.0 + 0.1 * static_cast<double>(anIndex % 3);
@@ -233,12 +233,22 @@ TEST(Geom2d_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
   aMults(1) = 4;
   aMults(2) = 1;
   aMults(3) = 2;
-  aMults(4) = 1;
+  aMults(4) = 3;
   aMults(5) = 4;
   Geom2d_BSplineCurve aCurve(aPoles, aWeights, aKnots, aMults, 3);
 
   const double aParameters[] =
-    {0.0, 0.1, std::nextafter(0.2, 0.0), 0.2, std::nextafter(0.2, 1.0), 0.5, 0.75, 0.9, 1.0};
+    {0.0,
+     0.1,
+     std::nextafter(0.2, 0.0),
+     0.2,
+     std::nextafter(0.2, 1.0),
+     std::nextafter(0.5, 0.0),
+     0.5,
+     std::nextafter(0.75, 0.0),
+     0.75,
+     0.9,
+     1.0};
   for (const double aParameter : aParameters)
   {
     gp_Pnt2d aRefPoint;
@@ -266,6 +276,10 @@ TEST(Geom2d_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
     expectVectorNear(aD1, aRefD1);
     expectVectorNear(aD2, aRefD2);
     expectVectorNear(aD3, aRefD3);
+
+    expectVectorNear(aCurve.DN(aParameter, 1), aRefD1);
+    expectVectorNear(aCurve.DN(aParameter, 2), aRefD2);
+    expectVectorNear(aCurve.DN(aParameter, 3), aRefD3);
   }
 }
 

--- a/src/ModelingData/TKG2d/GTests/Geom2d_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKG2d/GTests/Geom2d_BSplineCurve_Test.cxx
@@ -237,18 +237,17 @@ TEST(Geom2d_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
   aMults(5) = 4;
   Geom2d_BSplineCurve aCurve(aPoles, aWeights, aKnots, aMults, 3);
 
-  const double aParameters[] =
-    {0.0,
-     0.1,
-     std::nextafter(0.2, 0.0),
-     0.2,
-     std::nextafter(0.2, 1.0),
-     std::nextafter(0.5, 0.0),
-     0.5,
-     std::nextafter(0.75, 0.0),
-     0.75,
-     0.9,
-     1.0};
+  const double aParameters[] = {0.0,
+                                0.1,
+                                std::nextafter(0.2, 0.0),
+                                0.2,
+                                std::nextafter(0.2, 1.0),
+                                std::nextafter(0.5, 0.0),
+                                0.5,
+                                std::nextafter(0.75, 0.0),
+                                0.75,
+                                0.9,
+                                1.0};
   for (const double aParameter : aParameters)
   {
     gp_Pnt2d aRefPoint;

--- a/src/ModelingData/TKG2d/GTests/Geom2d_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKG2d/GTests/Geom2d_BSplineCurve_Test.cxx
@@ -12,6 +12,7 @@
 // commercial license or contractual agreement.
 
 #include <Geom2d_BSplineCurve.hxx>
+#include <BSplCLib.hxx>
 #include <gp_Pnt2d.hxx>
 #include <gp_Vec2d.hxx>
 #include <gp_Trsf2d.hxx>
@@ -45,6 +46,49 @@ protected:
 
   occ::handle<Geom2d_BSplineCurve> myOriginalCurve;
 };
+
+namespace
+{
+void evaluateWithCompressedKnots(const Geom2d_BSplineCurve& theCurve,
+                                 const double               theParameter,
+                                 gp_Pnt2d&                  thePoint,
+                                 gp_Vec2d&                  theD1,
+                                 gp_Vec2d&                  theD2,
+                                 gp_Vec2d&                  theD3)
+{
+  int    aSpanIndex = 0;
+  double aParameter = theParameter;
+  BSplCLib::LocateParameter(theCurve.Degree(),
+                            theCurve.Knots(),
+                            &theCurve.Multiplicities(),
+                            theParameter,
+                            theCurve.IsPeriodic(),
+                            aSpanIndex,
+                            aParameter);
+  if (aParameter < theCurve.Knots().Value(aSpanIndex))
+  {
+    --aSpanIndex;
+  }
+  BSplCLib::D3(aParameter,
+               aSpanIndex,
+               theCurve.Degree(),
+               theCurve.IsPeriodic(),
+               theCurve.Poles(),
+               theCurve.Weights(),
+               theCurve.Knots(),
+               &theCurve.Multiplicities(),
+               thePoint,
+               theD1,
+               theD2,
+               theD3);
+}
+
+void expectVectorNear(const gp_Vec2d& theActual, const gp_Vec2d& theExpected)
+{
+  EXPECT_NEAR(theActual.X(), theExpected.X(), 1.0e-12);
+  EXPECT_NEAR(theActual.Y(), theExpected.Y(), 1.0e-12);
+}
+} // namespace
 
 TEST_F(Geom2d_BSplineCurve_Test, CopyConstructorBasicProperties)
 {
@@ -162,6 +206,67 @@ TEST_F(Geom2d_BSplineCurve_Test, Evaluation_D2)
   gp_Vec2d aV1, aV2;
   myOriginalCurve->D2(0.5, aPnt, aV1, aV2);
   EXPECT_GT(aV1.Magnitude(), 0.0);
+}
+
+TEST(Geom2d_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
+{
+  NCollection_Array1<gp_Pnt2d> aPoles(1, 8);
+  for (int anIndex = 1; anIndex <= aPoles.Upper(); ++anIndex)
+  {
+    const double aX = static_cast<double>(anIndex - 1);
+    aPoles(anIndex) = gp_Pnt2d(aX, std::sin(aX));
+  }
+
+  NCollection_Array1<double> aWeights(1, 8);
+  for (int anIndex = 1; anIndex <= aWeights.Upper(); ++anIndex)
+  {
+    aWeights(anIndex) = 1.0 + 0.1 * static_cast<double>(anIndex % 3);
+  }
+
+  NCollection_Array1<double> aKnots(1, 5);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.2;
+  aKnots(3) = 0.5;
+  aKnots(4) = 0.75;
+  aKnots(5) = 1.0;
+  NCollection_Array1<int> aMults(1, 5);
+  aMults(1) = 4;
+  aMults(2) = 1;
+  aMults(3) = 2;
+  aMults(4) = 1;
+  aMults(5) = 4;
+  Geom2d_BSplineCurve aCurve(aPoles, aWeights, aKnots, aMults, 3);
+
+  const double aParameters[] =
+    {0.0, 0.1, std::nextafter(0.2, 0.0), 0.2, std::nextafter(0.2, 1.0), 0.5, 0.75, 0.9, 1.0};
+  for (const double aParameter : aParameters)
+  {
+    gp_Pnt2d aRefPoint;
+    gp_Vec2d aRefD1, aRefD2, aRefD3;
+    evaluateWithCompressedKnots(aCurve, aParameter, aRefPoint, aRefD1, aRefD2, aRefD3);
+
+    gp_Pnt2d aPoint;
+    aCurve.D0(aParameter, aPoint);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+
+    gp_Vec2d aD1;
+    aCurve.D1(aParameter, aPoint, aD1);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+
+    gp_Vec2d aD2;
+    aCurve.D2(aParameter, aPoint, aD1, aD2);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+    expectVectorNear(aD2, aRefD2);
+
+    gp_Vec2d aD3;
+    aCurve.D3(aParameter, aPoint, aD1, aD2, aD3);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+    expectVectorNear(aD2, aRefD2);
+    expectVectorNear(aD3, aRefD3);
+  }
 }
 
 TEST_F(Geom2d_BSplineCurve_Test, Evaluation_DN)
@@ -286,6 +391,18 @@ TEST_F(Geom2d_BSplineCurve_Test, PeriodicCurve)
   occ::handle<Geom2d_BSplineCurve> aCurve =
     new Geom2d_BSplineCurve(aPoles, aKnots, aMults, 3, true);
   EXPECT_TRUE(aCurve->IsPeriodic());
+
+  for (const double aParameter : {-0.1, 0.0, 0.2, 0.5, 1.0, 1.1})
+  {
+    gp_Pnt2d aRefPoint, aPoint;
+    gp_Vec2d aRefD1, aRefD2, aRefD3, aD1, aD2, aD3;
+    evaluateWithCompressedKnots(*aCurve, aParameter, aRefPoint, aRefD1, aRefD2, aRefD3);
+    aCurve->D3(aParameter, aPoint, aD1, aD2, aD3);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+    expectVectorNear(aD2, aRefD2);
+    expectVectorNear(aD3, aRefD3);
+  }
 
   gp_Pnt2d aVal1 = aCurve->Value(0.5);
   aCurve->SetNotPeriodic();

--- a/src/ModelingData/TKG2d/Geom2d/Geom2d_BSplineCurve_1.cxx
+++ b/src/ModelingData/TKG2d/Geom2d/Geom2d_BSplineCurve_1.cxx
@@ -184,13 +184,27 @@ gp_Pnt2d Geom2d_BSplineCurve::EvalD0(const double U) const
   int      aSpanIndex = 0;
   double   aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots.Value(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots.Value(aSpanIndex))
   {
     aSpanIndex--;
   }
 
-  BSplCLib::D0(aNewU, aSpanIndex, myDeg, myPeriodic, myPoles, Weights(), myKnots, &myMults, P);
+  BSplCLib::D0(aNewU,
+               aSpanIndex,
+               myDeg,
+               myPeriodic,
+               myPoles,
+               Weights(),
+               myFlatKnots,
+               BSplCLib::NoMults(),
+               P);
   return P;
 }
 
@@ -208,8 +222,14 @@ Geom2d_Curve::ResD1 Geom2d_BSplineCurve::EvalD1(const double U) const
   int                 aSpanIndex = 0;
   double              aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots.Value(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots.Value(aSpanIndex))
   {
     aSpanIndex--;
   }
@@ -220,8 +240,8 @@ Geom2d_Curve::ResD1 Geom2d_BSplineCurve::EvalD1(const double U) const
                myPeriodic,
                myPoles,
                Weights(),
-               myKnots,
-               &myMults,
+               myFlatKnots,
+               BSplCLib::NoMults(),
                aResult.Point,
                aResult.D1);
   return aResult;
@@ -241,8 +261,14 @@ Geom2d_Curve::ResD2 Geom2d_BSplineCurve::EvalD2(const double U) const
   int                 aSpanIndex = 0;
   double              aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots.Value(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots.Value(aSpanIndex))
   {
     aSpanIndex--;
   }
@@ -253,8 +279,8 @@ Geom2d_Curve::ResD2 Geom2d_BSplineCurve::EvalD2(const double U) const
                myPeriodic,
                myPoles,
                Weights(),
-               myKnots,
-               &myMults,
+               myFlatKnots,
+               BSplCLib::NoMults(),
                aResult.Point,
                aResult.D1,
                aResult.D2);
@@ -275,8 +301,14 @@ Geom2d_Curve::ResD3 Geom2d_BSplineCurve::EvalD3(const double U) const
   int                 aSpanIndex = 0;
   double              aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots.Value(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots.Value(aSpanIndex))
   {
     aSpanIndex--;
   }
@@ -287,8 +319,8 @@ Geom2d_Curve::ResD3 Geom2d_BSplineCurve::EvalD3(const double U) const
                myPeriodic,
                myPoles,
                Weights(),
-               myKnots,
-               &myMults,
+               myFlatKnots,
+               BSplCLib::NoMults(),
                aResult.Point,
                aResult.D1,
                aResult.D2,

--- a/src/ModelingData/TKG2d/Geom2d/Geom2d_BSplineCurve_1.cxx
+++ b/src/ModelingData/TKG2d/Geom2d/Geom2d_BSplineCurve_1.cxx
@@ -191,11 +191,6 @@ gp_Pnt2d Geom2d_BSplineCurve::EvalD0(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots.Value(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D0(aNewU,
                aSpanIndex,
                myDeg,
@@ -229,11 +224,6 @@ Geom2d_Curve::ResD1 Geom2d_BSplineCurve::EvalD1(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots.Value(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D1(aNewU,
                aSpanIndex,
                myDeg,
@@ -268,11 +258,6 @@ Geom2d_Curve::ResD2 Geom2d_BSplineCurve::EvalD2(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots.Value(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D2(aNewU,
                aSpanIndex,
                myDeg,
@@ -308,11 +293,6 @@ Geom2d_Curve::ResD3 Geom2d_BSplineCurve::EvalD3(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots.Value(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D3(aNewU,
                aSpanIndex,
                myDeg,

--- a/src/ModelingData/TKG3d/GTests/GeomGridEval_Curve_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/GeomGridEval_Curve_Test.cxx
@@ -537,6 +537,52 @@ TEST(GeomGridEval_BSplineCurveTest, MultiSpanBSpline)
   }
 }
 
+TEST(GeomGridEval_BSplineCurveTest, NearRepeatedKnotUsesActualSpan)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 7);
+  for (int anIndex = aPoles.Lower(); anIndex <= aPoles.Upper(); ++anIndex)
+  {
+    const double aValue = static_cast<double>(anIndex);
+    aPoles(anIndex)     = gp_Pnt(aValue, std::sin(aValue), aValue * aValue);
+  }
+
+  NCollection_Array1<double> aKnots(1, 3);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.5;
+  aKnots(3) = 1.0;
+  NCollection_Array1<int> aMults(1, 3);
+  aMults(1) = 4;
+  aMults(2) = 3;
+  aMults(3) = 4;
+
+  occ::handle<Geom_BSplineCurve> aCurve = new Geom_BSplineCurve(aPoles, aKnots, aMults, 3);
+  GeomGridEval_BSplineCurve      anEval(aCurve);
+
+  NCollection_Array1<double> aParams(1, 8);
+  aParams(1) = 0.45;
+  aParams(2) = 0.48;
+  aParams(3) = 0.49;
+  aParams(4) = std::nextafter(0.5, 0.0);
+  aParams(5) = 0.5;
+  aParams(6) = 0.51;
+  aParams(7) = 0.52;
+  aParams(8) = 0.55;
+
+  const NCollection_Array1<GeomGridEval::CurveD3> aGrid = anEval.EvaluateGridD3(aParams);
+  for (int anIndex = aParams.Lower(); anIndex <= aParams.Upper(); ++anIndex)
+  {
+    gp_Pnt aPoint;
+    gp_Vec aD1, aD2, aD3;
+    aCurve->D3(aParams(anIndex), aPoint, aD1, aD2, aD3);
+
+    const GeomGridEval::CurveD3& aGridValue = aGrid.Value(anIndex);
+    EXPECT_TRUE(aGridValue.Point.IsEqual(aPoint, THE_TOLERANCE));
+    EXPECT_TRUE(aGridValue.D1.IsEqual(aD1, THE_TOLERANCE, THE_TOLERANCE));
+    EXPECT_TRUE(aGridValue.D2.IsEqual(aD2, THE_TOLERANCE, THE_TOLERANCE));
+    EXPECT_TRUE(aGridValue.D3.IsEqual(aD3, THE_TOLERANCE, THE_TOLERANCE));
+  }
+}
+
 TEST(GeomGridEval_BSplineCurveTest, HighDegree)
 {
   // Create a higher degree B-spline (degree 5)

--- a/src/ModelingData/TKG3d/GTests/Geom_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/Geom_BSplineCurve_Test.cxx
@@ -228,14 +228,14 @@ TEST_F(Geom_BSplineCurve_Test, Evaluation_D3)
 
 TEST(Geom_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
 {
-  NCollection_Array1<gp_Pnt> aPoles(1, 8);
+  NCollection_Array1<gp_Pnt> aPoles(1, 10);
   for (int anIndex = 1; anIndex <= aPoles.Upper(); ++anIndex)
   {
     const double aX = static_cast<double>(anIndex - 1);
     aPoles(anIndex) = gp_Pnt(aX, std::sin(aX), 0.25 * aX * aX);
   }
 
-  NCollection_Array1<double> aWeights(1, 8);
+  NCollection_Array1<double> aWeights(1, 10);
   for (int anIndex = 1; anIndex <= aWeights.Upper(); ++anIndex)
   {
     aWeights(anIndex) = 1.0 + 0.1 * static_cast<double>(anIndex % 3);
@@ -251,12 +251,22 @@ TEST(Geom_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
   aMults(1) = 4;
   aMults(2) = 1;
   aMults(3) = 2;
-  aMults(4) = 1;
+  aMults(4) = 3;
   aMults(5) = 4;
   Geom_BSplineCurve aCurve(aPoles, aWeights, aKnots, aMults, 3);
 
   const double aParameters[] =
-    {0.0, 0.1, std::nextafter(0.2, 0.0), 0.2, std::nextafter(0.2, 1.0), 0.5, 0.75, 0.9, 1.0};
+    {0.0,
+     0.1,
+     std::nextafter(0.2, 0.0),
+     0.2,
+     std::nextafter(0.2, 1.0),
+     std::nextafter(0.5, 0.0),
+     0.5,
+     std::nextafter(0.75, 0.0),
+     0.75,
+     0.9,
+     1.0};
   for (const double aParameter : aParameters)
   {
     gp_Pnt aRefPoint;
@@ -284,6 +294,10 @@ TEST(Geom_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
     expectVectorNear(aD1, aRefD1);
     expectVectorNear(aD2, aRefD2);
     expectVectorNear(aD3, aRefD3);
+
+    expectVectorNear(aCurve.DN(aParameter, 1), aRefD1);
+    expectVectorNear(aCurve.DN(aParameter, 2), aRefD2);
+    expectVectorNear(aCurve.DN(aParameter, 3), aRefD3);
   }
 }
 

--- a/src/ModelingData/TKG3d/GTests/Geom_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/Geom_BSplineCurve_Test.cxx
@@ -255,18 +255,17 @@ TEST(Geom_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
   aMults(5) = 4;
   Geom_BSplineCurve aCurve(aPoles, aWeights, aKnots, aMults, 3);
 
-  const double aParameters[] =
-    {0.0,
-     0.1,
-     std::nextafter(0.2, 0.0),
-     0.2,
-     std::nextafter(0.2, 1.0),
-     std::nextafter(0.5, 0.0),
-     0.5,
-     std::nextafter(0.75, 0.0),
-     0.75,
-     0.9,
-     1.0};
+  const double aParameters[] = {0.0,
+                                0.1,
+                                std::nextafter(0.2, 0.0),
+                                0.2,
+                                std::nextafter(0.2, 1.0),
+                                std::nextafter(0.5, 0.0),
+                                0.5,
+                                std::nextafter(0.75, 0.0),
+                                0.75,
+                                0.9,
+                                1.0};
   for (const double aParameter : aParameters)
   {
     gp_Pnt aRefPoint;

--- a/src/ModelingData/TKG3d/GTests/Geom_BSplineCurve_Test.cxx
+++ b/src/ModelingData/TKG3d/GTests/Geom_BSplineCurve_Test.cxx
@@ -15,6 +15,7 @@
 
 #include <cmath>
 
+#include <BSplCLib.hxx>
 #include <Geom_BSplineCurve.hxx>
 #include <gp_Pnt.hxx>
 #include <gp_Vec.hxx>
@@ -47,6 +48,50 @@ protected:
 
   occ::handle<Geom_BSplineCurve> myOriginalCurve;
 };
+
+namespace
+{
+void evaluateWithCompressedKnots(const Geom_BSplineCurve& theCurve,
+                                 const double             theParameter,
+                                 gp_Pnt&                  thePoint,
+                                 gp_Vec&                  theD1,
+                                 gp_Vec&                  theD2,
+                                 gp_Vec&                  theD3)
+{
+  int    aSpanIndex = 0;
+  double aParameter = theParameter;
+  BSplCLib::LocateParameter(theCurve.Degree(),
+                            theCurve.Knots(),
+                            &theCurve.Multiplicities(),
+                            theParameter,
+                            theCurve.IsPeriodic(),
+                            aSpanIndex,
+                            aParameter);
+  if (aParameter < theCurve.Knots()(aSpanIndex))
+  {
+    --aSpanIndex;
+  }
+  BSplCLib::D3(aParameter,
+               aSpanIndex,
+               theCurve.Degree(),
+               theCurve.IsPeriodic(),
+               theCurve.Poles(),
+               theCurve.Weights(),
+               theCurve.Knots(),
+               &theCurve.Multiplicities(),
+               thePoint,
+               theD1,
+               theD2,
+               theD3);
+}
+
+void expectVectorNear(const gp_Vec& theActual, const gp_Vec& theExpected)
+{
+  EXPECT_NEAR(theActual.X(), theExpected.X(), 1.0e-12);
+  EXPECT_NEAR(theActual.Y(), theExpected.Y(), 1.0e-12);
+  EXPECT_NEAR(theActual.Z(), theExpected.Z(), 1.0e-12);
+}
+} // namespace
 
 TEST_F(Geom_BSplineCurve_Test, CopyConstructorBasicProperties)
 {
@@ -179,6 +224,67 @@ TEST_F(Geom_BSplineCurve_Test, Evaluation_D3)
   EXPECT_NEAR(aV3.X(), aV3b.X(), 1e-8);
   EXPECT_NEAR(aV3.Y(), aV3b.Y(), 1e-8);
   EXPECT_NEAR(aV3.Z(), aV3b.Z(), 1e-8);
+}
+
+TEST(Geom_BSplineCurve_EvaluationTest, FlatKnotsMatchCompressedKnots)
+{
+  NCollection_Array1<gp_Pnt> aPoles(1, 8);
+  for (int anIndex = 1; anIndex <= aPoles.Upper(); ++anIndex)
+  {
+    const double aX = static_cast<double>(anIndex - 1);
+    aPoles(anIndex) = gp_Pnt(aX, std::sin(aX), 0.25 * aX * aX);
+  }
+
+  NCollection_Array1<double> aWeights(1, 8);
+  for (int anIndex = 1; anIndex <= aWeights.Upper(); ++anIndex)
+  {
+    aWeights(anIndex) = 1.0 + 0.1 * static_cast<double>(anIndex % 3);
+  }
+
+  NCollection_Array1<double> aKnots(1, 5);
+  aKnots(1) = 0.0;
+  aKnots(2) = 0.2;
+  aKnots(3) = 0.5;
+  aKnots(4) = 0.75;
+  aKnots(5) = 1.0;
+  NCollection_Array1<int> aMults(1, 5);
+  aMults(1) = 4;
+  aMults(2) = 1;
+  aMults(3) = 2;
+  aMults(4) = 1;
+  aMults(5) = 4;
+  Geom_BSplineCurve aCurve(aPoles, aWeights, aKnots, aMults, 3);
+
+  const double aParameters[] =
+    {0.0, 0.1, std::nextafter(0.2, 0.0), 0.2, std::nextafter(0.2, 1.0), 0.5, 0.75, 0.9, 1.0};
+  for (const double aParameter : aParameters)
+  {
+    gp_Pnt aRefPoint;
+    gp_Vec aRefD1, aRefD2, aRefD3;
+    evaluateWithCompressedKnots(aCurve, aParameter, aRefPoint, aRefD1, aRefD2, aRefD3);
+
+    gp_Pnt aPoint;
+    aCurve.D0(aParameter, aPoint);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+
+    gp_Vec aD1;
+    aCurve.D1(aParameter, aPoint, aD1);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+
+    gp_Vec aD2;
+    aCurve.D2(aParameter, aPoint, aD1, aD2);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+    expectVectorNear(aD2, aRefD2);
+
+    gp_Vec aD3;
+    aCurve.D3(aParameter, aPoint, aD1, aD2, aD3);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+    expectVectorNear(aD2, aRefD2);
+    expectVectorNear(aD3, aRefD3);
+  }
 }
 
 TEST_F(Geom_BSplineCurve_Test, Evaluation_DN)
@@ -343,6 +449,18 @@ TEST_F(Geom_BSplineCurve_Test, PeriodicCurve)
 
   occ::handle<Geom_BSplineCurve> aCurve = new Geom_BSplineCurve(aPoles, aKnots, aMults, 3, true);
   EXPECT_TRUE(aCurve->IsPeriodic());
+
+  for (const double aParameter : {-0.1, 0.0, 0.2, 0.5, 1.0, 1.1})
+  {
+    gp_Pnt aRefPoint, aPoint;
+    gp_Vec aRefD1, aRefD2, aRefD3, aD1, aD2, aD3;
+    evaluateWithCompressedKnots(*aCurve, aParameter, aRefPoint, aRefD1, aRefD2, aRefD3);
+    aCurve->D3(aParameter, aPoint, aD1, aD2, aD3);
+    EXPECT_TRUE(aPoint.IsEqual(aRefPoint, 1.0e-12));
+    expectVectorNear(aD1, aRefD1);
+    expectVectorNear(aD2, aRefD2);
+    expectVectorNear(aD3, aRefD3);
+  }
 
   gp_Pnt aVal1 = aCurve->Value(0.5);
   aCurve->SetNotPeriodic();

--- a/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve_1.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve_1.cxx
@@ -190,11 +190,6 @@ gp_Pnt Geom_BSplineCurve::EvalD0(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D0(aNewU,
                aSpanIndex,
                myDeg,
@@ -228,11 +223,6 @@ Geom_Curve::ResD1 Geom_BSplineCurve::EvalD1(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D1(aNewU,
                aSpanIndex,
                myDeg,
@@ -267,11 +257,6 @@ Geom_Curve::ResD2 Geom_BSplineCurve::EvalD2(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D2(aNewU,
                aSpanIndex,
                myDeg,
@@ -307,11 +292,6 @@ Geom_Curve::ResD3 Geom_BSplineCurve::EvalD3(const double U) const
                             myPeriodic,
                             aSpanIndex,
                             aNewU);
-  if (aNewU < myFlatKnots(aSpanIndex))
-  {
-    aSpanIndex--;
-  }
-
   BSplCLib::D3(aNewU,
                aSpanIndex,
                myDeg,

--- a/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve_1.cxx
+++ b/src/ModelingData/TKG3d/Geom/Geom_BSplineCurve_1.cxx
@@ -183,13 +183,27 @@ gp_Pnt Geom_BSplineCurve::EvalD0(const double U) const
   int    aSpanIndex = 0;
   double aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots(aSpanIndex))
   {
     aSpanIndex--;
   }
 
-  BSplCLib::D0(aNewU, aSpanIndex, myDeg, myPeriodic, myPoles, Weights(), myKnots, &myMults, P);
+  BSplCLib::D0(aNewU,
+               aSpanIndex,
+               myDeg,
+               myPeriodic,
+               myPoles,
+               Weights(),
+               myFlatKnots,
+               BSplCLib::NoMults(),
+               P);
   return P;
 }
 
@@ -207,8 +221,14 @@ Geom_Curve::ResD1 Geom_BSplineCurve::EvalD1(const double U) const
   int               aSpanIndex = 0;
   double            aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots(aSpanIndex))
   {
     aSpanIndex--;
   }
@@ -219,8 +239,8 @@ Geom_Curve::ResD1 Geom_BSplineCurve::EvalD1(const double U) const
                myPeriodic,
                myPoles,
                Weights(),
-               myKnots,
-               &myMults,
+               myFlatKnots,
+               BSplCLib::NoMults(),
                aResult.Point,
                aResult.D1);
   return aResult;
@@ -240,8 +260,14 @@ Geom_Curve::ResD2 Geom_BSplineCurve::EvalD2(const double U) const
   int               aSpanIndex = 0;
   double            aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots(aSpanIndex))
   {
     aSpanIndex--;
   }
@@ -252,8 +278,8 @@ Geom_Curve::ResD2 Geom_BSplineCurve::EvalD2(const double U) const
                myPeriodic,
                myPoles,
                Weights(),
-               myKnots,
-               &myMults,
+               myFlatKnots,
+               BSplCLib::NoMults(),
                aResult.Point,
                aResult.D1,
                aResult.D2);
@@ -274,8 +300,14 @@ Geom_Curve::ResD3 Geom_BSplineCurve::EvalD3(const double U) const
   int               aSpanIndex = 0;
   double            aNewU(U);
   PeriodicNormalization(aNewU);
-  BSplCLib::LocateParameter(myDeg, myKnots, &myMults, U, myPeriodic, aSpanIndex, aNewU);
-  if (aNewU < myKnots(aSpanIndex))
+  BSplCLib::LocateParameter(myDeg,
+                            myFlatKnots,
+                            BSplCLib::NoMults(),
+                            U,
+                            myPeriodic,
+                            aSpanIndex,
+                            aNewU);
+  if (aNewU < myFlatKnots(aSpanIndex))
   {
     aSpanIndex--;
   }
@@ -286,8 +318,8 @@ Geom_Curve::ResD3 Geom_BSplineCurve::EvalD3(const double U) const
                myPeriodic,
                myPoles,
                Weights(),
-               myKnots,
-               &myMults,
+               myFlatKnots,
+               BSplCLib::NoMults(),
                aResult.Point,
                aResult.D1,
                aResult.D2,


### PR DESCRIPTION
- Use flat knot sequences in Geom_BSplineCurve and Geom2d_BSplineCurve
  D0-D3 evaluation;
- Avoid multiplicity traversal and BSplCLib::PoleIndex() on the direct
  evaluation path;
- Add 2D and 3D tests comparing flat-knot evaluation against the
  compressed-knot implementation;
- Cover rational curves, endpoints, internal knots, adjacent floating-point
  parameters, and periodic parameters.