### PR TITLE
Data Exchange - Harden malformed input handling

### DIFF
--- a/src/DataExchange/TKDEOBJ/GTests/FILES.cmake
+++ b/src/DataExchange/TKDEOBJ/GTests/FILES.cmake
@@ -2,4 +2,5 @@
 set(OCCT_TKDEOBJ_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKDEOBJ_GTests_FILES
+  RWObj_Reader_Test.cxx
 )

--- a/src/DataExchange/TKDEOBJ/GTests/RWObj_Reader_Test.cxx
+++ b/src/DataExchange/TKDEOBJ/GTests/RWObj_Reader_Test.cxx
@@ -1,0 +1,85 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <RWObj_TriangulationReader.hxx>
+#include <NCollection_LinearVector.hxx>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+namespace
+{
+class TrackingReader : public RWObj_TriangulationReader
+{
+public:
+  const NCollection_LinearVector<TCollection_AsciiString>& Groups() const { return myGroups; }
+
+protected:
+  bool addMesh(const RWObj_SubMesh& theMesh, const RWObj_SubMeshReason theReason) override
+  {
+    if (theReason == RWObj_SubMeshReason_NewGroup)
+    {
+      myGroups.Append(theMesh.Group);
+    }
+    return RWObj_TriangulationReader::addMesh(theMesh, theReason);
+  }
+
+private:
+  NCollection_LinearVector<TCollection_AsciiString> myGroups;
+};
+} // namespace
+
+TEST(RWObj_ReaderTest, IgnoresIncompleteCommands)
+{
+  for (const char* aContent :
+       {"f", "f ", "v", "v ", "vn", "vt", "g", "s", "o", "mtllib", "mtllib ", "usemtl"})
+  {
+    std::istringstream        anInput(aContent);
+    RWObj_TriangulationReader aReader;
+    EXPECT_TRUE(aReader.Read(anInput, "minimal.obj", Message_ProgressRange()));
+    EXPECT_TRUE(aReader.ResultShape().IsNull());
+  }
+}
+
+TEST(RWObj_ReaderTest, ParsesCompleteCommands)
+{
+  std::istringstream        anInput("v 0 0 0\n"
+                                    "v 1 0 0\n"
+                                    "v 0 1 0\n"
+                                    "f 1 2 3\n");
+  RWObj_TriangulationReader aReader;
+  ASSERT_TRUE(aReader.Read(anInput, "triangle.obj", Message_ProgressRange()));
+  EXPECT_FALSE(aReader.ResultShape().IsNull());
+}
+
+TEST(RWObj_ReaderTest, ProcessesEmptyGroupName)
+{
+  std::istringstream anInput("g named\ng \n");
+  TrackingReader     aReader;
+  ASSERT_TRUE(aReader.Read(anInput, "groups.obj", Message_ProgressRange()));
+  ASSERT_EQ(aReader.Groups().Size(), 2u);
+  EXPECT_TRUE(aReader.Groups().Value(0).IsEmpty());
+  EXPECT_EQ(aReader.Groups().Value(1), "named");
+}
+
+TEST(RWObj_ReaderTest, ParsesFinalLineWithoutNewline)
+{
+  std::istringstream        anInput("v 0 0 0\n"
+                                    "v 1 0 0\n"
+                                    "v 0 1 0\n"
+                                    "f 1 2 3");
+  RWObj_TriangulationReader aReader;
+  ASSERT_TRUE(aReader.Read(anInput, "triangle.obj", Message_ProgressRange()));
+  EXPECT_FALSE(aReader.ResultShape().IsNull());
+}

--- a/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.cxx
+++ b/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.cxx
@@ -31,6 +31,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <string_view>
 
 #if defined(_WIN32)
   #define ftell64(a) _ftelli64(a)
