### PR TITLE
Application Framework - Resolve deep XBF references after partial read

### DIFF
--- a/src/ApplicationFramework/TKBinL/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.cxx
+++ b/src/ApplicationFramework/TKBinL/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.cxx
@@ -21,15 +21,15 @@
 #include <BinMDF_ADriverTable.hxx>
 #include <BinObjMgt_Persistent.hxx>
 #include <CDM_Application.hxx>
-#include <Message_Messenger.hxx>
 #include <FSD_BinaryFile.hxx>
 #include <FSD_FileHeader.hxx>
+#include <Message_Messenger.hxx>
+#include <Message_ProgressScope.hxx>
+#include <NCollection_LinearVector.hxx>
 #include <OSD_FileSystem.hxx>
 #include <PCDM_ReadWriter.hxx>
+#include <PCDM_ReaderFilter.hxx>
 #include <Standard_Macro.hxx>
-#include <iostream>
-#include <iomanip>
-#include <fstream>
 #include <Standard_Type.hxx>
 #include <Storage_HeaderData.hxx>
 #include <Storage_Schema.hxx>
@@ -42,8 +42,11 @@
 #include <TDocStd_Document.hxx>
 #include <TDocStd_FormatVersion.hxx>
 #include <TDocStd_Owner.hxx>
-#include <Message_ProgressScope.hxx>
-#include <PCDM_ReaderFilter.hxx>
+
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
 
 IMPLEMENT_STANDARD_RTTIEXT(BinLDrivers_DocumentRetrievalDriver, PCDM_RetrievalDriver)
 
