### PR TITLE
Modeling Algorithms - Fix Defeaturing rejecting valid splits and sealing pockets

### DIFF
--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_RemoveFeatures.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_RemoveFeatures.cxx
@@ -52,6 +52,9 @@
 #include <TopTools_ShapeMapHasher.hxx>
 #include <NCollection_IndexedDataMap.hxx>
 
+#include <algorithm>
+#include <cmath>
+
 //=======================================================================
 // static methods declaration
 //=======================================================================
@@ -374,7 +377,8 @@ public: //! @name Constructors
   //! Empty constructor
   FillGap()
       : myRunParallel(false),
-        myHasAdjacentFaces(false)
+        myHasAdjacentFaces(false),
+        myTrimDegenerated(false)
   {
   }
 
@@ -440,17 +444,82 @@ public: //! @name Perform the operation
         return;
       }
 
-      // Extend the adjacent faces keeping the connection to the original faces
-      NCollection_IndexedDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>
-        aFaceExtFaceMap;
-      ExtendAdjacentFaces(aMFAdjacent, aFaceExtFaceMap, aPS.Next());
-      if (!aPS.More())
+      // The extension length is derived from the size of the feature, which may be too
+      // small for the extended adjacent faces to reach each other. In that case trimming
+      // of the extended faces degenerates and the untrimmed extensions leak into the
+      // result, making the reconstruction unusable. Retry with a longer extension,
+      // keeping the result of the first attempt if none of them succeeds.
+      Bnd_Box aFeatureBox;
+      BRepBndLib::Add(myFeature, aFeatureBox);
+      const double aFeatureSize = sqrt(aFeatureBox.SquareExtent());
+
+      // The distance at which the adjacent surfaces meet is not related to the size of
+      // the feature - for faces meeting at a small angle it grows without bound - so the
+      // number of attempts is taken from the size of the solids the feature belongs to.
+      // The last attempt is then the first extension spanning the whole model; beyond
+      // that length the extended faces already cover it and doubling cannot bring them
+      // together anymore.
+      Bnd_Box aSolidsBox;
+      for (int i = 1; i <= mySolids.Extent(); ++i)
       {
-        return;
+        BRepBndLib::Add(mySolids(i), aSolidsBox);
+      }
+      const double aSolidsSize = aSolidsBox.IsVoid() ? 0.0 : sqrt(aSolidsBox.SquareExtent());
+      const int    aNbAttempts =
+        (aSolidsSize > aFeatureSize)
+             ? std::max(THE_NB_EXTENSION_ATTEMPTS,
+                     1 + static_cast<int>(std::ceil(std::log2(aSolidsSize / aFeatureSize))))
+             : THE_NB_EXTENSION_ATTEMPTS;
+
+      NCollection_IndexedDataMap<TopoDS_Shape,
+                                 NCollection_List<TopoDS_Shape>,
+                                 TopTools_ShapeMapHasher>
+                                     aFacesFirst;
+      occ::handle<BRepTools_History> aHistoryFirst;
+
+      Message_ProgressScope aPSExt(aPS.Next(2), nullptr, aNbAttempts);
+      for (int anAttempt = 0; anAttempt < aNbAttempts; ++anAttempt)
+      {
+        myTrimDegenerated = false;
+        myFaces.Clear();
+        myHistory = new BRepTools_History();
+
+        Message_ProgressScope aPSAttempt(aPSExt.Next(), nullptr, 2);
+
+        // Extend the adjacent faces keeping the connection to the original faces
+        NCollection_IndexedDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>
+          aFaceExtFaceMap;
+        ExtendAdjacentFaces(aMFAdjacent,
+                            aFeatureSize * (1 << anAttempt),
+                            aFaceExtFaceMap,
+                            aPSAttempt.Next());
+        if (!aPSAttempt.More())
+        {
+          return;
+        }
+
+        // Trim the extended faces
+        TrimExtendedFaces(aFaceExtFaceMap, aPSAttempt.Next());
+
+        if (!myTrimDegenerated)
+        {
+          break;
+        }
+
+        if (anAttempt == 0)
+        {
+          aFacesFirst   = myFaces;
+          aHistoryFirst = myHistory;
+        }
       }
 