@@ -46,6 +47,30 @@ namespace
 {
 // The length of buffer to read (in bytes)
 static const size_t THE_BUFFER_SIZE = 4 * 1024;
+
+//! Parsed OBJ command and its possibly empty arguments.
+struct ObjCommand
+{
+  std::string_view Name;
+  std::string_view Arguments;
+};
+
+//! Split an OBJ line into a command name and its arguments.
+static ObjCommand splitCommand(const std::string_view theLine)
+{
+  const size_t aNameEnd = theLine.find_first_of(" \t");
+  if (aNameEnd == std::string_view::npos)
+  {
+    return {theLine, {}};
+  }
+
+  size_t anArgumentOffset = aNameEnd;
+  while (anArgumentOffset < theLine.size() && RWObj_Tools::isSpaceChar(theLine[anArgumentOffset]))
+  {
+    ++anArgumentOffset;
+  }
+  return {theLine.substr(0, aNameEnd), theLine.substr(anArgumentOffset)};
+}
 
 //! Return TRUE if given polygon has clockwise node order.
 static bool isClockwisePolygon(const occ::handle<BRepMesh_DataStructureOfDelaun>& theMesh,
@@ -181,61 +206,63 @@ bool RWObj_Reader::read(std::istream&                  theStream,
       continue;
     }
     isStart = false;
+    const std::string_view aLineView(aLine, aLineLen);
+    const ObjCommand       aCommand = splitCommand(aLineView);
 
     if (theToProbe)
     {
-      if (::strncmp(aLine, "mtllib", 6) == 0)
+      if (aCommand.Name == "mtllib")
       {
-        readMaterialLib(IsSpace(aLine[6]) ? aLine + 7 : "");
+        readMaterialLib(aCommand.Arguments);
       }
-      else if (aLine[0] == 'v' && RWObj_Tools::isSpaceChar(aLine[1]))
+      else if (aCommand.Name == "v" && !aCommand.Arguments.empty())
       {
         ++myNbProbeNodes;
       }
-      else if (aLine[0] == 'f' && RWObj_Tools::isSpaceChar(aLine[1]))
+      else if (aCommand.Name == "f" && !aCommand.Arguments.empty())
       {
         ++myNbProbeElems;
       }
       continue;
     }
 
-    if (aLine[0] == 'v' && RWObj_Tools::isSpaceChar(aLine[1]))
+    if (aCommand.Name == "v" && !aCommand.Arguments.empty())
     {
       ++myNbProbeNodes;
-      pushVertex(aLine + 2);
+      pushVertex(aCommand.Arguments.data());
     }
-    else if (aLine[0] == 'v' && aLine[1] == 'n' && RWObj_Tools::isSpaceChar(aLine[2]))
+    else if (aCommand.Name == "vn" && !aCommand.Arguments.empty())
     {
-      pushNormal(aLine + 3);
+      pushNormal(aCommand.Arguments.data());
     }
-    else if (aLine[0] == 'v' && aLine[1] == 't' && RWObj_Tools::isSpaceChar(aLine[2]))
+    else if (aCommand.Name == "vt" && !aCommand.Arguments.empty())
     {
-      pushTexel(aLine + 3);
+      pushTexel(aCommand.Arguments.data());
     }
-    else if (aLine[0] == 'f' && RWObj_Tools::isSpaceChar(aLine[1]))
+    else if (aCommand.Name == "f" && !aCommand.Arguments.empty())
     {
       ++myNbProbeElems;
-      pushIndices(aLine + 2);
+      pushIndices(aCommand.Arguments.data());
     }
-    else if (aLine[0] == 'g' && IsSpace(aLine[1]))
+    else if (aCommand.Name == "g")
     {
-      pushGroup(aLine + 2);
+      pushGroup(aCommand.Arguments);
     }
-    else if (aLine[0] == 's' && IsSpace(aLine[1]))
+    else if (aCommand.Name == "s")
     {
-      pushSmoothGroup(aLine + 2);
+      pushSmoothGroup(aCommand.Arguments);
     }
-    else if (aLine[0] == 'o' && IsSpace(aLine[1]))
+    else if (aCommand.Name == "o")
     {
-      pushObject(aLine + 2);
+      pushObject(aCommand.Arguments);
     }
-    else if (::strncmp(aLine, "mtllib", 6) == 0)
+    else if (aCommand.Name == "mtllib")
     {
-      readMaterialLib(IsSpace(aLine[6]) ? aLine + 7 : "");
+      readMaterialLib(aCommand.Arguments);
     }
-    else if (::strncmp(aLine, "usemtl", 6) == 0)
+    else if (aCommand.Name == "usemtl")
     {
-      pushMaterial(IsSpace(aLine[6]) ? aLine + 7 : "");
+      pushMaterial(aCommand.Arguments);
     }
 
     if (!checkMemory())
@@ -612,7 +639,7 @@ int RWObj_Reader::triangulatePolygon(const NCollection_Array1<int>& theIndices)
 
 //=================================================================================================
 
-void RWObj_Reader::pushObject(const char* theObjectName)
+void RWObj_Reader::pushObject(const std::string_view theObjectName)
 {
   TCollection_AsciiString aNewObject;
   if (!RWObj_Tools::ReadName(theObjectName, aNewObject))
@@ -628,7 +655,7 @@ void RWObj_Reader::pushObject(const char* theObjectName)
 
 //=================================================================================================
 
-void RWObj_Reader::pushGroup(const char* theGroupName)
+void RWObj_Reader::pushGroup(const std::string_view theGroupName)
 {
   TCollection_AsciiString aNewGroup;
   if (!RWObj_Tools::ReadName(theGroupName, aNewGroup))
@@ -644,7 +671,7 @@ void RWObj_Reader::pushGroup(const char* theGroupName)
 
 //=================================================================================================
 
-void RWObj_Reader::pushSmoothGroup(const char* theSmoothGroupIndex)
+void RWObj_Reader::pushSmoothGroup(const std::string_view theSmoothGroupIndex)
 {
   TCollection_AsciiString aNewSmoothGroup;
   RWObj_Tools::ReadName(theSmoothGroupIndex, aNewSmoothGroup);
@@ -669,7 +696,7 @@ void RWObj_Reader::pushSmoothGroup(const char* theSmoothGroupIndex)
 
 //=================================================================================================
 
-void RWObj_Reader::pushMaterial(const char* theMaterialName)
+void RWObj_Reader::pushMaterial(const std::string_view theMaterialName)
 {
   TCollection_AsciiString aNewMat;
   if (!RWObj_Tools::ReadName(theMaterialName, aNewMat))
@@ -697,7 +724,7 @@ void RWObj_Reader::pushMaterial(const char* theMaterialName)
 
 //=================================================================================================
 
-void RWObj_Reader::readMaterialLib(const char* theFileName)
+void RWObj_Reader::readMaterialLib(const std::string_view theFileName)
 {
   TCollection_AsciiString aMatPath;
   if (!RWObj_Tools::ReadName(theFileName, aMatPath))

--- a/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.hxx
+++ b/src/DataExchange/TKDEOBJ/RWObj/RWObj_Reader.hxx
@@ -32,6 +32,8 @@
 #include <Standard_HashUtils.hxx>
 #include <NCollection_LinearVector.hxx>
 
+#include <string_view>
+
 //! An abstract class implementing procedure to read OBJ file.
 //!
 //! This class is not bound to particular data structure
@@ -245,19 +247,19 @@ private:
   int triangulatePolygon(const NCollection_Array1<int>& theIndices);
 
   //! Handle "o ObjectName".
-  void pushObject(const char* theObjectName);
+  void pushObject(const std::string_view theObjectName);
 
   //! Handle "g GroupName".
-  void pushGroup(const char* theGroupName);
+  void pushGroup(const std::string_view theGroupName);
 
   //! Handle "s SmoothGroupIndex".
-  void pushSmoothGroup(const char* theSmoothGroupIndex);
+  void pushSmoothGroup(const std::string_view theSmoothGroupIndex);
 
   //! Handle "usemtl MaterialName".
-  void pushMaterial(const char* theMaterialName);
+  void pushMaterial(const std::string_view theMaterialName);
 
   //! Handle "mtllib FileName".
-  void readMaterialLib(const char* theFileName);
+  void readMaterialLib(const std::string_view theFileName);
 
   //! Check memory limits.
   //! @return FALSE on out of memory

--- a/src/DataExchange/TKDEOBJ/RWObj/RWObj_Tools.hxx
+++ b/src/DataExchange/TKDEOBJ/RWObj/RWObj_Tools.hxx
@@ -20,6 +20,8 @@
 #include <Standard_TypeDef.hxx>
 #include <TCollection_AsciiString.hxx>
 
+#include <string_view>
+
 //! Auxiliary tools for OBJ format parser.
 namespace RWObj_Tools
 {
@@ -48,30 +50,26 @@ inline bool ReadVec3(const char* thePos, char*& theNext, gp_XYZ& theVec)
 }
 
 //! Read string.
-inline bool ReadName(const char* thePos, TCollection_AsciiString& theName)
+inline bool ReadName(std::string_view theValue, TCollection_AsciiString& theName)
 {
-  int aFrom = 0;
-  int aTail = (int)std::strlen(thePos) - 1;
-  if (aTail >= 0 && thePos[aTail] == '\n')
+  while (!theValue.empty() && (theValue.back() == '\n' || theValue.back() == '\r'))
   {
-    --aTail;
+    theValue.remove_suffix(1);
   }
-  if (aTail >= 0 && thePos[aTail] == '\r')
+  while (!theValue.empty() && IsSpace(theValue.back()))
   {
-    --aTail;
+    theValue.remove_suffix(1);
   }
-  for (; aTail >= 0 && IsSpace(thePos[aTail]); --aTail)
+  while (!theValue.empty() && IsSpace(theValue.front()))
   {
-  } // RightAdjust
-  for (; aFrom < aTail && IsSpace(thePos[aFrom]); ++aFrom)
-  {
-  } // LeftAdjust
-  if (aFrom > aTail)
+    theValue.remove_prefix(1);
+  }
+  if (theValue.empty())
   {
     theName.Clear();
     return false;
   }
-  theName = TCollection_AsciiString(thePos + aFrom, aTail - aFrom + 1);
+  theName = theValue;
   return true;
 }
 

--- a/src/DataExchange/TKDESTEP/GTests/FILES.cmake
+++ b/src/DataExchange/TKDESTEP/GTests/FILES.cmake
@@ -16,6 +16,8 @@ set(OCCT_TKDESTEP_GTests_FILES
     StepTidy_PlaneReducer_Test.cxx
     StepTidy_Merger_Test.cxx
     StepTidy_VectorReducer_Test.cxx
+    StepShape_OrientedEdge_Test.cxx
+    StepToGeom_Test.cxx
     StepToTopoDS_TranslateFace_Test.cxx
     StepTransientReplacements_Test.cxx
     STEPCAFControl_Controller_Test.cxx

--- a/src/DataExchange/TKDESTEP/GTests/StepShape_OrientedEdge_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepShape_OrientedEdge_Test.cxx
@@ -50,6 +50,31 @@ TEST(StepShape_OrientedEdgeTest, RejectsCycles)
   EXPECT_TRUE(anEdge->EdgeEnd().IsNull());
 }
 
+TEST(StepShape_OrientedEdgeTest, ResolvesDeepAcyclicNesting)
+{
+  const occ::handle<TCollection_HAsciiString> aName  = new TCollection_HAsciiString("edge");
+  const occ::handle<StepShape_Vertex>         aStart = new StepShape_Vertex();
+  const occ::handle<StepShape_Vertex>         anEnd  = new StepShape_Vertex();
+  occ::handle<StepShape_Edge>                 anEdge = new StepShape_Edge();
+  anEdge->Init(aName, aStart, anEnd);
+
+  bool isReversed = false;
+  for (int anEdgeIdx = 0; anEdgeIdx < 256; ++anEdgeIdx)
+  {
+    const bool                                isForward  = anEdgeIdx % 3 != 0;
+    const occ::handle<StepShape_OrientedEdge> anOriented = new StepShape_OrientedEdge();
+    anOriented->Init(aName, anEdge, isForward);
+    anEdge = anOriented;
+    if (!isForward)
+    {
+      isReversed = !isReversed;
+    }
+  }
+
+  EXPECT_EQ(anEdge->EdgeStart(), isReversed ? anEnd : aStart);
+  EXPECT_EQ(anEdge->EdgeEnd(), isReversed ? aStart : anEnd);
+}
+
 TEST(StepShape_OrientedEdgeTest, RejectsSettingRedefinedEndpoints)
 {
   const occ::handle<StepShape_OrientedEdge> anEdge  = new StepShape_OrientedEdge();

--- a/src/DataExchange/TKDESTEP/GTests/StepShape_OrientedEdge_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepShape_OrientedEdge_Test.cxx
@@ -1,0 +1,59 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <StepShape_Edge.hxx>
+#include <StepShape_OrientedEdge.hxx>
+#include <StepShape_Vertex.hxx>
+#include <Standard_NotImplemented.hxx>
+#include <TCollection_HAsciiString.hxx>
+
+#include <gtest/gtest.h>
+
+TEST(StepShape_OrientedEdgeTest, ResolvesNestedOrientation)
+{
+  const occ::handle<TCollection_HAsciiString> aName  = new TCollection_HAsciiString("edge");
+  const occ::handle<StepShape_Vertex>         aStart = new StepShape_Vertex();
+  const occ::handle<StepShape_Vertex>         anEnd  = new StepShape_Vertex();
+  const occ::handle<StepShape_Edge>           anEdge = new StepShape_Edge();
+  anEdge->Init(aName, aStart, anEnd);
+
+  const occ::handle<StepShape_OrientedEdge> aReversed = new StepShape_OrientedEdge();
+  aReversed->Init(aName, anEdge, false);
+  const occ::handle<StepShape_OrientedEdge> aNested = new StepShape_OrientedEdge();
+  aNested->Init(aName, aReversed, true);
+  EXPECT_EQ(aNested->EdgeStart(), anEnd);
+  EXPECT_EQ(aNested->EdgeEnd(), aStart);
+}
+
+TEST(StepShape_OrientedEdgeTest, RejectsCycles)
+{
+  const occ::handle<TCollection_HAsciiString> aName  = new TCollection_HAsciiString("edge");
+  const occ::handle<StepShape_OrientedEdge>   anEdge = new StepShape_OrientedEdge();
+  anEdge->Init(aName, anEdge, true);
+  EXPECT_TRUE(anEdge->EdgeStart().IsNull());
+  EXPECT_TRUE(anEdge->EdgeEnd().IsNull());
+
+  const occ::handle<StepShape_OrientedEdge> anOther = new StepShape_OrientedEdge();
+  anOther->Init(aName, anEdge, true);
+  anEdge->SetEdgeElement(anOther);
+  EXPECT_TRUE(anEdge->EdgeStart().IsNull());
+  EXPECT_TRUE(anEdge->EdgeEnd().IsNull());
+}
+
+TEST(StepShape_OrientedEdgeTest, RejectsSettingRedefinedEndpoints)
+{
+  const occ::handle<StepShape_OrientedEdge> anEdge  = new StepShape_OrientedEdge();
+  const occ::handle<StepShape_Vertex>       aVertex = new StepShape_Vertex();
+  EXPECT_THROW(anEdge->SetEdgeStart(aVertex), Standard_NotImplemented);
+  EXPECT_THROW(anEdge->SetEdgeEnd(aVertex), Standard_NotImplemented);
+}

--- a/src/DataExchange/TKDESTEP/GTests/StepToGeom_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepToGeom_Test.cxx
@@ -1,0 +1,178 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <NCollection_HArray1.hxx>
+#include <Precision.hxx>
+#include <StepData_Logical.hxx>
+#include <StepGeom_BSplineCurveWithKnots.hxx>
+#include <StepGeom_CartesianPoint.hxx>
+#include <StepToGeom.hxx>
+#include <TCollection_HAsciiString.hxx>
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+namespace
+{
+static occ::handle<StepGeom_BSplineCurveWithKnots> createLinearCurve(const double theFirstKnot)
+{
+  const occ::handle<TCollection_HAsciiString> aName = new TCollection_HAsciiString("curve");
+  occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>> aPoles =
+    new NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>(1, 2);
+  for (int aPoleIdx = 1; aPoleIdx <= 2; ++aPoleIdx)
+  {
+    occ::handle<StepGeom_CartesianPoint> aPoint = new StepGeom_CartesianPoint();
+    aPoint->Init3D(aName, static_cast<double>(aPoleIdx), 0.0, 0.0);
+    aPoles->SetValue(aPoleIdx, aPoint);
+  }
+
+  occ::handle<NCollection_HArray1<int>> aMultiplicities = new NCollection_HArray1<int>(1, 2);
+  aMultiplicities->SetValue(1, 2);
+  aMultiplicities->SetValue(2, 2);
+  occ::handle<NCollection_HArray1<double>> aKnots = new NCollection_HArray1<double>(1, 2);
+  aKnots->SetValue(1, theFirstKnot);
+  aKnots->SetValue(2, 1.0);
+
+  occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = new StepGeom_BSplineCurveWithKnots();
+  aCurve->Init(aName,
+               1,
+               aPoles,
+               StepGeom_BSplineCurveForm::StepGeom_bscfUnspecified,
+               StepData_Logical::StepData_LFalse,
+               StepData_Logical::StepData_LFalse,
+               aMultiplicities,
+               aKnots,
+               StepGeom_KnotType::StepGeom_ktUnspecified);
+  return aCurve;
+}
+} // namespace
+
+TEST(StepToGeomTest, RejectsMismatchedBSplineKnotArrays)
+{
+  const occ::handle<TCollection_HAsciiString> aName = new TCollection_HAsciiString("curve");
+  occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>> aPoles =
+    new NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>(1, 3);
+  for (int aPoleIdx = 1; aPoleIdx <= 3; ++aPoleIdx)
+  {
+    occ::handle<StepGeom_CartesianPoint> aPoint = new StepGeom_CartesianPoint();
+    aPoint->Init3D(aName, static_cast<double>(aPoleIdx), 0.0, 0.0);
+    aPoles->SetValue(aPoleIdx, aPoint);
+  }
+
+  occ::handle<NCollection_HArray1<int>> aMultiplicities = new NCollection_HArray1<int>(1, 2);
+  aMultiplicities->SetValue(1, 2);
+  aMultiplicities->SetValue(2, 2);
+  occ::handle<NCollection_HArray1<double>> aKnots = new NCollection_HArray1<double>(1, 1);
+  aKnots->SetValue(1, 0.0);
+
+  occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = new StepGeom_BSplineCurveWithKnots();
+  aCurve->Init(aName,
+               1,
+               aPoles,
+               StepGeom_BSplineCurveForm::StepGeom_bscfUnspecified,
+               StepData_Logical::StepData_LFalse,
+               StepData_Logical::StepData_LFalse,
+               aMultiplicities,
+               aKnots,
+               StepGeom_KnotType::StepGeom_ktUnspecified);
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(aCurve).IsNull());
+}
+
+TEST(StepToGeomTest, RejectsMissingBSplineData)
+{
+  const occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = new StepGeom_BSplineCurveWithKnots();
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(aCurve).IsNull());
+}
+
+TEST(StepToGeomTest, RejectsInvalidKnotValues)
+{
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(createLinearCurve(Precision::Infinite())).IsNull());
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(createLinearCurve(-Precision::Infinite())).IsNull());
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(createLinearCurve(std::nan(""))).IsNull());
+}
+
+TEST(StepToGeomTest, RejectsLargeMergedKnotMultiplicities)
+{
+  const occ::handle<TCollection_HAsciiString> aName = new TCollection_HAsciiString("curve");
+  occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>> aPoles =
+    new NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>(1, 2);
+  for (int aPoleIdx = 1; aPoleIdx <= 2; ++aPoleIdx)
+  {
+    occ::handle<StepGeom_CartesianPoint> aPoint = new StepGeom_CartesianPoint();
+    aPoint->Init3D(aName, static_cast<double>(aPoleIdx), 0.0, 0.0);
+    aPoles->SetValue(aPoleIdx, aPoint);
+  }
+
+  occ::handle<NCollection_HArray1<int>> aMultiplicities = new NCollection_HArray1<int>(1, 3);
+  aMultiplicities->SetValue(1, 2000000000);
+  aMultiplicities->SetValue(2, 2000000000);
+  aMultiplicities->SetValue(3, 2);
+  occ::handle<NCollection_HArray1<double>> aKnots = new NCollection_HArray1<double>(1, 3);
+  aKnots->SetValue(1, 0.0);
+  aKnots->SetValue(2, 0.0);
+  aKnots->SetValue(3, 1.0);
+
+  occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = new StepGeom_BSplineCurveWithKnots();
+  aCurve->Init(aName,
+               1,
+               aPoles,
+               StepGeom_BSplineCurveForm::StepGeom_bscfUnspecified,
+               StepData_Logical::StepData_LFalse,
+               StepData_Logical::StepData_LFalse,
+               aMultiplicities,
+               aKnots,
+               StepGeom_KnotType::StepGeom_ktUnspecified);
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(aCurve).IsNull());
+}
+
+TEST(StepToGeomTest, RejectsInvalidInteriorKnotMultiplicity)
+{
+  const occ::handle<TCollection_HAsciiString> aName = new TCollection_HAsciiString("curve");
+  occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>> aPoles =
+    new NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>(1, 4);
+  for (int aPoleIdx = 1; aPoleIdx <= 4; ++aPoleIdx)
+  {
+    occ::handle<StepGeom_CartesianPoint> aPoint = new StepGeom_CartesianPoint();
+    aPoint->Init3D(aName, static_cast<double>(aPoleIdx), 0.0, 0.0);
+    aPoles->SetValue(aPoleIdx, aPoint);
+  }
+
+  occ::handle<NCollection_HArray1<int>>    aMultiplicities = new NCollection_HArray1<int>(1, 3);
+  occ::handle<NCollection_HArray1<double>> aKnots          = new NCollection_HArray1<double>(1, 3);
+  for (int aKnotIdx = 1; aKnotIdx <= 3; ++aKnotIdx)
+  {
+    aMultiplicities->SetValue(aKnotIdx, 2);
+    aKnots->SetValue(aKnotIdx, static_cast<double>(aKnotIdx - 1));
+  }
+
+  occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = new StepGeom_BSplineCurveWithKnots();
+  aCurve->Init(aName,
+               1,
+               aPoles,
+               StepGeom_BSplineCurveForm::StepGeom_bscfUnspecified,
+               StepData_Logical::StepData_LFalse,
+               StepData_Logical::StepData_LFalse,
+               aMultiplicities,
+               aKnots,
+               StepGeom_KnotType::StepGeom_ktUnspecified);
+
+  occ::handle<Geom_BSplineCurve> aResult;
+  EXPECT_NO_THROW(aResult = StepToGeom::MakeBSplineCurve(aCurve));
+  EXPECT_TRUE(aResult.IsNull());
+}
+
+TEST(StepToGeomTest, ConvertsValidBSplineCurve)
+{
+  EXPECT_FALSE(StepToGeom::MakeBSplineCurve(createLinearCurve(0.0)).IsNull());
+}

--- a/src/DataExchange/TKDESTEP/GTests/StepToGeom_Test.cxx
+++ b/src/DataExchange/TKDESTEP/GTests/StepToGeom_Test.cxx
@@ -15,6 +15,7 @@
 #include <Precision.hxx>
 #include <StepData_Logical.hxx>
 #include <StepGeom_BSplineCurveWithKnots.hxx>
+#include <StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve.hxx>
 #include <StepGeom_CartesianPoint.hxx>
 #include <StepToGeom.hxx>
 #include <TCollection_HAsciiString.hxx>
@@ -55,6 +56,30 @@ static occ::handle<StepGeom_BSplineCurveWithKnots> createLinearCurve(const doubl
                aKnots,
                StepGeom_KnotType::StepGeom_ktUnspecified);
   return aCurve;
+}
+
+static occ::handle<StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve> createRationalLinearCurve(
+  const double theFirstWeight,
+  const double theSecondWeight)
+{
+  const occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = createLinearCurve(0.0);
+  occ::handle<NCollection_HArray1<double>> aWeights        = new NCollection_HArray1<double>(1, 2);
+  aWeights->SetValue(1, theFirstWeight);
+  aWeights->SetValue(2, theSecondWeight);
+
+  occ::handle<StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve> aRationalCurve =
+    new StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve();
+  aRationalCurve->Init(aCurve->Name(),
+                       aCurve->Degree(),
+                       aCurve->ControlPointsList(),
+                       aCurve->CurveForm(),
+                       aCurve->ClosedCurve(),
+                       aCurve->SelfIntersect(),
+                       aCurve->KnotMultiplicities(),
+                       aCurve->Knots(),
+                       StepGeom_KnotType::StepGeom_ktUnspecified,
+                       aWeights);
+  return aRationalCurve;
 }
 } // namespace
 