@@ -54,6 +57,35 @@ IMPLEMENT_STANDARD_RTTIEXT(BinLDrivers_DocumentRetrievalDriver, PCDM_RetrievalDr
 #define DATATYPE_MIGRATION
 
 // #define DATATYPE_MIGRATION_DEB
+
+namespace
+{
+void skipDirectData(Standard_IStream& theIS, BinObjMgt_Persistent& thePersistent)
+{
+  if (!thePersistent.IsDirect())
+  {
+    return;
+  }
+
+  uint64_t aStreamSize = 0;
+  theIS.read(reinterpret_cast<char*>(&aStreamSize), sizeof(uint64_t));
+#if DO_INVERSE
+  aStreamSize = FSD_BinaryFile::InverseUint64(aStreamSize);
+#endif
+  constexpr uint64_t THE_SIZE_FIELD_SIZE = sizeof(uint64_t);
+  if (!theIS || aStreamSize < THE_SIZE_FIELD_SIZE
+      || aStreamSize - THE_SIZE_FIELD_SIZE
+           > static_cast<uint64_t>(std::numeric_limits<std::streamoff>::max()))
+  {
+    theIS.setstate(std::ios_base::failbit);
+    return;
+  }
+  const std::streamoff aPayloadSize =
+    static_cast<std::streamoff>(aStreamSize - THE_SIZE_FIELD_SIZE);
+  theIS.seekg(aPayloadSize, std::ios_base::cur);
+}
+} // namespace
+
 //=================================================================================================
 
 BinLDrivers_DocumentRetrievalDriver::BinLDrivers_DocumentRetrievalDriver()
@@ -131,10 +163,8 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
 
   if (!aHeaderData.IsNull())
   {
-    for (int i = 1; i <= aHeaderData->UserInfo().Length(); i++)
+    for (const TCollection_AsciiString& aLine : aHeaderData->UserInfo())
     {
-      const TCollection_AsciiString& aLine = aHeaderData->UserInfo().Value(i);
-
       if (aLine.Search(REFERENCE_COUNTER) != -1)
       {
         theDoc->SetReferenceCounter(aLine.Token(" ", 2).IntegerValue());
@@ -172,10 +202,9 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
   NCollection_Sequence<TCollection_AsciiString>        aTypeNames; // Sequence of types in file
   const NCollection_Sequence<TCollection_AsciiString>& aUserInfo = aHeaderData->UserInfo();
   bool                                                 begin     = false;
-  int                                                  i;
-  for (i = 1; i <= aUserInfo.Length(); i++)
+  for (const TCollection_AsciiString& theUserInfo : aUserInfo)
   {
-    TCollection_AsciiString aStr = aUserInfo(i);
+    TCollection_AsciiString aStr = theUserInfo;
     if (aStr == START_TYPES)
     {
       begin = true;
@@ -211,13 +240,20 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
   }
   myDrivers->AssignIds(aTypeNames);
 
+  myTreeNodeTypeId = 0;
+  if (!theFilter.IsNull())
+  {
+    occ::handle<BinMDF_ADriver> aTreeNodeDriver;
+    myTreeNodeTypeId = myDrivers->GetDriver(STANDARD_TYPE(TDataStd_TreeNode), aTreeNodeDriver);
+  }
+
   // recognize types not supported by drivers
   myMapUnsupported.Clear();
-  for (i = 1; i <= aTypeNames.Length(); i++)
+  for (int aTypeId = 1; aTypeId <= aTypeNames.Length(); ++aTypeId)
   {
-    if (myDrivers->GetDriver(i).IsNull())
+    if (myDrivers->GetDriver(aTypeId).IsNull())
     {
-      myMapUnsupported.Add(i);
+      myMapUnsupported.Add(aTypeId);
     }
   }
   if (!myMapUnsupported.IsEmpty())
@@ -226,11 +262,11 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
                         + "warning: "
                           "the following attributes have no driver:",
                       Message_Warning);
-    for (i = 1; i <= aTypeNames.Length(); i++)
+    for (int aTypeId = 1; aTypeId <= aTypeNames.Length(); ++aTypeId)
     {
-      if (myMapUnsupported.Contains(i))
+      if (myMapUnsupported.Contains(aTypeId))
       {
-        myMsgDriver->Send(aTypeNames(i), Message_Warning);
+        myMsgDriver->Send(aTypeNames.Value(aTypeId), Message_Warning);
       }
     }
   }
@@ -244,7 +280,7 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
   occ::handle<TDF_Data> aData =
     (!theFilter.IsNull() && theFilter->IsAppendMode()) ? aDoc->GetData() : new TDF_Data();
 
-  Message_ProgressScope aPS(theRange, "Reading data", 3);
+  Message_ProgressScope aPS(theRange, "Reading data", 4);
   bool                  aQuickPart = IsQuickPart(aFileVer);
 
   // 2b. Read the TOC of Sections
@@ -360,6 +396,9 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
   }
   EnableQuickPartReading(myMsgDriver, aQuickPart);
 
+  myUnresolvedLinks.Clear();
+  myTreeNodeLocations.Clear();
+
   // read sub-tree of the root label
   if (!theFilter.IsNull())
   {
@@ -367,13 +406,36 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
   }
   const auto aStreamStartPosition = theIStream.tellg();
   int nbRead = ReadSubTree(theIStream, aData->Root(), theFilter, aQuickPart, false, aPS.Next());
+  if (nbRead < 0)
+  {
+    Clear();
+    return;
+  }
   if (!myUnresolvedLinks.IsEmpty())
   {
-    // In case we have skipped some linked TreeNodes before getting to
-    // their children.
+    // Scan skipped labels once and remember TreeNode record positions. References to records
+    // preceding their dependants are resolved by direct seeks after the scan.
     theFilter->StartIteration();
     theIStream.seekg(aStreamStartPosition, std::ios_base::beg);
-    nbRead += ReadSubTree(theIStream, aData->Root(), theFilter, aQuickPart, true, aPS.Next());
+    const int aNbMissing =
+      ReadSubTree(theIStream, aData->Root(), theFilter, aQuickPart, true, aPS.Next());
+    if (aNbMissing < 0)
+    {
+      Clear();
+      return;
+    }
+    nbRead += aNbMissing;
+
+    if (!myUnresolvedLinks.IsEmpty())
+    {
+      const int aNbResolved = resolveUnresolvedLinks(theIStream, theFilter, aPS.Next());
+      if (aNbResolved < 0)
+      {
+        Clear();
+        return;
+      }
+      nbRead += aNbResolved;
+    }
   }
   if (!aPS.More())
   {
@@ -387,8 +449,6 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
     myReaderStatus = PCDM_RS_UserBreak;
     return;
   }
-  aPS.Next();
-
   if (nbRead > 0)
   {
     // attach data to the document
@@ -415,6 +475,194 @@ void BinLDrivers_DocumentRetrievalDriver::Read(Standard_IStream&                
       }
     }
   }
+}
+
+//=================================================================================================
+
+int BinLDrivers_DocumentRetrievalDriver::readAttribute(
+  Standard_IStream&                     theIS,
+  const TDF_Label&                      theLabel,
+  const occ::handle<PCDM_ReaderFilter>& theFilter)
+{
+  const occ::handle<BinMDF_ADriver> aDriver = myDrivers->GetDriver(myPAtt.TypeId());
+  if (aDriver.IsNull())
+  {
+    if (!myMapUnsupported.Contains(myPAtt.TypeId()))
+    {
+      myMsgDriver->Send(TCollection_ExtendedString(
+                          "BinLDrivers_DocumentRetrievalDriver: warning: type ID not registered in "
+                          "header: ")
+                          + myPAtt.TypeId(),
+                        Message_Warning);
+    }
+    skipDirectData(theIS, myPAtt);
+    return 0;
+  }
+
+  const int                              anId            = myPAtt.Id();
+  const occ::handle<Standard_Transient>* aBoundAttribute = myRelocTable.Seek(anId);
+  const bool                             isBound         = aBoundAttribute != nullptr;
+  occ::handle<TDF_Attribute>             anAttrib =
+    isBound ? occ::down_cast<TDF_Attribute>(*aBoundAttribute) : aDriver->NewEmpty();
+
+  if (!theFilter.IsNull() && !theFilter->IsPassed(anAttrib->DynamicType()))
+  {
+    skipDirectData(theIS, myPAtt);
+    return 0;
+  }
+
+  if (anAttrib->Label().IsNull())
+  {
+    if (!theFilter.IsNull() && theFilter->Mode() != PCDM_ReaderFilter::AppendMode_Forbid
+        && theLabel.IsAttribute(anAttrib->ID()))
+    {
+      if (theFilter->Mode() == PCDM_ReaderFilter::AppendMode_Protect)
+      {
+        skipDirectData(theIS, myPAtt);
+        return 1;
+      }
+      if (theFilter->Mode() == PCDM_ReaderFilter::AppendMode_Overwrite)
+      {
+        theLabel.ForgetAttribute(anAttrib->ID());
+      }
+    }
+    try
+    {
+      theLabel.AddAttribute(anAttrib);
+    }
+    catch (const Standard_DomainError&)
+    {
+      // The persistent GUID of attributes with user-defined IDs is read by the driver.
+      static const Standard_GUID aFallbackId;
+      anAttrib->SetID(aFallbackId);
+      theLabel.AddAttribute(anAttrib);
+    }
+  }
+  else
+  {
+    myMsgDriver->Send(
+      TCollection_ExtendedString(
+        "BinLDrivers_DocumentRetrievalDriver: warning: attempt to attach attribute ")
+        + aDriver->TypeName() + " to a second label",
+      Message_Warning);
+  }
+
+  if (!aDriver->Paste(myPAtt, anAttrib, myRelocTable))
+  {
+    myMsgDriver->Send(TCollection_ExtendedString(
+                        "BinLDrivers_DocumentRetrievalDriver: warning: failure reading attribute ")
+                        + aDriver->TypeName(),
+                      Message_Warning);
+    return 1;
+  }
+
+  if (!isBound)
+  {
+    myRelocTable.Bind(anId, anAttrib);
+  }
+
+  if (!theFilter.IsNull() && myPAtt.TypeId() == myTreeNodeTypeId)
+  {
+    myUnresolvedLinks.Remove(anId);
+    int aFatherId = -1;
+    if (myPAtt.SetPosition(BP_HEADSIZE) && (myPAtt >> aFatherId) && aFatherId > 0
+        && !isAttributeLoaded(aFatherId))
+    {
+      myUnresolvedLinks.Add(aFatherId);
+    }
+  }
+  return 1;
+}
+
+//=================================================================================================
+
+int BinLDrivers_DocumentRetrievalDriver::resolveUnresolvedLinks(
+  Standard_IStream&                     theIS,
+  const occ::handle<PCDM_ReaderFilter>& theFilter,
+  const Message_ProgressRange&          theRange)
+{
+  Message_ProgressScope         aPS(theRange, "Resolving attribute links", 1);
+  NCollection_LinearVector<int> aPendingIds;
+  int                           aNbRead = 0;
+  while (!myUnresolvedLinks.IsEmpty())
+  {
+    aPendingIds.Clear();
+    aPendingIds.Reserve(myUnresolvedLinks.Size());
+    for (const int anId : myUnresolvedLinks)
+    {
+      aPendingIds.Append(anId);
+    }
+    myUnresolvedLinks.Clear();
+
+    for (const int anId : aPendingIds)
+    {
+      if (!aPS.More())
+      {
+        myReaderStatus = PCDM_RS_UserBreak;
+        return -1;
+      }
+      myUnresolvedLinks.Remove(anId);
+      if (isAttributeLoaded(anId))
+      {
+        continue;
+      }
+      const LabelLocation* aLocation = myTreeNodeLocations.Seek(anId);
+      if (aLocation == nullptr)
+      {
+        myMsgDriver->Send(TCollection_ExtendedString(
+                            "BinLDrivers_DocumentRetrievalDriver: error: unresolved TreeNode ")
+                            + anId,
+                          Message_Fail);
+        myReaderStatus = PCDM_RS_UnrecognizedFileFormat;
+        return -1;
+      }
+
+      const auto& [aPosition, aLabel] = *aLocation;
+      theIS.clear();
+      theIS.seekg(aPosition, std::ios_base::beg);
+      for (theIS >> myPAtt; theIS && myPAtt.TypeId() > 0 && myPAtt.Id() > 0 && !theIS.eof();
+           theIS >> myPAtt)
+      {
+        if (isAttributeLoaded(myPAtt.Id()))
+        {
+          skipDirectData(theIS, myPAtt);
+          continue;
+        }
+        aNbRead += readAttribute(theIS, aLabel, theFilter);
+      }
+      if (!theIS || myPAtt.TypeId() != BinLDrivers_ENDATTRLIST)
+      {
+        myMsgDriver->Send("BinLDrivers_DocumentRetrievalDriver: error: invalid attribute list",
+                          Message_Fail);
+        myReaderStatus = PCDM_RS_UnrecognizedFileFormat;
+        return -1;
+      }
+      if (!isAttributeLoaded(anId))
+      {
+        myMsgDriver->Send(
+          TCollection_ExtendedString(
+            "BinLDrivers_DocumentRetrievalDriver: error: failed to resolve TreeNode ")
+            + anId,
+          Message_Fail);
+        myReaderStatus = PCDM_RS_UnrecognizedFileFormat;
+        return -1;
+      }
+    }
+  }
+  return aNbRead;
+}
+
+//=================================================================================================
+
+bool BinLDrivers_DocumentRetrievalDriver::isAttributeLoaded(const int theId) const
+{
+  const occ::handle<Standard_Transient>* anObject = myRelocTable.Seek(theId);
+  if (anObject == nullptr)
+  {
+    return false;
+  }
+  const occ::handle<TDF_Attribute> anAttribute = occ::down_cast<TDF_Attribute>(*anObject);
+  return !anAttribute.IsNull() && !anAttribute->Label().IsNull();
 }
 
 //=================================================================================================