-      // Trim the extended faces
-      TrimExtendedFaces(aFaceExtFaceMap, aPS.Next());
+      if (myTrimDegenerated)
+      {
+        // None of the attempts produced a properly trimmed reconstruction -
+        // keep the result of the first one.
+        myFaces   = aFacesFirst;
+        myHistory = aHistoryFirst;
+      }
     }
     catch (Standard_Failure const&)
     {
@@ -576,16 +645,11 @@ private: //! @name Private methods performing the operation
   //! Extends the found adjacent faces and binds them to the original faces.
   void ExtendAdjacentFaces(
     const NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher>& theMFAdjacent,
+    const double                                                         theExtLength,
     NCollection_IndexedDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>&
                                  theFaceExtFaceMap,
     const Message_ProgressRange& theRange)
   {
-    // Get the extension value for the faces - half of the diagonal of bounding box of the feature
-    Bnd_Box aFeatureBox;
-    BRepBndLib::Add(myFeature, aFeatureBox);
-
-    const double anExtLength = sqrt(aFeatureBox.SquareExtent());
-
     const int             aNbFA = theMFAdjacent.Extent();
     Message_ProgressScope aPS(theRange, "Extending adjacent faces", aNbFA);
     for (int i = 1; i <= aNbFA && aPS.More(); ++i, aPS.Next())
@@ -593,7 +657,7 @@ private: //! @name Private methods performing the operation
       const TopoDS_Face& aF = TopoDS::Face(theMFAdjacent(i));
       // Extend the face
       TopoDS_Face aFExt;
-      BRepLib::ExtendFace(aF, anExtLength, true, true, true, true, aFExt);
+      BRepLib::ExtendFace(aF, theExtLength, true, true, true, true, aFExt);
       theFaceExtFaceMap.Add(aF, aFExt);
       myHistory->AddModified(aF, aFExt);
     }
@@ -835,6 +899,11 @@ private: //! @name Private methods performing the operation
     }
     else if (aLFTrimmed.IsEmpty())
     {
+      // The extended face could not be trimmed by the bounds of the original face -
+      // most likely the extension is too small for the extended faces to intersect
+      // each other. Signal it, so that the extension can be retried with a greater
+      // length.
+      myTrimDegenerated = true;
       // Use all splits, including those having the bounds of extended face
       anExpF.ReInit();
       for (; anExpF.More(); anExpF.Next())
@@ -888,7 +957,12 @@ private: //! @name Fields
   NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> mySolids;                //!< Solids participating in the feature removal
   NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher> myFaces;  //!< Reconstructed adjacent faces
   occ::handle<BRepTools_History> myHistory;                //!< History of the adjacent faces reconstruction
+  bool myTrimDegenerated;                 //!< Flag to show that trimming of the extended faces has failed
   // clang-format on
+
+  //! Least number of attempts to extend the adjacent faces, each one doubling the
+  //! extension length; more are made when the model is much larger than the feature
+  static constexpr int THE_NB_EXTENSION_ATTEMPTS = 3;
 };
 
 typedef NCollection_DynamicArray<FillGap> VectorOfFillGap;

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_RemoveFeatures.cxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_RemoveFeatures.cxx
@@ -92,6 +92,10 @@ static void FindShape(const TopoDS_Shape& theSWhat,
 static void GetValidSolids(
   BOPAlgo_MakerVolume&                                          theMV,
   const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& theFacesToCheckOri,
+  const NCollection_IndexedDataMap<TopoDS_Shape,
+                                   NCollection_List<TopoDS_Shape>,
+                                   TopTools_ShapeMapHasher>&    theAdjFaces,
+  const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& theAnchoredFaces,
   const NCollection_List<TopoDS_Shape>&                         aSharedFaces,
   const TopoDS_Shape&                                           theOrigFaces,
   const int                                                     theNbSol,
@@ -105,7 +109,8 @@ static void FindExtraShapes(
   const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& theShapesToCheckOri,
   BOPAlgo_Builder&                                              theBuilder,
   NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>&       theShapesToAvoid,
-  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>*       theValidShapes = nullptr);
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>*       theValidShapes = nullptr,
+  const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>* theInternalOK  = nullptr);
 
 static void AvoidExtraSharedFaces(NCollection_List<TopoDS_Shape>&       theLSolids,
                                   const NCollection_List<TopoDS_Shape>& theLFSharedToAvoid,
@@ -474,14 +479,16 @@ public: //! @name Perform the operation
       NCollection_IndexedDataMap<TopoDS_Shape,
                                  NCollection_List<TopoDS_Shape>,
                                  TopTools_ShapeMapHasher>
-                                     aFacesFirst;
-      occ::handle<BRepTools_History> aHistoryFirst;
+                                                             aFacesFirst;
+      occ::handle<BRepTools_History>                         aHistoryFirst;
+      NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> anAnchoredFirst;
 
       Message_ProgressScope aPSExt(aPS.Next(2), nullptr, aNbAttempts);
       for (int anAttempt = 0; anAttempt < aNbAttempts; ++anAttempt)
       {
         myTrimDegenerated = false;
         myFaces.Clear();
+        myAnchoredFaces.Clear();
         myHistory = new BRepTools_History();
 
         Message_ProgressScope aPSAttempt(aPSExt.Next(), nullptr, 2);
@@ -508,8 +515,9 @@ public: //! @name Perform the operation
 
         if (anAttempt == 0)
         {
-          aFacesFirst   = myFaces;
-          aHistoryFirst = myHistory;
+          aFacesFirst     = myFaces;
+          anAnchoredFirst = myAnchoredFaces;
+          aHistoryFirst   = myHistory;
         }
       }
 
@@ -517,8 +525,9 @@ public: //! @name Perform the operation
       {
         // None of the attempts produced a properly trimmed reconstruction -
         // keep the result of the first one.
-        myFaces   = aFacesFirst;
-        myHistory = aHistoryFirst;
+        myFaces         = aFacesFirst;
+        myAnchoredFaces = anAnchoredFirst;
+        myHistory       = aHistoryFirst;
       }
     }
     catch (Standard_Failure const&)
@@ -526,6 +535,7 @@ public: //! @name Perform the operation
       // Make sure the warning will be given on the higher level
       myHasAdjacentFaces = true;
       myFaces.Clear();
+      myAnchoredFaces.Clear();
     }
   }
 
@@ -546,6 +556,13 @@ public: //! @name Obtain the result
     Faces() const
   {
     return myFaces;
+  }
+
+  //! Returns the reconstructed faces whose orientation is validated
+  //! by a non-feature edge of the original adjacent face
+  const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& AnchoredFaces() const
+  {
+    return myAnchoredFaces;
   }
 
   //! Returns the initial solids participating in the feature removal
@@ -721,7 +738,7 @@ private: //! @name Private methods performing the operation
     {
       const TopoDS_Face& aFOriginal = TopoDS::Face(theFaceExtFaceMap.FindKey(i));
       const TopoDS_Face& aFExt      = TopoDS::Face(theFaceExtFaceMap(i));
-      TrimFace(aFExt, aFOriginal, aFeatureEdgesMap, anEFExtMap, aGFInter);
+      TrimFace(aFExt, aFOriginal, aFeatureEdgesMap, anEFExtMap, theFaceExtFaceMap, aGFInter);
     }
   }
 
@@ -734,7 +751,9 @@ private: //! @name Private methods performing the operation
     const NCollection_IndexedDataMap<TopoDS_Shape,
                                      NCollection_List<TopoDS_Shape>,
                                      TopTools_ShapeMapHasher>&           theEFExtMap,