@@ -170,6 +195,46 @@ TEST(StepToGeomTest, RejectsInvalidInteriorKnotMultiplicity)
   occ::handle<Geom_BSplineCurve> aResult;
   EXPECT_NO_THROW(aResult = StepToGeom::MakeBSplineCurve(aCurve));
   EXPECT_TRUE(aResult.IsNull());
+}
+
+TEST(StepToGeomTest, RejectsOversizedMultiplicitySum)
+{
+  const occ::handle<TCollection_HAsciiString> aName = new TCollection_HAsciiString("curve");
+  occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>> aPoles =
+    new NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>(1, 2);
+  for (int aPoleIdx = 1; aPoleIdx <= 2; ++aPoleIdx)
+  {
+    occ::handle<StepGeom_CartesianPoint> aPoint = new StepGeom_CartesianPoint();
+    aPoint->Init3D(aName, static_cast<double>(aPoleIdx), 0.0, 0.0);
+    aPoles->SetValue(aPoleIdx, aPoint);
+  }
+
+  occ::handle<NCollection_HArray1<int>>    aMultiplicities = new NCollection_HArray1<int>(1, 5);
+  occ::handle<NCollection_HArray1<double>> aKnots          = new NCollection_HArray1<double>(1, 5);
+  for (int aKnotIdx = 1; aKnotIdx <= 5; ++aKnotIdx)
+  {
+    aMultiplicities->SetValue(aKnotIdx, 1);
+    aKnots->SetValue(aKnotIdx, static_cast<double>(aKnotIdx - 1));
+  }
+
+  occ::handle<StepGeom_BSplineCurveWithKnots> aCurve = new StepGeom_BSplineCurveWithKnots();
+  aCurve->Init(aName,
+               1,
+               aPoles,
+               StepGeom_BSplineCurveForm::StepGeom_bscfUnspecified,
+               StepData_Logical::StepData_LFalse,
+               StepData_Logical::StepData_LFalse,
+               aMultiplicities,
+               aKnots,
+               StepGeom_KnotType::StepGeom_ktUnspecified);
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(aCurve).IsNull());
+}
+
+TEST(StepToGeomTest, ValidatesRationalWeights)
+{
+  EXPECT_FALSE(StepToGeom::MakeBSplineCurve(createRationalLinearCurve(1.0, 2.0)).IsNull());
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(createRationalLinearCurve(1.0, std::nan(""))).IsNull());
+  EXPECT_TRUE(StepToGeom::MakeBSplineCurve(createRationalLinearCurve(1.0, 0.0)).IsNull());
 }
 
 TEST(StepToGeomTest, ConvertsValidBSplineCurve)

--- a/src/DataExchange/TKDESTEP/StepShape/StepShape_OrientedEdge.cxx
+++ b/src/DataExchange/TKDESTEP/StepShape/StepShape_OrientedEdge.cxx
@@ -13,9 +13,43 @@
 
 #include <StepShape_OrientedEdge.hxx>
 #include <StepShape_Vertex.hxx>
+#include <Standard_NotImplemented.hxx>
 #include <TCollection_HAsciiString.hxx>
 
+#include <NCollection_FlatMap.hxx>
+
 IMPLEMENT_STANDARD_RTTIEXT(StepShape_OrientedEdge, StepShape_Edge)
+
+namespace
+{
+//! Resolve an oriented-edge endpoint iteratively and reject cyclic edge references.
+occ::handle<StepShape_Vertex> resolveVertex(const occ::handle<StepShape_Edge>& theEdgeElement,
+                                            const bool                         theToStart)
+{
+  NCollection_FlatMap<occ::handle<StepShape_Edge>> aVisitedEdges;
+  occ::handle<StepShape_Edge>                      anEdge  = theEdgeElement;
+  bool                                             isStart = theToStart;
+  while (!anEdge.IsNull())
+  {
+    const occ::handle<StepShape_OrientedEdge> anOrientedEdge =
+      occ::down_cast<StepShape_OrientedEdge>(anEdge);
+    if (anOrientedEdge.IsNull())
+    {
+      return isStart ? anEdge->EdgeStart() : anEdge->EdgeEnd();
+    }
+    if (!aVisitedEdges.Add(anEdge))
+    {
+      return nullptr;
+    }
+    if (!anOrientedEdge->Orientation())
+    {
+      isStart = !isStart;
+    }
+    anEdge = anOrientedEdge->EdgeElement();
+  }
+  return nullptr;
+}
+} // namespace
 
 StepShape_OrientedEdge::StepShape_OrientedEdge() = default;
 
@@ -56,50 +90,22 @@ bool StepShape_OrientedEdge::Orientation() const
 
 void StepShape_OrientedEdge::SetEdgeStart(const occ::handle<StepShape_Vertex>& /*aEdgeStart*/)
 {
-  // WARNING : the field is redefined.
-  // field set up forbidden.
-  std::cout << "Field is redefined, SetUp Forbidden" << '\n';
+  throw Standard_NotImplemented(
+    "StepShape_OrientedEdge::SetEdgeStart: redefined field cannot be set");
 }
 
 occ::handle<StepShape_Vertex> StepShape_OrientedEdge::EdgeStart() const
 {
-  // WARNING : the field is redefined.
-  // method body is not yet automatically wrote
-  if (edgeElement.IsNull())
-  {
-    return nullptr;
-  }
-  if (Orientation())
-  {
-    return edgeElement->EdgeStart();
-  }
-  else
-  {
-    return edgeElement->EdgeEnd();
-  }
+  return resolveVertex(edgeElement, Orientation());
 }
 
 void StepShape_OrientedEdge::SetEdgeEnd(const occ::handle<StepShape_Vertex>& /*aEdgeEnd*/)
 {
-  // WARNING : the field is redefined.
-  // field set up forbidden.
-  std::cout << "Field is redefined, SetUp Forbidden" << '\n';
+  throw Standard_NotImplemented(
+    "StepShape_OrientedEdge::SetEdgeEnd: redefined field cannot be set");
 }
 
 occ::handle<StepShape_Vertex> StepShape_OrientedEdge::EdgeEnd() const
 {
-  // WARNING : the field is redefined.
-  // method body is not yet automatically wrote
-  if (edgeElement.IsNull())
-  {
-    return nullptr;
-  }
-  if (Orientation())
-  {
-    return edgeElement->EdgeEnd();
-  }
-  else
-  {
-    return edgeElement->EdgeStart();
-  }
+  return resolveVertex(edgeElement, !Orientation());
 }

--- a/src/DataExchange/TKDESTEP/StepShape/StepShape_OrientedEdge.hxx
+++ b/src/DataExchange/TKDESTEP/StepShape/StepShape_OrientedEdge.hxx
@@ -44,10 +44,12 @@ public:
 
   Standard_EXPORT bool Orientation() const;
 
+  //! @throw Standard_NotImplemented because edge_start is redefined by the oriented edge.
   Standard_EXPORT void SetEdgeStart(const occ::handle<StepShape_Vertex>& aEdgeStart) override;
 
   Standard_EXPORT occ::handle<StepShape_Vertex> EdgeStart() const override;
 
+  //! @throw Standard_NotImplemented because edge_end is redefined by the oriented edge.
   Standard_EXPORT void SetEdgeEnd(const occ::handle<StepShape_Vertex>& aEdgeEnd) override;
 
   Standard_EXPORT occ::handle<StepShape_Vertex> EdgeEnd() const override;

--- a/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
+++ b/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
@@ -830,8 +830,9 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
 
   const size_t                     aMaxMultiplicity         = static_cast<size_t>(aDegree) + 1;
   const size_t                     aMaxRelevantMultiplicity = aNbPoles + aMaxMultiplicity;
-  NCollection_LinearVector<double> aUniqueKnotValues;
-  NCollection_LinearVector<size_t> aMergedKnotMultiplicities;
+  const size_t                     aMergeCapacity = std::min(aNbKnots, aMaxRelevantMultiplicity);
+  NCollection_LinearVector<double> aUniqueKnotValues(aMergeCapacity);
+  NCollection_LinearVector<size_t> aMergedKnotMultiplicities(aMergeCapacity);
   const double                     aFirstKnot = aKnots->At(0);
   if (aKnotMultiplicities->At(0) <= 0 || !isValidReal(aFirstKnot))
   {
@@ -875,6 +876,7 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
   NCollection_LinearVector<int> aUniqueKnotMultiplicityValues(aNbUniqueKnots);
   size_t                        aFirstMultiplicityExcess = 0;
   size_t                        aLastMultiplicityExcess  = 0;
+  size_t                        aMultiplicitySum         = 0;
   for (size_t aKnotIdx = 0; aKnotIdx < aNbUniqueKnots; ++aKnotIdx)
   {
     const size_t aMultiplicity = aMergedKnotMultiplicities.Value(aKnotIdx);
@@ -893,13 +895,18 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
                 << "\nChanged to " << aDegree + 1 << std::endl;
 #endif
     }
-    aUniqueKnotMultiplicityValues.Append(
-      static_cast<int>(std::min(aMultiplicity, aMaxMultiplicity)));
+    const size_t aClampedMultiplicity = std::min(aMultiplicity, aMaxMultiplicity);
+    if (aClampedMultiplicity > aMaxRelevantMultiplicity - aMultiplicitySum)
+    {
+      return nullptr;
+    }
+    aMultiplicitySum += aClampedMultiplicity;
+    aUniqueKnotMultiplicityValues.Append(static_cast<int>(aClampedMultiplicity));
   }
 
   NCollection_Array1<double> aUniqueKnots(aUniqueKnotValues.Data(), aNbUniqueKnots);
   NCollection_Array1<int>    aUniqueKnotMultiplicities(aUniqueKnotMultiplicityValues.Data(),
-                                                    aNbUniqueKnots);
+                                                       aNbUniqueKnots);
 
   if (aFirstMultiplicityExcess > aNbPoles
       || aLastMultiplicityExcess > aNbPoles - aFirstMultiplicityExcess)
@@ -912,26 +919,9 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
   {
     return nullptr;
   }
-  TPntArray aPoles(aNbUniquePoles);
-
-  for (size_t aPoleIdx = aFirstMultiplicityExcess; aPoleIdx < aNbPoles - aLastMultiplicityExcess;
-       ++aPoleIdx)
+  if (aMultiplicitySum > aNbUniquePoles + aMaxMultiplicity)
   {
-    occ::handle<TCartesianPoint> aPoint =
-      (*thePointMakerFunction)(aControlPointsList->At(aPoleIdx), theLocalFactors);
-    if (!aPoint.IsNull())
-    {
-      const TGpPnt aPnt = ((*aPoint).*thePntGetterFunction)();
-      if (!isValidPoint(aPnt))
-      {
-        return nullptr;
-      }
-      aPoles.ChangeAt(aPoleIdx - aFirstMultiplicityExcess) = aPnt;
-    }
-    else
-    {
-      return nullptr;
-    }
+    return nullptr;
   }
 
   // Match the descriptor against the same pole-count contract used by the curve constructors.
@@ -944,12 +934,10 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
     return nullptr;
   }
 
-  occ::handle<TBSplineCurve> aBSplineCurve;
-  if (theStepGeom_BSplineCurve->IsKind(
-        STANDARD_TYPE(StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve)))
+  occ::handle<NCollection_HArray1<double>> aWeights;
+  if (!aBSplineCurveWithKnotsAndRationalBSplineCurve.IsNull())
   {
-    const occ::handle<NCollection_HArray1<double>>& aWeights =
-      aBSplineCurveWithKnotsAndRationalBSplineCurve->WeightsData();
+    aWeights = aBSplineCurveWithKnotsAndRationalBSplineCurve->WeightsData();
     if (aWeights.IsNull() || static_cast<size_t>(aWeights->Length()) != aNbPoles)
     {
       return nullptr;
@@ -962,6 +950,29 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
         return nullptr;
       }
     }