@@ -474,6 +722,10 @@ int BinLDrivers_DocumentRetrievalDriver::ReadSubTree(
       myReaderStatus = PCDM_RS_UserBreak;
       return -1;
     }
+    if (theReadMissing && myPAtt.TypeId() == myTreeNodeTypeId)
+    {
+      myTreeNodeLocations.TryEmplace(myPAtt.Id(), anAttStartPosition, theLabel);
+    }
     if (myUnresolvedLinks.Remove(myPAtt.Id()) && aSkipAttrs)
     {
       aSkipAttrs = false;
@@ -482,108 +734,15 @@ int BinLDrivers_DocumentRetrievalDriver::ReadSubTree(
     }
     if (aSkipAttrs)
     {
-      if (myPAtt.IsDirect()) // skip direct written stream
-      {
-        uint64_t aStreamSize = 0;
-        theIS.read(reinterpret_cast<char*>(&aStreamSize), sizeof(uint64_t));
-        aStreamSize -= sizeof(uint64_t); // size is already passed, so, reduce it by size
-        theIS.seekg(aStreamSize, std::ios_base::cur);
-      }
+      skipDirectData(theIS, myPAtt);
       continue;
     }
-
-    // get a driver according to TypeId
-    occ::handle<BinMDF_ADriver> aDriver = myDrivers->GetDriver(myPAtt.TypeId());
-    if (!aDriver.IsNull())
+    if (theReadMissing && isAttributeLoaded(myPAtt.Id()))
     {
-      // create transient attribute
-      int                        anID = myPAtt.Id();
-      occ::handle<TDF_Attribute> tAtt;
-      bool                       isBound = myRelocTable.IsBound(anID);
-      if (isBound)
-      {
-        tAtt = occ::down_cast<TDF_Attribute>(myRelocTable.Find(anID));
-      }
-      else
-      {
-        tAtt = aDriver->NewEmpty();
-      }
-
-      if (!theFilter.IsNull() && !theFilter->IsPassed(tAtt->DynamicType()))
-      {
-        if (myPAtt.IsDirect()) // skip direct written stream
-        {
-          uint64_t aStreamSize = 0;
-          theIS.read(reinterpret_cast<char*>(&aStreamSize), sizeof(uint64_t));
-          aStreamSize -= sizeof(uint64_t); // size is already passed, so, reduce it by size
-          theIS.seekg(aStreamSize, std::ios_base::cur);
-        }
-        continue;
-      }
-      nbRead++;
-
-      if (tAtt->Label().IsNull())
-      {
-        if (!theFilter.IsNull() && theFilter->Mode() != PCDM_ReaderFilter::AppendMode_Forbid
-            && theLabel.IsAttribute(tAtt->ID()))
-        {
-          if (theFilter->Mode() == PCDM_ReaderFilter::AppendMode_Protect)
-          {
-            continue; // do not overwrite the existing attribute
-          }
-          if (theFilter->Mode() == PCDM_ReaderFilter::AppendMode_Overwrite)
-          {
-            theLabel.ForgetAttribute(tAtt->ID()); // forget old attribute to write a new one
-          }
-        }
-        try
-        {
-          theLabel.AddAttribute(tAtt);
-        }
-        catch (const Standard_DomainError&)
-        {
-          // For attributes that can have arbitrary GUID (e.g. TDataStd_Integer), exception
-          // will be raised in valid case if attribute of that type with default GUID is already
-          // present  on the same label; the reason is that actual GUID will be read later.
-          // To avoid this, set invalid (null) GUID to the newly added attribute (see #29669)
-          static const Standard_GUID fbidGuid;
-          tAtt->SetID(fbidGuid);
-          theLabel.AddAttribute(tAtt);
-        }
-      }
-      else
-      {
-        myMsgDriver->Send(aMethStr + "warning: attempt to attach attribute " + aDriver->TypeName()
-                            + " to a second label",
-                          Message_Warning);
-      }
-
-      bool ok = aDriver->Paste(myPAtt, tAtt, myRelocTable);
-      if (!ok)
-      {
-        // error converting persistent to transient
-        myMsgDriver->Send(aMethStr + "warning: failure reading attribute " + aDriver->TypeName(),
-                          Message_Warning);
-      }
-      else if (!isBound)
-      {
-        myRelocTable.Bind(anID, tAtt);
-        occ::handle<TDataStd_TreeNode> aNode = occ::down_cast<TDataStd_TreeNode>(tAtt);
-        if (!theFilter.IsNull() && !aNode.IsNull() && !aNode->Father().IsNull()
-            && aNode->Father()->IsNew())
-        {
-          int anUnresolvedLink;
-          myPAtt.SetPosition(BP_HEADSIZE);
-          myPAtt >> anUnresolvedLink;
-          myUnresolvedLinks.Add(anUnresolvedLink);
-        }
-      }
+      skipDirectData(theIS, myPAtt);
+      continue;
     }
-    else if (!myMapUnsupported.Contains(myPAtt.TypeId()))
-    {
-      myMsgDriver->Send(aMethStr + "warning: type ID not registered in header: " + myPAtt.TypeId(),
-                        Message_Warning);
-    }
+    nbRead += readAttribute(theIS, theLabel, theFilter);
   }
   if (!theIS || myPAtt.TypeId() != BinLDrivers_ENDATTRLIST)
   {
@@ -708,6 +867,9 @@ void BinLDrivers_DocumentRetrievalDriver::Clear()
   myPAtt.Destroy(); // free buffer
   myRelocTable.Clear();
   myMapUnsupported.Clear();
+  myUnresolvedLinks.Clear();
+  myTreeNodeLocations.Clear();
+  myTreeNodeTypeId = 0;
 }
 
 //=================================================================================================