-    BOPAlgo_Builder&                                                     theGFInter)
+    const NCollection_IndexedDataMap<TopoDS_Shape, TopoDS_Shape, TopTools_ShapeMapHasher>&
+                     theFaceExtFaceMap,
+    BOPAlgo_Builder& theGFInter)
   {
     // Map all edges of the extended face, to filter the result of trim
     // from the faces containing these edges
@@ -771,6 +790,10 @@ private: //! @name Private methods performing the operation
 
     // Add edges of the original faces
     NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aMEdgesToCheckOri;
+    // Edges whose other faces are all adjacent (reconstructed) or feature faces.
+    // A split containing such an edge as INTERNAL legitimately spans both its sides
+    // (e.g. two patches of one surface both adjacent to the feature).
+    NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aMInternalOK;
     anExpE.Init(theFOriginal, TopAbs_EDGE);
     for (; anExpE.More(); anExpE.Next())
     {
@@ -778,6 +801,29 @@ private: //! @name Private methods performing the operation
       if (!theFeatureEdgesMap.Contains(aE))
       {
         aGFTrim.AddArgument(aE);
+        const NCollection_List<TopoDS_Shape>* pLF = myEFMap->Seek(aE);
+        if (pLF)
+        {
+          bool                                     bOtherOK = false;
+          NCollection_List<TopoDS_Shape>::Iterator itLF(*pLF);
+          for (; itLF.More(); itLF.Next())
+          {
+            const TopoDS_Shape& aFOther = itLF.Value();
+            if (aFOther.IsSame(theFOriginal))
+            {
+              continue;
+            }
+            bOtherOK = theFaceExtFaceMap.Contains(aFOther) || myFeatureFacesMap.Contains(aFOther);
+            if (!bOtherOK)
+            {
+              break;
+            }
+          }
+          if (bOtherOK)
+          {
+            aMInternalOK.Add(aE);
+          }
+        }
         if (!BRep_Tool::Degenerated(aE) && !BRep_Tool::IsClosed(aE, theFOriginal))
         {
           if (!aMEdgesToCheckOri.Add(aE))
@@ -822,6 +868,10 @@ private: //! @name Private methods performing the operation
       }
     }
 
+    // Splits validated by the orientation of an edge of the original face
+    NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aValidFaces;
+    const bool bSingleSplit = (aLFTrimmed.Extent() == 1);
+
     if (aLFTrimmed.Extent() > 1)
     {
       // Chose the correct faces - the ones that contains edges with proper
@@ -837,8 +887,13 @@ private: //! @name Private methods performing the operation
       }
 
       // Check edges orientations
-      NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aFacesToAvoid, aValidFaces;
-      FindExtraShapes(anEFMap, aMEdgesToCheckOri, aGFTrim, aFacesToAvoid, &aValidFaces);
+      NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aFacesToAvoid;
+      FindExtraShapes(anEFMap,
+                      aMEdgesToCheckOri,
+                      aGFTrim,
+                      aFacesToAvoid,
+                      &aValidFaces,
+                      &aMInternalOK);
 
       if (aLFTrimmed.Extent() - aFacesToAvoid.Extent() > 1)
       {
@@ -918,6 +973,18 @@ private: //! @name Private methods performing the operation
       RemoveInternalWires(aLFTrimmed);
 
       myFaces.Add(theFOriginal, aLFTrimmed);
+
+      // Remember the splits whose orientation is confirmed by an edge of the original face;
+      // they are the trusted evidence for classifying the cells built by MakerVolume.
+      const bool bAllAnchored = bSingleSplit && !aMEdgesToCheckOri.IsEmpty() && !myTrimDegenerated;
+      NCollection_List<TopoDS_Shape>::Iterator itLFA(aLFTrimmed);
+      for (; itLFA.More(); itLFA.Next())
+      {
+        if (bAllAnchored || aValidFaces.Contains(itLFA.Value()))
+        {
+          myAnchoredFaces.Add(itLFA.Value());
+        }
+      }
     }
 
     // Update history after intersection of the extended face with bounds
@@ -956,6 +1023,7 @@ private: //! @name Fields
   bool myHasAdjacentFaces;                //!< Flag to show whether the adjacent faces have been found or not
   NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> mySolids;                //!< Solids participating in the feature removal
   NCollection_IndexedDataMap<TopoDS_Shape, NCollection_List<TopoDS_Shape>, TopTools_ShapeMapHasher> myFaces;  //!< Reconstructed adjacent faces
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> myAnchoredFaces; //!< Reconstructed faces validated by an edge of the original face
   occ::handle<BRepTools_History> myHistory;                //!< History of the adjacent faces reconstruction
   bool myTrimDegenerated;                 //!< Flag to show that trimming of the extended faces has failed
   // clang-format on
@@ -1055,6 +1123,7 @@ void BOPAlgo_RemoveFeatures::RemoveFeatures(const Message_ProgressRange& theRang
                   aFG.FeatureFacesMap(),
                   aFG.HasAdjacentFaces(),
                   aFG.Faces(),
+                  aFG.AnchoredFaces(),
                   aFG.History(),
                   isSolidsHistoryNeeded,
                   aPSLoop.Next());
@@ -1071,6 +1140,7 @@ void BOPAlgo_RemoveFeatures::RemoveFeature(
   const NCollection_IndexedDataMap<TopoDS_Shape,
                                    NCollection_List<TopoDS_Shape>,
                                    TopTools_ShapeMapHasher>&           theAdjFaces,
+  const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>&        theAnchoredFaces,
   const occ::handle<BRepTools_History>&                                theAdjFacesHistory,
   const bool                                                           theSolidsHistoryNeeded,
   const Message_ProgressRange&                                         theRange)
@@ -1278,6 +1348,8 @@ void BOPAlgo_RemoveFeatures::RemoveFeature(
   NCollection_List<TopoDS_Shape> aRemovedShapes;
   GetValidSolids(aMV,
                  aFacesToCheckOri,
+                 theAdjFaces,
+                 theAnchoredFaces,
                  aSharedFaces,
                  anOrigF,
                  theSolids.Extent(),
@@ -1728,6 +1800,10 @@ void FindShape(const TopoDS_Shape& theSWhat, const TopoDS_Shape& theSWhere, Topo
 void GetValidSolids(
   BOPAlgo_MakerVolume&                                          theMV,
   const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& theFacesToCheckOri,
+  const NCollection_IndexedDataMap<TopoDS_Shape,
+                                   NCollection_List<TopoDS_Shape>,
+                                   TopTools_ShapeMapHasher>&    theAdjFaces,
+  const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& theAnchoredFaces,
   const NCollection_List<TopoDS_Shape>&                         aSharedFaces,
   const TopoDS_Shape&                                           theOrigFaces,
   const int                                                     theNbSol,
@@ -1749,7 +1825,8 @@ void GetValidSolids(
                                TopTools_ShapeMapHasher>
       aFSMap;
     TopExp::MapShapesAndAncestors(theMV.Shape(), TopAbs_FACE, TopAbs_SOLID, aFSMap);
-    FindExtraShapes(aFSMap, theFacesToCheckOri, theMV, aSolidsToAvoid);
+    NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aValidSolids;
+    FindExtraShapes(aFSMap, theFacesToCheckOri, theMV, aSolidsToAvoid, &aValidSolids);
 
     NCollection_List<TopoDS_Shape>::Iterator itLS(theLSRes);
     for (; itLS.More();)
@@ -1761,6 +1838,77 @@ void GetValidSolids(
       else
       {
         itLS.Next();
+      }
+    }
+
+    // The solids containing no faces of the original shape are classified by the
+    // reconstructed adjacent faces: a solid lying on the wrong side of any of them
+    // is a void (e.g. the inside of a pocket whose mouth got closed by an extension
+    // of the top face), unless a split validated by an edge of the original face
+    // confirms the solid as material. Without this check such a void would be
+    // merged into the result by AvoidExtraSharedFaces.
+    if (theLSRes.Extent() > theNbSol)
+    {
+      NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher> aVoidSolids, aMaterialSolids;
+      const int                                              aNbAF = theAdjFaces.Extent();
+      for (int i = 1; i <= aNbAF; ++i)
+      {
+        NCollection_List<TopoDS_Shape>::Iterator itLFA(theAdjFaces(i));
+        for (; itLFA.More(); itLFA.Next())
+        {
+          const TopoDS_Face&             aFA       = TopoDS::Face(itLFA.Value());
+          const bool                     bAnchored = theAnchoredFaces.Contains(aFA);
+          NCollection_List<TopoDS_Shape> aLFIm;
+          TakeModified(aFA, theMV, aLFIm);
+          NCollection_List<TopoDS_Shape>::Iterator itLFIm(aLFIm);
+          for (; itLFIm.More(); itLFIm.Next())
+          {
+            const NCollection_List<TopoDS_Shape>* pLS = aFSMap.Seek(itLFIm.Value());
+            if (!pLS)
+            {
+              continue;
+            }
+            NCollection_List<TopoDS_Shape>::Iterator itLS1(*pLS);
+            for (; itLS1.More(); itLS1.Next())
+            {
+              const TopoDS_Shape& aSol = itLS1.Value();
+              if (aValidSolids.Contains(aSol))
+              {
+                continue;
+              }
+              TopoDS_Face aFInSol;
+              FindShape(itLFIm.Value(), aSol, aFInSol);
+              if (aFInSol.IsNull())
+              {
+                continue;
+              }
+              // Compare with the reconstructed face, not with the original one: the
+              // image usually lies outside the parametric bounds of the original face,
+              // where the projection used by IsSplitToReverse is unreliable.
+              if (BOPTools_AlgoTools::IsSplitToReverse(aFInSol, aFA, theMV.Context()))
+              {
+                aVoidSolids.Add(aSol);
+              }
+              else if (bAnchored)
+              {
+                aMaterialSolids.Add(aSol);
+              }
+            }
+          }
+        }
+      }
+
+      for (itLS.Initialize(theLSRes); itLS.More();)
+      {
+        if (aVoidSolids.Contains(itLS.Value()) && !aMaterialSolids.Contains(itLS.Value()))
+        {
+          theRemovedShapes.Append(itLS.Value());
+          theLSRes.Remove(itLS);
+        }
+        else
+        {
+          itLS.Next();
+        }
       }
     }
   }
@@ -1816,7 +1964,8 @@ void FindExtraShapes(
   const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>& theShapesToCheckOri,
   BOPAlgo_Builder&                                              theBuilder,
   NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>&       theShapesToAvoid,
-  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>*       theValidShapes)
+  NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>*       theValidShapes,
+  const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>* theInternalOK)
 {
   occ::handle<IntTools_Context>                           aCtx = theBuilder.Context();
   NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>  aValidShapes;
@@ -1853,7 +2002,13 @@ void FindExtraShapes(
         TopoDS_Face aSInShape;
         FindShape(aSIm, aShapeToValidate, aSInShape);
 
-        bool bSameOri = !BOPTools_AlgoTools::IsSplitToReverse(aSInShape, aSToCheckOri, aCtx);
+        // An edge that is INTERNAL in a split is not shared with any other split, so its
+        // orientation says nothing about the split: the split spans both sides of the edge.
+        // It is legitimate only when the faces on the other side of the edge are themselves
+        // reconstructed or removed (see TrimFace), otherwise the split overlaps a kept face.
+        bool bSameOri = (aSInShape.Orientation() == TopAbs_INTERNAL && theInternalOK)
+                          ? theInternalOK->Contains(aSToCheckOri)
+                          : !BOPTools_AlgoTools::IsSplitToReverse(aSInShape, aSToCheckOri, aCtx);
 
         if (bSameOri)
         {

--- a/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_RemoveFeatures.hxx
+++ b/src/ModelingAlgorithms/TKBO/BOPAlgo/BOPAlgo_RemoveFeatures.hxx
@@ -235,6 +235,7 @@ protected: //! @name Protected methods performing the removal
     const NCollection_IndexedDataMap<TopoDS_Shape,
                                      NCollection_List<TopoDS_Shape>,
                                      TopTools_ShapeMapHasher>&           theAdjFaces,
+    const NCollection_Map<TopoDS_Shape, TopTools_ShapeMapHasher>&        theAnchoredFaces,
     const occ::handle<BRepTools_History>&                                theAdjFacesHistory,
     const bool                                                           theSolidsHistoryNeeded,
     const Message_ProgressRange&                                         theRange);

--- a/src/ModelingAlgorithms/TKBO/GTests/BRepAlgoAPI_Defeaturing_Test.cxx
+++ b/src/ModelingAlgorithms/TKBO/GTests/BRepAlgoAPI_Defeaturing_Test.cxx
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 OPEN CASCADE SAS
+//
+// This file is part of Open CASCADE Technology software library.
+//
+// This library is free software; you can redistribute it and/or modify it under
+// the terms of the GNU Lesser General Public License version 2.1 as published
+// by the Free Software Foundation, with special exception defined in the file
+// OCCT_LGPL_EXCEPTION.txt. Consult the file LICENSE_LGPL_21.txt included in OCCT
+// distribution for complete text of the license and disclaimer of any warranty.
+//
+// Alternatively, this file may be used under the terms of Open CASCADE
+// commercial license or contractual agreement.
+
+#include "BOPTest_Utilities.pxx"
+
+#include <BRepAdaptor_Surface.hxx>
+#include <BRepAlgoAPI_Defeaturing.hxx>
+#include <BRepBuilderAPI_MakeFace.hxx>
+#include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRepCheck_Analyzer.hxx>
+#include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepPrimAPI_MakePrism.hxx>
+#include <BRep_Tool.hxx>
+
+#include <TopExp.hxx>
+#include <TopTools_ShapeMapHasher.hxx>
+
+namespace
+{
+typedef NCollection_IndexedMap<TopoDS_Shape, TopTools_ShapeMapHasher> ShapeMap;
+
+const double THE_WEDGE_ANGLE  = 15.0; // degrees between the two faces of the wedge
+const double THE_WEDGE_LENGTH = 60.0;
+const double THE_WEDGE_DEPTH  = 5.0;
+const double THE_ROUND_RADIUS = 5.0;
+
+int CountFaces(const TopoDS_Shape& theShape)
+{
+  ShapeMap aMap;
+  TopExp::MapShapes(theShape, TopAbs_FACE, aMap);
+  return aMap.Extent();
+}
+
+//! A wedge with a round on its sharp edge.
+struct WedgeModel
+{
+  TopoDS_Shape myWedge;   //!< wedge with a sharp edge
+  TopoDS_Shape myRounded; //!< the same wedge with the edge rounded
+  TopoDS_Face  myRound;   //!< the round face of myRounded
+};
+
+//! Build a wedge of the given angle and put a round on its sharp edge.
+//!
+//! The round is short, so its bounding box is much smaller than the distance
+//! from it to the sharp edge it replaces: the faces of the wedge have to be
+//! extended by several times the size of the round before they meet each other
+//! again. With the angle and the radius used here the round measures about 12,
+//! while its tangency lines stand about 38 away from the edge.
+WedgeModel MakeRoundedWedge()
+{
+  const double aHalfAngle = 0.5 * THE_WEDGE_ANGLE * M_PI / 180.0;
+
+  BRepBuilderAPI_MakePolygon aProfile;
+  aProfile.Add(gp_Pnt(0.0, 0.0, 0.0));
+  aProfile.Add(gp_Pnt(THE_WEDGE_LENGTH, 0.0, 0.0));
+  aProfile.Add(gp_Pnt(THE_WEDGE_LENGTH, 0.0, THE_WEDGE_LENGTH * tan(2.0 * aHalfAngle)));
+  aProfile.Close();
+
+  WedgeModel        aModel;
+  const TopoDS_Face aFace = BRepBuilderAPI_MakeFace(aProfile.Wire()).Face();
+  aModel.myWedge          = BRepPrimAPI_MakePrism(aFace, gp_Vec(0.0, THE_WEDGE_DEPTH, 0.0)).Shape();
+
+  // The sharp edge of the wedge runs along Y through the origin.
+  TopoDS_Edge anEdge;
+  ShapeMap    anEdges;
+  TopExp::MapShapes(aModel.myWedge, TopAbs_EDGE, anEdges);
+  for (int anIndex = 1; anIndex <= anEdges.Extent() && anEdge.IsNull(); ++anIndex)
+  {
+    const TopoDS_Edge& aCandidate = TopoDS::Edge(anEdges(anIndex));
+    TopoDS_Vertex      aV1, aV2;
+    TopExp::Vertices(aCandidate, aV1, aV2);
+    const gp_Pnt aP1 = BRep_Tool::Pnt(aV1);
+    const gp_Pnt aP2 = BRep_Tool::Pnt(aV2);
+    if (aP1.X() < Precision::Confusion() && aP1.Z() < Precision::Confusion()
+        && aP2.X() < Precision::Confusion() && aP2.Z() < Precision::Confusion())
+    {
+      anEdge = aCandidate;
+    }
+  }
+  if (anEdge.IsNull())
+  {
+    return aModel;
+  }
+
+  BRepFilletAPI_MakeFillet aFilletMaker(aModel.myWedge);
+  aFilletMaker.Add(THE_ROUND_RADIUS, anEdge);
+  aFilletMaker.Build();
+  if (!aFilletMaker.IsDone())
+  {
+    return aModel;
+  }
+  aModel.myRounded = aFilletMaker.Shape();
+
+  ShapeMap aFaces;
+  TopExp::MapShapes(aModel.myRounded, TopAbs_FACE, aFaces);
+  for (int anIndex = 1; anIndex <= aFaces.Extent(); ++anIndex)
+  {
+    const TopoDS_Face&        aCandidate = TopoDS::Face(aFaces(anIndex));
+    const BRepAdaptor_Surface aSurface(aCandidate);
+    if (aSurface.GetType() == GeomAbs_Cylinder
+        && std::abs(aSurface.Cylinder().Radius() - THE_ROUND_RADIUS) < Precision::Confusion())
+    {
+      aModel.myRound = aCandidate;
+      break;
+    }
+  }
+  return aModel;
+}
+} // namespace
+
+// The extension of the adjacent faces used to be sized by the bounding box of
+// the feature alone, which is far too short for the faces of a wedge this
+// sharp to reach each other. Trimming of the extended faces then degenerated,
+// the untrimmed extensions leaked into the reconstruction and no solid could
+// be built.
+TEST(BRepAlgoAPI_DefeaturingTest, WedgeRound_ExtensionShorterThanTheGap_RoundRemoved)
+{
+  const WedgeModel aModel = MakeRoundedWedge();
+  ASSERT_FALSE(aModel.myRounded.IsNull()) << "failed to round the wedge";
+  ASSERT_FALSE(aModel.myRound.IsNull()) << "the round was not found";
+
+  BRepAlgoAPI_Defeaturing aDefeaturing;
+  aDefeaturing.SetShape(aModel.myRounded);
+  aDefeaturing.AddFaceToRemove(aModel.myRound);
+  aDefeaturing.Build();
+
+  ASSERT_TRUE(aDefeaturing.IsDone());
+  EXPECT_FALSE(aDefeaturing.HasWarnings()) << "the round was not removed";
+
+  const TopoDS_Shape aResult = aDefeaturing.Shape();
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+
+  // Removing the round must give back the sharp wedge it was built on.
+  EXPECT_NEAR(BOPTest_Utilities::GetVolume(aModel.myWedge),
+              BOPTest_Utilities::GetVolume(aResult),
+              1.0e-3);
+  EXPECT_EQ(CountFaces(aModel.myWedge), CountFaces(aResult));
+}

--- a/src/ModelingAlgorithms/TKBO/GTests/BRepAlgoAPI_Defeaturing_Test.cxx
+++ b/src/ModelingAlgorithms/TKBO/GTests/BRepAlgoAPI_Defeaturing_Test.cxx
@@ -14,11 +14,15 @@
 #include "BOPTest_Utilities.pxx"
 
 #include <BRepAdaptor_Surface.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
 #include <BRepAlgoAPI_Defeaturing.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepBuilderAPI_MakeFace.hxx>
 #include <BRepBuilderAPI_MakePolygon.hxx>
 #include <BRepCheck_Analyzer.hxx>
 #include <BRepFilletAPI_MakeFillet.hxx>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
 #include <BRepPrimAPI_MakePrism.hxx>
 #include <BRep_Tool.hxx>
 
@@ -33,6 +37,18 @@ const double THE_WEDGE_ANGLE  = 15.0; // degrees between the two faces of the we
 const double THE_WEDGE_LENGTH = 60.0;
 const double THE_WEDGE_DEPTH  = 5.0;
 const double THE_ROUND_RADIUS = 5.0;
+
+const double THE_BLANK_HALF_SIZE = 30.0;
+const double THE_BLANK_DEPTH     = 10.0;
+const double THE_POCKET_RADIUS   = 20.0;
+const double THE_POCKET_TILT     = 7.0; // degrees
+const double THE_TOOL_HEIGHT     = 5.0;
+const double THE_BLEND_RADIUS    = 0.5;
+
+//! Expected number of blend faces of the model: four free form ones along the
+//! elliptical top edge and the two cusps, two toroidal ones along the bottom
+//! arc and two cylindrical ones along the straight bottom segment.
+const int THE_BLEND_COUNT = 8;
 
 int CountFaces(const TopoDS_Shape& theShape)
 {
@@ -116,6 +132,135 @@ WedgeModel MakeRoundedWedge()
   }
   return aModel;
 }
+
+//! A pocket reproducing the shape of a valve recess of a piston crown, which
+//! is the configuration the feature removal used to choke on.
+struct PocketModel
+{
+  TopoDS_Shape                   myPocket;  //!< pocket with sharp edges
+  TopoDS_Shape                   myBlended; //!< the same pocket, all its edges blended
+  NCollection_List<TopoDS_Shape> myBlends;  //!< the blend faces of myBlended
+};
+
+//! Build a blended pocket whose wall is split into two faces.
+//!
+//! A blank with a flat top face is cut by a cylinder whose axis is tilted, so
+//! that the base plane of the cylinder crosses the top face right at the axis.
+//! The pocket is therefore a half lens which fades to zero depth at two cusps,
+//! exactly like a valve recess machined into a piston crown.
+//!
+//! The cutting cylinder is built from two halves, so that the wall of the
+//! pocket consists of two faces lying on one and the same cylindrical surface
+//! and sharing a generatrix. This is the essential ingredient: the only edge
+//! of either wall face which does not belong to a blend is that shared
+//! generatrix, and it falls inside the split of the reconstructed floor
+//! instead of bounding it.
+//!
+//! @param theSplitAngle position of the shared generatrix, in degrees from the
+//!                      deepest point of the pocket
+PocketModel MakeSplitWallPocket(const double theSplitAngle)
+{
+  const double aTilt = THE_POCKET_TILT * M_PI / 180.0;
+
+  // The axis leans towards +X, so the pocket is deepest at +X and the
+  // reference direction of the cylinder points at that deepest generatrix.
+  const gp_Pnt anApex(0.0, 0.0, 0.0);
+  const gp_Dir anAxis(sin(aTilt), 0.0, cos(aTilt));
+  const gp_Dir aRefDir(cos(aTilt), 0.0, -sin(aTilt));
+
+  const TopoDS_Shape aBlank =
+    BRepPrimAPI_MakeBox(gp_Pnt(-THE_BLANK_HALF_SIZE, -THE_BLANK_HALF_SIZE, -THE_BLANK_DEPTH),
+                        gp_Pnt(THE_BLANK_HALF_SIZE, THE_BLANK_HALF_SIZE, 0.0))
+      .Shape();
+
+  gp_Ax2 aFirstHalf(anApex, anAxis, aRefDir);
+  aFirstHalf.Rotate(gp_Ax1(anApex, anAxis), theSplitAngle * M_PI / 180.0);
+  gp_Ax2 aSecondHalf = aFirstHalf;
+  aSecondHalf.Rotate(gp_Ax1(anApex, anAxis), M_PI);
+
+  const TopoDS_Shape aHalf1 =
+    BRepPrimAPI_MakeCylinder(aFirstHalf, THE_POCKET_RADIUS, THE_TOOL_HEIGHT, M_PI).Shape();
+  const TopoDS_Shape aHalf2 =
+    BRepPrimAPI_MakeCylinder(aSecondHalf, THE_POCKET_RADIUS, THE_TOOL_HEIGHT, M_PI).Shape();
+  const TopoDS_Shape aTool = BRepAlgoAPI_Fuse(aHalf1, aHalf2).Shape();
+
+  PocketModel aModel;
+  aModel.myPocket = BRepAlgoAPI_Cut(aBlank, aTool).Shape();
+
+  // Blend every edge introduced by the cut, i.e. every edge which the blank
+  // does not already have.
+  ShapeMap aBlankEdges;
+  TopExp::MapShapes(aBlank, TopAbs_EDGE, aBlankEdges);
+  ShapeMap aPocketEdges;
+  TopExp::MapShapes(aModel.myPocket, TopAbs_EDGE, aPocketEdges);
+
+  BRepFilletAPI_MakeFillet aFilletMaker(aModel.myPocket);
+  for (int anIndex = 1; anIndex <= aPocketEdges.Extent(); ++anIndex)
+  {
+    const TopoDS_Edge& anEdge = TopoDS::Edge(aPocketEdges(anIndex));
+    if (BRep_Tool::Degenerated(anEdge) || aBlankEdges.Contains(anEdge))
+    {
+      continue;
+    }
+    aFilletMaker.Add(THE_BLEND_RADIUS, anEdge);
+  }
+  aFilletMaker.Build();
+  if (!aFilletMaker.IsDone())
+  {
+    return aModel;
+  }
+  aModel.myBlended = aFilletMaker.Shape();
+
+  // Collect the blends: the wall and the floor are the only faces left on a
+  // surface of the cutting cylinder, everything else of the pocket is planar.
+  ShapeMap aBlendedFaces;
+  TopExp::MapShapes(aModel.myBlended, TopAbs_FACE, aBlendedFaces);
+  for (int anIndex = 1; anIndex <= aBlendedFaces.Extent(); ++anIndex)
+  {
+    const TopoDS_Face&        aFace = TopoDS::Face(aBlendedFaces(anIndex));
+    const BRepAdaptor_Surface aSurface(aFace);
+    const bool                isBlend =
+      aSurface.GetType() == GeomAbs_BSplineSurface
+      || (aSurface.GetType() == GeomAbs_Torus
+          && std::abs(aSurface.Torus().MinorRadius() - THE_BLEND_RADIUS) < Precision::Confusion())
+      || (aSurface.GetType() == GeomAbs_Cylinder
+          && std::abs(aSurface.Cylinder().Radius() - THE_BLEND_RADIUS) < Precision::Confusion());
+    if (isBlend)
+    {
+      aModel.myBlends.Append(aFace);
+    }
+  }
+  return aModel;
+}
+
+//! Remove the blends of the model and check that the sharp pocket is restored.
+void CheckBlendsRemoved(const PocketModel& theModel)
+{
+  ASSERT_FALSE(theModel.myBlended.IsNull()) << "failed to blend the pocket";
+  ASSERT_EQ(THE_BLEND_COUNT, theModel.myBlends.Extent());
+
+  BRepAlgoAPI_Defeaturing aDefeaturing;
+  aDefeaturing.SetShape(theModel.myBlended);
+  aDefeaturing.AddFacesToRemove(theModel.myBlends);
+  aDefeaturing.Build();
+
+  ASSERT_TRUE(aDefeaturing.IsDone());
+  EXPECT_FALSE(aDefeaturing.HasWarnings()) << "the blends were not removed";
+
+  const TopoDS_Shape aResult = aDefeaturing.Shape();
+  EXPECT_TRUE(BRepCheck_Analyzer(aResult).IsValid());
+
+  // Removing the blends must give back exactly the pocket they were built on,
+  // in particular the pocket must not be sealed by the removal.
+  EXPECT_NEAR(BOPTest_Utilities::GetVolume(theModel.myPocket),
+              BOPTest_Utilities::GetVolume(aResult),
+              1.0e-3);
+
+  // The two halves of the wall and of the floor are rebuilt as single faces,
+  // so the four sides and the bottom of the blank are joined by the top face,
+  // the wall and the floor.
+  EXPECT_EQ(8, CountFaces(aResult));
+}
 } // namespace
 
 // The extension of the adjacent faces used to be sized by the bounding box of
@@ -145,4 +290,20 @@ TEST(BRepAlgoAPI_DefeaturingTest, WedgeRound_ExtensionShorterThanTheGap_RoundRem
               BOPTest_Utilities::GetVolume(aResult),
               1.0e-3);
   EXPECT_EQ(CountFaces(aModel.myWedge), CountFaces(aResult));
+}
+
+// The wall is split on the deepest generatrix of the pocket. The split of the
+// reconstructed floor used to be rejected as reversed, which left the floor
+// unsupported and the blends in place.
+TEST(BRepAlgoAPI_DefeaturingTest, SplitWallPocket_SeamOnDeepestGeneratrix_BlendsRemoved)
+{
+  CheckBlendsRemoved(MakeSplitWallPocket(0.0));
+}
+
+// The wall is split away from the deepest generatrix. Here the blends were
+// removed without any warning, but the cell freed by them was merged into the
+// body and silently sealed the pocket.
+TEST(BRepAlgoAPI_DefeaturingTest, SplitWallPocket_SeamOffCentre_PocketNotSealed)
+{
+  CheckBlendsRemoved(MakeSplitWallPocket(30.0));
 }

--- a/src/ModelingAlgorithms/TKBO/GTests/FILES.cmake
+++ b/src/ModelingAlgorithms/TKBO/GTests/FILES.cmake
@@ -10,6 +10,7 @@ set(OCCT_TKBO_GTests_FILES
   BRepAlgoAPI_Cut_Test_1.cxx
   BRepAlgoAPI_Fuse_Test.cxx
   BRepAlgoAPI_Common_Test.cxx
+  BRepAlgoAPI_Defeaturing_Test.cxx
   BOPAlgo_BOP_Test.cxx
   BOPAlgo_MakePeriodic_Test.cxx
   BOPAlgo_PaveFiller_Test.cxx


### PR DESCRIPTION
## Pre-Submission Checks

- [x] I checked existing issues, pull requests, discussions, and forum topics for related work.
- [x] I followed the contribution guidance in `.github/CONTRIBUTING.md`.
- [x] I used a PR title in the `Group - Summary` format.

## Problem / Motivation

On the piston attached as `tests/boolean/removefeatures/data/defeaturing_piston.step`, `BRepAlgoAPI_Defeaturing` behaves inconsistently on the blends around each of the four slots:

| faces removed | today |
|---|---|
| the 5 blends + the 2 slot walls | `BOPAlgo_AlertUnableToRemoveTheFeature`, shape returned unmodified |
| the 5 blends alone | reported OK, but the slot is **sealed**: about +710 mm³ instead of the +2.4 mm³ a 0.5 mm rim fillet accounts for |

The second row is the worse one, since nothing tells the caller the result is wrong.

Two things go wrong in `BOPAlgo_RemoveFeatures.cxx`:

1. **A valid split is rejected.** The two slot walls are patches of one cylinder. Their only edge that is not part of the feature has no intersection curve behind it in the reconstruction, so it lands `INTERNAL` inside the correct split of the extended floor. `FindExtraShapes` compares that edge with the original one through the same-curve shortcut of `BOPTools_AlgoTools::IsSplitToReverse`, which only compares orientation flags. `INTERNAL != FORWARD`, the split is put in the "avoid" list, the floor is left unsupported and `BOPAlgo_MakerVolume` builds nothing.

2. **Extra cells are merged into the body.** Once that split is accepted, `MakerVolume` builds two cells: the body and the pocket freed by the walls. `GetValidSolids` classifies cells by the kept *original* faces only. The pocket cell has none, so it survives `FindExtraShapes`, and `AvoidExtraSharedFaces` merges it into the body, sealing the pocket. The blend-only removal already reaches this point today, which is the silent volume gain of the second row.

## Proposed Solution

- `FillGap::TrimFace` records which splits of an extended face were validated by an edge of the original face ("anchored" splits). An `INTERNAL` anchor means the split straddles that edge; it is accepted only when every face across the edge is itself being reconstructed or removed, i.e. when the split cannot overlap a kept face. Where the face across the edge is kept, the current "avoid" is right (it is on this part: one selection would otherwise gain 0.58 mm³ by overlapping a corner blend), and it is preserved.

- `GetValidSolids` first keeps what the original faces validate, as today. Cells that own no original face are then classified by the images of the reconstructed adjacent faces: a cell bounded by such an image from the wrong side is void, unless an anchored split bounds it from the material side. Comparison is done against the reconstructed split, not the original face: `IsSplitToReverse(face, face)` projects a sample point with a projector bounded by the original face's UV range, and on a curved surface a point outside that range snaps to the boundary and returns the wrong normal (on the existing A9 chamfer case this gave opposite verdicts for two identical half-cylinders).

- `RemoveFeature` gains one parameter to carry the anchored set, hence the header change.

Rules I tried and rejected, for the record: trusting anchored splits alone leaves the rim wedge cell unclassified (+60 mm³); voiding a cell on any reversed image breaks A9 and B3, where boss cells legitimately sit on the wrong side of the plate-top extension; letting every image vote lets garbage sealing faces vote material. Consulting the original faces first, as the code already does, is exactly what separates those cases from the piston.

The cell classification follows the CFACE scheme of Woo's cell-based decomposition: cells that carry a piece of an original face are decided by that face, and cells bounded only by extensions are decided by whether each extension faces the same way as the face it extends (E-CFACE) or the opposite way (C-CFACE). Only the classification idea is borrowed; the anchored-split refinement and the treatment of `INTERNAL` anchors are specific to how `BOPAlgo_RemoveFeatures` trims its extensions.

- Y. Woo, "Fast cell-based decomposition and applications to solid modeling", Computer-Aided Design 35 (2003) 969-977.
- Y. Woo, H. Sakurai, "Recognition of maximal features by volume decomposition", Computer-Aided Design 34 (2002) 195-207.

### Performance

Only removals that end up with extra cells after `FindExtraShapes` run the new classification, and it costs one orientation test per adjacent-face image per cell. On the piston, the previously failing selection goes from 0.34 s (failure) to 0.52 s (success); every other measured selection is within noise of the current code, including one 76 s multi-feature case.

## Validation

### Original:
<img width="1344" height="600" alt="image" src="https://github.com/user-attachments/assets/9960ffaf-acbf-43de-8ebd-20a96f231e68" />


### defeatured:
<img width="1344" height="600" alt="image" src="https://github.com/user-attachments/assets/33312973-1fe0-4db8-9fe8-e19751c09cc2" />


Built and tested on Linux x64, GCC, on this branch's base (`IR` @ `c7ea5bf865`, `8.1.0.dev1`), same build with the patch toggled through a relinked `TKBO`.

`testgrid boolean removefeatures`:

| | result |
|---|---|
| without the patch | 4 FAILED, 28 OK, 31 SKIPPED |
| with the patch | **32 OK**, 31 SKIPPED |

The four failures are the new tests G6-G9. All 28 pre-existing runnable cases keep identical `Mass` and `nbshapes` output.

Beyond the grid, a battery of 20 face selections on the piston: the two rows above are fixed for all four slots, and every selection that succeeds today returns a byte-identical result, with one exception: removing the two walls without the blends now discards two sliver cells (volumes 0.006 and 0.000 mm³) that were previously merged, so the result differs slightly (both results are valid).

Checks performed:

- [x] Relevant tests were added or updated when applicable.
- [x] Relevant local tests were run.

## CLA Confirmation

- [x] I confirm that I have read the contribution requirements, and that I have signed and submitted the CLA or I am covered by an approved company CLA.

CLA ID / submission reference: Pending

## Review Notes

**Stacked on #1522.** The anchored-split bookkeeping relies on the `myTrimDegenerated` flag and the retry loop introduced there, so this branch contains that commit; only the second commit is new. Happy to rebase once #1522 lands or to fold both together if preferred.

**Data file.** The piston model ships inside the PR at `tests/boolean/removefeatures/data/defeaturing_piston.step` (900 KB, FreeCAD export), so G6-G9 run without dataset changes; move or rename it as you see fit when integrating.

31 of the 63 `removefeatures` cases were SKIPPED locally because their data files are absent from the public `opencascade-dataset` archives (7.7.0, 7.8.0 and 7.9.0 alike), so I could not exercise them; CI covers them. I would particularly value the `bug28840_*` and `bug29481_window_slots` results, as they are multi-feature removals on real parts.

Not addressed here: on the same piston, removing certain single blends still fails, and three selections return an invalid solid today; those are separate problems.