+  }
+
+  TPntArray aPoles(aNbUniquePoles);
+  for (size_t aPoleIdx = aFirstMultiplicityExcess; aPoleIdx < aNbPoles - aLastMultiplicityExcess;
+       ++aPoleIdx)
+  {
+    occ::handle<TCartesianPoint> aPoint =
+      (*thePointMakerFunction)(aControlPointsList->At(aPoleIdx), theLocalFactors);
+    if (aPoint.IsNull())
+    {
+      return nullptr;
+    }
+    const TGpPnt aPnt = ((*aPoint).*thePntGetterFunction)();
+    if (!isValidPoint(aPnt))
+    {
+      return nullptr;
+    }
+    aPoles.ChangeAt(aPoleIdx - aFirstMultiplicityExcess) = aPnt;
+  }
+
+  occ::handle<TBSplineCurve> aBSplineCurve;
+  if (!aWeights.IsNull())
+  {
     NCollection_Array1<double> aUniqueWeights(aNbUniquePoles);
     for (size_t aPoleIdx = aFirstMultiplicityExcess; aPoleIdx < aNbPoles - aLastMultiplicityExcess;
          ++aPoleIdx)

--- a/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
+++ b/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
@@ -62,6 +62,8 @@
 #include <Geom2d_VectorWithMagnitude.hxx>
 #include <Geom2dConvert.hxx>
 
+#include <BSplCLib.hxx>
+#include <gp.hxx>
 #include <gp_Trsf.hxx>
 #include <gp_Trsf2d.hxx>
 #include <gp_Lin.hxx>
@@ -134,6 +136,11 @@
 #include <StepRepr_GlobalUnitAssignedContext.hxx>
 #include <StepRepr_ReprItemAndMeasureWithUnit.hxx>
 #include <STEPConstruct_UnitContext.hxx>
+#include <NCollection_LinearVector.hxx>
+#include <Precision.hxx>
+
+#include <algorithm>
+#include <cmath>
 
 //=============================================================================
 // Creation d' un Ax1Placement de Geom a partir d' un axis1_placement de Step
@@ -223,15 +230,15 @@ occ::handle<Geom_Axis2Placement> StepToGeom::MakeAxis2Placement(
     theSP->A() * cos(theSP->Gamma()) + theSP->B() * sin(theSP->Gamma()) * sin(theSP->Alpha());
   double aLocY =
     theSP->A() * sin(theSP->Gamma()) - theSP->B() * cos(theSP->Gamma()) * sin(theSP->Alpha());
-  double aLocZ   = theSP->C() + theSP->B() * cos(theSP->Alpha());
-  double anAsisX = sin(theSP->Gamma()) * sin(theSP->Alpha());
-  double anAxisY = -cos(theSP->Gamma()) * sin(theSP->Alpha());
-  double anAxisZ = cos(theSP->Alpha());
-  double aDirX   = cos(theSP->Gamma()) * cos(theSP->Beta())
-                 - sin(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
-  double aDirY = sin(theSP->Gamma()) * cos(theSP->Beta())
-                 + cos(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
-  double       aDirZ = sin(theSP->Alpha()) * sin(theSP->Beta());
+  double       aLocZ   = theSP->C() + theSP->B() * cos(theSP->Alpha());
+  double       anAsisX = sin(theSP->Gamma()) * sin(theSP->Alpha());
+  double       anAxisY = -cos(theSP->Gamma()) * sin(theSP->Alpha());
+  double       anAxisZ = cos(theSP->Alpha());
+  double       aDirX   = cos(theSP->Gamma()) * cos(theSP->Beta())
+                         - sin(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
+  double       aDirY   = sin(theSP->Gamma()) * cos(theSP->Beta())
+                         + cos(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
+  double       aDirZ   = sin(theSP->Alpha()) * sin(theSP->Beta());
   const gp_Pnt Pgp(aLocX, aLocY, aLocZ);
   const gp_Dir Ngp(anAsisX, anAxisY, anAxisZ);
   const gp_Dir Vxgp(aDirX, aDirY, aDirZ);
@@ -747,6 +754,21 @@ occ::handle<Geom_BoundedSurface> StepToGeom::MakeBoundedSurface(
 // Template function for use in MakeBSplineCurve / MakeBSplineCurve2d
 //=============================================================================
 
+static bool isValidReal(const double theValue)
+{
+  return std::isfinite(theValue) && !Precision::IsInfinite(theValue);
+}
+
+static bool isValidPoint(const gp_Pnt& thePoint)
+{
+  return isValidReal(thePoint.X()) && isValidReal(thePoint.Y()) && isValidReal(thePoint.Z());
+}
+
+static bool isValidPoint(const gp_Pnt2d& thePoint)
+{
+  return isValidReal(thePoint.X()) && isValidReal(thePoint.Y());
+}
+
 template <class TPntArray, class TCartesianPoint, class TGpPnt, class TBSplineCurve>
 occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
   const occ::handle<StepGeom_BSplineCurve>& theStepGeom_BSplineCurve,
@@ -755,6 +777,11 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
   occ::handle<TCartesianPoint> (*thePointMakerFunction)(const occ::handle<StepGeom_CartesianPoint>&,
                                                         const StepData_Factors&))
 {
+  if (theStepGeom_BSplineCurve.IsNull())
+  {
+    return nullptr;
+  }
+
   occ::handle<StepGeom_BSplineCurveWithKnots> aBSplineCurveWithKnots;
   occ::handle<StepGeom_BSplineCurveWithKnotsAndRationalBSplineCurve>
     aBSplineCurveWithKnotsAndRationalBSplineCurve;
@@ -773,96 +800,133 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
       occ::down_cast<StepGeom_BSplineCurveWithKnots>(theStepGeom_BSplineCurve);
   }
 
-  const int aDegree = aBSplineCurveWithKnots->Degree();
-  const int NbPoles = aBSplineCurveWithKnots->NbControlPointsList();
-  const int NbKnots = aBSplineCurveWithKnots->NbKnotMultiplicities();
+  if (aBSplineCurveWithKnots.IsNull())
+  {
+    return nullptr;
+  }
 
   const occ::handle<NCollection_HArray1<int>>& aKnotMultiplicities =
     aBSplineCurveWithKnots->KnotMultiplicities();
   const occ::handle<NCollection_HArray1<double>>& aKnots = aBSplineCurveWithKnots->Knots();
-
-  // Count number of unique knots
-  int    NbUniqueKnots = 0;
-  double lastKnot      = RealFirst();
-  for (int i = 1; i <= NbKnots; ++i)
-  {
-    if (aKnots->Value(i) - lastKnot > Epsilon(std::abs(lastKnot)))
-    {
-      NbUniqueKnots++;
-      lastKnot = aKnots->Value(i);
-    }
-  }
-  if (NbUniqueKnots <= 1)
+  const occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>>& aControlPointsList =
+    aBSplineCurveWithKnots->ControlPointsList();
+  if (aKnotMultiplicities.IsNull() || aKnots.IsNull() || aControlPointsList.IsNull()
+      || aKnotMultiplicities->Length() != aKnots->Length())
   {
     return nullptr;
   }
-  NCollection_Array1<double> aUniqueKnots(1, NbUniqueKnots);
-  NCollection_Array1<int>    aUniqueKnotMultiplicities(1, NbUniqueKnots);
-  lastKnot = aKnots->Value(1);
-  aUniqueKnots.SetValue(1, aKnots->Value(1));
-  aUniqueKnotMultiplicities.SetValue(1, aKnotMultiplicities->Value(1));
-  int aKnotPosition = 1;
-  for (int i = 2; i <= NbKnots; i++)
+  const int    aDegree  = aBSplineCurveWithKnots->Degree();
+  const size_t aNbPoles = static_cast<size_t>(aControlPointsList->Length());
+  if (aDegree < 1 || aDegree > TBSplineCurve::MaxDegree()
+      || aNbPoles <= static_cast<size_t>(aDegree))
   {
-    if (aKnots->Value(i) - lastKnot > Epsilon(std::abs(lastKnot)))
+    return nullptr;
+  }
+  const size_t aNbKnots = static_cast<size_t>(aKnotMultiplicities->Length());
+  if (aNbKnots == 0)
+  {
+    return nullptr;
+  }
+
+  const size_t                     aMaxMultiplicity         = static_cast<size_t>(aDegree) + 1;
+  const size_t                     aMaxRelevantMultiplicity = aNbPoles + aMaxMultiplicity;
+  NCollection_LinearVector<double> aUniqueKnotValues;
+  NCollection_LinearVector<size_t> aMergedKnotMultiplicities;
+  const double                     aFirstKnot = aKnots->At(0);
+  if (aKnotMultiplicities->At(0) <= 0 || !isValidReal(aFirstKnot))
+  {
+    return nullptr;
+  }
+  aUniqueKnotValues.Append(aFirstKnot);
+  aMergedKnotMultiplicities.Append(
+    std::min(static_cast<size_t>(aKnotMultiplicities->At(0)), aMaxRelevantMultiplicity));
+  for (size_t aKnotIdx = 1; aKnotIdx < aNbKnots; ++aKnotIdx)
+  {
+    const double aKnot           = aKnots->At(aKnotIdx);
+    const double aLastUniqueKnot = aUniqueKnotValues.Last();
+    if (aKnotMultiplicities->At(aKnotIdx) <= 0 || !isValidReal(aKnot)
+        || aKnot < aKnots->At(aKnotIdx - 1))
     {
-      aKnotPosition++;
-      aUniqueKnots.SetValue(aKnotPosition, aKnots->Value(i));
-      aUniqueKnotMultiplicities.SetValue(aKnotPosition, aKnotMultiplicities->Value(i));
-      lastKnot = aKnots->Value(i);
+      return nullptr;
+    }
+    if (aKnot - aLastUniqueKnot > Epsilon(std::abs(aLastUniqueKnot)))
+    {
+      aUniqueKnotValues.Append(aKnot);
+      aMergedKnotMultiplicities.Append(
+        std::min(static_cast<size_t>(aKnotMultiplicities->At(aKnotIdx)), aMaxRelevantMultiplicity));
     }
     else
     {
       // Knot not unique, increase multiplicity
-      int aCurrentMultiplicity = aUniqueKnotMultiplicities.Value(aKnotPosition);
-      aUniqueKnotMultiplicities.SetValue(aKnotPosition,
-                                         aCurrentMultiplicity + aKnotMultiplicities->Value(i));
+      const size_t aCurrentMultiplicity = aMergedKnotMultiplicities.Last();
+      const size_t anAddedMultiplicity  = static_cast<size_t>(aKnotMultiplicities->At(aKnotIdx));
+      aMergedKnotMultiplicities.ChangeLast() =
+        anAddedMultiplicity > aMaxRelevantMultiplicity - aCurrentMultiplicity
+          ? aMaxRelevantMultiplicity
+          : aCurrentMultiplicity + anAddedMultiplicity;
     }
   }
 
-  int aFirstMuultypisityDifference = 0;
-  int aLastMuultypisityDifference  = 0;
-  for (int i = 1; i <= NbUniqueKnots; ++i)
-  {
-    int aCurrentVal = aUniqueKnotMultiplicities.Value(i);
-    if (aCurrentVal > aDegree + 1)
-    {
-      if (i == 1)
-      {
-        aFirstMuultypisityDifference = aCurrentVal - aDegree - 1;
-      }
-      if (i == NbUniqueKnots)
-      {
-        aLastMuultypisityDifference = aCurrentVal - aDegree - 1;
-      }
-#ifdef OCCT_DEBUG
-      std::cout << "\nWrong multiplicity " << aCurrentVal << " on " << i << " knot!"
-                << "\nChanged to " << aDegree + 1 << std::endl;
-#endif
-      aCurrentVal = aDegree + 1;
-    }
-    aUniqueKnotMultiplicities.SetValue(i, aCurrentVal);
-  }
-
-  const occ::handle<NCollection_HArray1<occ::handle<StepGeom_CartesianPoint>>>& aControlPointsList =
-    aBSplineCurveWithKnots->ControlPointsList();
-  int aSummaryMuultypisityDifference = aFirstMuultypisityDifference + aLastMuultypisityDifference;
-  int NbUniquePoles                  = NbPoles - aSummaryMuultypisityDifference;
-  if (NbUniquePoles <= 0)
+  const size_t aNbUniqueKnots = aUniqueKnotValues.Size();
+  if (aNbUniqueKnots <= 1)
   {
     return nullptr;
   }
-  TPntArray Poles(1, NbPoles - aSummaryMuultypisityDifference);
+  NCollection_LinearVector<int> aUniqueKnotMultiplicityValues(aNbUniqueKnots);
+  size_t                        aFirstMultiplicityExcess = 0;
+  size_t                        aLastMultiplicityExcess  = 0;
+  for (size_t aKnotIdx = 0; aKnotIdx < aNbUniqueKnots; ++aKnotIdx)
+  {
+    const size_t aMultiplicity = aMergedKnotMultiplicities.Value(aKnotIdx);
+    if (aMultiplicity > aMaxMultiplicity)
+    {
+      if (aKnotIdx == 0)
+      {
+        aFirstMultiplicityExcess = aMultiplicity - aMaxMultiplicity;
+      }
+      if (aKnotIdx == aNbUniqueKnots - 1)
+      {
+        aLastMultiplicityExcess = aMultiplicity - aMaxMultiplicity;
+      }
+#ifdef OCCT_DEBUG
+      std::cout << "\nWrong multiplicity " << aMultiplicity << " on " << aKnotIdx << " knot!"
+                << "\nChanged to " << aDegree + 1 << std::endl;
+#endif
+    }
+    aUniqueKnotMultiplicityValues.Append(
+      static_cast<int>(std::min(aMultiplicity, aMaxMultiplicity)));
+  }
 
-  for (int i = 1 + aFirstMuultypisityDifference; i <= NbPoles - aLastMuultypisityDifference; ++i)
+  NCollection_Array1<double> aUniqueKnots(aUniqueKnotValues.Data(), aNbUniqueKnots);
+  NCollection_Array1<int>    aUniqueKnotMultiplicities(aUniqueKnotMultiplicityValues.Data(),
+                                                       aNbUniqueKnots);
+
+  if (aFirstMultiplicityExcess > aNbPoles
+      || aLastMultiplicityExcess > aNbPoles - aFirstMultiplicityExcess)
+  {
+    return nullptr;
+  }
+  const size_t aTotalMultiplicityExcess = aFirstMultiplicityExcess + aLastMultiplicityExcess;
+  const size_t aNbUniquePoles           = aNbPoles - aTotalMultiplicityExcess;
+  if (aNbUniquePoles <= static_cast<size_t>(aDegree))
+  {
+    return nullptr;
+  }
+  TPntArray aPoles(aNbUniquePoles);
+
+  for (size_t aPoleIdx = aFirstMultiplicityExcess; aPoleIdx < aNbPoles - aLastMultiplicityExcess;
+       ++aPoleIdx)
   {
     occ::handle<TCartesianPoint> aPoint =
-      (*thePointMakerFunction)(aControlPointsList->Value(i), theLocalFactors);
+      (*thePointMakerFunction)(aControlPointsList->At(aPoleIdx), theLocalFactors);
     if (!aPoint.IsNull())
     {
-      TCartesianPoint* pPoint = aPoint.get();
-      TGpPnt           aGpPnt = (pPoint->*thePntGetterFunction)();
-      Poles.SetValue(i - aFirstMuultypisityDifference, aGpPnt);
+      const TGpPnt aPnt = ((*aPoint).*thePntGetterFunction)();
+      if (!isValidPoint(aPnt))
+      {
+        return nullptr;
+      }
+      aPoles.ChangeAt(aPoleIdx - aFirstMultiplicityExcess) = aPnt;
     }
     else
     {
@@ -870,27 +934,14 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
     }
   }
 
-  // --- Does the Curve descriptor LOOKS like a periodic descriptor ? ---
-  int aSummaryMuultypisity = 0;
-  for (int i = 1; i <= NbUniqueKnots; i++)
+  // Match the descriptor against the same pole-count contract used by the curve constructors.
+  const int  aNbExpectedPoles = static_cast<int>(aNbUniquePoles);
+  const bool shouldBePeriodic =
+    BSplCLib::NbPoles(aDegree, false, aUniqueKnotMultiplicities) != aNbExpectedPoles;
+  if (shouldBePeriodic
+      && BSplCLib::NbPoles(aDegree, true, aUniqueKnotMultiplicities) != aNbExpectedPoles)
   {
-    aSummaryMuultypisity += aUniqueKnotMultiplicities.Value(i);
-  }
-
-  bool shouldBePeriodic;
-  if (aSummaryMuultypisity == (NbPoles + aDegree + 1))
-  {
-    shouldBePeriodic = false;
-  }
-  else if ((aUniqueKnotMultiplicities.Value(1) == aUniqueKnotMultiplicities.Value(NbUniqueKnots))
-           && ((aSummaryMuultypisity - aUniqueKnotMultiplicities.Value(1)) == NbPoles))
-  {
-    shouldBePeriodic = true;
-  }
-  else
-  {
-    // --- What is that ??? ---
-    shouldBePeriodic = false;
+    return nullptr;
   }
 
   occ::handle<TBSplineCurve> aBSplineCurve;
@@ -899,12 +950,25 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
   {
     const occ::handle<NCollection_HArray1<double>>& aWeights =
       aBSplineCurveWithKnotsAndRationalBSplineCurve->WeightsData();
-    NCollection_Array1<double> aUniqueWeights(1, NbPoles - aSummaryMuultypisityDifference);
-    for (int i = 1 + aFirstMuultypisityDifference; i <= NbPoles - aLastMuultypisityDifference; ++i)
+    if (aWeights.IsNull() || static_cast<size_t>(aWeights->Length()) != aNbPoles)
     {
-      aUniqueWeights.SetValue(i - aFirstMuultypisityDifference, aWeights->Value(i));
+      return nullptr;
     }
-    aBSplineCurve = new TBSplineCurve(Poles,
+    for (size_t aPoleIdx = 0; aPoleIdx < aNbPoles; ++aPoleIdx)
+    {
+      const double aWeight = aWeights->At(aPoleIdx);
+      if (!isValidReal(aWeight) || aWeight <= gp::Resolution())
+      {
+        return nullptr;
+      }
+    }
+    NCollection_Array1<double> aUniqueWeights(aNbUniquePoles);
+    for (size_t aPoleIdx = aFirstMultiplicityExcess; aPoleIdx < aNbPoles - aLastMultiplicityExcess;
+         ++aPoleIdx)
+    {
+      aUniqueWeights.ChangeAt(aPoleIdx - aFirstMultiplicityExcess) = aWeights->At(aPoleIdx);
+    }
+    aBSplineCurve = new TBSplineCurve(aPoles,
                                       aUniqueWeights,
                                       aUniqueKnots,
                                       aUniqueKnotMultiplicities,
@@ -914,7 +978,7 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
   else
   {
     aBSplineCurve =
-      new TBSplineCurve(Poles, aUniqueKnots, aUniqueKnotMultiplicities, aDegree, shouldBePeriodic);
+      new TBSplineCurve(aPoles, aUniqueKnots, aUniqueKnotMultiplicities, aDegree, shouldBePeriodic);
   }
 
   // abv 04.07.00 CAX-IF TRJ4: trj4_k1_top-md-203.stp #716 (face #581):

--- a/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
+++ b/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
@@ -230,15 +230,15 @@ occ::handle<Geom_Axis2Placement> StepToGeom::MakeAxis2Placement(
     theSP->A() * cos(theSP->Gamma()) + theSP->B() * sin(theSP->Gamma()) * sin(theSP->Alpha());
   double aLocY =
     theSP->A() * sin(theSP->Gamma()) - theSP->B() * cos(theSP->Gamma()) * sin(theSP->Alpha());
-  double       aLocZ   = theSP->C() + theSP->B() * cos(theSP->Alpha());
-  double       anAsisX = sin(theSP->Gamma()) * sin(theSP->Alpha());
-  double       anAxisY = -cos(theSP->Gamma()) * sin(theSP->Alpha());
-  double       anAxisZ = cos(theSP->Alpha());
-  double       aDirX   = cos(theSP->Gamma()) * cos(theSP->Beta())
-                         - sin(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
-  double       aDirY   = sin(theSP->Gamma()) * cos(theSP->Beta())
-                         + cos(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
-  double       aDirZ   = sin(theSP->Alpha()) * sin(theSP->Beta());
+  double aLocZ   = theSP->C() + theSP->B() * cos(theSP->Alpha());
+  double anAsisX = sin(theSP->Gamma()) * sin(theSP->Alpha());
+  double anAxisY = -cos(theSP->Gamma()) * sin(theSP->Alpha());
+  double anAxisZ = cos(theSP->Alpha());
+  double aDirX   = cos(theSP->Gamma()) * cos(theSP->Beta())
+                 - sin(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
+  double aDirY = sin(theSP->Gamma()) * cos(theSP->Beta())
+                 + cos(theSP->Gamma()) * cos(theSP->Alpha()) * sin(theSP->Beta());
+  double       aDirZ = sin(theSP->Alpha()) * sin(theSP->Beta());
   const gp_Pnt Pgp(aLocX, aLocY, aLocZ);
   const gp_Dir Ngp(anAsisX, anAxisY, anAxisZ);
   const gp_Dir Vxgp(aDirX, aDirY, aDirZ);
@@ -899,7 +899,7 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
 
   NCollection_Array1<double> aUniqueKnots(aUniqueKnotValues.Data(), aNbUniqueKnots);
   NCollection_Array1<int>    aUniqueKnotMultiplicities(aUniqueKnotMultiplicityValues.Data(),
-                                                       aNbUniqueKnots);
+                                                    aNbUniqueKnots);
 
   if (aFirstMultiplicityExcess > aNbPoles
       || aLastMultiplicityExcess > aNbPoles - aFirstMultiplicityExcess)

--- a/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
+++ b/src/DataExchange/TKDESTEP/StepToGeom/StepToGeom.cxx
@@ -906,7 +906,7 @@ occ::handle<TBSplineCurve> MakeBSplineCurveCommon(
 
   NCollection_Array1<double> aUniqueKnots(aUniqueKnotValues.Data(), aNbUniqueKnots);
   NCollection_Array1<int>    aUniqueKnotMultiplicities(aUniqueKnotMultiplicityValues.Data(),
-                                                       aNbUniqueKnots);
+                                                    aNbUniqueKnots);
 
   if (aFirstMultiplicityExcess > aNbPoles
       || aLastMultiplicityExcess > aNbPoles - aFirstMultiplicityExcess)

--- a/src/DataExchange/TKDESTL/GTests/FILES.cmake
+++ b/src/DataExchange/TKDESTL/GTests/FILES.cmake
@@ -4,4 +4,5 @@ set(OCCT_TKDESTL_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 set(OCCT_TKDESTL_GTests_FILES
   DEMesh_ShapeWriteStl_Test.cxx
   DESTL_Provider_Test.cxx
+  RWStl_Reader_Test.cxx
 )

--- a/src/DataExchange/TKDESTL/GTests/RWStl_Reader_Test.cxx
+++ b/src/DataExchange/TKDESTL/GTests/RWStl_Reader_Test.cxx
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Poly_Triangulation.hxx>
+#include <RWStl.hxx>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+TEST(RWStl_ReaderTest, RejectsTruncatedAsciiKeywords)
+{
+  for (const char* aContent : {"solid s\nf", "solid s\nfacet normal 0 0 1\no"})
+  {
+    std::istringstream anInput(aContent);
+    EXPECT_TRUE(RWStl::ReadAsciiStream(anInput).IsNull());
+  }
+}
+
+TEST(RWStl_ReaderTest, RejectsIncompleteFacet)
+{
+  std::istringstream anInput("solid s\n"
+                             "facet normal 0 0 0\n"
+                             "outer loop\n"
+                             "vertex 0 0 0\n"
+                             "endloop\n"
+                             "endfacet\n"
+                             "endsolid\n");
+  EXPECT_TRUE(RWStl::ReadAsciiStream(anInput).IsNull());
+}
+
+TEST(RWStl_ReaderTest, ReadsCompleteAsciiKeywords)
+{
+  std::istringstream                    anInput("solid triangle\n"
+                                                "facet normal 0 0 1\n"
+                                                "outer loop\n"
+                                                "vertex 0 0 0\n"
+                                                "vertex 1 0 0\n"
+                                                "vertex 0 1 0\n"
+                                                "endloop\n"
+                                                "endfacet\n"
+                                                "endsolid triangle\n");
+  const occ::handle<Poly_Triangulation> aTriangulation = RWStl::ReadAsciiStream(anInput);
+  ASSERT_FALSE(aTriangulation.IsNull());
+  EXPECT_EQ(aTriangulation->NbTriangles(), 1);
+}

--- a/src/DataExchange/TKDESTL/GTests/RWStl_Reader_Test.cxx
+++ b/src/DataExchange/TKDESTL/GTests/RWStl_Reader_Test.cxx
@@ -39,6 +39,45 @@ TEST(RWStl_ReaderTest, RejectsIncompleteFacet)
   EXPECT_TRUE(RWStl::ReadAsciiStream(anInput).IsNull());
 }
 
+TEST(RWStl_ReaderTest, RejectsMalformedFacetClosures)
+{
+  for (const char* aContent : {"solid s\n"
+                               "facet normal 0 0 1\n"
+                               "outer loop\n"
+                               "vertex 0 0 0\n"
+                               "vertex 1 0 0\n"
+                               "vertex 0 1 0\n"
+                               "not_endloop\n"
+                               "endfacet\n"
+                               "endsolid\n",
+                               "solid s\n"
+                               "facet normal 0 0 1\n"
+                               "outer loop\n"
+                               "vertex 0 0 0\n"
+                               "vertex 1 0 0\n"
+                               "vertex 0 1 0\n"
+                               "endloop\n"
+                               "not_endfacet\n"
+                               "endsolid\n",
+                               "solid s\n"
+                               "facet normal 0 0 1\n"
+                               "outer loop\n"
+                               "vertex 0 0 0\n"
+                               "vertex 1 0 0\n"
+                               "vertex 0 1 0\n",
+                               "solid s\n"
+                               "facet normal 0 0 1\n"
+                               "outer loop\n"
+                               "vertex 0 0 0\n"
+                               "vertex 1 0 0\n"
+                               "vertex 0 1 0\n"
+                               "endloop\n"})
+  {
+    std::istringstream anInput(aContent);
+    EXPECT_TRUE(RWStl::ReadAsciiStream(anInput).IsNull());
+  }
+}
+
 TEST(RWStl_ReaderTest, ReadsCompleteAsciiKeywords)
 {
   std::istringstream                    anInput("solid triangle\n"

--- a/src/DataExchange/TKDESTL/RWStl/RWStl_Reader.cxx
+++ b/src/DataExchange/TKDESTL/RWStl/RWStl_Reader.cxx
@@ -27,7 +27,9 @@
 #include <Standard_CLocaleSentry.hxx>
 
 #include <algorithm>
+#include <cctype>
 #include <limits>
+#include <string_view>
 
 IMPLEMENT_STANDARD_RTTIEXT(RWStl_Reader, Standard_Transient)
 
@@ -251,32 +253,57 @@ bool RWStl_Reader::IsAscii(Standard_IStream& theStream, const bool isSeekgAvaila
   #define GETPOS(aPos) ((int64_t)aPos)
 #endif
 
-static inline bool str_starts_with(const char* theStr, const char* theWord, int theN)
+static bool startsWithKeywordIgnoreCase(const std::string_view theLine,
+                                        const std::string_view theKeyword)
 {
-  while (isspace(*theStr) && *theStr != '\0')
+  size_t anOffset = 0;
+  while (anOffset < theLine.size()
+         && std::isspace(static_cast<unsigned char>(theLine[anOffset])) != 0)
   {
-    theStr++;
+    ++anOffset;
   }
-  return !strncasecmp(theStr, theWord, theN);
+  if (theLine.size() - anOffset < theKeyword.size()
+      || strncasecmp(theLine.data() + anOffset, theKeyword.data(), theKeyword.size()) != 0)
+  {
+    return false;
+  }
+  const size_t anEndOffset = anOffset + theKeyword.size();
+  return anEndOffset == theLine.size()
+         || std::isspace(static_cast<unsigned char>(theLine[anEndOffset])) != 0;
 }
 
-static bool ReadVertex(const char* theStr, double& theX, double& theY, double& theZ)
+static bool readVertex(const std::string_view theLine, double& theX, double& theY, double& theZ)
 {
-  const char* aStr = theStr;
-
-  // skip 'vertex'
-  while (isspace((unsigned char)*aStr) || isalpha((unsigned char)*aStr))
+  if (!startsWithKeywordIgnoreCase(theLine, "vertex"))
   {
-    ++aStr;
+    return false;
   }
 
-  // read values
-  char* aEnd;
-  theX = Strtod(aStr, &aEnd);
-  theY = Strtod(aStr = aEnd, &aEnd);
-  theZ = Strtod(aStr = aEnd, &aEnd);
+  const char* aPosition = theLine.data();
 
-  return aEnd != aStr;
+  while (std::isspace(static_cast<unsigned char>(*aPosition)) != 0)
+  {
+    ++aPosition;
+  }
+  aPosition += sizeof("vertex") - 1;
+
+  // read values
+  char* aNextPosition;
+  theX = Strtod(aPosition, &aNextPosition);
+  if (aNextPosition == aPosition)
+  {
+    return false;
+  }
+  aPosition = aNextPosition;
+  theY      = Strtod(aPosition, &aNextPosition);
+  if (aNextPosition == aPosition)
+  {
+    return false;
+  }
+  aPosition = aNextPosition;
+  theZ      = Strtod(aPosition, &aNextPosition);
+
+  return aNextPosition != aPosition;
 }
 
 //=================================================================================================
@@ -334,12 +361,12 @@ bool RWStl_Reader::ReadAscii(Standard_IStream&            theStream,
       Message::SendFail("Error: premature end of file");
       return false;
     }
-    if (str_starts_with(aLine, "endsolid", 8))
+    if (startsWithKeywordIgnoreCase(std::string_view(aLine, aLineLen), "endsolid"))
     {
       // end of STL code
       break;
     }
-    if (!str_starts_with(aLine, "facet", 5))
+    if (!startsWithKeywordIgnoreCase(std::string_view(aLine, aLineLen), "facet"))
     {
       Message::SendFail(TCollection_AsciiString("Error: unexpected format of facet at line ")
                         + (aNbLine + 1));
@@ -347,7 +374,8 @@ bool RWStl_Reader::ReadAscii(Standard_IStream&            theStream,
     }
 
     aLine = theBuffer.ReadLine(theStream, aLineLen); // "outer loop"
-    if (aLine == nullptr || !str_starts_with(aLine, "outer", 5))
+    if (aLine == nullptr
+        || !startsWithKeywordIgnoreCase(std::string_view(aLine, aLineLen), "outer"))
     {
       Message::SendFail(TCollection_AsciiString("Error: unexpected format of facet at line ")
                         + (aNbLine + 1));
@@ -365,7 +393,7 @@ bool RWStl_Reader::ReadAscii(Standard_IStream&            theStream,
         break;
       }
       gp_XYZ aReadVertex;
-      if (!ReadVertex(aLine,
+      if (!readVertex(std::string_view(aLine, aLineLen),
                       aReadVertex.ChangeCoord(1),
                       aReadVertex.ChangeCoord(2),
                       aReadVertex.ChangeCoord(3)))

--- a/src/DataExchange/TKDESTL/RWStl/RWStl_Reader.cxx
+++ b/src/DataExchange/TKDESTL/RWStl/RWStl_Reader.cxx
@@ -405,21 +405,34 @@ bool RWStl_Reader::ReadAscii(Standard_IStream&            theStream,
       aVertex[i] = aReadVertex;
     }
 
-    // stop reading if end of file is reached;
-    // note that well-formatted file never ends by the vertex line
+    // A well-formed facet always contains all vertices and both closing records.
     if (isEOF)
     {
-      break;
+      Message::SendFail("Error: premature end of file while reading facet vertices");
+      return false;
     }
 
     aNbLine += 5;
 
-    // add triangle
+    aLine = theBuffer.ReadLine(theStream, aLineLen); // "endloop"
+    if (aLine == nullptr
+        || !startsWithKeywordIgnoreCase(std::string_view(aLine, aLineLen), "endloop"))
+    {
+      Message::SendFail(TCollection_AsciiString("Error: expected endloop at line ")
+                        + (aNbLine + 1));
+      return false;
+    }
+
+    aLine = theBuffer.ReadLine(theStream, aLineLen); // "endfacet"
+    if (aLine == nullptr
+        || !startsWithKeywordIgnoreCase(std::string_view(aLine, aLineLen), "endfacet"))
+    {
+      Message::SendFail(TCollection_AsciiString("Error: expected endfacet at line ")
+                        + (aNbLine + 2));
+      return false;
+    }
+
     aMergeTool.AddTriangle(aVertex);
-
-    theBuffer.ReadLine(theStream, aLineLen); // skip "endloop"
-    theBuffer.ReadLine(theStream, aLineLen); // skip "endfacet"
-
     aNbLine += 2;
   }
 

--- a/src/DataExchange/TKDEVRML/GTests/FILES.cmake
+++ b/src/DataExchange/TKDEVRML/GTests/FILES.cmake
@@ -3,4 +3,7 @@ set(OCCT_TKDEVRML_GTests_FILES_LOCATION "${CMAKE_CURRENT_LIST_DIR}")
 
 set(OCCT_TKDEVRML_GTests_FILES
   DEVRML_Provider_Test.cxx
+  VrmlData_IndexedFaceSet_Test.cxx
+  VrmlData_IndexedLineSet_Test.cxx
+  VrmlData_Scene_Test.cxx
 )

--- a/src/DataExchange/TKDEVRML/GTests/VrmlData_IndexedFaceSet_Test.cxx
+++ b/src/DataExchange/TKDEVRML/GTests/VrmlData_IndexedFaceSet_Test.cxx
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <DEVRML_ConfigurationNode.hxx>
+#include <DEVRML_Provider.hxx>
+#include <DE_Provider.hxx>
+#include <TopoDS_Shape.hxx>
+#include <VrmlData_Coordinate.hxx>
+#include <VrmlData_IndexedFaceSet.hxx>
+#include <VrmlData_Scene.hxx>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <sstream>
+#include <string>
+
+namespace
+{
+static bool readVrmlShape(const std::string& theContent, TopoDS_Shape& theShape)
+{
+  const occ::handle<DEVRML_Provider> aProvider =
+    new DEVRML_Provider(new DEVRML_ConfigurationNode());
+  std::istringstream          anInput(theContent);
+  DE_Provider::ReadStreamList aStreams;
+  aStreams.Append(DE_Provider::ReadStreamNode("indexed-face-set.vrml", anInput));
+  return aProvider->Read(aStreams, theShape);
+}
+} // namespace
+
+TEST(VrmlData_IndexedFaceSetTest, RejectsInvalidCoordinateIndex)
+{
+  const std::string aContent = "#VRML V2.0 utf8\n"
+                               "Shape { geometry IndexedFaceSet { "
+                               "coord Coordinate { point [ 0 0 0, 1 0 0, 0 1 0 ] } "
+                               "coordIndex [ 0, 1, 3, -1 ] } }\n";
+  TopoDS_Shape      aShape;
+  EXPECT_FALSE(readVrmlShape(aContent, aShape));
+  EXPECT_TRUE(aShape.IsNull());
+}
+
+TEST(VrmlData_IndexedFaceSetTest, ComputesNormalsForInvalidNormalIndex)
+{
+  const std::string aContent = "#VRML V2.0 utf8\n"
+                               "Shape { geometry IndexedFaceSet { "
+                               "coord Coordinate { point [ 0 0 0, 1 0 0, 0 1 0 ] } "
+                               "coordIndex [ 0, 1, 2, -1 ] "
+                               "normal Normal { vector [ 0 0 1, 0 0 1, 0 0 1 ] } "
+                               "normalIndex [ 0, 1, 3, -1 ] normalPerVertex TRUE } }\n";
+  TopoDS_Shape      aShape;
+  ASSERT_TRUE(readVrmlShape(aContent, aShape));
+  EXPECT_FALSE(aShape.IsNull());
+}
+
+TEST(VrmlData_IndexedFaceSetTest, RejectsNegativeCoordinateIndex)
+{
+  VrmlData_Scene                         aScene;
+  const std::array<gp_XYZ, 3>            aPoints = {gp_XYZ(0.0, 0.0, 0.0),
+                                                    gp_XYZ(1.0, 0.0, 0.0),
+                                                    gp_XYZ(0.0, 1.0, 0.0)};
+  const occ::handle<VrmlData_Coordinate> aCoordinates =
+    new VrmlData_Coordinate(aScene, "coordinates", aPoints.size(), aPoints.data());
+  const std::array<int, 4>  aPolygon  = {3, 0, -2, 1};
+  std::array<const int*, 1> aPolygons = {aPolygon.data()};
+
+  VrmlData_IndexedFaceSet aFaceSet(aScene, "faces");
+  aFaceSet.SetCoordinates(aCoordinates);
+  aFaceSet.SetPolygons(aPolygons.size(), aPolygons.data());
+  EXPECT_TRUE(aFaceSet.TShape().IsNull());
+}

--- a/src/DataExchange/TKDEVRML/GTests/VrmlData_IndexedLineSet_Test.cxx
+++ b/src/DataExchange/TKDEVRML/GTests/VrmlData_IndexedLineSet_Test.cxx
@@ -1,0 +1,58 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <DEVRML_ConfigurationNode.hxx>
+#include <DEVRML_Provider.hxx>
+#include <DE_Provider.hxx>
+#include <TopoDS_Shape.hxx>
+#include <VrmlData_Coordinate.hxx>
+#include <VrmlData_IndexedLineSet.hxx>
+#include <VrmlData_Scene.hxx>
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <sstream>
+#include <string>
+
+TEST(VrmlData_IndexedLineSetTest, RejectsInvalidCoordinateIndex)
+{
+  const std::string                  aContent = "#VRML V2.0 utf8\n"
+                                                "Shape { geometry IndexedLineSet { "
+                                                "coord Coordinate { point [ 0 0 0, 1 0 0, 0 1 0 ] } "
+                                                "coordIndex [ 0, 1, 3, -1 ] } }\n";
+  const occ::handle<DEVRML_Provider> aProvider =
+    new DEVRML_Provider(new DEVRML_ConfigurationNode());
+  std::istringstream          anInput(aContent);
+  DE_Provider::ReadStreamList aStreams;
+  aStreams.Append(DE_Provider::ReadStreamNode("indexed-line-set.vrml", anInput));
+
+  TopoDS_Shape aShape;
+  EXPECT_FALSE(aProvider->Read(aStreams, aShape));
+  EXPECT_TRUE(aShape.IsNull());
+}
+
+TEST(VrmlData_IndexedLineSetTest, RejectsNegativeCoordinateIndex)
+{
+  VrmlData_Scene                         aScene;
+  const std::array<gp_XYZ, 2>            aPoints = {gp_XYZ(0.0, 0.0, 0.0), gp_XYZ(1.0, 0.0, 0.0)};
+  const occ::handle<VrmlData_Coordinate> aCoordinates =
+    new VrmlData_Coordinate(aScene, "coordinates", aPoints.size(), aPoints.data());
+  const std::array<int, 3>  aPolyline  = {2, 0, -2};
+  std::array<const int*, 1> aPolylines = {aPolyline.data()};
+
+  VrmlData_IndexedLineSet aLineSet(aScene, "lines");
+  aLineSet.SetCoordinates(aCoordinates);
+  aLineSet.SetPolygons(aPolylines.size(), aPolylines.data());
+  EXPECT_TRUE(aLineSet.TShape().IsNull());
+}

--- a/src/DataExchange/TKDEVRML/GTests/VrmlData_Scene_Test.cxx
+++ b/src/DataExchange/TKDEVRML/GTests/VrmlData_Scene_Test.cxx
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <VrmlData_InBuffer.hxx>
+#include <VrmlData_Scene.hxx>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+
+TEST(VrmlData_SceneTest, HandlesTrailingQuotedEscape)
+{
+  std::istringstream anInput("\"unterminated\\\n");
+  VrmlData_InBuffer  aBuffer(anInput);
+  EXPECT_EQ(VrmlData_Scene::ReadLine(aBuffer), VrmlData_StatusOK);
+  EXPECT_STREQ(aBuffer.Line.data(), "\"unterminated\\");
+}
+
+TEST(VrmlData_SceneTest, RejectsLineExceedingInputBuffer)
+{
+  std::istringstream anInput(std::string(9000, 'a'));
+  VrmlData_InBuffer  aBuffer(anInput);
+  EXPECT_EQ(VrmlData_Scene::ReadLine(aBuffer), VrmlData_UnrecoverableError);
+}

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_Coordinate.hxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_Coordinate.hxx
@@ -44,12 +44,12 @@ public:
 
   /**
    * Query one point
-   * @param i
+   * @param theIndex
    *   index in the array of points [0 .. N-1]
    * @return
    *   the coordinate for the index. If index irrelevant, returns (0., 0., 0.)
    */
-  inline const gp_XYZ& Coordinate(const int i) const { return Value(i); }
+  inline const gp_XYZ& Coordinate(const size_t theIndex) const { return Value(theIndex); }
 
   /**
    * Create a copy of this node.

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_InBuffer.hxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_InBuffer.hxx
@@ -18,19 +18,22 @@
 
 #include <Standard_IStream.hxx>
 
+#include <array>
+
 /**
  * Structure passed to the methods dealing with input stream.
  */
 struct VrmlData_InBuffer
 {
-  Standard_IStream& Input;
-  char              Line[8096];
-  char*             LinePtr;
-  bool              IsProcessed;
-  int               LineCount;
+  Standard_IStream&      Input;
+  std::array<char, 8096> Line;
+  char*                  LinePtr;
+  bool                   IsProcessed;
+  int                    LineCount;
   VrmlData_InBuffer(Standard_IStream& theStream)
       : Input(theStream),
-        LinePtr(&Line[0]),
+        Line{},
+        LinePtr(Line.data()),
         IsProcessed(false),
         LineCount(0) {};
 

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedFaceSet.cxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedFaceSet.cxx
@@ -26,6 +26,7 @@
 #include <Precision.hxx>
 #include <NCollection_DynamicArray.hxx>
 #include <NCollection_DataMap.hxx>
+#include <NCollection_FlatMap.hxx>
 #include <Poly.hxx>
 #include <Standard_ShortReal.hxx>
 #include <NCollection_Array1.hxx>
@@ -100,50 +101,58 @@ const occ::handle<TopoDS_TShape>& VrmlData_IndexedFaceSet::TShape()
     return myTShape;
   }
 
-  // list of nodes:
-  const gp_XYZ* arrNodes = myCoords->Values();
-  const int     nNodes   = (int)myCoords->Length();
+  if (myCoords.IsNull() || myArrPolygons == nullptr)
+  {
+    myTShape.Nullify();
+    return myTShape;
+  }
 
-  NCollection_Map<int>                        mapNodeId;
-  NCollection_Map<int>                        mapPolyId;
+  const size_t aNbNodes = myCoords->Length();
+
+  NCollection_FlatMap<size_t>                 aNodeIds;
+  NCollection_FlatMap<size_t>                 aPolygonIds;
   NCollection_List<NCollection_Sequence<int>> aPolygons;
   NCollection_List<gp_Dir>                    aNorms;
-  int                                         i = 0;
-  for (; i < (int)myNbPolygons; i++)
+  for (size_t aPolygonIdx = 0; aPolygonIdx < myNbPolygons; ++aPolygonIdx)
   {
-    const int* arrIndice = myArrPolygons[i];
-    int        nn        = arrIndice[0];
-    if (nn < 3)
+    const int* aPolygonData = myArrPolygons[aPolygonIdx];
+    if (aPolygonData == nullptr)
+    {
+      continue;
+    }
+    const int aNbPolygonNodes = aPolygonData[0];
+    if (aNbPolygonNodes < 3)
     {
       // bad polygon
       continue;
     }
     NCollection_Sequence<int> aPolygon;
-    int                       in = 1;
-    for (; in <= nn; in++)
+    int                       aPolygonNodeIdx = 1;
+    for (; aPolygonNodeIdx <= aNbPolygonNodes; ++aPolygonNodeIdx)
     {
-      if (arrIndice[in] > nNodes)
+      const int aCoordIdx = aPolygonData[aPolygonNodeIdx];
+      if (aCoordIdx < 0 || static_cast<size_t>(aCoordIdx) >= aNbNodes)
       {
         break;
       }
-      aPolygon.Append(arrIndice[in]);
+      aPolygon.Append(aCoordIdx);
     }
-    if (in <= nn)
+    if (aPolygonNodeIdx <= aNbPolygonNodes)
     {
       // bad index of node in polygon
       continue;
     }
     // calculate normal
     gp_XYZ aSum;
-    gp_XYZ aPrevP = arrNodes[aPolygon(1)];
-    for (in = 2; in < aPolygon.Length(); in++)
+    gp_XYZ aPrevP = myCoords->Coordinate(static_cast<size_t>(aPolygon.First()));
+    for (int aNodeIdx = 2; aNodeIdx < aPolygon.Length(); ++aNodeIdx)
     {
-      gp_XYZ aP1 = arrNodes[aPolygon(in)];
-      gp_XYZ aP2 = arrNodes[aPolygon(in + 1)];
-      gp_XYZ aV1 = aP1 - aPrevP;
-      gp_XYZ aV2 = aP2 - aPrevP;
-      gp_XYZ S   = aV1.Crossed(aV2);
-      aSum += S;
+      gp_XYZ aP1           = myCoords->Coordinate(static_cast<size_t>(aPolygon(aNodeIdx)));
+      gp_XYZ aP2           = myCoords->Coordinate(static_cast<size_t>(aPolygon(aNodeIdx + 1)));
+      gp_XYZ aV1           = aP1 - aPrevP;
+      gp_XYZ aV2           = aP2 - aPrevP;
+      gp_XYZ aCrossProduct = aV1.Crossed(aV2);
+      aSum += aCrossProduct;
     }
     if (aSum.Modulus() < Precision::Confusion())
     {
@@ -151,18 +160,17 @@ const occ::handle<TopoDS_TShape>& VrmlData_IndexedFaceSet::TShape()
       continue;
     }
     gp_Dir aNormal(aSum);
-    mapPolyId.Add(i);
+    aPolygonIds.Add(aPolygonIdx);
     aPolygons.Append(aPolygon);
     aNorms.Append(aNormal);
     // collect info about used indices
-    for (in = 1; in <= aPolygon.Length(); in++)
+    for (int aNodeIdx = 1; aNodeIdx <= aPolygon.Length(); ++aNodeIdx)
     {
-      mapNodeId.Add(arrIndice[in]);
+      aNodeIds.Add(static_cast<size_t>(aPolygonData[aNodeIdx]));
     }
   }
 
-  const int nbNodes(mapNodeId.Extent());
-  if (!nbNodes)
+  if (aNodeIds.IsEmpty())
   {
     myIsModified = false;
     myTShape.Nullify();
@@ -170,38 +178,38 @@ const occ::handle<TopoDS_TShape>& VrmlData_IndexedFaceSet::TShape()
   }
   // prepare vector of nodes
   NCollection_DynamicArray<gp_XYZ> aNodes;
-  NCollection_DataMap<int, int>    mapIdId;
-  for (i = 0; i < nNodes; i++)
+  NCollection_DataMap<size_t, int> aNodeIdMap;
+  for (size_t aNodeIdx = 0; aNodeIdx < aNbNodes; ++aNodeIdx)
   {
-    if (mapNodeId.Contains(i))
+    if (aNodeIds.Contains(aNodeIdx))
     {
-      const gp_XYZ& aN1 = arrNodes[i];
-      mapIdId.Bind(i, aNodes.Length());
-      aNodes.Append(aN1);
+      aNodeIdMap.Bind(aNodeIdx, aNodes.Length());
+      aNodes.Append(myCoords->Coordinate(aNodeIdx));
     }
   }
   // update polygon indices
-  NCollection_List<NCollection_Sequence<int>>::Iterator itP(aPolygons);
-  for (; itP.More(); itP.Next())
+  NCollection_List<NCollection_Sequence<int>>::Iterator aPolygonIter(aPolygons);
+  for (; aPolygonIter.More(); aPolygonIter.Next())
   {
-    NCollection_Sequence<int>& aPolygon = itP.ChangeValue();
-    for (int in = 1; in <= aPolygon.Length(); in++)
+    NCollection_Sequence<int>& aPolygon = aPolygonIter.ChangeValue();
+    for (int aNodeIdx = 1; aNodeIdx <= aPolygon.Length(); ++aNodeIdx)
     {
-      int newIdx               = mapIdId.Find(aPolygon.Value(in));
-      aPolygon.ChangeValue(in) = newIdx;
+      const int aNewNodeIdx = aNodeIdMap.Find(static_cast<size_t>(aPolygon.Value(aNodeIdx)));
+      aPolygon.ChangeValue(aNodeIdx) = aNewNodeIdx;
     }
   }
   // calculate triangles
   NCollection_List<Poly_Triangle> aTriangles;
-  itP.Init(aPolygons);
-  for (NCollection_List<gp_Dir>::Iterator itN(aNorms); itP.More(); itP.Next(), itN.Next())
+  aPolygonIter.Init(aPolygons);
+  for (NCollection_List<gp_Dir>::Iterator aNormalIter(aNorms); aPolygonIter.More();
+       aPolygonIter.Next(), aNormalIter.Next())
   {
     NCollection_List<Poly_Triangle> aTrias;
     try
     {
       NCollection_List<NCollection_Sequence<int>> aPList;
-      aPList.Append(itP.Value());
-      BRepMesh_Triangulator aTriangulator(aNodes, aPList, itN.Value());
+      aPList.Append(aPolygonIter.Value());
+      BRepMesh_Triangulator aTriangulator(aNodes, aPList, aNormalIter.Value());
       aTriangulator.Perform(aTrias);
       aTriangles.Append(aTrias);
     }
@@ -219,15 +227,15 @@ const occ::handle<TopoDS_TShape>& VrmlData_IndexedFaceSet::TShape()
   occ::handle<Poly_Triangulation> aTriangulation =
     new Poly_Triangulation(aNodes.Length(), aTriangles.Extent(), false);
   // Copy the triangulation vertices
-  for (i = 0; i < aNodes.Length(); i++)
+  for (int aNodeIdx = 0; aNodeIdx < aNodes.Length(); ++aNodeIdx)
   {
-    aTriangulation->SetNode(i + 1, gp_Pnt(aNodes(i)));
+    aTriangulation->SetNode(aNodeIdx + 1, gp_Pnt(aNodes(aNodeIdx)));
   }
   // Copy the triangles.
-  NCollection_List<Poly_Triangle>::Iterator itT(aTriangles);
-  for (i = 1; itT.More(); itT.Next(), i++)
+  NCollection_List<Poly_Triangle>::Iterator aTriangleIter(aTriangles);
+  for (int aTriangleIdx = 1; aTriangleIter.More(); aTriangleIter.Next(), ++aTriangleIdx)
   {
-    aTriangulation->SetTriangle(i, itT.Value());
+    aTriangulation->SetTriangle(aTriangleIdx, aTriangleIter.Value());
   }
 
   occ::handle<BRep_TFace> aFace = new BRep_TFace();
@@ -244,29 +252,88 @@ const occ::handle<TopoDS_TShape>& VrmlData_IndexedFaceSet::TShape()
     // Copy the normals. Currently only normals-per-vertex are supported.
     if (myNormalPerVertex)
     {
-      aTriangulation->AddNormals();
+      bool hasValidNormals = true;
       if (myArrNormalInd == nullptr)
       {
-        for (i = 0; i < nbNodes; i++)
+        for (size_t aNodeIdx = 0; aNodeIdx < aNbNodes; ++aNodeIdx)
         {
-          const gp_XYZ& aNormal = myNormals->Normal(i);
-          aTriangulation->SetNormal(i + 1, aNormal);
+          if (aNodeIdMap.IsBound(aNodeIdx) && aNodeIdx >= myNormals->Length())
+          {
+            hasValidNormals = false;
+            break;
+          }
         }
       }
       else
       {
-        for (i = 0; i < (int)myNbPolygons; i++)
+        for (size_t aPolygonIdx = 0; aPolygonIdx < myNbPolygons && hasValidNormals; ++aPolygonIdx)
         {
-          if (mapPolyId.Contains(i)) // check to avoid previously skipped faces
+          if (!aPolygonIds.Contains(aPolygonIdx))
           {
-            const int* anArrNodes;
-            Polygon(i, anArrNodes);
-            const int* arrIndice;
-            int        nbn = IndiceNormals(i, arrIndice);
-            for (int j = 0; j < nbn; j++)
+            continue;
+          }
+          if (aPolygonIdx >= myNbNormals || myArrNormalInd[aPolygonIdx] == nullptr)
+          {
+            hasValidNormals = false;
+            break;
+          }
+          const int* aCoordIndices;
+          const int  aNbPolygonNodes = Polygon(aPolygonIdx, aCoordIndices);
+          const int* aNormalIndices;
+          const int  aNbNormalIndices = IndiceNormals(aPolygonIdx, aNormalIndices);
+          if (aNbNormalIndices != aNbPolygonNodes)
+          {
+            hasValidNormals = false;
+            break;
+          }
+          for (size_t aNodeIdx = 0; aNodeIdx < static_cast<size_t>(aNbNormalIndices); ++aNodeIdx)
+          {
+            const int aNormalIdx = aNormalIndices[aNodeIdx];
+            if (aNormalIdx < 0 || static_cast<size_t>(aNormalIdx) >= myNormals->Length())
             {
-              const gp_XYZ& aNormal = myNormals->Normal(arrIndice[j]);
-              aTriangulation->SetNormal(mapIdId(anArrNodes[j]) + 1, aNormal);
+              hasValidNormals = false;
+              break;
+            }
+          }
+        }
+      }
+
+      if (!hasValidNormals)
+      {
+        Poly::ComputeNormals(aTriangulation);
+      }
+      else
+      {
+        aTriangulation->AddNormals();
+        if (myArrNormalInd == nullptr)
+        {
+          for (size_t aNodeIdx = 0; aNodeIdx < aNbNodes; ++aNodeIdx)
+          {
+            if (aNodeIdMap.IsBound(aNodeIdx))
+            {
+              aTriangulation->SetNormal(aNodeIdMap.Find(aNodeIdx) + 1, myNormals->Normal(aNodeIdx));
+            }
+          }
+        }
+        else
+        {
+          for (size_t aPolygonIdx = 0; aPolygonIdx < myNbPolygons; ++aPolygonIdx)
+          {
+            if (aPolygonIds.Contains(aPolygonIdx)) // check to avoid previously skipped faces
+            {
+              const int* aCoordIndices;
+              Polygon(aPolygonIdx, aCoordIndices);
+              const int* aNormalIndices;
+              const int  aNbNormalIndices = IndiceNormals(aPolygonIdx, aNormalIndices);
+              for (size_t aNodeIdx = 0; aNodeIdx < static_cast<size_t>(aNbNormalIndices);
+                   ++aNodeIdx)
+              {
+                const gp_XYZ& aNormal =
+                  myNormals->Normal(static_cast<size_t>(aNormalIndices[aNodeIdx]));
+                aTriangulation->SetNormal(aNodeIdMap(static_cast<size_t>(aCoordIndices[aNodeIdx]))
+                                            + 1,
+                                          aNormal);
+              }
             }
           }
         }

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedFaceSet.hxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedFaceSet.hxx
@@ -105,16 +105,16 @@ public:
 
   /**
    * Query one polygon.
-   * @param iFace
+   * @param theFaceIndex
    *   rank of the polygon [0 .. N-1]
-   * @param outIndice
+   * @param theIndices
    *   <tt>[out]</tt> array of vertex indice
    * @return
    *   number of vertice in the polygon - the dimension of outIndice array
    */
-  inline int Polygon(const int iFace, const int*& outIndice)
+  inline int Polygon(const size_t theFaceIndex, const int*& theIndices)
   {
-    return *(outIndice = myArrPolygons[iFace])++;
+    return *(theIndices = myArrPolygons[theFaceIndex])++;
   }
 
   /**
@@ -153,16 +153,16 @@ public:
   /**
    * Query normals indice for one face. This method should be called after
    * checking myArrNormalInd != NULL, otherwise exception will be thrown.
-   * @param iFace
+   * @param theFaceIndex
    *   rank of the face [0 .. N-1]
-   * @param outIndice
+   * @param theIndices
    *   <tt>[out]</tt> array of normals indice
    * @return
    *   number of indice in the array - the dimension of outIndice array
    */
-  inline int IndiceNormals(const int iFace, const int*& outIndice)
+  inline int IndiceNormals(const size_t theFaceIndex, const int*& theIndices)
   {
-    return *(outIndice = myArrNormalInd[iFace])++;
+    return *(theIndices = myArrNormalInd[theFaceIndex])++;
   }
 
   /**

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedLineSet.cxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedLineSet.cxx
@@ -55,30 +55,69 @@ const occ::handle<TopoDS_TShape>& VrmlData_IndexedLineSet::TShape()
   }
   else if (myIsModified)
   {
-    int           i;
-    BRep_Builder  aBuilder;
-    const gp_XYZ* arrNodes = myCoords->Values();
+    if (myCoords.IsNull() || myArrPolygons == nullptr)
+    {
+      myTShape.Nullify();
+      return myTShape;
+    }
+
+    BRep_Builder aBuilder;
+    const size_t aNbCoords = myCoords->Length();
 
     // Create the Wire
     TopoDS_Wire aWire;
     aBuilder.MakeWire(aWire);
-    for (i = 0; i < (int)myNbPolygons; i++)
+    bool hasPolyline = false;
+    for (size_t aPolylineIdx = 0; aPolylineIdx < myNbPolygons; ++aPolylineIdx)
     {
-      const int*                 arrIndice;
-      const int                  nNodes = Polygon(i, arrIndice);
-      NCollection_Array1<gp_Pnt> arrPoint(1, nNodes);
-      NCollection_Array1<double> arrParam(1, nNodes);
-      for (int j = 0; j < nNodes; j++)
+      if (myArrPolygons[aPolylineIdx] == nullptr)
       {
-        arrPoint(j + 1).SetXYZ(arrNodes[arrIndice[j]]);
-        arrParam(j + 1) = j;
+        continue;
       }
-      const occ::handle<Poly_Polygon3D> aPolyPolygon = new Poly_Polygon3D(arrPoint, arrParam);
+      const int* aCoordIndices;
+      const int  aNbPolylineNodes = Polygon(aPolylineIdx, aCoordIndices);
+      if (aNbPolylineNodes < 2)
+      {
+        continue;
+      }
+
+      bool hasInvalidCoordIndex = false;
+      for (size_t aNodeIdx = 0; aNodeIdx < static_cast<size_t>(aNbPolylineNodes); ++aNodeIdx)
+      {
+        const int aCoordIdx = aCoordIndices[aNodeIdx];
+        if (aCoordIdx < 0 || static_cast<size_t>(aCoordIdx) >= aNbCoords)
+        {
+          hasInvalidCoordIndex = true;
+          break;
+        }
+      }
+      if (hasInvalidCoordIndex)
+      {
+        continue;
+      }
+
+      NCollection_Array1<gp_Pnt> aPoints(static_cast<size_t>(aNbPolylineNodes));
+      NCollection_Array1<double> aParameters(static_cast<size_t>(aNbPolylineNodes));
+      for (size_t aNodeIdx = 0; aNodeIdx < static_cast<size_t>(aNbPolylineNodes); ++aNodeIdx)
+      {
+        aPoints.ChangeAt(aNodeIdx).SetXYZ(
+          myCoords->Coordinate(static_cast<size_t>(aCoordIndices[aNodeIdx])));
+        aParameters.ChangeAt(aNodeIdx) = static_cast<double>(aNodeIdx);
+      }
+      const occ::handle<Poly_Polygon3D> aPolyPolygon = new Poly_Polygon3D(aPoints, aParameters);
       TopoDS_Edge                       anEdge;
       aBuilder.MakeEdge(anEdge, aPolyPolygon);
       aBuilder.Add(aWire, anEdge);
+      hasPolyline = true;
     }
-    myTShape = aWire.TShape();
+    if (hasPolyline)
+    {
+      myTShape = aWire.TShape();
+    }
+    else
+    {
+      myTShape.Nullify();
+    }
   }
   return myTShape;
 }

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedLineSet.hxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_IndexedLineSet.hxx
@@ -94,16 +94,16 @@ public:
 
   /**
    * Query one polygon.
-   * @param iPolygon
+   * @param thePolygonIndex
    *   rank of the polygon [0 .. N-1]
-   * @param outIndice
+   * @param theIndices
    *   <tt>[out]</tt> array of vertex indice
    * @return
    *   number of vertice in the polygon - the dimension of outIndice array
    */
-  inline int Polygon(const int iPolygon, const int*& outIndice)
+  inline int Polygon(const size_t thePolygonIndex, const int*& theIndices)
   {
-    return *(outIndice = myArrPolygons[iPolygon])++;
+    return *(theIndices = myArrPolygons[thePolygonIndex])++;
   }
 
   /**

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_Normal.hxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_Normal.hxx
@@ -44,12 +44,12 @@ public:
 
   /**
    * Query one normal
-   * @param i
+   * @param theIndex
    *   index in the array of normals [0 .. N-1]
    * @return
    *   the normal value for the index. If index irrelevant, returns (0., 0., 0.)
    */
-  inline const gp_XYZ& Normal(const int i) const { return Value(i); }
+  inline const gp_XYZ& Normal(const size_t theIndex) const { return Value(theIndex); }
 
   /**
    * Create a copy of this node.

--- a/src/DataExchange/TKDEVRML/VrmlData/VrmlData_Scene.cxx
+++ b/src/DataExchange/TKDEVRML/VrmlData/VrmlData_Scene.cxx
@@ -204,13 +204,15 @@ VrmlData_ErrorStatus VrmlData_Scene::readLine(VrmlData_InBuffer& theBuffer)
     return VrmlData_EndOfFile;
   }
   // Read a line.
-  theBuffer.Input.getline(theBuffer.Line, sizeof(theBuffer.Line));
+  theBuffer.Input.getline(theBuffer.Line.data(),
+                          static_cast<std::streamsize>(theBuffer.Line.size()));
 
   // Check the number of read symbols.
   // If maximum number is read, process the array of symbols separately
   // rolling back the array to the last comma or space symbol.
   std::streamsize aNbChars = theBuffer.Input.gcount();
-  if (theBuffer.Input.rdstate() & std::ios::failbit && aNbChars == sizeof(theBuffer.Line) - 1)
+  if (theBuffer.Input.rdstate() & std::ios::failbit
+      && aNbChars == static_cast<std::streamsize>(theBuffer.Line.size() - 1))
   {
     // Clear the error.
     // We will fix it here below.
@@ -250,7 +252,7 @@ VrmlData_ErrorStatus VrmlData_Scene::readLine(VrmlData_InBuffer& theBuffer)
       aStatus = VrmlData_GeneralError;
     }
   }
-  theBuffer.LinePtr     = &theBuffer.Line[0];
+  theBuffer.LinePtr     = theBuffer.Line.data();
   theBuffer.IsProcessed = false;
   return aStatus;
 }
@@ -287,32 +289,36 @@ nonempty_line:
   // Try to detect comment
   if (!theBuffer.IsProcessed)
   {
-    bool  isQuoted(false);
-    int   anOffset(0);
-    char* ptr = theBuffer.LinePtr;
-    for (; *ptr != '\0'; ptr++)
+    bool        isQuoted  = false;
+    const char* aReadPtr  = theBuffer.LinePtr;
+    char*       aWritePtr = theBuffer.LinePtr;
+    while (*aReadPtr != '\0')
     {
-      if (anOffset)
-      {
-        *ptr = ptr[anOffset];
-      }
-      if (*ptr == '\n' || *ptr == '\r' || *ptr == '#')
+      const char aChar = *aReadPtr++;
+      if (aChar == '\n' || aChar == '\r' || aChar == '#')
       {
         if (!isQuoted)
         {
-          *ptr = '\0';
           break;
         }
       }
-      else if (*ptr == '\\' && isQuoted)
+      else if (aChar == '\\' && isQuoted)
       {
-        ptr[0] = ptr[++anOffset];
+        if (*aReadPtr == '\0')
+        {
+          *aWritePtr++ = aChar;
+          break;
+        }
+        *aWritePtr++ = *aReadPtr++;
+        continue;
       }
-      else if (*ptr == '\"')
+      else if (aChar == '\"')
       {
         isQuoted = !isQuoted;
       }
+      *aWritePtr++ = aChar;
     }
+    *aWritePtr            = '\0';
     theBuffer.IsProcessed = true;
   }
   return aStatus;

--- a/src/FoundationClasses/TKernel/GTests/FILES.cmake
+++ b/src/FoundationClasses/TKernel/GTests/FILES.cmake
@@ -48,6 +48,7 @@ set(OCCT_TKernel_GTests_FILES
   Standard_Failure_Test.cxx
   Standard_GUID_Test.cxx
   Standard_Handle_Test.cxx
+  Standard_ReadLineBuffer_Test.cxx
   Standard_Strtod_Test.cxx
   TCollection_AsciiString_Test.cxx
   TCollection_ExtendedString_Test.cxx

--- a/src/FoundationClasses/TKernel/GTests/Standard_ReadLineBuffer_Test.cxx
+++ b/src/FoundationClasses/TKernel/GTests/Standard_ReadLineBuffer_Test.cxx
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include <Standard_ReadLineBuffer.hxx>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <string_view>
+
+TEST(Standard_ReadLineBufferTest, TerminatesFinalLine)
+{
+  const std::string       aContent = "unterminated";
+  std::istringstream      anInput(aContent);
+  Standard_ReadLineBuffer aBuffer(4);
+
+  size_t      aLineLength = 0;
+  const char* aLine       = aBuffer.ReadLine(anInput, aLineLength);
+  ASSERT_NE(aLine, nullptr);
+  EXPECT_EQ(aLineLength, aContent.size());
+  EXPECT_EQ(std::string_view(aLine, aLineLength), aContent);
+  EXPECT_EQ(aLine[aLineLength], '\0');
+}

--- a/src/FoundationClasses/TKernel/Standard/Standard_ReadLineBuffer.hxx
+++ b/src/FoundationClasses/TKernel/Standard/Standard_ReadLineBuffer.hxx
@@ -51,7 +51,7 @@ public:
   }
 
   //! Read next line from the stream.
-  //! @return pointer to the line or NULL on error / end of reading buffer
+  //! @return null-terminated line or NULL on error / end of reading buffer
   //!         (in case of NULL result theStream should be checked externally to identify the
   //!         presence of errors).
   //!          Empty lines will be returned also with zero length.
@@ -65,7 +65,7 @@ public:
   }
 
   //! Read next line from the stream.
-  //! @return pointer to the line or NULL on error / end of reading buffer
+  //! @return null-terminated line or NULL on error / end of reading buffer
   //!         (in case of NULL result theStream should be checked externally to identify the
   //!         presence of errors).
   //!          Empty lines will be returned also with zero length.
@@ -105,7 +105,8 @@ public:
           // end of the stream
           if (myUseReadBufferLastStr)
           {
-            theLineLength          = myReadBufferLastStr.Size();
+            theLineLength = myReadBufferLastStr.Size();
+            myReadBufferLastStr.Append('\0');
             aResultLine            = myReadBufferLastStr.Data();
             myUseReadBufferLastStr = false;
           }


### PR DESCRIPTION
- Validate line lengths and preserve null-terminated text buffers;
- Parse OBJ commands with bounded views and preserve empty names;
- Validate STL and VRML records before accessing geometry data;
- Reject inconsistent STEP B-spline data using the curve construction contract;
- Resolve nested oriented edges iteratively and reject cycles;
- Add focused GTests for malformed and valid input cases.