--- a/src/ApplicationFramework/TKBinL/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.hxx
+++ b/src/ApplicationFramework/TKBinL/BinLDrivers/BinLDrivers_DocumentRetrievalDriver.hxx
@@ -18,24 +18,25 @@
 
 #include <Standard.hxx>
 
+#include <BinLDrivers_DocumentSection.hxx>
 #include <BinObjMgt_Persistent.hxx>
 #include <BinObjMgt_RRelocationTable.hxx>
-#include <Standard_Integer.hxx>
-#include <NCollection_Map.hxx>
 #include <NCollection_DynamicArray.hxx>
-#include <BinLDrivers_DocumentSection.hxx>
+#include <NCollection_FlatDataMap.hxx>
+#include <NCollection_FlatMap.hxx>
 #include <PCDM_RetrievalDriver.hxx>
 #include <Standard_IStream.hxx>
-#include <Storage_Position.hxx>
 #include <Storage_Data.hxx>
+#include <Storage_Position.hxx>
+#include <TDF_Label.hxx>
+
+#include <utility>
 
 class BinMDF_ADriverTable;
 class Message_Messenger;
 class TCollection_ExtendedString;
 class CDM_Document;
 class CDM_Application;
-class TDF_Label;
-class BinLDrivers_DocumentSection;
 
 class BinLDrivers_DocumentRetrievalDriver : public PCDM_RetrievalDriver
 {
@@ -117,10 +118,25 @@ protected:
   occ::handle<Message_Messenger>   myMsgDriver;
 
 private:
+  using LabelLocation = std::pair<std::streampos, TDF_Label>;
+
+  int readAttribute(Standard_IStream&                     theIS,
+                    const TDF_Label&                      theLabel,
+                    const occ::handle<PCDM_ReaderFilter>& theFilter);
+
+  int resolveUnresolvedLinks(Standard_IStream&                     theIS,
+                             const occ::handle<PCDM_ReaderFilter>& theFilter,
+                             const Message_ProgressRange&          theRange);
+
+  bool isAttributeLoaded(const int theId) const;
+
+private:
   BinObjMgt_Persistent                                  myPAtt;
-  NCollection_Map<int>                                  myMapUnsupported;
+  NCollection_FlatMap<int>                              myMapUnsupported;
   NCollection_DynamicArray<BinLDrivers_DocumentSection> mySections;
-  NCollection_Map<int>                                  myUnresolvedLinks;
+  NCollection_FlatMap<int>                              myUnresolvedLinks;
+  NCollection_FlatDataMap<int, LabelLocation>           myTreeNodeLocations;
+  int                                                   myTreeNodeTypeId = 0;
 };
 
 #endif // _BinLDrivers_DocumentRetrievalDriver_HeaderFile

--- a/src/ApplicationFramework/TKXml/GTests/TDocStd_Storage_Test.cxx
+++ b/src/ApplicationFramework/TKXml/GTests/TDocStd_Storage_Test.cxx
@@ -103,6 +103,10 @@
 #include <gp_Trsf.hxx>
 #include <gp_Vec.hxx>
 #include <TopLoc_Location.hxx>
+#include <XCAFDoc.hxx>
+#include <XCAFDoc_DocumentTool.hxx>
+#include <XCAFDoc_Location.hxx>
+#include <XCAFDoc_ShapeTool.hxx>
 
 #include <cmath>
 #include <cstring>
@@ -212,6 +216,122 @@ static PCDM_ReaderStatus OpenDocumentStream(const occ::handle<TDocStd_Applicatio
   theStream.clear();
   theStream.seekg(0);
   return theApplication->Open(theStream, theDocument, theFilter);
+}
+
+// bugs/caf/bug33855: partial XBF retrieval resolves a complete chain of TreeNode references.
+TEST(TDocStd_Storage_Test, Cbf_CafBug33855_DeepTreeNodeReferencesAfterPartialRead)
+{
+  occ::handle<TDocStd_Application> anApplication = NewApplication();
+  occ::handle<TDocStd_Document>    aDocument     = NewDocument(anApplication, "BinOcaf");
+  ASSERT_FALSE(aDocument.IsNull());
+
+  const int aChainStarts[] = {1, 5};
+  for (const int aStartTag : aChainStarts)
+  {
+    occ::handle<TDataStd_TreeNode> aParentNode;
+    for (size_t anOffset = 0; anOffset < 4; ++anOffset)
+    {
+      const int                      aTag   = aStartTag + static_cast<int>(anOffset);
+      const TDF_Label                aLabel = aDocument->Main().FindChild(aTag, true);
+      occ::handle<TDataStd_TreeNode> aNode  = TDataStd_TreeNode::Set(aLabel);
+      ASSERT_FALSE(aNode.IsNull());
+      if (!aParentNode.IsNull())
+      {
+        ASSERT_TRUE(aParentNode->Append(aNode));
+      }
+      aParentNode = aNode;
+    }
+  }
+
+  std::stringstream aStream;
+  SaveDocumentStream(anApplication, aDocument, aStream);
+  anApplication->Close(aDocument);
+
+  occ::handle<PCDM_ReaderFilter> aFilter = new PCDM_ReaderFilter;
+  aFilter->AddPath("0:1:4");
+  aFilter->AddPath("0:1:8");
+  occ::handle<TDocStd_Document> aRestored;
+  ASSERT_EQ(OpenDocumentStream(anApplication, aStream, aRestored, aFilter), PCDM_RS_OK);
+  ASSERT_FALSE(aRestored.IsNull());
+
+  const int aLeafTags[] = {4, 8};
+  for (const int aLeafTag : aLeafTags)
+  {
+    occ::handle<TDataStd_TreeNode> aNode;
+    ASSERT_TRUE(aRestored->Main()
+                  .FindChild(aLeafTag, false)
+                  .FindAttribute(TDataStd_TreeNode::GetDefaultTreeID(), aNode));
+    for (size_t anOffset = 1; anOffset < 4; ++anOffset)
+    {
+      aNode = aNode->Father();
+      ASSERT_FALSE(aNode.IsNull());
+      ASSERT_FALSE(aNode->Label().IsNull());
+      EXPECT_EQ(aNode->Label().Tag(), aLeafTag - static_cast<int>(anOffset));
+    }
+    EXPECT_TRUE(aNode->Father().IsNull());
+  }
+  anApplication->Close(aRestored);
+}
+
+// bugs/caf/bug33855: XCAF shape references remain usable after partial XBF retrieval.
+TEST(TDocStd_Storage_Test, Cbf_CafBug33855_DeepShapeReferencesAfterPartialRead)
+{
+  occ::handle<TDocStd_Application> anApplication = NewApplication();
+  BinXCAFDrivers::DefineFormat(anApplication);
+  occ::handle<TDocStd_Document> aDocument = NewDocument(anApplication, "BinXCAF");
+  ASSERT_FALSE(aDocument.IsNull());
+
+  const TopoDS_Shape             aBox       = BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape();
+  occ::handle<XCAFDoc_ShapeTool> aShapeTool = XCAFDoc_DocumentTool::ShapeTool(aDocument->Main());
+  ASSERT_FALSE(aShapeTool.IsNull());
+  TDF_Label aReferredLabel = aShapeTool->AddShape(aBox);
+  ASSERT_FALSE(aReferredLabel.IsNull());
+
+  TDF_Label aReferenceLabel;
+  for (size_t aDepth = 0; aDepth < 4; ++aDepth)
+  {
+    aReferenceLabel = TDF_TagSource::NewChild(aShapeTool->Label());
+    ASSERT_FALSE(aReferenceLabel.IsNull());
+    ASSERT_FALSE(XCAFDoc_Location::Set(aReferenceLabel, TopLoc_Location()).IsNull());
+    occ::handle<TDataStd_TreeNode> aMainNode =
+      TDataStd_TreeNode::Set(aReferredLabel, XCAFDoc::ShapeRefGUID());
+    occ::handle<TDataStd_TreeNode> aReferenceNode =
+      TDataStd_TreeNode::Set(aReferenceLabel, XCAFDoc::ShapeRefGUID());
+    ASSERT_FALSE(aMainNode.IsNull());
+    ASSERT_FALSE(aReferenceNode.IsNull());
+    ASSERT_TRUE(aMainNode->Append(aReferenceNode));
+    aReferredLabel = aReferenceLabel;
+  }
+
+  TCollection_AsciiString aReferenceEntry;
+  TDF_Tool::Entry(aReferenceLabel, aReferenceEntry);
+  std::stringstream aStream;
+  SaveDocumentStream(anApplication, aDocument, aStream);
+  anApplication->Close(aDocument);
+
+  occ::handle<PCDM_ReaderFilter> aFilter = new PCDM_ReaderFilter;
+  aFilter->AddPath(aReferenceEntry);
+  occ::handle<TDocStd_Document> aRestored;
+  ASSERT_EQ(OpenDocumentStream(anApplication, aStream, aRestored, aFilter), PCDM_RS_OK);
+  ASSERT_FALSE(aRestored.IsNull());
+
+  TDF_Label aRestoredReference;
+  TDF_Tool::Label(aRestored->GetData(), aReferenceEntry, aRestoredReference, false);
+  ASSERT_FALSE(aRestoredReference.IsNull());
+  TopoDS_Shape aRestoredShape;
+  ASSERT_NO_THROW(EXPECT_TRUE(XCAFDoc_ShapeTool::GetShape(aRestoredReference, aRestoredShape)));
+  ASSERT_FALSE(aRestoredShape.IsNull());
+  Bnd_Box aBounds;
+  BRepBndLib::Add(aRestoredShape, aBounds);
+  const auto [aXMin, aXMax, aYMin, aYMax, aZMin, aZMax] = aBounds.Get();
+  const double aTolerance                               = 2.0 * Precision::Confusion();
+  EXPECT_NEAR(aXMin, 0.0, aTolerance);
+  EXPECT_NEAR(aYMin, 0.0, aTolerance);
+  EXPECT_NEAR(aZMin, 0.0, aTolerance);
+  EXPECT_NEAR(aXMax, 10.0, aTolerance);
+  EXPECT_NEAR(aYMax, 20.0, aTolerance);
+  EXPECT_NEAR(aZMax, 30.0, aTolerance);
+  anApplication->Close(aRestored);
 }
 
 static void RunBinaryEmptyLists()


### PR DESCRIPTION
- Index TreeNode locations during a single missing-data scan.
- Resolve backward reference chains by direct stream seeks.
- Validate direct payload sizes and preserve filtered-read semantics.
- Add synthetic OCAF and XCAF regressions for deep reference chains.